### PR TITLE
Add Act instructions for developers

### DIFF
--- a/doc/source/getting-started-for-contributors.rst
+++ b/doc/source/getting-started-for-contributors.rst
@@ -72,6 +72,19 @@ Run Linters and Tests
 
   $ ./dev/test.sh
 
+Run Github Actions (CI) locally
+~~~~~~~~~~~~~~~~~~~~~
+
+Developers could run the full set of Github Actions workflows under their local
+environment by using `Act <https://github.com/nektos/act>_`. Please refer to
+the installation instructions under the linked repository and run the next
+command under Flower main cloned repository folder::
+
+  $ act
+
+The Flower default workflow would run by setting up the required Docker
+machines underneath.
+
 
 Build Release
 -------------


### PR DESCRIPTION
The documentation has been updated for the case where developers could run CI actions locally on their computers. This has been widely useful in https://github.com/adap/flower/pull/952.

An issue has not been created for this purpose as small changes are appended to this pull request.