### PR TITLE
Rename strategy methods

### DIFF
--- a/doc/source/implementing-strategies.rst
+++ b/doc/source/implementing-strategies.rst
@@ -43,11 +43,6 @@ The strategy abstraction defines a few abstract methods that need to be implemen
         @abstractmethod
         def evaluate(self, weights: Weights) -> Optional[Tuple[float, float]]:
 
-        @abstractmethod
-        def on_conclude_round(
-            self, rnd: int, loss: Optional[float], acc: Optional[float]
-        ) -> bool:
-
 Creating a new strategy means implmenting a new :code:`class` derived from the abstract base class :code:`Strategy` which provides implementations for the previously shown abstract methods:
 
 .. code-block:: python
@@ -67,9 +62,6 @@ Creating a new strategy means implmenting a new :code:`class` derived from the a
             # Your implementation here
 
         def evaluate(self, weights):
-            # Your implementation here
-
-        def on_conclude_round(self, rnd, loss, acc):
             # Your implementation here
 
 The following sections describe each of those methods in detail.
@@ -96,10 +88,5 @@ The :code:`on_aggregate_evaluate` method
 
 The :code:`evaluate` method
 ---------------------------
-
-*coming soon*
-
-The :code:`on_conclude_round` method
-------------------------------------
 
 *coming soon*

--- a/doc/source/implementing-strategies.rst
+++ b/doc/source/implementing-strategies.rst
@@ -104,9 +104,9 @@ The :code:`evaluate` method
 Deprecated methods
 ------------------
 
-The following methods are deprecated and will be removed in a future release.
-Migrate to the new versions by renaming them (i.e., removing the :code:`on_`
-prefix):
+The following methods were replaced by updated versions with the same type
+signature. Migrate to the new versions by renaming them (i.e., remove the
+:code:`on_` prefix):
 
 * :code:`on_configure_fit` (replaced by :code:`configure_fit`)
 * :code:`on_aggregate_fit` (replaced by :code:`aggregate_fit`)

--- a/doc/source/implementing-strategies.rst
+++ b/doc/source/implementing-strategies.rst
@@ -1,26 +1,34 @@
 Implementing Strategies
 =======================
 
-The strategy abstraction enables implementation of fully custom strategies. A strategy is basically the federated learning algorithm that runs on the server. Strategies decide how to sample clients, how to configure clients for traning, how to aggregate updates, and how to evaluate models. Flower provides a few built-in strategies which are based on the same API described below.
+The strategy abstraction enables implementation of fully custom strategies. A
+strategy is basically the federated learning algorithm that runs on the server.
+Strategies decide how to sample clients, how to configure clients for traning,
+how to aggregate updates, and how to evaluate models. Flower provides a few
+built-in strategies which are based on the same API described below.
 
 The :code:`Strategy` abstraction
 --------------------------------
 
-All strategy implementation are derived from the abstract base class :code:`flwr.server.strategy.Strategy`, both built-in implementations and third party implementations. This means that custom strategy implementations have the exact same capabilities at their disposal as built-in ones.
+All strategy implementation are derived from the abstract base class
+:code:`flwr.server.strategy.Strategy`, both built-in implementations and third
+party implementations. This means that custom strategy implementations have the
+exact same capabilities at their disposal as built-in ones.
 
-The strategy abstraction defines a few abstract methods that need to be implemented:
+The strategy abstraction defines a few abstract methods that need to be
+implemented:
 
 .. code-block:: python
 
     class Strategy(ABC):
 
         @abstractmethod
-        def on_configure_fit(
+        def configure_fit(
             self, rnd: int, weights: Weights, client_manager: ClientManager
         ) -> List[Tuple[ClientProxy, FitIns]]:
 
         @abstractmethod
-        def on_aggregate_fit(
+        def aggregate_fit(
             self,
             rnd: int,
             results: List[Tuple[ClientProxy, FitRes]],
@@ -28,12 +36,12 @@ The strategy abstraction defines a few abstract methods that need to be implemen
         ) -> Optional[Weights]:
 
         @abstractmethod
-        def on_configure_evaluate(
+        def configure_evaluate(
             self, rnd: int, weights: Weights, client_manager: ClientManager
         ) -> List[Tuple[ClientProxy, EvaluateIns]]:
 
         @abstractmethod
-        def on_aggregate_evaluate(
+        def aggregate_evaluate(
             self,
             rnd: int,
             results: List[Tuple[ClientProxy, EvaluateRes]],
@@ -43,22 +51,24 @@ The strategy abstraction defines a few abstract methods that need to be implemen
         @abstractmethod
         def evaluate(self, weights: Weights) -> Optional[Tuple[float, float]]:
 
-Creating a new strategy means implmenting a new :code:`class` derived from the abstract base class :code:`Strategy` which provides implementations for the previously shown abstract methods:
+Creating a new strategy means implmenting a new :code:`class` derived from the
+abstract base class :code:`Strategy` which provides implementations for the
+previously shown abstract methods:
 
 .. code-block:: python
 
     class SotaStrategy(Strategy):
 
-        def on_configure_fit(self, rnd, weights, client_manager):
+        def configure_fit(self, rnd, weights, client_manager):
             # Your implementation here
 
-        def on_aggregate_fit(self, rnd, results, failures):
+        def aggregate_fit(self, rnd, results, failures):
             # Your implementation here
 
-        def on_configure_evaluate(self, rnd, weights, client_manager):
+        def configure_evaluate(self, rnd, weights, client_manager):
             # Your implementation here
 
-        def on_aggregate_evaluate(self, rnd, results, failures):
+        def aggregate_evaluate(self, rnd, results, failures):
             # Your implementation here
 
         def evaluate(self, weights):
@@ -66,22 +76,22 @@ Creating a new strategy means implmenting a new :code:`class` derived from the a
 
 The following sections describe each of those methods in detail.
 
-The :code:`on_configure_fit` method
+The :code:`configure_fit` method
 -----------------------------------
 
 *coming soon*
 
-The :code:`on_aggregate_fit` method
+The :code:`aggregate_fit` method
 -----------------------------------
 
 *coming soon*
 
-The :code:`on_configure_evaluate` method
+The :code:`configure_evaluate` method
 ----------------------------------------
 
 *coming soon*
 
-The :code:`on_aggregate_evaluate` method
+The :code:`aggregate_evaluate` method
 ----------------------------------------
 
 *coming soon*
@@ -90,3 +100,15 @@ The :code:`evaluate` method
 ---------------------------
 
 *coming soon*
+
+Deprecated methods
+------------------
+
+The following methods are deprecated and will be removed in a future release.
+Migrate to the new versions by renaming them (i.e., removing the :code:`on_`
+prefix):
+
+* :code:`on_configure_fit` (replaced by :code:`configure_fit`)
+* :code:`on_aggregate_fit` (replaced by :code:`aggregate_fit`)
+* :code:`on_configure_evaluate` (replaced by :code:`configure_evaluate`)
+* :code:`on_aggregate_evaluate` (replaced by :code:`aggregate_evaluate`)

--- a/src/py/flwr/server/server.py
+++ b/src/py/flwr/server/server.py
@@ -129,7 +129,7 @@ class Server:
     ) -> Optional[Tuple[Optional[float], EvaluateResultsAndFailures]]:
         """Validate current global model on a number of clients."""
         # Get clients and their respective instructions from strategy
-        client_instructions = self.strategy.on_configure_evaluate(
+        client_instructions = self.strategy.configure_evaluate(
             rnd=rnd, weights=self.weights, client_manager=self._client_manager
         )
         if not client_instructions:
@@ -151,13 +151,13 @@ class Server:
             len(failures),
         )
         # Aggregate the evaluation results
-        loss_aggregated = self.strategy.on_aggregate_evaluate(rnd, results, failures)
+        loss_aggregated = self.strategy.aggregate_evaluate(rnd, results, failures)
         return loss_aggregated, results_and_failures
 
     def fit_round(self, rnd: int) -> Optional[Weights]:
         """Perform a single round of federated averaging."""
         # Get clients and their respective instructions from strategy
-        client_instructions = self.strategy.on_configure_fit(
+        client_instructions = self.strategy.configure_fit(
             rnd=rnd, weights=self.weights, client_manager=self._client_manager
         )
         log(
@@ -180,7 +180,7 @@ class Server:
         )
 
         # Aggregate training results
-        return self.strategy.on_aggregate_fit(rnd, results, failures)
+        return self.strategy.aggregate_fit(rnd, results, failures)
 
     def _get_initial_weights(self) -> Weights:
         """Get initial weights from one of the available clients."""

--- a/src/py/flwr/server/server.py
+++ b/src/py/flwr/server/server.py
@@ -114,13 +114,6 @@ class Server:
                     rnd=current_round, loss=cast(float, loss_fed)
                 )
 
-            # Conclude round
-            loss = res_cen[0] if res_cen is not None else None
-            acc = res_cen[1] if res_cen is not None else None
-            should_continue = self.strategy.on_conclude_round(current_round, loss, acc)
-            if not should_continue:
-                break
-
         # Send shutdown signal to all clients
         all_clients = self._client_manager.all()
         _ = shutdown(clients=[all_clients[k] for k in all_clients.keys()])

--- a/src/py/flwr/server/strategy/fast_and_slow.py
+++ b/src/py/flwr/server/strategy/fast_and_slow.py
@@ -103,7 +103,7 @@ class FastAndSlow(FedAvg):
         return rep
 
     # pylint: disable=too-many-locals
-    def on_configure_fit(
+    def configure_fit(
         self, rnd: int, weights: Weights, client_manager: ClientManager
     ) -> List[Tuple[ClientProxy, FitIns]]:
         """Configure the next round of training."""
@@ -292,7 +292,7 @@ class FastAndSlow(FedAvg):
             use_softmax=False,
         )
 
-    def on_aggregate_fit(
+    def aggregate_fit(
         self,
         rnd: int,
         results: List[Tuple[ClientProxy, FitRes]],
@@ -341,7 +341,7 @@ class FastAndSlow(FedAvg):
 
         return weights_prime
 
-    def on_aggregate_evaluate(
+    def aggregate_evaluate(
         self,
         rnd: int,
         results: List[Tuple[ClientProxy, EvaluateRes]],

--- a/src/py/flwr/server/strategy/fault_tolerant_fedavg.py
+++ b/src/py/flwr/server/strategy/fault_tolerant_fedavg.py
@@ -58,7 +58,7 @@ class FaultTolerantFedAvg(FedAvg):
     def __repr__(self) -> str:
         return "FaultTolerantFedAvg()"
 
-    def on_aggregate_fit(
+    def aggregate_fit(
         self,
         rnd: int,
         results: List[Tuple[ClientProxy, FitRes]],
@@ -79,7 +79,7 @@ class FaultTolerantFedAvg(FedAvg):
         ]
         return aggregate(weights_results)
 
-    def on_aggregate_evaluate(
+    def aggregate_evaluate(
         self,
         rnd: int,
         results: List[Tuple[ClientProxy, EvaluateRes]],

--- a/src/py/flwr/server/strategy/fault_tolerant_fedavg_test.py
+++ b/src/py/flwr/server/strategy/fault_tolerant_fedavg_test.py
@@ -24,7 +24,7 @@ from flwr.server.client_proxy import ClientProxy
 from .fault_tolerant_fedavg import FaultTolerantFedAvg
 
 
-def test_on_aggregate_fit_no_results_no_failures() -> None:
+def test_aggregate_fit_no_results_no_failures() -> None:
     """Test evaluate function."""
     # Prepare
     strategy = FaultTolerantFedAvg(min_completion_rate_fit=0.1)
@@ -33,13 +33,13 @@ def test_on_aggregate_fit_no_results_no_failures() -> None:
     expected: Optional[Weights] = None
 
     # Execute
-    actual = strategy.on_aggregate_fit(1, results, failures)
+    actual = strategy.aggregate_fit(1, results, failures)
 
     # Assert
     assert actual == expected
 
 
-def test_on_aggregate_fit_no_results() -> None:
+def test_aggregate_fit_no_results() -> None:
     """Test evaluate function."""
     # Prepare
     strategy = FaultTolerantFedAvg(min_completion_rate_fit=0.1)
@@ -48,13 +48,13 @@ def test_on_aggregate_fit_no_results() -> None:
     expected: Optional[Weights] = None
 
     # Execute
-    actual = strategy.on_aggregate_fit(1, results, failures)
+    actual = strategy.aggregate_fit(1, results, failures)
 
     # Assert
     assert actual == expected
 
 
-def test_on_aggregate_fit_not_enough_results() -> None:
+def test_aggregate_fit_not_enough_results() -> None:
     """Test evaluate function."""
     # Prepare
     strategy = FaultTolerantFedAvg(min_completion_rate_fit=0.5)
@@ -65,13 +65,13 @@ def test_on_aggregate_fit_not_enough_results() -> None:
     expected: Optional[Weights] = None
 
     # Execute
-    actual = strategy.on_aggregate_fit(1, results, failures)
+    actual = strategy.aggregate_fit(1, results, failures)
 
     # Assert
     assert actual == expected
 
 
-def test_on_aggregate_fit_just_enough_results() -> None:
+def test_aggregate_fit_just_enough_results() -> None:
     """Test evaluate function."""
     # Prepare
     strategy = FaultTolerantFedAvg(min_completion_rate_fit=0.5)
@@ -82,13 +82,13 @@ def test_on_aggregate_fit_just_enough_results() -> None:
     expected: Optional[Weights] = []
 
     # Execute
-    actual = strategy.on_aggregate_fit(1, results, failures)
+    actual = strategy.aggregate_fit(1, results, failures)
 
     # Assert
     assert actual == expected
 
 
-def test_on_aggregate_fit_no_failures() -> None:
+def test_aggregate_fit_no_failures() -> None:
     """Test evaluate function."""
     # Prepare
     strategy = FaultTolerantFedAvg(min_completion_rate_fit=0.99)
@@ -99,13 +99,13 @@ def test_on_aggregate_fit_no_failures() -> None:
     expected: Optional[Weights] = []
 
     # Execute
-    actual = strategy.on_aggregate_fit(1, results, failures)
+    actual = strategy.aggregate_fit(1, results, failures)
 
     # Assert
     assert actual == expected
 
 
-def test_on_aggregate_evaluate_no_results_no_failures() -> None:
+def test_aggregate_evaluate_no_results_no_failures() -> None:
     """Test evaluate function."""
     # Prepare
     strategy = FaultTolerantFedAvg(min_completion_rate_evaluate=0.1)
@@ -114,13 +114,13 @@ def test_on_aggregate_evaluate_no_results_no_failures() -> None:
     expected: Optional[float] = None
 
     # Execute
-    actual = strategy.on_aggregate_evaluate(1, results, failures)
+    actual = strategy.aggregate_evaluate(1, results, failures)
 
     # Assert
     assert actual == expected
 
 
-def test_on_aggregate_evaluate_no_results() -> None:
+def test_aggregate_evaluate_no_results() -> None:
     """Test evaluate function."""
     # Prepare
     strategy = FaultTolerantFedAvg(min_completion_rate_evaluate=0.1)
@@ -129,13 +129,13 @@ def test_on_aggregate_evaluate_no_results() -> None:
     expected: Optional[float] = None
 
     # Execute
-    actual = strategy.on_aggregate_evaluate(1, results, failures)
+    actual = strategy.aggregate_evaluate(1, results, failures)
 
     # Assert
     assert actual == expected
 
 
-def test_on_aggregate_evaluate_not_enough_results() -> None:
+def test_aggregate_evaluate_not_enough_results() -> None:
     """Test evaluate function."""
     # Prepare
     strategy = FaultTolerantFedAvg(min_completion_rate_evaluate=0.5)
@@ -146,13 +146,13 @@ def test_on_aggregate_evaluate_not_enough_results() -> None:
     expected: Optional[float] = None
 
     # Execute
-    actual = strategy.on_aggregate_evaluate(1, results, failures)
+    actual = strategy.aggregate_evaluate(1, results, failures)
 
     # Assert
     assert actual == expected
 
 
-def test_on_aggregate_evaluate_just_enough_results() -> None:
+def test_aggregate_evaluate_just_enough_results() -> None:
     """Test evaluate function."""
     # Prepare
     strategy = FaultTolerantFedAvg(min_completion_rate_evaluate=0.5)
@@ -163,13 +163,13 @@ def test_on_aggregate_evaluate_just_enough_results() -> None:
     expected: Optional[float] = 2.3
 
     # Execute
-    actual = strategy.on_aggregate_evaluate(1, results, failures)
+    actual = strategy.aggregate_evaluate(1, results, failures)
 
     # Assert
     assert actual == expected
 
 
-def test_on_aggregate_evaluate_no_failures() -> None:
+def test_aggregate_evaluate_no_failures() -> None:
     """Test evaluate function."""
     # Prepare
     strategy = FaultTolerantFedAvg(min_completion_rate_evaluate=0.99)
@@ -180,7 +180,7 @@ def test_on_aggregate_evaluate_no_failures() -> None:
     expected: Optional[float] = 2.3
 
     # Execute
-    actual = strategy.on_aggregate_evaluate(1, results, failures)
+    actual = strategy.aggregate_evaluate(1, results, failures)
 
     # Assert
     assert actual == expected

--- a/src/py/flwr/server/strategy/fedavg.py
+++ b/src/py/flwr/server/strategy/fedavg.py
@@ -176,9 +176,3 @@ class FedAvg(Strategy):
                 for _, evaluate_res in results
             ]
         )
-
-    def on_conclude_round(
-        self, rnd: int, loss: Optional[float], acc: Optional[float]
-    ) -> bool:
-        """Always continue training."""
-        return True

--- a/src/py/flwr/server/strategy/fedavg.py
+++ b/src/py/flwr/server/strategy/fedavg.py
@@ -86,7 +86,7 @@ class FedAvg(Strategy):
             return None
         return self.eval_fn(weights)
 
-    def on_configure_fit(
+    def configure_fit(
         self, rnd: int, weights: Weights, client_manager: ClientManager
     ) -> List[Tuple[ClientProxy, FitIns]]:
         """Configure the next round of training."""
@@ -108,7 +108,7 @@ class FedAvg(Strategy):
         # Return client/config pairs
         return [(client, fit_ins) for client in clients]
 
-    def on_configure_evaluate(
+    def configure_evaluate(
         self, rnd: int, weights: Weights, client_manager: ClientManager
     ) -> List[Tuple[ClientProxy, EvaluateIns]]:
         """Configure the next round of evaluation."""
@@ -139,7 +139,7 @@ class FedAvg(Strategy):
         # Return client/config pairs
         return [(client, evaluate_ins) for client in clients]
 
-    def on_aggregate_fit(
+    def aggregate_fit(
         self,
         rnd: int,
         results: List[Tuple[ClientProxy, FitRes]],
@@ -158,7 +158,7 @@ class FedAvg(Strategy):
         ]
         return aggregate(weights_results)
 
-    def on_aggregate_evaluate(
+    def aggregate_evaluate(
         self,
         rnd: int,
         results: List[Tuple[ClientProxy, EvaluateRes]],

--- a/src/py/flwr/server/strategy/fedfs_v0.py
+++ b/src/py/flwr/server/strategy/fedfs_v0.py
@@ -87,7 +87,7 @@ class FedFSv0(FedAvg):
         return rep
 
     # pylint: disable=too-many-locals
-    def on_configure_fit(
+    def configure_fit(
         self, rnd: int, weights: Weights, client_manager: ClientManager
     ) -> List[Tuple[ClientProxy, FitIns]]:
         """Configure the next round of training."""
@@ -160,7 +160,7 @@ class FedFSv0(FedAvg):
             use_softmax=False,
         )
 
-    def on_aggregate_fit(
+    def aggregate_fit(
         self,
         rnd: int,
         results: List[Tuple[ClientProxy, FitRes]],
@@ -197,7 +197,7 @@ class FedFSv0(FedAvg):
 
         return weights_prime
 
-    def on_aggregate_evaluate(
+    def aggregate_evaluate(
         self,
         rnd: int,
         results: List[Tuple[ClientProxy, EvaluateRes]],

--- a/src/py/flwr/server/strategy/fedfs_v1.py
+++ b/src/py/flwr/server/strategy/fedfs_v1.py
@@ -95,7 +95,7 @@ class FedFSv1(FedAvg):
         return rep
 
     # pylint: disable=too-many-locals
-    def on_configure_fit(
+    def configure_fit(
         self, rnd: int, weights: Weights, client_manager: ClientManager
     ) -> List[Tuple[ClientProxy, FitIns]]:
         """Configure the next round of training."""
@@ -235,7 +235,7 @@ class FedFSv1(FedAvg):
             use_softmax=False,
         )
 
-    def on_aggregate_fit(
+    def aggregate_fit(
         self,
         rnd: int,
         results: List[Tuple[ClientProxy, FitRes]],
@@ -282,7 +282,7 @@ class FedFSv1(FedAvg):
 
         return weights_prime
 
-    def on_aggregate_evaluate(
+    def aggregate_evaluate(
         self,
         rnd: int,
         results: List[Tuple[ClientProxy, EvaluateRes]],

--- a/src/py/flwr/server/strategy/qffedavg.py
+++ b/src/py/flwr/server/strategy/qffedavg.py
@@ -95,7 +95,7 @@ class QffedAvg(FedAvg):
             return None
         return self.eval_fn(weights)
 
-    def on_configure_fit(
+    def configure_fit(
         self, rnd: int, weights: Weights, client_manager: ClientManager
     ) -> List[Tuple[ClientProxy, FitIns]]:
         """Configure the next round of training."""
@@ -118,7 +118,7 @@ class QffedAvg(FedAvg):
         # Return client/config pairs
         return [(client, fit_ins) for client in clients]
 
-    def on_configure_evaluate(
+    def configure_evaluate(
         self, rnd: int, weights: Weights, client_manager: ClientManager
     ) -> List[Tuple[ClientProxy, EvaluateIns]]:
         """Configure the next round of evaluation."""
@@ -146,7 +146,7 @@ class QffedAvg(FedAvg):
         # Return client/config pairs
         return [(client, evaluate_ins) for client in clients]
 
-    def on_aggregate_fit(
+    def aggregate_fit(
         self,
         rnd: int,
         results: List[Tuple[ClientProxy, FitRes]],
@@ -174,7 +174,7 @@ class QffedAvg(FedAvg):
         hs_ffl = []
 
         if self.pre_weights is None:
-            raise Exception("QffedAvg pre_weights are None in on_aggregate_fit")
+            raise Exception("QffedAvg pre_weights are None in aggregate_fit")
 
         weights_before = self.pre_weights
         eval_result = self.evaluate(weights_before)
@@ -202,7 +202,7 @@ class QffedAvg(FedAvg):
 
         return aggregate_qffl(weights_before, deltas, hs_ffl)
 
-    def on_aggregate_evaluate(
+    def aggregate_evaluate(
         self,
         rnd: int,
         results: List[Tuple[ClientProxy, EvaluateRes]],

--- a/src/py/flwr/server/strategy/qffedavg.py
+++ b/src/py/flwr/server/strategy/qffedavg.py
@@ -220,9 +220,3 @@ class QffedAvg(FedAvg):
                 for client, evaluate_res in results
             ]
         )
-
-    def on_conclude_round(
-        self, rnd: int, loss: Optional[float], acc: Optional[float]
-    ) -> bool:
-        """Always continue training."""
-        return True

--- a/src/py/flwr/server/strategy/strategy.py
+++ b/src/py/flwr/server/strategy/strategy.py
@@ -135,19 +135,3 @@ class Strategy(ABC):
         Returns:
             The evaluation result, usually a Tuple containing loss and accuracy.
         """
-
-    @abstractmethod
-    def on_conclude_round(
-        self, rnd: int, loss: Optional[float], acc: Optional[float]
-    ) -> bool:
-        """Conclude federated learning round and decide whether to continue or
-        not.
-
-        Arguments:
-            rnd: int. The current round of federated learning.
-            loss: Optional[float]. The loss of the global model weights.
-            acc: Optional[float]. The accuracy of the global model weights.
-
-        Returns:
-            A boolean indicating whether the server should continue or not.
-        """

--- a/src/py/flwr/server/strategy/strategy.py
+++ b/src/py/flwr/server/strategy/strategy.py
@@ -16,11 +16,9 @@
 
 
 from abc import ABC, abstractmethod
-from logging import WARNING
 from typing import List, Optional, Tuple
 
 from flwr.common import EvaluateIns, EvaluateRes, FitIns, FitRes, Weights
-from flwr.common.logger import log
 from flwr.server.client_manager import ClientManager
 from flwr.server.client_proxy import ClientProxy
 

--- a/src/py/flwr/server/strategy/strategy.py
+++ b/src/py/flwr/server/strategy/strategy.py
@@ -16,18 +16,20 @@
 
 
 from abc import ABC, abstractmethod
+from logging import WARNING
 from typing import List, Optional, Tuple
 
 from flwr.common import EvaluateIns, EvaluateRes, FitIns, FitRes, Weights
+from flwr.common.logger import log
 from flwr.server.client_manager import ClientManager
 from flwr.server.client_proxy import ClientProxy
 
 
 class Strategy(ABC):
-    """Abstract class to implement custom server strategies."""
+    """Abstract base class for server strategy implementations."""
 
     @abstractmethod
-    def on_configure_fit(
+    def configure_fit(
         self, rnd: int, weights: Weights, client_manager: ClientManager
     ) -> List[Tuple[ClientProxy, FitIns]]:
         """Configure the next round of training.
@@ -45,8 +47,21 @@ class Strategy(ABC):
             will not participate in the next round of federated learning.
         """
 
+    def on_configure_fit(
+        self, rnd: int, weights: Weights, client_manager: ClientManager
+    ) -> List[Tuple[ClientProxy, EvaluateIns]]:
+        """DEPRECATED: Use `configure_fit` instead."""
+        warning = """
+        Detected usage of the deprecated Strategy method
+        `on_configure_fit`, please migrate by renaming to `configure_fit`.
+        """
+        log(WARNING, warning)
+        return self.configure_fit(
+            rnd=rnd, weights=weights, client_manager=client_manager
+        )
+
     @abstractmethod
-    def on_configure_evaluate(
+    def configure_evaluate(
         self, rnd: int, weights: Weights, client_manager: ClientManager
     ) -> List[Tuple[ClientProxy, EvaluateIns]]:
         """Configure the next round of evaluation.
@@ -65,8 +80,21 @@ class Strategy(ABC):
             evaluation.
         """
 
+    def on_configure_evaluate(
+        self, rnd: int, weights: Weights, client_manager: ClientManager
+    ) -> List[Tuple[ClientProxy, EvaluateIns]]:
+        """DEPRECATED: Use `configure_evaluate` instead."""
+        warning = """
+        Detected usage of the deprecated Strategy method
+        `on_configure_evaluate`, please migrate by renaming to `configure_evaluate`.
+        """
+        log(WARNING, warning)
+        return self.configure_evaluate(
+            rnd=rnd, weights=weights, client_manager=client_manager
+        )
+
     @abstractmethod
-    def on_aggregate_fit(
+    def aggregate_fit(
         self,
         rnd: int,
         results: List[Tuple[ClientProxy, FitRes]],
@@ -96,8 +124,22 @@ class Strategy(ABC):
             the same.
         """
 
+    def on_aggregate_fit(
+        self,
+        rnd: int,
+        results: List[Tuple[ClientProxy, FitRes]],
+        failures: List[BaseException],
+    ) -> Optional[Weights]:
+        """DEPRECATED: Use `aggregate_fit` instead."""
+        warning = """
+        Detected usage of the deprecated Strategy method
+        `on_aggregate_fit`, please migrate by renaming to `aggregate_fit`.
+        """
+        log(WARNING, warning)
+        return self.aggregate_fit(rnd=rnd, results=results, failures=failures)
+
     @abstractmethod
-    def on_aggregate_evaluate(
+    def aggregate_evaluate(
         self,
         rnd: int,
         results: List[Tuple[ClientProxy, EvaluateRes]],
@@ -121,6 +163,20 @@ class Strategy(ABC):
             Optional `float` representing the aggregated evaluation result. Aggregation
             typically uses some variant of a weighted average.
         """
+
+    def on_aggregate_evaluate(
+        self,
+        rnd: int,
+        results: List[Tuple[ClientProxy, EvaluateRes]],
+        failures: List[BaseException],
+    ) -> Optional[float]:
+        """DEPRECATED: Use `aggregate_evaluate` instead."""
+        warning = """
+        Detected usage of the deprecated Strategy method
+        `on_aggregate_evaluate`, please migrate by renaming to `aggregate_evaluate`.
+        """
+        log(WARNING, warning)
+        return self.aggregate_evaluate(rnd=rnd, results=results, failures=failures)
 
     @abstractmethod
     def evaluate(self, weights: Weights) -> Optional[Tuple[float, float]]:

--- a/src/py/flwr/server/strategy/strategy.py
+++ b/src/py/flwr/server/strategy/strategy.py
@@ -47,52 +47,6 @@ class Strategy(ABC):
             will not participate in the next round of federated learning.
         """
 
-    def on_configure_fit(
-        self, rnd: int, weights: Weights, client_manager: ClientManager
-    ) -> List[Tuple[ClientProxy, FitIns]]:
-        """DEPRECATED: Use `configure_fit` instead."""
-        warning = """
-        Detected usage of the deprecated Strategy method
-        `on_configure_fit`, please migrate by renaming to `configure_fit`.
-        """
-        log(WARNING, warning)
-        return self.configure_fit(
-            rnd=rnd, weights=weights, client_manager=client_manager
-        )
-
-    @abstractmethod
-    def configure_evaluate(
-        self, rnd: int, weights: Weights, client_manager: ClientManager
-    ) -> List[Tuple[ClientProxy, EvaluateIns]]:
-        """Configure the next round of evaluation.
-
-        Arguments:
-            rnd: Integer. The current round of federated learning.
-            weights: Weights. The current (global) model weights.
-            client_manager: ClientManager. The client manger which knows about all
-                currently connected clients.
-
-        Returns:
-            A list of tuples. Each tuple in the list identifies a `ClientProxy` and the
-            `EvaluateIns` for this particular `ClientProxy`. If a particular
-            `ClientProxy` is not included in this list, it means that this
-            `ClientProxy` will not participate in the next round of federated
-            evaluation.
-        """
-
-    def on_configure_evaluate(
-        self, rnd: int, weights: Weights, client_manager: ClientManager
-    ) -> List[Tuple[ClientProxy, EvaluateIns]]:
-        """DEPRECATED: Use `configure_evaluate` instead."""
-        warning = """
-        Detected usage of the deprecated Strategy method
-        `on_configure_evaluate`, please migrate by renaming to `configure_evaluate`.
-        """
-        log(WARNING, warning)
-        return self.configure_evaluate(
-            rnd=rnd, weights=weights, client_manager=client_manager
-        )
-
     @abstractmethod
     def aggregate_fit(
         self,
@@ -124,19 +78,25 @@ class Strategy(ABC):
             the same.
         """
 
-    def on_aggregate_fit(
-        self,
-        rnd: int,
-        results: List[Tuple[ClientProxy, FitRes]],
-        failures: List[BaseException],
-    ) -> Optional[Weights]:
-        """DEPRECATED: Use `aggregate_fit` instead."""
-        warning = """
-        Detected usage of the deprecated Strategy method
-        `on_aggregate_fit`, please migrate by renaming to `aggregate_fit`.
+    @abstractmethod
+    def configure_evaluate(
+        self, rnd: int, weights: Weights, client_manager: ClientManager
+    ) -> List[Tuple[ClientProxy, EvaluateIns]]:
+        """Configure the next round of evaluation.
+
+        Arguments:
+            rnd: Integer. The current round of federated learning.
+            weights: Weights. The current (global) model weights.
+            client_manager: ClientManager. The client manger which knows about all
+                currently connected clients.
+
+        Returns:
+            A list of tuples. Each tuple in the list identifies a `ClientProxy` and the
+            `EvaluateIns` for this particular `ClientProxy`. If a particular
+            `ClientProxy` is not included in this list, it means that this
+            `ClientProxy` will not participate in the next round of federated
+            evaluation.
         """
-        log(WARNING, warning)
-        return self.aggregate_fit(rnd=rnd, results=results, failures=failures)
 
     @abstractmethod
     def aggregate_evaluate(
@@ -163,20 +123,6 @@ class Strategy(ABC):
             Optional `float` representing the aggregated evaluation result. Aggregation
             typically uses some variant of a weighted average.
         """
-
-    def on_aggregate_evaluate(
-        self,
-        rnd: int,
-        results: List[Tuple[ClientProxy, EvaluateRes]],
-        failures: List[BaseException],
-    ) -> Optional[float]:
-        """DEPRECATED: Use `aggregate_evaluate` instead."""
-        warning = """
-        Detected usage of the deprecated Strategy method
-        `on_aggregate_evaluate`, please migrate by renaming to `aggregate_evaluate`.
-        """
-        log(WARNING, warning)
-        return self.aggregate_evaluate(rnd=rnd, results=results, failures=failures)
 
     @abstractmethod
     def evaluate(self, weights: Weights) -> Optional[Tuple[float, float]]:

--- a/src/py/flwr/server/strategy/strategy.py
+++ b/src/py/flwr/server/strategy/strategy.py
@@ -49,7 +49,7 @@ class Strategy(ABC):
 
     def on_configure_fit(
         self, rnd: int, weights: Weights, client_manager: ClientManager
-    ) -> List[Tuple[ClientProxy, EvaluateIns]]:
+    ) -> List[Tuple[ClientProxy, FitIns]]:
         """DEPRECATED: Use `configure_fit` instead."""
         warning = """
         Detected usage of the deprecated Strategy method


### PR DESCRIPTION
Please review #483 first

This PR unifies the naming of Flower's public APIs. Other public methods/functions (e.g., every method in `Client`, but also `Strategy.evaluate`) do not use the `on_` prefix, which is why we're removing it from the four methods in `Strategy`.