### PR TITLE
Fix typos & edit link in docs

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -75,8 +75,7 @@ html_theme_options = {
     # GitHub
     "repository_url": "https://github.com/adap/flower",
     "repository_branch": "main",
-    "path_to_docs": "doc",
-
+    "path_to_docs": "doc/source/",
     "home_page_in_toc": True,
     "use_repository_button": True,
     "use_issues_button": True,

--- a/doc/source/evaluation.rst
+++ b/doc/source/evaluation.rst
@@ -40,7 +40,7 @@ An evaluation function is any function that can take the current global model pa
 
     # Create strategy
     strategy = fl.server.strategy.FedAvg(
-        # ... other FedAvg agruments 
+        # ... other FedAvg arguments 
         eval_fn=get_eval_fn(model),
     )
 

--- a/doc/source/saving-progress.rst
+++ b/doc/source/saving-progress.rst
@@ -3,7 +3,7 @@ Saving Progress
 
 The Flower server does not prescribe a way to persist model updates or evaluation results.
 Flower does not (yet) automatically save model updates on the server-side.
-It's on the roadmap to provide a built-in way of doing this, 
+It's on the roadmap to provide a built-in way of doing this.
 
 Model Checkpointing
 -------------------


### PR DESCRIPTION
While learning about flower, I saw this typo in the docs.

I also noticed that the "Suggest edit" functionality in the docs currently causes a 404 because there is a component missing in the URL. E.g., on the "evaluation" page, the link points to https://github.com/adap/flower/edit/main/doc/evaluation.rst although the actual file is located at https://github.com/adap/flower/edit/main/doc/**source**/evaluation.rst. The responsible HTML partial does not seem to be in the public flower repo but I would assume that the bug is in topbar.html:

https://github.com/lbhm/flower/blob/a5b21ca4204d1138bf49d2efbc333171056e8ac1/doc/source/_templates/layout.html#L37