### PR TITLE
Improving support for Ray simulation with GPUs

### DIFF
--- a/examples/simulation_ray/resource_parser.py
+++ b/examples/simulation_ray/resource_parser.py
@@ -1,0 +1,40 @@
+import torch
+
+
+def parse_ray_resources(cpus: int, vram: int):
+    """ Given the amount of VRAM specified for a given experiment,
+        figure out what's the corresponding ration in the GPU assigned
+        for experiment. Return % of GPU to use. Here we take into account
+        that the CUDA runtime allocates ~1GB upon initialization. We therefore
+        substract first that amount from the total detected VRAM. CPU resources
+        as returned without modification."""
+
+    gpu_ratio = 0.0
+    if torch.cuda.is_available():
+        # use that figure to get a good estimate of the VRAM needed per experiment
+        # (taking into account ~600MB of just CUDA init stuff)
+
+        # Get VRAM of first GPU
+        total_vram = torch.cuda.get_device_properties(0).total_memory
+
+        # convert to MB (since the user inputs VRAM in MB)
+        total_vram = float(total_vram)/(1024**2)
+
+        # discard 1GB VRAM (which is roughtly what takes for CUDA runtime)
+        # You can verify this yourself by just running:
+        # `t = torch.randn(10).cuda()` (will use ~1GB VRAM)
+        total_vram -= 1024
+
+        gpu_ratio = float(vram)/total_vram
+        print(f"GPU percentage per client: {100*gpu_ratio:.2f} % ({vram}/{total_vram})")
+
+        # ! Limitation: this won't work well if multiple GPUs with different VRAMs are detected by Ray
+        # The code above asumes therefore all GPUs have the same amount of VRAM. The same `gpu_ratio` will
+        # be used in GPUs #1, #2, etc (even though there won't be 1GB taken by CUDA runtime)
+        # TODO: probably we can do something smarter: run a single training batch and monitor the real memory usage. This remove user's input an no longer requiring the user to specify VRAM (which often takes a few rounds of trial-error)
+    else:
+        print("No CUDA device found. Disabling GPU usage for Flower clients.")
+
+    # these keys are the ones expected by ray to specify CPU and GPU resources for each
+    # Ray Task, representing a client workload.
+    return {'num_cpus': cpus, 'num_gpus': gpu_ratio}


### PR DESCRIPTION
I introduce a simple helper function that transforms the user-defined VRAM (in MBs) that a Ray client will need for training into the corresponding GPU ratio given the GPU resources in your system. Unlike CPU resources, Ray requires a `num_gpus` to be a ratio [0:1]. 

This PR also extends the PyTorch example in `examples/simulation_ray` showing how specify GPU resources. 

One of the limitations that the parser function in `examples/simulation_ray/resource_parser.py` addresses is the fact that the VRAM usage is not only a function of the model architecture and batch size but also other factors such as the CUDA runtime (which roughly takes 1GB of VRAM in CUDA 11 and PyTorch 1.8). The parser takes care of this and discounts that 1GB from the available VRAM when computing the ratio of GPU a client needs. In summary, this prevents a potential OOM error.

I'm not very familiar with TF, but I presume other type of parsing might be needed taking into account how TF allocates GPU resources.