### PR TITLE
update tf quickstart documentation

### DIFF
--- a/doc/source/quickstart_tensorflow.rst
+++ b/doc/source/quickstart_tensorflow.rst
@@ -26,79 +26,60 @@ Next, in a file called :code:`client.py`, import Flower and TensorFlow:
     import flwr as fl
     import tensorflow as tf
 
-We use the Keras utilities of TF to load MNIST, a popular "Hello, World!"
+We use the Keras utilities of TF to load CIFAR10, a popular colored image classification
 dataset for machine learning. The call to
-:code:`tf.keras.datasets.mnist.load_data()` downloads MNIST, caches it locally,
+:code:`tf.keras.datasets.cifar10.load_data()` downloads CIFAR10, caches it locally,
 and then returns the entire training and test set as NumPy ndarrays.
 
 .. code-block:: python
 
-    (x_train, y_train), (x_test, y_test) = tf.keras.datasets.mnist.load_data()
-    x_train, x_test = x_train / 255.0, x_test / 255.0
+    (x_train, y_train), (x_test, y_test) = tf.keras.datasets.cifar10.load_data()
 
-We also normalize the data (division by :code:`255`). Next we need a model. For
-the purpose of this tutorial, a simple fully-connected neural network should
-suffice:
+Next, we need a model. For the purpose of this tutorial, a MobilNetV2 network that is predefined in Keras with 10 output classes:
 
 .. code-block:: python
 
-    model = tf.keras.models.Sequential(
-        [
-            tf.keras.layers.Flatten(input_shape=(28, 28)),
-            tf.keras.layers.Dense(128, activation="relu"),
-            tf.keras.layers.Dropout(0.2),
-            tf.keras.layers.Dense(10, activation="softmax"),
-        ]
-    )
-    model.compile(
-        optimizer="adam", loss="sparse_categorical_crossentropy", metrics=["accuracy"]
-    )
+    model = tf.keras.applications.MobileNetV2((32, 32, 3), classes=10, weights=None)
+    model.compile("adam", "sparse_categorical_crossentropy", metrics=["accuracy"])
 
 The Flower server interacts with clients through an interface called
 :code:`Client`. When the server selects a particular client for training, it
-sends training inststructions over the network. The client receives those
+sends training instructions over the network. The client receives those
 instructions and calls one of the :code:`Client` methods to run your code
 (i.e., to train the neural network we defined earlier).
 
-Flower provides a convenience class called :code:`KerasClient` which makes it
+Flower provides a convenience class called :code:`NumPyClient` which makes it
 easier to implement the :code:`Client` interface when your workload uses Keras.
-The :code:`KerasClient` interface defines three methods which can be
+The :code:`NumPyClient` interface defines three methods which can be
 implemented in the following way:
 
 .. code-block:: python
 
-    class MnistClient(fl.client.KerasClient):
-        def __init__(self, cid, model, x_train, y_train, x_test, y_test):
-            super().__init__()
-            self.model = model
-            self.x_train, self.y_train = x_train, y_train
-            self.x_test, self.y_test = x_test, y_test
-
-        def get_weights(self):
+    class CifarClient(fl.client.NumPyClient):
+        def get_parameters(self):  # type: ignore
             return model.get_weights()
 
-        def fit(self, weights, config):
-            self.model.set_weights(weights)
-            self.model.fit(x_train, y_train, epochs=5)
-            return self.model.get_weights(), len(self.x_train), len(self.x_train)
+        def fit(self, parameters, config):  # type: ignore
+            model.set_weights(parameters)
+            model.fit(x_train, y_train, epochs=1, batch_size=32, steps_per_epoch=3)
+            return model.get_weights(), len(x_train)
 
-        def evaluate(self, weights, config):
-            self.model.set_weights(weights)
-            loss, accuracy = self.model.evaluate(x_test, y_test)
-            return len(self.x_test), loss, accuracy
+        def evaluate(self, parameters, config):  # type: ignore
+            model.set_weights(parameters)
+            loss, accuracy = model.evaluate(x_test, y_test)
+            return len(x_test), loss, accuracy
 
-We can now create an instance of our class :code:`MnistClient` and add one line
+
+We can now create an instance of our class :code:`CifarClient` and add one line
 to actually run this client:
 
 .. code-block:: python
 
-    client = MnistClient("0", model, x_train, y_train, x_test, y_test)
-    fl.client.start_keras_client(server_address="[::]:8080", client=client)
+     fl.client.start_numpy_client("[::]:8080", client=CifarClient())
+
 
 That's it for the client. We only have to implement :code:`Client` or
-:code:`KerasClient` and call :code:`fl.client.start_client()`. The string
-:code:`"[::]:8080"` tells the client which server to connect to. In our case we
-can run the server and the client on the same machine, therefore we use
+:code:`NumPyClient` and call :code:`fl.client.start_client()` or :code:` fl.client.start_numpy_client()`. The string :code:`"[::]:8080"` tells the client which server to connect to. In our case we can run the server and the client on the same machine, therefore we use
 :code:`"[::]:8080"`. If we run a truly federated workload with the server and
 clients running on different machines, all that needs to change is the
 :code:`server_address` we point the client at.
@@ -175,5 +156,5 @@ that started the server):
     INFO flower 2020-07-15 10:07:56,396 | app.py:77 | app_evaluate: failures []
 
 Congratulations! You've successfully built and run your first federated
-learning system. The full source code for this can be found in
-:code:`src/py/flwr_example/quickstart_tensorflow`.
+learning system. The full `source code <https://github.com/adap/flower/blob/main/examples/quickstart_tensorflow/client.py>`_ for this can be found in
+:code:`examples/quickstart_tensorflow/client.py`.

--- a/doc/source/quickstart_tensorflow.rst
+++ b/doc/source/quickstart_tensorflow.rst
@@ -35,7 +35,7 @@ and then returns the entire training and test set as NumPy ndarrays.
 
     (x_train, y_train), (x_test, y_test) = tf.keras.datasets.cifar10.load_data()
 
-Next, we need a model. For the purpose of this tutorial, a MobilNetV2 network that is predefined in Keras with 10 output classes:
+Next, we need a model. For the purpose of this tutorial, we use MobilNetV2 with 10 output classes:
 
 .. code-block:: python
 
@@ -56,15 +56,15 @@ implemented in the following way:
 .. code-block:: python
 
     class CifarClient(fl.client.NumPyClient):
-        def get_parameters(self):  # type: ignore
+        def get_parameters(self):
             return model.get_weights()
 
-        def fit(self, parameters, config):  # type: ignore
+        def fit(self, parameters, config):
             model.set_weights(parameters)
             model.fit(x_train, y_train, epochs=1, batch_size=32, steps_per_epoch=3)
             return model.get_weights(), len(x_train)
 
-        def evaluate(self, parameters, config):  # type: ignore
+        def evaluate(self, parameters, config):
             model.set_weights(parameters)
             loss, accuracy = model.evaluate(x_test, y_test)
             return len(x_test), loss, accuracy


### PR DESCRIPTION
Adjust tensorflow quickstart documentation:
- change dataset to cifar
- change Client to NumPyClient
- change code 
- change link to flower quickstarter example