### PR TITLE
feature/Advanced TF example: Added accuracy custom metric aggregation

### DIFF
--- a/examples/advanced_tensorflow/server.py
+++ b/examples/advanced_tensorflow/server.py
@@ -14,7 +14,7 @@ class AggregateCustomMetricStrategy(fl.server.strategy.FedAvg):
         results: List[Tuple[ClientProxy, EvaluateRes]],
         failures: List[BaseException],
     ) -> Optional[float]:
-        """Aggregate evaluation losses using weighted average."""
+        """Aggregate evaluation accuracies using weighted average."""
         if not results:
             return None
 


### PR DESCRIPTION
The server side custom metric aggregation strategy has been set to comply with https://github.com/adap/flower/issues/983 description, as we were not aggregating the `accuracy` metric given by the clients.

A log of the `python3 -m poetry run ./run.sh` is attached below.

<details><summary>See log contents relevant part</summary>

```text
INFO flower 2022-01-06 09:21:15,045 | server.py:148 | fit progress: (4, 2.347806453704834, {'accuracy': 0.14000000059604645}, 307.9660143000001)
INFO flower 2022-01-06 09:21:15,045 | server.py:199 | evaluate_round: no clients selected, cancel
INFO flower 2022-01-06 09:21:15,045 | server.py:172 | FL finished in 307.96627069999977
INFO flower 2022-01-06 09:21:15,045 | app.py:119 | app_fit: losses_distributed []
INFO flower 2022-01-06 09:21:15,045 | app.py:120 | app_fit: metrics_distributed {}
INFO flower 2022-01-06 09:21:15,045 | app.py:121 | app_fit: losses_centralized [(0, 2.3025827407836914), (1, 2.313997507095337), (2, 2.3028578758239746), (3, 2.282471179962158), (4, 2.347806453704834)]
INFO flower 2022-01-06 09:21:15,045 | app.py:122 | app_fit: metrics_centralized {'accuracy': [(0, 0.12919999659061432), (1, 0.09700000286102295), (2, 0.10239999741315842), (3, 0.11720000207424164), (4, 0.14000000059604645)]}
DEBUG flower 2022-01-06 09:21:15,054 | connection.py:68 | Insecure gRPC channel closed
```
</details>