### PR TITLE
Proto Linter | Add clang-format to Flower

### DIFF
--- a/.github/workflows/flower.yml
+++ b/.github/workflows/flower.yml
@@ -22,6 +22,7 @@ jobs:
           python-version: ${{ matrix.python }}
       - name: Install build tools
         run: |
+          sudo apt-get install clang-format-10
           python -m pip install -U pip==20.2.4
           python -m pip install -U setuptools==49.3.1
           python -m pip install -U poetry==1.1.4

--- a/dev/format.sh
+++ b/dev/format.sh
@@ -8,6 +8,9 @@ python -m black -q --exclude src/py/flwr/proto src/py
 python -m docformatter -i -r src/py/flwr -e src/py/flwr/proto
 python -m docformatter -i -r src/py/flwr_experimental
 
+# Protos
+find src/proto/flwr/proto -name *.proto | grep "\.proto" | xargs clang-format-10 -i
+
 # Examples
 python -m isort -rc examples
 python -m black -q examples

--- a/dev/test.sh
+++ b/dev/test.sh
@@ -4,6 +4,7 @@ cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"/../
 
 echo "=== test.sh ==="
 
+clang-format-10 --Werror --dry-run src/proto/flwr/proto/*      && echo "- clang-format: done" &&
 isort --skip src/py/flwr/proto --check-only -rc src/py/flwr    && echo "- isort:  done" &&
 black -q --exclude "src\/py\/flwr\/proto" --check src/py/flwr  && echo "- black:  done" &&
 docformatter -c -r src/py/flwr -e src/py/flwr/proto            && echo "- docformatter:  done" &&

--- a/src/proto/flwr/proto/transport.proto
+++ b/src/proto/flwr/proto/transport.proto
@@ -59,13 +59,13 @@ message ClientMessage {
   message FitRes {
     Parameters parameters = 1;
     int64 num_examples = 2;
-    int64 num_examples_ceil = 3 [deprecated = true];
-    float fit_duration = 4 [deprecated = true];
+    int64 num_examples_ceil = 3 [ deprecated = true ];
+    float fit_duration = 4 [ deprecated = true ];
   }
   message EvaluateRes {
     int64 num_examples = 1;
     float loss = 2;
-    float accuracy = 3 [deprecated = true];
+    float accuracy = 3 [ deprecated = true ];
     map<string, Scalar> metrics = 4;
   }
 


### PR DESCRIPTION
This PR will add clang-format to `test.sh` and `format.sh` in the Flower repository. Refers to #583 .