### PR TITLE
Fix typo in tf quickstart doc

### DIFF
--- a/doc/source/quickstart_tensorflow.rst
+++ b/doc/source/quickstart_tensorflow.rst
@@ -79,7 +79,7 @@ to actually run this client:
 
 
 That's it for the client. We only have to implement :code:`Client` or
-:code:`NumPyClient` and call :code:`fl.client.start_client()` or :code:` fl.client.start_numpy_client()`. The string :code:`"[::]:8080"` tells the client which server to connect to. In our case we can run the server and the client on the same machine, therefore we use
+:code:`NumPyClient` and call :code:`fl.client.start_client()` or :code:`fl.client.start_numpy_client()`. The string :code:`"[::]:8080"` tells the client which server to connect to. In our case we can run the server and the client on the same machine, therefore we use
 :code:`"[::]:8080"`. If we run a truly federated workload with the server and
 clients running on different machines, all that needs to change is the
 :code:`server_address` we point the client at.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
This typo was introduced in #522 
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved.
-->

#### What does this implement/fix? Explain your changes.
Removes an extra space after the `code:` block which prevented the code from being formatted properly.
<!--
Explain why this PR is needed and what kind of changes have you done.
Example: the variable rnd was not clear and therefore renamed to fl_round. 
-->

#### Any other comments?


<!--
Please be aware that it may take some time until we can check this PR. 
If you have an urgent request or question please use the Flower Slack channel.
The Slack channel is really active and contributors respond pretty fast. 

We value your contribution and are aware of the time you put into this PR.
Therefore, thank you for your contribution. 
-->