### PR TITLE
Fixing script to work with Ray ^1.6.0 without mypy `--no-implicit-reexport` issues.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ paramiko = { version = "^2.7.1", optional = true }
 docker = { version = "^4.2.0", optional = true }
 matplotlib = { version = "^3.2.1", optional = true }
 tqdm = { version = "^4.48.2", optional = true }
-ray = { extras = ["default"], version = "^1.5.2", optional = true }
+ray = { extras = ["default"], version = "^1.6.0", optional = true }
 
 [tool.poetry.extras]
 simulation = ["ray"]

--- a/src/py/flwr/simulation/ray_transport/ray_client_proxy.py
+++ b/src/py/flwr/simulation/ray_transport/ray_client_proxy.py
@@ -40,7 +40,7 @@ class RayClientProxy(ClientProxy):
         future_paramseters_res = launch_and_get_parameters.options(
             **self.resources
         ).remote(self.client_fn, self.cid)
-        res = ray.get(future_paramseters_res)
+        res = ray.worker.get(future_paramseters_res)
         return cast(
             common.ParametersRes,
             res,
@@ -51,7 +51,7 @@ class RayClientProxy(ClientProxy):
         future_fit_res = launch_and_fit.options(**self.resources).remote(
             self.client_fn, self.cid, ins
         )
-        res = ray.get(future_fit_res)
+        res = ray.worker.get(future_fit_res)
         return cast(
             common.FitRes,
             res,
@@ -62,7 +62,7 @@ class RayClientProxy(ClientProxy):
         future_evaluate_res = launch_and_evaluate.options(**self.resources).remote(
             self.client_fn, self.cid, ins
         )
-        res = ray.get(future_evaluate_res)
+        res = ray.worker.get(future_evaluate_res)
         return cast(
             common.EvaluateRes,
             res,


### PR DESCRIPTION
This took a long time. Ray changed the way it structures the internal imports. Now one should call directly the submodule `ray.worker` to access `get`.