### PR TITLE
Modify pytorch doc

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -17,7 +17,7 @@ Flower's design goals was to make this simple. Read on to learn more.
    :maxdepth: 2
    :caption: User Guide
 
-   quickstart
+   quickstart_keras
    quickstart_pytorch
    installation
    examples

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -18,6 +18,7 @@ Flower's design goals was to make this simple. Read on to learn more.
    :caption: User Guide
 
    quickstart
+   quickstart_pytorch
    installation
    examples
    howto-aws

--- a/doc/source/quickstart.rst
+++ b/doc/source/quickstart.rst
@@ -1,5 +1,5 @@
-Flower Quickstart
-=================
+Flower Quickstart (with Keras)
+==============================
 
 Let's build a federated learning system in less than 50 lines of code!
 

--- a/doc/source/quickstart_keras.rst
+++ b/doc/source/quickstart_keras.rst
@@ -69,7 +69,7 @@ implemented in the following way:
 
     class MnistClient(fl.client.KerasClient):
         def __init__(self, cid, model, x_train, y_train, x_test, y_test):
-            super().__init__(cid)
+            super().__init__()
             self.model = model
             self.x_train, self.y_train = x_train, y_train
             self.x_test, self.y_test = x_test, y_test

--- a/doc/source/quickstart_pytorch.rst
+++ b/doc/source/quickstart_pytorch.rst
@@ -1,5 +1,5 @@
 Flower Quickstart (with PyTorch)
-=================
+================================
 
 In this tutorial we will learn how to train a Convolutional Neural Network on MNIST using Flower and PyTorch. 
 


### PR DESCRIPTION
1. Link Quickstart PyTorch to index 
2. Rename Quickstart to Quickstart Keras
3. Fix warnings (Title underline too short)