### PR TITLE
Fixed max_workers mypy related error

### DIFF
--- a/src/py/flwr/server/server.py
+++ b/src/py/flwr/server/server.py
@@ -357,7 +357,7 @@ def reconnect_client(
 
 def fit_clients(
     client_instructions: List[Tuple[ClientProxy, FitIns]],
-    max_workers: Optional[int],
+    max_workers: Optional[int] = None,
 ) -> FitResultsAndFailures:
     """Refine parameters concurrently on all selected clients."""
     with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
@@ -388,7 +388,7 @@ def fit_client(client: ClientProxy, ins: FitIns) -> Tuple[ClientProxy, FitRes]:
 
 def evaluate_clients(
     client_instructions: List[Tuple[ClientProxy, EvaluateIns]],
-    max_workers: Optional[int],
+    max_workers: Optional[int] = None,
 ) -> EvaluateResultsAndFailures:
     """Evaluate parameters concurrently on all selected clients."""
     with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:

--- a/src/py/flwr/server/server.py
+++ b/src/py/flwr/server/server.py
@@ -388,7 +388,7 @@ def fit_client(client: ClientProxy, ins: FitIns) -> Tuple[ClientProxy, FitRes]:
 
 def evaluate_clients(
     client_instructions: List[Tuple[ClientProxy, EvaluateIns]],
-    max_workers: Optional[int]
+    max_workers: Optional[int],
 ) -> EvaluateResultsAndFailures:
     """Evaluate parameters concurrently on all selected clients."""
     with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:

--- a/src/py/flwr/server/server.py
+++ b/src/py/flwr/server/server.py
@@ -100,7 +100,7 @@ class Server:
             tensors=[], tensor_type="numpy.ndarray"
         )
         self.strategy: Strategy = strategy if strategy is not None else FedAvg()
-        self.max_workers: Optional[int]
+        self.max_workers: Optional[int] = None
 
     def set_max_workers(self, max_workers: Optional[int]) -> None:
         """Set the max_workers used by ThreadPoolExecutor."""

--- a/src/py/flwr/server/server.py
+++ b/src/py/flwr/server/server.py
@@ -357,7 +357,7 @@ def reconnect_client(
 
 def fit_clients(
     client_instructions: List[Tuple[ClientProxy, FitIns]],
-    max_workers: Optional[int] = None,
+    max_workers: Optional[int],
 ) -> FitResultsAndFailures:
     """Refine parameters concurrently on all selected clients."""
     with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
@@ -388,7 +388,7 @@ def fit_client(client: ClientProxy, ins: FitIns) -> Tuple[ClientProxy, FitRes]:
 
 def evaluate_clients(
     client_instructions: List[Tuple[ClientProxy, EvaluateIns]],
-    max_workers: Optional[int] = None,
+    max_workers: Optional[int],
 ) -> EvaluateResultsAndFailures:
     """Evaluate parameters concurrently on all selected clients."""
     with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:

--- a/src/py/flwr/server/server.py
+++ b/src/py/flwr/server/server.py
@@ -100,7 +100,7 @@ class Server:
             tensors=[], tensor_type="numpy.ndarray"
         )
         self.strategy: Strategy = strategy if strategy is not None else FedAvg()
-        self.max_workers: Optional[int] = None
+        self.max_workers: Optional[int]
 
     def set_max_workers(self, max_workers: Optional[int]) -> None:
         """Set the max_workers used by ThreadPoolExecutor."""
@@ -357,7 +357,7 @@ def reconnect_client(
 
 def fit_clients(
     client_instructions: List[Tuple[ClientProxy, FitIns]],
-    max_workers: Optional[int] = None,
+    max_workers: Optional[int],
 ) -> FitResultsAndFailures:
     """Refine parameters concurrently on all selected clients."""
     with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
@@ -388,7 +388,7 @@ def fit_client(client: ClientProxy, ins: FitIns) -> Tuple[ClientProxy, FitRes]:
 
 def evaluate_clients(
     client_instructions: List[Tuple[ClientProxy, EvaluateIns]],
-    max_workers: Optional[int] = None,
+    max_workers: Optional[int]
 ) -> EvaluateResultsAndFailures:
     """Evaluate parameters concurrently on all selected clients."""
     with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:

--- a/src/py/flwr/server/server_test.py
+++ b/src/py/flwr/server/server_test.py
@@ -91,7 +91,7 @@ def test_fit_clients() -> None:
     client_instructions = [(c, ins) for c in clients]
 
     # Execute
-    results, failures = fit_clients(client_instructions)
+    results, failures = fit_clients(client_instructions, None)
 
     # Assert
     assert len(results) == 1
@@ -115,7 +115,7 @@ def test_eval_clients() -> None:
     client_instructions = [(c, ins) for c in clients]
 
     # Execute
-    results, failures = evaluate_clients(client_instructions)
+    results, failures = evaluate_clients(client_instructions, None)
 
     # Assert
     assert len(results) == 1


### PR DESCRIPTION
Related to https://github.com/adap/flower/pull/978.
There was an error about the default value for the optional `max_workers` parameter when running `mypy` as pointed out by our _Continuous Integration_ system.
The proposed fix has been tested successfully in a local environment without inconvenience.