### PR TITLE
Move docs to enable top-level landing page

### DIFF
--- a/dev/deploy-docs.sh
+++ b/dev/deploy-docs.sh
@@ -21,4 +21,4 @@ cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"/../
 cd doc
 make docs
 cd build/html
-aws s3 sync --delete --exclude ".*" --acl public-read --cache-control "no-cache" ./ s3://flower.dev
+aws s3 sync --delete --exclude ".*" --acl public-read --cache-control "no-cache" ./ s3://flower.dev/docs


### PR DESCRIPTION
We are adding a new landing page and the docs will be available under https://flower.dev/docs in the future.  