### PR TITLE
Upgrade TF version in examples

### DIFF
--- a/.github/workflows/flower.yml
+++ b/.github/workflows/flower.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Install dependencies (mandatory + optional)
         run: |
           python -m poetry install --extras "baseline"
-          python -m pip install -U tensorflow-cpu==2.4.0
+          python -m pip install -U tensorflow-cpu==2.6.0
       - name: Cache Datasets
         uses: actions/cache@v2
         with:

--- a/dev/aws-ami-bootstrap-tf.sh
+++ b/dev/aws-ami-bootstrap-tf.sh
@@ -30,7 +30,7 @@ sudo apt install -y python3.7 python3-pip
 python3.7 -m pip install -U pip==21.2.4 setuptools==57.5.0
 python3.7 -m pip install -U numpy==1.18.1 grpcio==1.27.2 google==2.0.3 protobuf==3.12.1 \
     boto3==1.12.36 boto3_type_annotations==0.3.1 paramiko==2.7.1 docker==4.2.0 matplotlib==3.2.1 \
-    tensorflow-cpu==2.4.0
+    tensorflow-cpu==2.6.0
 
 # Preload datasets
 python3.7 -c "import tensorflow as tf; tf.keras.datasets.mnist.load_data()"

--- a/examples/advanced_tensorflow/pyproject.toml
+++ b/examples/advanced_tensorflow/pyproject.toml
@@ -13,4 +13,4 @@ authors = ["The Flower Authors <enquiries@flower.dev>"]
 [tool.poetry.dependencies]
 python = "^3.6.2"
 flwr = "^0.16.0"  # For development: { path = "../../", develop = true }
-tensorflow-cpu = "^2.4.1"
+tensorflow-cpu = "^2.6.0"

--- a/examples/quickstart_tensorflow/pyproject.toml
+++ b/examples/quickstart_tensorflow/pyproject.toml
@@ -13,4 +13,4 @@ authors = ["The Flower Authors <enquiries@flower.dev>"]
 [tool.poetry.dependencies]
 python = "^3.6.2"
 flwr = "^0.15.0"  # For development: { path = "../../", develop = true }
-tensorflow-cpu = "2.4.1"
+tensorflow-cpu = "2.6.0"

--- a/examples/simulation/Dockerfile
+++ b/examples/simulation/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && apt-get install -y python3 python3-pip git curl
 
 # Install flower and dependencies for machine learning
 RUN python3 --version
-RUN pip3 install flwr==0.15.0 numpy==1.19.5 tensorflow-cpu==2.4.1
+RUN pip3 install flwr==0.15.0 numpy==1.19.5 tensorflow-cpu==2.6.0
 
 # Cache the CIFAR-10 dataset which we will use later
 RUN python3 -c "import tensorflow as tf; tf.keras.datasets.cifar10.load_data()"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ google = "^2.0.3"
 protobuf = "^3.12.1"
 dataclasses = { version = "==0.6", markers = "python_version < '3.7'"  }
 # Optional dependencies
-tensorflow-cpu = { version = "==2.4.0", optional = true }
+tensorflow-cpu = { version = "==2.6.0", optional = true }
 torch = { version = "^1.9.0", optional = true }
 torchvision = { version = "^0.10.0", optional = true }
 boto3 = { version = "^1.12.36", optional = true }

--- a/src/docker/default.Dockerfile
+++ b/src/docker/default.Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.7.9-slim-stretch
 
 # Install the biggest dependencies before copying the wheel
-RUN pip install tensorflow-cpu==2.4.1 numpy==1.19.5
+RUN pip install tensorflow-cpu==2.6.0 numpy==1.19.5
 
 COPY dist/flwr-0.17.0-py3-none-any.whl flwr-0.17.0-py3-none-any.whl
 RUN python3.7 -m pip install --no-cache-dir 'flwr-0.17.0-py3-none-any.whl[examples-pytorch,examples-tensorflow,http-logger,baseline,ops]'

--- a/src/docker/sshd.Dockerfile
+++ b/src/docker/sshd.Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get clean && \
 
 WORKDIR /root
 
-RUN python3.7 -m pip install tensorflow-cpu==2.4.1 torch==1.7.1 torchvision==0.8.2 numpy==1.19.5
+RUN python3.7 -m pip install tensorflow-cpu==2.6.0 torch==1.7.1 torchvision==0.8.2 numpy==1.19.5
 COPY dist/flwr-0.17.0-py3-none-any.whl flwr-0.17.0-py3-none-any.whl
 RUN python3.7 -m pip install --no-cache-dir 'flwr-0.17.0-py3-none-any.whl[examples-pytorch,examples-tensorflow,http-logger,baseline,ops]' && \
     rm flwr-0.17.0-py3-none-any.whl


### PR DESCRIPTION
This PR updates the TF version of all the examples in the code base which should also fix the dependabot security warning.