### PR TITLE
Improve notebook compatibility

### DIFF
--- a/src/py/flwr/simulation/app.py
+++ b/src/py/flwr/simulation/app.py
@@ -68,7 +68,9 @@ def start_simulation(  # pylint: disable=too-many-arguments
 
     # Initialize Ray
     if not ray_init_args:
-        ray_init_args = {}
+        ray_init_args = {
+            "ignore_reinit_error": True,
+        }
     ray.init(**ray_init_args)
     log(
         INFO,

--- a/src/py/flwr/simulation/app.py
+++ b/src/py/flwr/simulation/app.py
@@ -62,7 +62,7 @@ def start_simulation(  # pylint: disable=too-many-arguments
         An implementation of the abstract base class `flwr.server.Strategy`. If
         no strategy is provided, then `start_server` will use
         `flwr.server.strategy.FedAvg`.
-    ray_init_args : Optional[Dict[str, Any]] (default: None)
+    ray_init_args : Optional[Dict[str, Any]] (default: {'ignore_reinit_error': True})
         Optional dictionary containing `ray.init` arguments.
     """
 


### PR DESCRIPTION
Pass `ignore_reinit_error=True` to `ray.init()`. The flag prevents an error raised by Ray when calling `ray.init()` repeatedly. The error should not be raised in common command-line scenarios, however, in notebooks (such as Colab), it will happen quite often.