### PR TITLE
Updating PyTorch to 1.8.0 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ exclude = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.6.1"
+python = "^3.6.2"
 # Mandatory dependencies
 numpy = "^1.19.0"
 grpcio = "^1.27.2"
@@ -54,8 +54,8 @@ protobuf = "^3.12.1"
 dataclasses = { version = "==0.6", markers = "python_version < '3.7'"  }
 # Optional dependencies
 tensorflow-cpu = { version = "==2.4.0", optional = true }
-torch = { version = "^1.7.0", optional = true }
-torchvision = { version = "^0.8.1", optional = true }
+torch = { version = "^1.8.0", optional = true }
+torchvision = { version = "^0.9.0", optional = true }
 boto3 = { version = "^1.12.36", optional = true }
 boto3_type_annotations = { version = "^0.3.1", optional = true }
 paramiko = { version = "^2.7.1", optional = true }


### PR DESCRIPTION
Adding PyTorch 1.8.0, torchvision 0.9.0 and python 3.6.2 (needed by PyTorch 1.8.0)