### PR TITLE
Seperate dataclass for easier import

### DIFF
--- a/src/py/flwr_experimental/baseline/command.py
+++ b/src/py/flwr_experimental/baseline/command.py
@@ -17,7 +17,7 @@
 
 from typing import Optional
 
-from flwr_experimental.ops.cluster import Instance
+from flwr_experimental.ops.instance import Instance
 
 
 def install_wheel(wheel_remote_path: str) -> str:

--- a/src/py/flwr_experimental/baseline/common/config.py
+++ b/src/py/flwr_experimental/baseline/common/config.py
@@ -20,7 +20,7 @@ from typing import List, Optional, Tuple
 
 import numpy as np
 
-from flwr_experimental.ops.cluster import Instance
+from flwr_experimental.ops.instance import Instance
 
 # We assume that devices which are older will have at most
 # ~80% of the the Samsung Galaxy Note 5 compute performance.

--- a/src/py/flwr_experimental/baseline/run.py
+++ b/src/py/flwr_experimental/baseline/run.py
@@ -28,10 +28,11 @@ import flwr_experimental.baseline.tf_fashion_mnist.settings as tf_fashion_mnist_
 import flwr_experimental.baseline.tf_hotkey.settings as tf_hotkey_settings
 from flwr.common.logger import configure, log
 from flwr_experimental.baseline import command
-from flwr_experimental.ops.cluster import Cluster, Instance
+from flwr_experimental.ops.cluster import Cluster
 from flwr_experimental.ops.compute.adapter import Adapter
 from flwr_experimental.ops.compute.docker_adapter import DockerAdapter
 from flwr_experimental.ops.compute.ec2_adapter import EC2Adapter
+from flwr_experimental.ops.instance import Instance
 
 OPS_INI_PATH = path.normpath(
     f"{path.dirname(path.realpath(__file__))}/../../../.flower_ops"

--- a/src/py/flwr_experimental/baseline/setting.py
+++ b/src/py/flwr_experimental/baseline/setting.py
@@ -17,7 +17,7 @@
 from dataclasses import dataclass
 from typing import List, Optional
 
-from flwr_experimental.ops.cluster import Instance
+from flwr_experimental.ops.instance import Instance
 
 
 @dataclass

--- a/src/py/flwr_experimental/baseline/tf_cifar/settings.py
+++ b/src/py/flwr_experimental/baseline/tf_cifar/settings.py
@@ -21,7 +21,7 @@ from flwr_experimental.baseline.common import (
     sample_delay_factors,
 )
 from flwr_experimental.baseline.setting import Baseline, ClientSetting, ServerSetting
-from flwr_experimental.ops.cluster import Instance
+from flwr_experimental.ops.instance import Instance
 
 ROUNDS = 20
 MIN_NUM_CLIENTS = 80

--- a/src/py/flwr_experimental/baseline/tf_fashion_mnist/settings.py
+++ b/src/py/flwr_experimental/baseline/tf_fashion_mnist/settings.py
@@ -23,7 +23,7 @@ from flwr_experimental.baseline.common import (
     sample_real_delay_factors,
 )
 from flwr_experimental.baseline.setting import Baseline, ClientSetting, ServerSetting
-from flwr_experimental.ops.cluster import Instance
+from flwr_experimental.ops.instance import Instance
 
 N20_ROUNDS = 50
 ROUNDS = 20

--- a/src/py/flwr_experimental/baseline/tf_hotkey/settings.py
+++ b/src/py/flwr_experimental/baseline/tf_hotkey/settings.py
@@ -23,7 +23,7 @@ from flwr_experimental.baseline.common import (
     sample_real_delay_factors,
 )
 from flwr_experimental.baseline.setting import Baseline, ClientSetting, ServerSetting
-from flwr_experimental.ops.cluster import Instance
+from flwr_experimental.ops.instance import Instance
 
 ROUNDS = 50
 MIN_NUM_CLIENTS = 45

--- a/src/py/flwr_experimental/ops/cluster.py
+++ b/src/py/flwr_experimental/ops/cluster.py
@@ -15,7 +15,6 @@
 """Implments compute classes for EC2."""
 import concurrent.futures
 from contextlib import contextmanager
-from dataclasses import dataclass
 from itertools import groupby
 from logging import DEBUG, ERROR
 from typing import Dict, Iterator, List, Optional, Tuple
@@ -26,28 +25,9 @@ from paramiko.sftp_attr import SFTPAttributes
 from flwr.common.logger import log
 
 from .compute.adapter import Adapter
+from .instance import Instance
 
 ExecInfo = Tuple[str, str]
-
-
-# pylint: disable=too-many-instance-attributes
-@dataclass
-class Instance:
-    """Represents an instance."""
-
-    # Specs
-    name: str
-    group: str
-    num_cpu: int
-    num_ram: float
-    gpu: bool = False
-
-    # Runtime information
-    instance_id: Optional[str] = None
-    private_ip: Optional[str] = None
-    public_ip: Optional[str] = None
-    ssh_port: Optional[int] = None
-    state: Optional[str] = None
 
 
 class StartFailed(Exception):
@@ -281,6 +261,8 @@ class Cluster:
             _, stdout, stderr = client.exec_command(command)
             stdout = stdout.readlines()
             stderr = stderr.readlines()
+
+        print(stdout, stderr)
 
         return stdout, stderr
 

--- a/src/py/flwr_experimental/ops/cluster_test.py
+++ b/src/py/flwr_experimental/ops/cluster_test.py
@@ -21,12 +21,12 @@ from unittest.mock import MagicMock
 
 from .cluster import (
     Cluster,
-    Instance,
     InstanceMismatch,
     create_instances,
     group_instances_by_specs,
 )
 from .compute.ec2_adapter import EC2Adapter
+from .instance import Instance
 
 IMAGE_ID = "ami-0370b0294d7241341"
 KEY_NAME = "flower"

--- a/src/py/flwr_experimental/ops/instance.py
+++ b/src/py/flwr_experimental/ops/instance.py
@@ -1,0 +1,37 @@
+# Copyright 2020 Adap GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Provides dataclass Instance."""
+from dataclasses import dataclass
+from typing import Optional
+
+
+# pylint: disable=too-many-instance-attributes
+@dataclass
+class Instance:
+    """Represents an instance."""
+
+    # Specs
+    name: str
+    group: str
+    num_cpu: int
+    num_ram: float
+    gpu: bool = False
+
+    # Runtime information
+    instance_id: Optional[str] = None
+    private_ip: Optional[str] = None
+    public_ip: Optional[str] = None
+    ssh_port: Optional[int] = None
+    state: Optional[str] = None


### PR DESCRIPTION
Move the dataclass auf of a module so it can be imported by other modules without the dependencies of the cluster.py module becoming required.