### PR TITLE
Activate gRPC retry mechanism

### DIFF
--- a/src/py/flwr/client/grpc_client/connection.py
+++ b/src/py/flwr/client/grpc_client/connection.py
@@ -18,7 +18,7 @@ import json
 from contextlib import contextmanager
 from logging import DEBUG
 from queue import Queue
-from typing import Callable, Iterator, Tuple
+from typing import Callable, Iterator, List, Tuple, Union
 
 import grpc
 
@@ -59,7 +59,7 @@ def insecure_grpc_connection(
             ]
         }
     )
-    options = []
+    options: List[Tuple[str, Union[int, str]]] = []
     # NOTE: the retry feature will be enabled by default >=v1.40.0
     options.append(("grpc.enable_retries", 1))
     options.append(("grpc.service_config", service_config_json))


### PR DESCRIPTION
This will enable the clients to retry in case the server can not be reached when establishing the initial stream connection. It should reduce errors where the server started up slowly or the network connection was unstable for few seconds.