### PR TITLE
Decrease default gRPC keepalive time

### DIFF
--- a/src/py/flwr/client/grpc_client/connection.py
+++ b/src/py/flwr/client/grpc_client/connection.py
@@ -27,8 +27,11 @@ from flwr.proto.transport_pb2 import ClientMessage, ServerMessage
 from flwr.proto.transport_pb2_grpc import FlowerServiceStub
 
 # Uncomment these flags in case you are debugging
+# import os
 # os.environ["GRPC_VERBOSITY"] = "debug"
-# os.environ["GRPC_TRACE"] = "connectivity_state"
+# os.environ["GRPC_TRACE"] = "tcp,http"
+# Check possible values here:
+# https://github.com/grpc/grpc/blob/master/doc/environment_variables.md
 
 
 def on_channel_state_change(channel_connectivity: str) -> None:
@@ -49,7 +52,7 @@ def grpc_connection(
     server_address : str
         The IPv6 address of the server. If the Flower server runs on the same machine
         on port 8080, then `server_address` would be `"[::]:8080"`.
-    grpc_max_message_length : int
+    max_message_length : int
         The maximum length of gRPC messages that can be exchanged with the Flower
         server. The default should be sufficient for most models. Users who train
         very large models might need to increase this value. Note that the Flower
@@ -73,7 +76,7 @@ def grpc_connection(
     >>> from pathlib import Path
     >>> with grpc_connection(
     >>>     server_address,
-    >>>     max_message_length=grpc_max_message_length,
+    >>>     max_message_length=max_message_length,
     >>>     root_certificates=Path("/crts/root.pem").read_bytes(),
     >>> ) as conn:
     >>>     receive, send = conn
@@ -81,6 +84,8 @@ def grpc_connection(
     >>>     # do something here
     >>>     send(client_message)
     """
+    # Possible options:
+    # https://github.com/grpc/grpc/blob/v1.43.x/include/grpc/impl/codegen/grpc_types.h
     channel_options = [
         ("grpc.max_send_message_length", max_message_length),
         ("grpc.max_receive_message_length", max_message_length),

--- a/src/py/flwr/client/grpc_client/connection.py
+++ b/src/py/flwr/client/grpc_client/connection.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Provides contextmanager which manages a gRPC channel to connect to the
-server."""
+"""Contextmanager managing a gRPC channel to the Flower server."""
+
+
 from contextlib import contextmanager
 from logging import DEBUG, INFO
 from queue import Queue
@@ -26,12 +27,11 @@ from flwr.common.logger import log
 from flwr.proto.transport_pb2 import ClientMessage, ServerMessage
 from flwr.proto.transport_pb2_grpc import FlowerServiceStub
 
-# Uncomment these flags in case you are debugging
+# The following flags can be uncommented for debugging. Other possible values:
+# https://github.com/grpc/grpc/blob/master/doc/environment_variables.md
 # import os
 # os.environ["GRPC_VERBOSITY"] = "debug"
 # os.environ["GRPC_TRACE"] = "tcp,http"
-# Check possible values here:
-# https://github.com/grpc/grpc/blob/master/doc/environment_variables.md
 
 
 def on_channel_state_change(channel_connectivity: str) -> None:

--- a/src/py/flwr/server/grpc_server/grpc_server.py
+++ b/src/py/flwr/server/grpc_server/grpc_server.py
@@ -52,6 +52,7 @@ def start_grpc_server(
     server_address: str,
     max_concurrent_workers: int = 1000,
     max_message_length: int = GRPC_MAX_MESSAGE_LENGTH,
+    keepalive_time_ms: int = 7200000,
     certificates: Optional[Tuple[bytes, bytes, bytes]] = None,
 ) -> grpc.Server:
     """Create gRPC server and return instance of grpc.Server.
@@ -75,6 +76,25 @@ def start_grpc_server(
     max_message_length : int
         Maximum message length that the server can send or receive.
         Int valued in bytes. -1 means unlimited. (default: GRPC_MAX_MESSAGE_LENGTH)
+    keepalive_time_ms : int
+        The primary reason we are customizing this setting is that some cloud
+        providers, for example, Azure clean up idle TCP connections aggressively
+        and terminate them after some time (in case of Azure 4 minutes). As of
+        2022-02-13 Flower has no application level keepalive signals and relies on
+        the assumption that the transport layer will fail in case the connection is
+        no longer active. Configuring the gRPC keepalive to 210000 seconds (3 minutes
+        30 seconds) will ensure that on most cloud providers we can keep the long
+        running streaming connection which is as of 2022-02-13 the default in Flower.
+        The actual gRPC default of this setting is 7200000 (2 hours).
+
+        These settings are related to the issue described here:
+        - https://github.com/grpc/proposal/blob/master/A8-client-side-keepalive.md
+        - https://github.com/grpc/grpc/blob/master/doc/keepalive.md
+        - https://grpc.io/docs/guides/performance/
+
+        Users using mobile Flower clients may increase it if their server environment
+        allows them to have long running idle TCP connections.
+        (default: 210000)
     certificates : Tuple[bytes, bytes, bytes] (default: None)
         Tuple containing root certificate, server certificate, and private key to
         start a secure SSL-enabled server. The tuple is expected to have three bytes
@@ -104,22 +124,34 @@ def start_grpc_server(
     >>>     ),
     >>> )
     """
+    # Possible options:
+    # https://github.com/grpc/grpc/blob/v1.43.x/include/grpc/impl/codegen/grpc_types.h
+    options = [
+        # Maximum number of concurrent incoming streams to allow on a http2
+        # connection. Int valued.
+        ("grpc.max_concurrent_streams", max(100, max_concurrent_workers)),
+        # Maximum message length that the channel can send.
+        # Int valued, bytes. -1 means unlimited.
+        ("grpc.max_send_message_length", max_message_length),
+        # Maximum message length that the channel can receive.
+        # Int valued, bytes. -1 means unlimited.
+        ("grpc.max_receive_message_length", max_message_length),
+        # The actual gRPC default of this setting is 7200000 (2 hours). We are going
+        # to set it to 210000 (3 minutes and 30 seconds to cover Azure and others).
+        # Users using mobile Flower clients may increase it if their server environment
+        # allows them to have long running idle TCP connections.
+        ("grpc.keepalive_time_ms", 210000),
+        # Setting this to zero will allow sending unlimited keepalive's between sending
+        # a data frame. This is especially important
+        ("grpc.http2.max_pings_without_data", 0),
+    ]
+
     server = grpc.server(
         concurrent.futures.ThreadPoolExecutor(max_workers=max_concurrent_workers),
         # Set the maximum number of concurrent RPCs this server will service before
         # returning RESOURCE_EXHAUSTED status, or None to indicate no limit.
         maximum_concurrent_rpcs=max_concurrent_workers,
-        options=[
-            # Maximum number of concurrent incoming streams to allow on a http2
-            # connection. Int valued.
-            ("grpc.max_concurrent_streams", max(100, max_concurrent_workers)),
-            # Maximum message length that the channel can send.
-            # Int valued, bytes. -1 means unlimited.
-            ("grpc.max_send_message_length", max_message_length),
-            # Maximum message length that the channel can receive.
-            # Int valued, bytes. -1 means unlimited.
-            ("grpc.max_receive_message_length", max_message_length),
-        ],
+        options=options,
     )
 
     servicer = fss.FlowerServiceServicer(client_manager)

--- a/src/py/flwr/server/grpc_server/grpc_server.py
+++ b/src/py/flwr/server/grpc_server/grpc_server.py
@@ -47,7 +47,7 @@ def valid_certificates(certificates: Tuple[bytes, bytes, bytes]) -> bool:
     return is_valid
 
 
-def start_grpc_server(
+def start_grpc_server(  # pylint: disable=too-many-arguments
     client_manager: ClientManager,
     server_address: str,
     max_concurrent_workers: int = 1000,

--- a/src/py/flwr/server/grpc_server/grpc_server.py
+++ b/src/py/flwr/server/grpc_server/grpc_server.py
@@ -82,11 +82,11 @@ def start_grpc_server(  # pylint: disable=too-many-arguments
         TCP connections by terminating them after some time (4 minutes in the case
         of Azure). Flower does not use application-level keepalive signals and relies
         on the assumption that the transport layer will fail in cases where the
-        connection is not longer active. `keepalive_time_ms` can be used to customize
+        connection is no longer active. `keepalive_time_ms` can be used to customize
         the keepalive interval for specific environments. The default Flower gRPC
         keepalive of 210000 ms (3 minutes 30 seconds) ensures that Flower can keep
-        the long running streaming connection alive most cloud providers. The actual
-        gRPC default of this setting is 7200000 (2 hours), which results dropped
+        the long running streaming connection alive in most environments. The actual
+        gRPC default of this setting is 7200000 (2 hours), which results in dropped
         connections in some cloud environments.
 
         These settings are related to the issue described here:


### PR DESCRIPTION
#### Reference Issues/PRs

This PR resolves the issue which was reported on Slack.

#### What does this implement/fix? Explain your changes.

Some cloud providers kill idle TCP connections, for example, Azure after 4min on Virtual Machines. The keepalive is now set to a default of 4min. This will most probably cover all cloud providers. We also expose in this PR a possibility to the user to set it higher. In some cases a keepalive of 4min might be bad of battery lifetime.
