### PR TITLE
correct num_examples calculation

### DIFF
--- a/doc/source/example-pytorch-from-centralized-to-federated.rst
+++ b/doc/source/example-pytorch-from-centralized-to-federated.rst
@@ -68,7 +68,8 @@ The :code:`load_data()` function loads the CIFAR-10 training and test sets. The 
         trainloader = torch.utils.data.DataLoader(trainset, batch_size=32, shuffle=True)
         testset = CIFAR10(DATA_ROOT, train=False, download=True, transform=transform)
         testloader = torch.utils.data.DataLoader(testset, batch_size=32, shuffle=False)
-        return trainloader, testloader
+        num_examples = {"trainset" : len(trainset), "testset" : len(testset)}
+        return trainloader, testloader, num_examples
 
 We now need to define the training (function :code:`train()`) which loops over the training set, measures the the loss, backpropagetes it, and then takes one optimizer step for each batch of training examples.
 
@@ -140,7 +141,7 @@ Having defined defining the data loading, model architecture, training, and eval
         DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
         print("Centralized PyTorch training")
         print("Load data")
-        trainloader, testloader = load_data()
+        trainloader, testloader, _ = load_data()
         print("Start training")
         net=Net().to(DEVICE)
         train(net=net, trainloader=trainloader, epochs=2, device=DEVICE)
@@ -243,10 +244,12 @@ We included type annotations to give you a better understanding of the data type
             model: cifar.Net,
             trainloader: torch.utils.data.DataLoader,
             testloader: torch.utils.data.DataLoader,
+            num_examples: dict(),
         ) -> None:
             self.model = model
             self.trainloader = trainloader
             self.testloader = testloader
+            self.num_examples = num_examples
 
         def get_parameters(self) -> List[np.ndarray]:
             # Return model parameters as a list of NumPy ndarrays
@@ -264,7 +267,7 @@ We included type annotations to give you a better understanding of the data type
             # Set model parameters, train model, return updated model parameters
             self.set_parameters(parameters)
             cifar.train(self.model, self.trainloader, epochs=1, device=DEVICE)
-            return self.get_parameters(), len(self.trainloader)
+            return self.get_parameters(), self.num_examples["trainset"], {}
 
         def evaluate(
             self, parameters: List[np.ndarray], config: Dict[str, str]
@@ -272,7 +275,7 @@ We included type annotations to give you a better understanding of the data type
             # Set model parameters, evaluate model on local test dataset, return result
             self.set_parameters(parameters)
             loss, accuracy = cifar.test(self.model, self.testloader, device=DEVICE)
-            return len(self.testloader), float(loss), float(accuracy)
+            return float(loss), self.num_examples["testset"], {"accuracy": float(accuracy)}
 
 All that's left to do it to define a function that loads both model and data, creates a :code:`CifarClient`, and starts this client.
 You load your data and model by using :code:`cifar.py`. Start :code:`CifarClient` with the function :code:`fl.client.start_numpy_client()` by pointing it at the same IP adress we used in :code:`server.py`: 
@@ -285,10 +288,10 @@ You load your data and model by using :code:`cifar.py`. Start :code:`CifarClient
         # Load model and data
         model = cifar.Net()
         model.to(DEVICE)
-        trainloader, testloader = cifar.load_data()
+        trainloader, testloader, num_examples = cifar.load_data()
 
         # Start client
-        client = CifarClient(model, trainloader, testloader)
+        client = CifarClient(model, trainloader, testloader, num_examples)
         fl.client.start_numpy_client("0.0.0.0:8080", client)
 
 

--- a/doc/source/example-pytorch-from-centralized-to-federated.rst
+++ b/doc/source/example-pytorch-from-centralized-to-federated.rst
@@ -19,7 +19,7 @@ You can keep all these imports as they are even when we add the federated learni
 
 .. code-block:: python
 
-    from typing import Tuple
+    from typing import Tuple, Dict
 
     import torch
     import torch.nn as nn
@@ -59,7 +59,7 @@ The :code:`load_data()` function loads the CIFAR-10 training and test sets. The 
 
     DATA_ROOT = "~/data/cifar-10"
 
-    def load_data() -> Tuple[torch.utils.data.DataLoader, torch.utils.data.DataLoader]:
+    def load_data() -> Tuple[torch.utils.data.DataLoader, torch.utils.data.DataLoader, Dict]:
         """Load CIFAR-10 (training and test set)."""
         transform = transforms.Compose(
             [transforms.ToTensor(), transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))]
@@ -244,7 +244,7 @@ We included type annotations to give you a better understanding of the data type
             model: cifar.Net,
             trainloader: torch.utils.data.DataLoader,
             testloader: torch.utils.data.DataLoader,
-            num_examples: dict(),
+            num_examples: Dict,
         ) -> None:
             self.model = model
             self.trainloader = trainloader
@@ -263,7 +263,7 @@ We included type annotations to give you a better understanding of the data type
 
         def fit(
             self, parameters: List[np.ndarray], config: Dict[str, str]
-        ) -> Tuple[List[np.ndarray], int]:
+        ) -> Tuple[List[np.ndarray], int, Dict]:
             # Set model parameters, train model, return updated model parameters
             self.set_parameters(parameters)
             cifar.train(self.model, self.trainloader, epochs=1, device=DEVICE)
@@ -271,7 +271,7 @@ We included type annotations to give you a better understanding of the data type
 
         def evaluate(
             self, parameters: List[np.ndarray], config: Dict[str, str]
-        ) -> Tuple[int, float, float]:
+        ) -> Tuple[float, int, Dict]:
             # Set model parameters, evaluate model on local test dataset, return result
             self.set_parameters(parameters)
             loss, accuracy = cifar.test(self.model, self.testloader, device=DEVICE)

--- a/doc/source/quickstart_pytorch.rst
+++ b/doc/source/quickstart_pytorch.rst
@@ -63,7 +63,8 @@ We use PyTorch to load CIFAR10, a popular colored image classification dataset f
         testset = CIFAR10(".", train=False, download=True, transform=transform)
         trainloader = DataLoader(trainset, batch_size=32, shuffle=True)
         testloader = DataLoader(testset, batch_size=32)
-        return trainloader, testloader
+        num_examples = {"trainset" : len(trainset), "testset" : len(testset)}
+        return trainloader, testloader, num_examples
 
 Define the loss and optimizer with PyTorch. The training of the dataset is done by looping over the dataset, measure the corresponding loss and optimize it. 
 
@@ -127,7 +128,7 @@ The Flower clients will use a simle CNN adapted from 'PyTorch: A 60 Minute Blitz
 
     # Load model and data
     net = Net().to(DEVICE)
-    trainloader, testloader = load_data()
+    trainloader, testloader, num_examples = load_data()
 
 After loading the data set with :code:`load_data()` we define the Flower interface. 
 
@@ -169,12 +170,12 @@ which can be implemented in the following way:
         def fit(self, parameters, config):
             self.set_parameters(parameters)
             train(net, trainloader, epochs=1)
-            return self.get_parameters(), len(trainloader), {}
+            return self.get_parameters(), num_examples["trainset"], {}
 
         def evaluate(self, parameters, config):
             self.set_parameters(parameters)
             loss, accuracy = test(net, testloader)
-            return float(loss), len(testloader), {"accuracy":float(accuracy)}
+            return float(loss), num_examples["testset"], {"accuracy": float(accuracy)}
 
 We can now create an instance of our class :code:`CifarClient` and add one line
 to actually run this client:
@@ -255,8 +256,8 @@ You should now see how the training does in the very first terminal (the one tha
     DEBUG flower 2021-02-25 14:03:09,276 | server.py:139 | evaluate: strategy sampled 2 clients
     DEBUG flower 2021-02-25 14:03:11,852 | server.py:149 | evaluate received 2 results and 0 failures
     INFO flower 2021-02-25 14:03:11,852 | app.py:121 | app_evaluate: federated loss: 473.76959228515625
-    INFO flower 2021-02-25 14:03:11,852 | app.py:125 | app_evaluate: results [('ipv6:[::1]:54758', EvaluateRes(loss=473.76959228515625, num_examples=313, accuracy=0.0, metrics={'accuracy': 0.4439})), ('ipv6:[::1]:54760', EvaluateRes(loss=473.76959228515625, num_examples=313, accuracy=0.0, metrics={'accuracy': 0.4439}))]
-    INFO flower 2021-02-25 14:03:11,852 | app.py:127 | app_evaluate: failures []
+    INFO flower 2021-02-25 14:03:11,852 | app.py:122 | app_evaluate: results [('ipv6:[::1]:36602', EvaluateRes(loss=351.4906005859375, num_examples=10000, accuracy=0.0, metrics={'accuracy': 0.6067})), ('ipv6:[::1]:36604', EvaluateRes(loss=353.92742919921875, num_examples=10000, accuracy=0.0, metrics={'accuracy': 0.6005}))]
+    INFO flower 2021-02-25 14:03:27,514 | app.py:127 | app_evaluate: failures []
 
 Congratulations!
 You've successfully built and run your first federated learning system.

--- a/examples/pytorch_from_centralized_to_federated/cifar.py
+++ b/examples/pytorch_from_centralized_to_federated/cifar.py
@@ -61,7 +61,8 @@ def load_data() -> Tuple[torch.utils.data.DataLoader, torch.utils.data.DataLoade
     trainloader = torch.utils.data.DataLoader(trainset, batch_size=32, shuffle=True)
     testset = CIFAR10(DATA_ROOT, train=False, download=True, transform=transform)
     testloader = torch.utils.data.DataLoader(testset, batch_size=32, shuffle=False)
-    return trainloader, testloader
+    num_examples = {"trainset" : len(trainset), "testset" : len(testset)}
+    return trainloader, testloader, num_examples
 
 
 def train(
@@ -132,7 +133,7 @@ def main():
     DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
     print("Centralized PyTorch training")
     print("Load data")
-    trainloader, testloader = load_data()
+    trainloader, testloader, _ = load_data()
     net = Net().to(DEVICE)
     net.eval()
     print("Start training")

--- a/examples/pytorch_from_centralized_to_federated/cifar.py
+++ b/examples/pytorch_from_centralized_to_federated/cifar.py
@@ -11,7 +11,7 @@ https://pytorch.org/tutorials/beginner/blitz/cifar10_tutorial.html
 # pylint: disable=W0223
 
 
-from typing import Tuple
+from typing import Tuple, Dict
 
 import torch
 import torch.nn as nn
@@ -52,7 +52,7 @@ class Net(nn.Module):
         return x
 
 
-def load_data() -> Tuple[torch.utils.data.DataLoader, torch.utils.data.DataLoader]:
+def load_data() -> Tuple[torch.utils.data.DataLoader, torch.utils.data.DataLoader, Dict]:
     """Load CIFAR-10 (training and test set)."""
     transform = transforms.Compose(
         [transforms.ToTensor(), transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))]

--- a/examples/pytorch_from_centralized_to_federated/client.py
+++ b/examples/pytorch_from_centralized_to_federated/client.py
@@ -29,7 +29,7 @@ class CifarClient(fl.client.NumPyClient):
         model: cifar.Net,
         trainloader: torch.utils.data.DataLoader,
         testloader: torch.utils.data.DataLoader,
-        num_examples: dict(),
+        num_examples: Dict,
     ) -> None:
         self.model = model
         self.trainloader = trainloader
@@ -64,7 +64,7 @@ class CifarClient(fl.client.NumPyClient):
 
     def fit(
         self, parameters: List[np.ndarray], config: Dict[str, str]
-    ) -> Tuple[List[np.ndarray], int]:
+    ) -> Tuple[List[np.ndarray], int, Dict]:
         # Set model parameters, train model, return updated model parameters
         self.set_parameters(parameters)
         cifar.train(self.model, self.trainloader, epochs=1, device=DEVICE)
@@ -72,7 +72,7 @@ class CifarClient(fl.client.NumPyClient):
 
     def evaluate(
         self, parameters: List[np.ndarray], config: Dict[str, str]
-    ) -> Tuple[int, float, float]:
+    ) -> Tuple[float, int, Dict]:
         # Set model parameters, evaluate model on local test dataset, return result
         self.set_parameters(parameters)
         loss, accuracy = cifar.test(self.model, self.testloader, device=DEVICE)

--- a/examples/pytorch_from_centralized_to_federated/client.py
+++ b/examples/pytorch_from_centralized_to_federated/client.py
@@ -29,10 +29,12 @@ class CifarClient(fl.client.NumPyClient):
         model: cifar.Net,
         trainloader: torch.utils.data.DataLoader,
         testloader: torch.utils.data.DataLoader,
+        num_examples: dict(),
     ) -> None:
         self.model = model
         self.trainloader = trainloader
         self.testloader = testloader
+        self.num_examples = num_examples
 
     def get_parameters(self) -> List[np.ndarray]:
         self.model.train()
@@ -66,7 +68,7 @@ class CifarClient(fl.client.NumPyClient):
         # Set model parameters, train model, return updated model parameters
         self.set_parameters(parameters)
         cifar.train(self.model, self.trainloader, epochs=1, device=DEVICE)
-        return self.get_parameters(), len(self.trainloader), {}
+        return self.get_parameters(), self.num_examples["trainset"], {}
 
     def evaluate(
         self, parameters: List[np.ndarray], config: Dict[str, str]
@@ -74,14 +76,14 @@ class CifarClient(fl.client.NumPyClient):
         # Set model parameters, evaluate model on local test dataset, return result
         self.set_parameters(parameters)
         loss, accuracy = cifar.test(self.model, self.testloader, device=DEVICE)
-        return float(loss), len(self.testloader), {"accuracy": float(accuracy)}
+        return float(loss), self.num_examples["testset"], {"accuracy": float(accuracy)}
 
 
 def main() -> None:
     """Load data, start CifarClient."""
 
     # Load data
-    trainloader, testloader = cifar.load_data()
+    trainloader, testloader, num_examples = cifar.load_data()
 
     # Load model
     model = cifar.Net().to(DEVICE).train()
@@ -90,7 +92,7 @@ def main() -> None:
     _ = model(next(iter(trainloader))[0].to(DEVICE))
 
     # Start client
-    client = CifarClient(model, trainloader, testloader)
+    client = CifarClient(model, trainloader, testloader, num_examples)
     fl.client.start_numpy_client("[::]:8080", client)
 
 


### PR DESCRIPTION
- change num_examples from len(trainloader) to len(trainset)
- update Pytorch: From centralized to federated example
-  update Pytorch quickstarter
- update doc (Pytorch: from centralized to federated)
- update doc (Pytorch quickstarter)