### PR TITLE
Changed tensor convertor from torch.Tensor() to torch.tensor()

### DIFF
--- a/doc/source/quickstart_pytorch.rst
+++ b/doc/source/quickstart_pytorch.rst
@@ -163,7 +163,7 @@ which can be implemented in the following way:
 
         def set_parameters(self, parameters):
             params_dict = zip(net.state_dict().keys(), parameters)
-            state_dict = OrderedDict({k: torch.Tensor(v) for k, v in params_dict})
+            state_dict = OrderedDict({k: torch.tensor(v) for k, v in params_dict})
             net.load_state_dict(state_dict, strict=True)
 
         def fit(self, parameters, config):


### PR DESCRIPTION
So I was working with this repo : https://github.com/amirhosseinh77/UNet-AerialSegmentation
I cloned it and refactored it to train the model over flower. I used the code provided in the flower pytorch quickstart example.

However, the load_state_dict method threw the following error :
```IndexError: index 0 is out of bounds for dimension 0 with size 0```

Seemed like an issue of shape mismatch. So I changed the set_parameters method to the following to analyse the situation:
```py
        def set_parameters(self, parameters):
            params_dict = zip(model.state_dict().keys(), parameters)
            state_dict = OrderedDict({k: torch.Tensor(v) for k, v in params_dict})

            it1 = model.state_dict().items()
            it2 = state_dict.items()

            l1 = len(it1)
            l2 = len(it2)

            if l1!=l2 :
                print(f"{l1} : {l2} length do not match")
            else :
                for i in model.state_dict() :
                    if not model.state_dict()[i].shape == state_dict[i].shape:
                        print(i, model.state_dict()[i].shape, state_dict[i].shape,"Different")

            model.load_state_dict(state_dict, strict=False)
```

And I get the following output from the if-else block :
```
inc.double_conv.1.num_batches_tracked torch.Size([]) torch.Size([0]) Different
inc.double_conv.4.num_batches_tracked torch.Size([]) torch.Size([0]) Different
down1.maxpool_conv.1.double_conv.1.num_batches_tracked torch.Size([]) torch.Size([0]) Different
down1.maxpool_conv.1.double_conv.4.num_batches_tracked torch.Size([]) torch.Size([0]) Different
down2.maxpool_conv.1.double_conv.1.num_batches_tracked torch.Size([]) torch.Size([0]) Different
down2.maxpool_conv.1.double_conv.4.num_batches_tracked torch.Size([]) torch.Size([0]) Different
down3.maxpool_conv.1.double_conv.1.num_batches_tracked torch.Size([]) torch.Size([0]) Different
down3.maxpool_conv.1.double_conv.4.num_batches_tracked torch.Size([]) torch.Size([0]) Different
down4.maxpool_conv.1.double_conv.1.num_batches_tracked torch.Size([]) torch.Size([0]) Different
down4.maxpool_conv.1.double_conv.4.num_batches_tracked torch.Size([]) torch.Size([0]) Different
up1.conv.double_conv.1.num_batches_tracked torch.Size([]) torch.Size([0]) Different
up1.conv.double_conv.4.num_batches_tracked torch.Size([]) torch.Size([0]) Different
up2.conv.double_conv.1.num_batches_tracked torch.Size([]) torch.Size([0]) Different
up2.conv.double_conv.4.num_batches_tracked torch.Size([]) torch.Size([0]) Different
up3.conv.double_conv.1.num_batches_tracked torch.Size([]) torch.Size([0]) Different
up3.conv.double_conv.4.num_batches_tracked torch.Size([]) torch.Size([0]) Different
up4.conv.double_conv.1.num_batches_tracked torch.Size([]) torch.Size([0]) Different
up4.conv.double_conv.4.num_batches_tracked torch.Size([]) torch.Size([0]) Different
``` 

So, it turns out to be a case of mismatch when the client side expects torch.Size([]) but the server side message is parsed to torch.Size([0]). On checking online, I found this link : https://discuss.pytorch.org/t/what-does-torch-size-0-means/21559

and tried to come up with a solution, and turn out it was just changing the wrapper : 
![image](https://user-images.githubusercontent.com/58355527/137803936-6154e7ba-1323-41cd-82fa-449f35f1614d.png)

 Here you can see that torch.tensor() preserves the shape properly in both cases. But torch.Tensor() is unable to handle empty tensors. So, when I changed my code to : 
```py
        def set_parameters(self, parameters):
            params_dict = zip(model.state_dict().keys(), parameters)
            state_dict = OrderedDict({k: torch.tensor(v) for k, v in params_dict})

            it1 = model.state_dict().items()
            it2 = state_dict.items()

            l1 = len(it1)
            l2 = len(it2)

            if l1!=l2 :
                print(f"{l1} : {l2} length do not match")
            else :
                for i in model.state_dict() :
                    if not model.state_dict()[i].shape == state_dict[i].shape:
                        print(i, model.state_dict()[i].shape, state_dict[i].shape,"Different")

            model.load_state_dict(state_dict, strict=False)
```
The code executed without any errors.

I believe making this small change in the example will make the it more deployment ready and error free.