### PR TITLE
Fix Ray dependency to 1.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ paramiko = { version = "^2.7.1", optional = true }
 docker = { version = "^4.2.0", optional = true }
 matplotlib = { version = "^3.2.1", optional = true }
 tqdm = { version = "^4.48.2", optional = true }
-ray = { extras = ["default"], version = "^1.6.0", optional = true }
+ray = { extras = ["default"], version = "==1.6.0", optional = true }
 
 [tool.poetry.extras]
 simulation = ["ray"]


### PR DESCRIPTION
Ray 1.7.0 breaks Flower on Google Colab. This PR fixes the Ray dependency, which means we have to manually upgrade from one Ray release to another until Ray backwards-compatibility improves.