### PR TITLE
CLI Tooling for Server

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ docker = { version = "^4.2.0", optional = true }
 matplotlib = { version = "^3.2.1", optional = true }
 tqdm = { version = "^4.48.2", optional = true }
 ray = { extras = ["default"], version = "^1.5.2", optional = true }
+click = "^8.0.1"
 
 [tool.poetry.extras]
 simulation = ["ray"]
@@ -115,3 +116,6 @@ testpaths = [
     "src/py/flwr",
     "src/py/flwr_tool",
 ]
+
+[tool.poetry.scripts]
+flwr = "flwr.cli:cli"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,4 +118,4 @@ testpaths = [
 ]
 
 [tool.poetry.scripts]
-flwr = "flwr.cli:cli"
+flwr = "flwr.cli.cli:app"

--- a/src/py/flwr/cli/cli.py
+++ b/src/py/flwr/cli/cli.py
@@ -1,6 +1,61 @@
 import click
-import flwr as fl
+from flwr.server import start_server
+from flwr.server.strategy.fast_and_slow import FastAndSlow
+from flwr.server.strategy.fault_tolerant_fedavg import FaultTolerantFedAvg
+from flwr.server.strategy.fedadagrad import FedAdagrad
+from flwr.server.strategy.fedavg import FedAvg
+from flwr.server.strategy.fedfs_v0 import FedFSv0
+from flwr.server.strategy.fedfs_v1 import FedFSv1
+from flwr.server.strategy.fedopt import FedOpt
+from flwr.server.strategy.qfedavg import QFedAvg
+from flwr.common import GRPC_MAX_MESSAGE_LENGTH
 
-@click.command()
-def cli():
-    fl.server.start_server(config={"num_rounds": 1})
+import json
+
+strategy_mapping = {
+    "fault_tolerant_fedavg" : FaultTolerantFedAvg,
+    "fedadagrad" : FedAdagrad,
+    "fast_and_slow" : FastAndSlow,
+    "fedavg" : FedAvg,
+    "fedfs_v0" : FedFSv0,
+    "fedfs_v1" : FedFSv1,
+    "fedopt" : FedOpt,
+    "qfedavg": QFedAvg
+}
+
+@click.group()
+def app():
+    pass
+
+@app.group()
+def server():
+    pass
+    
+
+@server.command()
+@click.option("-a","--server-address",type=str,default="[::]:8080",help="string (default: “[::]:8080”). The IPv6 address of the server.")
+@click.option("-l","--grpc-max-message-length",type=int,default=GRPC_MAX_MESSAGE_LENGTH,help="int (default: 536_870_912, this equals 512MB). The maximum length of gRPC messages that can be exchanged with the Flower clients. The default should be sufficient for most models. Users who train very large models might need to increase this value. Note that the Flower clients need to be started with the same value (see flwr.client.start_client), otherwise clients will not know about the increased limit and block larger messages.")
+@click.option("-f","--force-final-distributed-eval",type=bool,default=False,help="bool (default: False). Forces a distributed evaulation to occur after the last training epoch when enabled.")
+@click.option("-s","--strategy",type=str,default="fedavg",help="fault_tolerant_fedavg | fedadagrad | aggregate | default | fast_and_slow | fault_tolerant_fedavg | fedavg | fedfs_v0 | fedfs_v1 | fedopt | qfedavg . Sets the strategy for Federated Learning.")
+@click.option("-n",'--num-rounds',type=int,default=3,help="int (default: 3). Number of Rounds during Federated Learning")
+@click.option("-p","--strategy-params",type=str,help="JSON. Sets the parameters for selected strategy. Parameters available are: fraction_fit: float, fraction_eval: float, min_fit_clients: int, min_eval_clients: int, min_available_clients:int, accept_failures: bool")
+
+def start(server_address,grpc_max_message_length,force_final_distributed_eval,strategy,num_rounds, strategy_params):
+    print(server_address,grpc_max_message_length,force_final_distributed_eval,strategy,num_rounds, strategy_params)
+    if not strategy in strategy_mapping:
+        raise ValueError("Value for strategy is invalid")
+    
+    selected_strategy = strategy_mapping[strategy]()
+
+    if strategy_params:
+        strategy_params = strategy_params.replace("'",'"')
+        strategy_params = json.loads(strategy_params)
+        selected_strategy = strategy_mapping[strategy](**strategy_params)
+
+    start_server(
+        server_address=server_address,
+        grpc_max_message_length=grpc_max_message_length,
+        force_final_distributed_eval=force_final_distributed_eval,
+        strategy=selected_strategy,
+        config={num_rounds:num_rounds}
+    )

--- a/src/py/flwr/cli/cli.py
+++ b/src/py/flwr/cli/cli.py
@@ -1,61 +1,8 @@
 import click
-from flwr.server import start_server
-from flwr.server.strategy.fast_and_slow import FastAndSlow
-from flwr.server.strategy.fault_tolerant_fedavg import FaultTolerantFedAvg
-from flwr.server.strategy.fedadagrad import FedAdagrad
-from flwr.server.strategy.fedavg import FedAvg
-from flwr.server.strategy.fedfs_v0 import FedFSv0
-from flwr.server.strategy.fedfs_v1 import FedFSv1
-from flwr.server.strategy.fedopt import FedOpt
-from flwr.server.strategy.qfedavg import QFedAvg
-from flwr.common import GRPC_MAX_MESSAGE_LENGTH
-
-import json
-
-strategy_mapping = {
-    "fault_tolerant_fedavg" : FaultTolerantFedAvg,
-    "fedadagrad" : FedAdagrad,
-    "fast_and_slow" : FastAndSlow,
-    "fedavg" : FedAvg,
-    "fedfs_v0" : FedFSv0,
-    "fedfs_v1" : FedFSv1,
-    "fedopt" : FedOpt,
-    "qfedavg": QFedAvg
-}
+from flwr.cli.server.server import server
 
 @click.group()
 def app():
     pass
 
-@app.group()
-def server():
-    pass
-    
-
-@server.command()
-@click.option("-a","--server-address",type=str,default="[::]:8080",help="string (default: “[::]:8080”). The IPv6 address of the server.")
-@click.option("-l","--grpc-max-message-length",type=int,default=GRPC_MAX_MESSAGE_LENGTH,help="int (default: 536_870_912, this equals 512MB). The maximum length of gRPC messages that can be exchanged with the Flower clients. The default should be sufficient for most models. Users who train very large models might need to increase this value. Note that the Flower clients need to be started with the same value (see flwr.client.start_client), otherwise clients will not know about the increased limit and block larger messages.")
-@click.option("-f","--force-final-distributed-eval",type=bool,default=False,help="bool (default: False). Forces a distributed evaulation to occur after the last training epoch when enabled.")
-@click.option("-s","--strategy",type=str,default="fedavg",help="fault_tolerant_fedavg | fedadagrad | aggregate | default | fast_and_slow | fault_tolerant_fedavg | fedavg | fedfs_v0 | fedfs_v1 | fedopt | qfedavg . Sets the strategy for Federated Learning.")
-@click.option("-n",'--num-rounds',type=int,default=3,help="int (default: 3). Number of Rounds during Federated Learning")
-@click.option("-p","--strategy-params",type=str,help="JSON. Sets the parameters for selected strategy. Parameters available are: fraction_fit: float, fraction_eval: float, min_fit_clients: int, min_eval_clients: int, min_available_clients:int, accept_failures: bool")
-
-def start(server_address,grpc_max_message_length,force_final_distributed_eval,strategy,num_rounds, strategy_params):
-    print(server_address,grpc_max_message_length,force_final_distributed_eval,strategy,num_rounds, strategy_params)
-    if not strategy in strategy_mapping:
-        raise ValueError("Value for strategy is invalid")
-    
-    selected_strategy = strategy_mapping[strategy]()
-
-    if strategy_params:
-        strategy_params = strategy_params.replace("'",'"')
-        strategy_params = json.loads(strategy_params)
-        selected_strategy = strategy_mapping[strategy](**strategy_params)
-
-    start_server(
-        server_address=server_address,
-        grpc_max_message_length=grpc_max_message_length,
-        force_final_distributed_eval=force_final_distributed_eval,
-        strategy=selected_strategy,
-        config={num_rounds:num_rounds}
-    )
+app.add_command(server)

--- a/src/py/flwr/cli/cli.py
+++ b/src/py/flwr/cli/cli.py
@@ -1,0 +1,6 @@
+import click
+import flwr as fl
+
+@click.command()
+def cli():
+    fl.server.start_server(config={"num_rounds": 1})

--- a/src/py/flwr/cli/server/server.py
+++ b/src/py/flwr/cli/server/server.py
@@ -1,0 +1,56 @@
+import click
+from flwr.server import start_server
+from flwr.server.strategy.fast_and_slow import FastAndSlow
+from flwr.server.strategy.fault_tolerant_fedavg import FaultTolerantFedAvg
+from flwr.server.strategy.fedadagrad import FedAdagrad
+from flwr.server.strategy.fedavg import FedAvg
+from flwr.server.strategy.fedfs_v0 import FedFSv0
+from flwr.server.strategy.fedfs_v1 import FedFSv1
+from flwr.server.strategy.fedopt import FedOpt
+from flwr.server.strategy.qfedavg import QFedAvg
+from flwr.common import GRPC_MAX_MESSAGE_LENGTH
+
+import json
+
+strategy_mapping = {
+    "fault_tolerant_fedavg" : FaultTolerantFedAvg,
+    "fedadagrad" : FedAdagrad,
+    "fast_and_slow" : FastAndSlow,
+    "fedavg" : FedAvg,
+    "fedfs_v0" : FedFSv0,
+    "fedfs_v1" : FedFSv1,
+    "fedopt" : FedOpt,
+    "qfedavg": QFedAvg
+}
+
+@click.group()
+def server():
+    pass
+
+@server.command()
+@click.option("-a","--server-address",type=str,default="[::]:8080",help="string (default: “[::]:8080”). The IPv6 address of the server.")
+@click.option("-l","--grpc-max-message-length",type=int,default=GRPC_MAX_MESSAGE_LENGTH,help="int (default: 536_870_912, this equals 512MB). The maximum length of gRPC messages that can be exchanged with the Flower clients. The default should be sufficient for most models. Users who train very large models might need to increase this value. Note that the Flower clients need to be started with the same value (see flwr.client.start_client), otherwise clients will not know about the increased limit and block larger messages.")
+@click.option("-f","--force-final-distributed-eval",type=bool,default=False,help="bool (default: False). Forces a distributed evaulation to occur after the last training epoch when enabled.")
+@click.option("-s","--strategy",type=str,default="fedavg",help="fault_tolerant_fedavg | fedadagrad | aggregate | default | fast_and_slow | fault_tolerant_fedavg | fedavg | fedfs_v0 | fedfs_v1 | fedopt | qfedavg . Sets the strategy for Federated Learning.")
+@click.option("-n",'--num-rounds',type=int,default=3,help="int (default: 3). Number of Rounds during Federated Learning")
+@click.option("-p","--strategy-params",type=str,help="JSON. Sets the parameters for selected strategy. Parameters available are: fraction_fit: float, fraction_eval: float, min_fit_clients: int, min_eval_clients: int, min_available_clients:int, accept_failures: bool")
+
+def start(server_address,grpc_max_message_length,force_final_distributed_eval,strategy,num_rounds, strategy_params):
+    print(server_address,grpc_max_message_length,force_final_distributed_eval,strategy,num_rounds, strategy_params)
+    if not strategy in strategy_mapping:
+        raise ValueError("Value for strategy is invalid")
+    
+    selected_strategy = strategy_mapping[strategy]()
+
+    if strategy_params:
+        strategy_params = strategy_params.replace("'",'"')
+        strategy_params = json.loads(strategy_params)
+        selected_strategy = strategy_mapping[strategy](**strategy_params)
+
+    start_server(
+        server_address=server_address,
+        grpc_max_message_length=grpc_max_message_length,
+        force_final_distributed_eval=force_final_distributed_eval,
+        strategy=selected_strategy,
+        config={num_rounds:num_rounds}
+    )

--- a/src/py/flwr/cli/server/server.py
+++ b/src/py/flwr/cli/server/server.py
@@ -31,7 +31,7 @@ def server():
 @click.option("-a","--server-address",type=str,default="[::]:8080",help="string (default: “[::]:8080”). The IPv6 address of the server.")
 @click.option("-l","--grpc-max-message-length",type=int,default=GRPC_MAX_MESSAGE_LENGTH,help="int (default: 536_870_912, this equals 512MB). The maximum length of gRPC messages that can be exchanged with the Flower clients. The default should be sufficient for most models. Users who train very large models might need to increase this value. Note that the Flower clients need to be started with the same value (see flwr.client.start_client), otherwise clients will not know about the increased limit and block larger messages.")
 @click.option("-f","--force-final-distributed-eval",type=bool,default=False,help="bool (default: False). Forces a distributed evaulation to occur after the last training epoch when enabled.")
-@click.option("-s","--strategy",type=str,default="fedavg",help="fault_tolerant_fedavg | fedadagrad | aggregate | default | fast_and_slow | fault_tolerant_fedavg | fedavg | fedfs_v0 | fedfs_v1 | fedopt | qfedavg . Sets the strategy for Federated Learning.")
+@click.option("-s","--strategy",type=str,default="fedavg",help=f"{' | '.join(strategy_mapping.keys())} . Sets the strategy for Federated Learning.")
 @click.option("-n",'--num-rounds',type=int,default=3,help="int (default: 3). Number of Rounds during Federated Learning")
 @click.option("-p","--strategy-params",type=str,help="JSON. Sets the parameters for selected strategy. Parameters available are: fraction_fit: float, fraction_eval: float, min_fit_clients: int, min_eval_clients: int, min_available_clients:int, accept_failures: bool")
 

--- a/src/py/flwr/server/app.py
+++ b/src/py/flwr/server/app.py
@@ -27,6 +27,7 @@ from flwr.server.strategy import FedAvg, Strategy
 
 DEFAULT_SERVER_ADDRESS = "[::]:8080"
 
+
 def start_server(  # pylint: disable=too-many-arguments
     server_address: str = DEFAULT_SERVER_ADDRESS,
     server: Optional[Server] = None,
@@ -127,7 +128,8 @@ def _fl(
         # Evaluate the final trained model
         res = server.evaluate_round(rnd=-1)
         if res is not None:
-            loss, metrics, (results, failures) = res
+            loss, _, (results, failures) = res
+            log(INFO, "app_evaluate: federated loss: %s", str(loss))
             log(
                 INFO,
                 "app_evaluate: results %s",

--- a/src/py/flwr/server/app.py
+++ b/src/py/flwr/server/app.py
@@ -128,8 +128,9 @@ def _fl(
         # Evaluate the final trained model
         res = server.evaluate_round(rnd=-1)
         if res is not None:
-            loss, _, (results, failures) = res
+            loss, metrics, (results, failures) = res
             print("===========SENDING LOSS TO LOCAL SERVER=========")
+            print(metrics)
             r = requests.post(url = "http://localhost:8000/result", json = {'loss':loss,'accuracy':results[0][1].metrics['accuracy']})
             print("======================SENT=======================")
             log(INFO, "app_evaluate: federated loss: %s", str(loss))

--- a/src/py/flwr/server/app.py
+++ b/src/py/flwr/server/app.py
@@ -26,7 +26,6 @@ from flwr.server.server import Server
 from flwr.server.strategy import FedAvg, Strategy
 
 DEFAULT_SERVER_ADDRESS = "[::]:8080"
-import requests
 
 def start_server(  # pylint: disable=too-many-arguments
     server_address: str = DEFAULT_SERVER_ADDRESS,
@@ -129,11 +128,6 @@ def _fl(
         res = server.evaluate_round(rnd=-1)
         if res is not None:
             loss, metrics, (results, failures) = res
-            print("===========SENDING LOSS TO LOCAL SERVER=========")
-            print(metrics)
-            r = requests.post(url = "http://localhost:8000/result", json = {'loss':loss,'accuracy':results[0][1].metrics['accuracy']})
-            print("======================SENT=======================")
-            log(INFO, "app_evaluate: federated loss: %s", str(loss))
             log(
                 INFO,
                 "app_evaluate: results %s",

--- a/src/py/flwr/server/app.py
+++ b/src/py/flwr/server/app.py
@@ -130,7 +130,7 @@ def _fl(
         if res is not None:
             loss, _, (results, failures) = res
             print("===========SENDING LOSS TO LOCAL SERVER=========")
-            r = requests.post(url = "http://localhost:8000/result", json = {'loss':loss})
+            r = requests.post(url = "http://localhost:8000/result", json = {'loss':loss,'accuracy':results[0][1].metrics['accuracy']})
             print("======================SENT=======================")
             log(INFO, "app_evaluate: federated loss: %s", str(loss))
             log(

--- a/src/py/flwr/server/app.py
+++ b/src/py/flwr/server/app.py
@@ -26,7 +26,7 @@ from flwr.server.server import Server
 from flwr.server.strategy import FedAvg, Strategy
 
 DEFAULT_SERVER_ADDRESS = "[::]:8080"
-
+import requests
 
 def start_server(  # pylint: disable=too-many-arguments
     server_address: str = DEFAULT_SERVER_ADDRESS,
@@ -129,6 +129,7 @@ def _fl(
         res = server.evaluate_round(rnd=-1)
         if res is not None:
             loss, _, (results, failures) = res
+            r = requests.post(url = "http://localhost:8000", data = {'loss':loss})
             log(INFO, "app_evaluate: federated loss: %s", str(loss))
             log(
                 INFO,

--- a/src/py/flwr/server/app.py
+++ b/src/py/flwr/server/app.py
@@ -130,7 +130,7 @@ def _fl(
         if res is not None:
             loss, _, (results, failures) = res
             print("===========SENDING LOSS TO LOCAL SERVER=========")
-            r = requests.post(url = "http://localhost:8000/result", data = {'loss':loss})
+            r = requests.post(url = "http://localhost:8000/result", json = {'loss':loss})
             print("======================SENT=======================")
             log(INFO, "app_evaluate: federated loss: %s", str(loss))
             log(

--- a/src/py/flwr/server/app.py
+++ b/src/py/flwr/server/app.py
@@ -129,7 +129,9 @@ def _fl(
         res = server.evaluate_round(rnd=-1)
         if res is not None:
             loss, _, (results, failures) = res
-            r = requests.post(url = "http://localhost:8000", data = {'loss':loss})
+            print("===========SENDING LOSS TO LOCAL SERVER=========")
+            r = requests.post(url = "http://localhost:8000/result", data = {'loss':loss})
+            print("======================SENT=======================")
             log(INFO, "app_evaluate: federated loss: %s", str(loss))
             log(
                 INFO,


### PR DESCRIPTION
Fixes #557 
Adds CLI tooling for easy set up of flwr server.

Parameters available include:

1. --server-address (shorthand: -a)
2. --grpc-max-message-length (shorthand: -l)
3. --force-final-distributed-eval (shorthand: -f)
4. --strategy (shorthand: -s)
5. --num-rounds (shorthand: -n)
6. --strategy-params (shorthand: -p)

Do let me know if any changes are required!