### PR TITLE
Align order of client methods

### DIFF
--- a/src/py/flwr/client/client.py
+++ b/src/py/flwr/client/client.py
@@ -32,16 +32,6 @@ class Client(ABC):
     """Abstract base class for Flower clients."""
 
     @abstractmethod
-    def get_parameters(self) -> ParametersRes:
-        """Return the current local model parameters.
-
-        Returns
-        -------
-        ParametersRes
-            The current local model parameters.
-        """
-
-    @abstractmethod
     def get_properties(self, ins: PropertiesIns) -> PropertiesRes:
         """Return set of client's properties.
 
@@ -49,6 +39,16 @@ class Client(ABC):
         -------
         PropertiesRes
             Client's properties.
+        """
+
+    @abstractmethod
+    def get_parameters(self) -> ParametersRes:
+        """Return the current local model parameters.
+
+        Returns
+        -------
+        ParametersRes
+            The current local model parameters.
         """
 
     @abstractmethod

--- a/src/py/flwr/client/keras_client.py
+++ b/src/py/flwr/client/keras_client.py
@@ -44,16 +44,6 @@ class KerasClient(ABC):
     """Abstract base class for Flower clients which use Keras."""
 
     @abstractmethod
-    def get_weights(self) -> Weights:
-        """Return the current local model weights.
-
-        Returns:
-            The local model weights as a list of NumPy ndarrays. In many cases,
-            it will be sufficient to just return the return value of Keras'
-            `model.get_weights()`.
-        """
-
-    @abstractmethod
     def get_properties(self, config: Config) -> Properties:
         """Returns a client's set of properties.
 
@@ -68,6 +58,16 @@ class KerasClient(ABC):
         -------
         PropertiesRes:
             Response containing `properties` of the client.
+        """
+
+    @abstractmethod
+    def get_weights(self) -> Weights:
+        """Return the current local model weights.
+
+        Returns:
+            The local model weights as a list of NumPy ndarrays. In many cases,
+            it will be sufficient to just return the return value of Keras'
+            `model.get_weights()`.
         """
 
     @abstractmethod
@@ -130,15 +130,16 @@ class KerasClientWrapper(Client):
     def __init__(self, keras_client: KerasClient) -> None:
         self.keras_client = keras_client
 
+    def get_properties(self, ins: PropertiesIns) -> PropertiesRes:
+        """Return the current client properties."""
+        properties = self.keras_client.get_properties(ins.config)
+        return PropertiesRes(properties=properties)
+
     def get_parameters(self) -> ParametersRes:
         """Return the current local model parameters."""
         weights = self.keras_client.get_weights()
         parameters = weights_to_parameters(weights)
         return ParametersRes(parameters=parameters)
-
-    def get_properties(self, ins: PropertiesIns) -> PropertiesRes:
-        properties = self.keras_client.get_properties(ins.config)
-        return PropertiesRes(properties=properties)
 
     def fit(self, ins: FitIns) -> FitRes:
         """Refine the provided weights using the locally held dataset."""

--- a/src/py/flwr/client/numpy_client.py
+++ b/src/py/flwr/client/numpy_client.py
@@ -94,16 +94,6 @@ class NumPyClient(ABC):
     """Abstract base class for Flower clients using NumPy."""
 
     @abstractmethod
-    def get_parameters(self) -> List[np.ndarray]:
-        """Return the current local model parameters.
-
-        Returns
-        -------
-        parameters : List[numpy.ndarray]
-            The local model parameters as a list of NumPy ndarrays.
-        """
-
-    @abstractmethod
     def get_properties(self, config: Config) -> Properties:
         """Returns a client's set of properties.
 
@@ -118,6 +108,16 @@ class NumPyClient(ABC):
         -------
         PropertiesRes :
             Response containing `properties` of the client.
+        """
+
+    @abstractmethod
+    def get_parameters(self) -> List[np.ndarray]:
+        """Return the current local model parameters.
+
+        Returns
+        -------
+        parameters : List[numpy.ndarray]
+            The local model parameters as a list of NumPy ndarrays.
         """
 
     @abstractmethod
@@ -198,6 +198,7 @@ class NumPyClientWrapper(Client):
         self.numpy_client = numpy_client
 
     def get_properties(self, ins: PropertiesIns) -> PropertiesRes:
+        """Return the current client properties."""
         properties = self.numpy_client.get_properties(ins.config)
         return PropertiesRes(properties=properties)
 

--- a/src/py/flwr/server/client_proxy.py
+++ b/src/py/flwr/server/client_proxy.py
@@ -39,12 +39,12 @@ class ClientProxy(ABC):
         self.properties: Properties = {}
 
     @abstractmethod
-    def get_parameters(self) -> ParametersRes:
-        """Return the current local model parameters."""
-
-    @abstractmethod
     def get_properties(self, ins: PropertiesIns) -> PropertiesRes:
         """Returns the client's properties."""
+
+    @abstractmethod
+    def get_parameters(self) -> ParametersRes:
+        """Return the current local model parameters."""
 
     @abstractmethod
     def fit(self, ins: FitIns) -> FitRes:

--- a/src/py/flwr/server/grpc_server/grpc_client_proxy.py
+++ b/src/py/flwr/server/grpc_server/grpc_client_proxy.py
@@ -33,15 +33,6 @@ class GrpcClientProxy(ClientProxy):
         super().__init__(cid)
         self.bridge = bridge
 
-    def get_parameters(self) -> common.ParametersRes:
-        """Return the current local model parameters."""
-        get_parameters_msg = serde.get_parameters_to_proto()
-        client_msg: ClientMessage = self.bridge.request(
-            ServerMessage(get_parameters=get_parameters_msg)
-        )
-        parameters_res = serde.parameters_res_from_proto(client_msg.parameters_res)
-        return parameters_res
-
     def get_properties(self, ins: common.PropertiesIns) -> common.PropertiesRes:
         """Requests client's set of internal properties."""
         properties_msg = serde.properties_ins_to_proto(ins)
@@ -50,6 +41,15 @@ class GrpcClientProxy(ClientProxy):
         )
         properties_res = serde.properties_res_from_proto(client_msg.properties_res)
         return properties_res
+
+    def get_parameters(self) -> common.ParametersRes:
+        """Return the current local model parameters."""
+        get_parameters_msg = serde.get_parameters_to_proto()
+        client_msg: ClientMessage = self.bridge.request(
+            ServerMessage(get_parameters=get_parameters_msg)
+        )
+        parameters_res = serde.parameters_res_from_proto(client_msg.parameters_res)
+        return parameters_res
 
     def fit(self, ins: common.FitIns) -> common.FitRes:
         """Refine the provided weights using the locally held dataset."""

--- a/src/py/flwr/server/server_test.py
+++ b/src/py/flwr/server/server_test.py
@@ -41,11 +41,12 @@ from .server import Server, evaluate_clients, fit_clients
 class SuccessClient(ClientProxy):
     """Test class."""
 
-    def get_parameters(self) -> ParametersRes:
+    def get_properties(self, ins: PropertiesIns) -> PropertiesRes:
         # This method is not expected to be called
         raise Exception()
 
-    def get_properties(self, ins: PropertiesIns) -> PropertiesRes:
+    def get_parameters(self) -> ParametersRes:
+        # This method is not expected to be called
         raise Exception()
 
     def fit(self, ins: FitIns) -> FitRes:
@@ -63,10 +64,10 @@ class SuccessClient(ClientProxy):
 class FailingClient(ClientProxy):
     """Test class."""
 
-    def get_parameters(self) -> ParametersRes:
+    def get_properties(self, ins: PropertiesIns) -> PropertiesRes:
         raise Exception()
 
-    def get_properties(self, ins: PropertiesIns) -> PropertiesRes:
+    def get_parameters(self) -> ParametersRes:
         raise Exception()
 
     def fit(self, ins: FitIns) -> FitRes:


### PR DESCRIPTION
The different clients implementation (and client wrappers) had different method ordering. This PR aligns them by putting the new `get_properties` first.