### PR TITLE
Update CI Python patch versions to latest

### DIFF
--- a/.github/workflows/baselines.yml
+++ b/.github/workflows/baselines.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8.3
+          python-version: 3.8.12
       - name: Install build tools
         run: |
           python -m pip install -U pip==21.2.4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Build docs
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7.9
+          python-version: 3.7.12
       - name: Install build tools
         run: |
           python -m pip install -U pip==21.2.4
@@ -40,7 +40,7 @@ jobs:
       - name: Deploy docs
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7.9
+          python-version: 3.7.12
       - name: Install build tools
         run: |
           python -m pip install -U pip==21.2.4

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7.9
+          python-version: 3.7.12
       - name: Install
         run: |
           python -m pip install poetry==1.1.10
@@ -28,7 +28,7 @@ jobs:
       - name: Cache Datasets
         uses: actions/cache@v2
         with:
-          path: './examples/quickstart_pytorch/dataset'
+          path: "./examples/quickstart_pytorch/dataset"
           key: pytorch-datasets
       - name: Download Datasets
         run: |
@@ -48,10 +48,10 @@ jobs:
             then echo "Client process 1 started correctly";
             else echo "Client process 1 crashed" && exit 1;
           fi
-          
+
           python client.py 2 &
           sleep 3
-          
+
           if [[ $(ps aux | grep "[p]ython client.py 2" | awk '{ print $2 }') ]];
             then echo "Client process 2 started correctly";
             else echo "Client process 2 crashed" && exit 1;
@@ -71,7 +71,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7.9
+          python-version: 3.7.12
       - name: Install
         run: |
           python -m pip install poetry==1.1.10
@@ -83,7 +83,7 @@ jobs:
       - name: Cache Datasets
         uses: actions/cache@v2
         with:
-          path: '~/.keras'
+          path: "~/.keras"
           key: keras-datasets
       - name: Download Datasets
         run: |
@@ -102,10 +102,10 @@ jobs:
             then echo "Client process 1 started correctly";
             else echo "Client process 1 crashed" && exit 1;
           fi
-          
+
           python client.py 2 &
           sleep 3
-          
+
           if [[ $(ps aux | grep "[p]ython client.py 2" | awk '{ print $2 }') ]];
             then echo "Client process 2 started correctly";
             else echo "Client process 2 crashed" && exit 1;
@@ -125,7 +125,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7.9
+          python-version: 3.7.12
       - name: Install
         run: |
           python -m pip install poetry==1.1.10
@@ -137,7 +137,7 @@ jobs:
       - name: Cache Datasets
         uses: actions/cache@v2
         with:
-          path: './examples/pytorch_from_centralized_to_federated/dataset'
+          path: "./examples/pytorch_from_centralized_to_federated/dataset"
           key: pytorch-datasets
       - name: Download Datasets
         run: |
@@ -181,7 +181,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7.9
+          python-version: 3.7.12
       - name: Install
         run: |
           python -m pip install poetry==1.1.10

--- a/.github/workflows/flower.yml
+++ b/.github/workflows/flower.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python: [3.6.11, 3.7.9, 3.8.3, 3.9.5]
+        python: [3.6.15, 3.7.12, 3.8.12, 3.9.9]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
@@ -41,7 +41,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7.9
+          python-version: 3.7.12
       - name: Install build tools
         run: |
           python -m pip install -U pip==21.2.4
@@ -55,7 +55,7 @@ jobs:
       - name: Cache Datasets
         uses: actions/cache@v2
         with:
-          path: '~/.keras'
+          path: "~/.keras"
           key: keras-datasets
       - name: Download Datasets
         run: |
@@ -70,7 +70,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7.9
+          python-version: 3.7.12
       - name: Install build tools
         run: |
           python -m pip install -U pip==21.2.4
@@ -90,7 +90,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7.9
+          python-version: 3.7.12
       - name: Install build tools
         run: |
           python -m pip install -U pip==21.2.4

--- a/.github/workflows/flower_nightly.yml
+++ b/.github/workflows/flower_nightly.yml
@@ -2,7 +2,7 @@ name: Nightly Release
 
 on:
   schedule:
-    - cron:  '0 23 * * *'
+    - cron: "0 23 * * *"
 
 jobs:
   release:
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7.9
+          python-version: 3.7.12
       - name: Install build tools
         run: |
           python -m pip install -U pip==21.2.4

--- a/.github/workflows/flower_ops.yml
+++ b/.github/workflows/flower_ops.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7.9
+          python-version: 3.7.12
       - name: Install build tools
         run: |
           python -m pip install -U pip==21.2.4

--- a/.github/workflows/flower_tool.yml
+++ b/.github/workflows/flower_tool.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7.9
+          python-version: 3.7.12
       - name: Install build tools
         run: |
           python -m pip install -U pip==21.2.4


### PR DESCRIPTION
Some tests in current Python patch versions failed in a recent PR because the GitHub CI wasn't able to install our current version. We had this issue a while ago and updating fixed it at that time. I thought its a good idea to update the patch versions again.

Example from #952 => https://github.com/adap/flower/runs/4638198208

Merging this PR should fix that issue.