### PR TITLE
Log decentralized metrics

### DIFF
--- a/src/py/flwr/server/server.py
+++ b/src/py/flwr/server/server.py
@@ -169,13 +169,12 @@ class Server:
             # Evaluate model on a sample of available clients
             res_fed = self.evaluate_round(rnd=current_round)
             if res_fed:
-                loss_fed, evaluate_metrics_fed, _ = res_fed
+                loss_fed, _, (metrics_res,_) = res_fed 
                 if loss_fed:
                     history.add_loss_distributed(rnd=current_round, loss=loss_fed)
                     history.add_metrics_distributed(
-                        rnd=current_round, metrics=evaluate_metrics_fed
+                        rnd=current_round, metrics={f"Client {i}": metrics_res[i][1].metrics for i in range(len(metrics_res))}
                     )
-
         # Bookkeeping
         end_time = timeit.default_timer()
         elapsed = end_time - start_time


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->


#### What does this implement/fix? Explain your changes.

<!--
Explain why this PR is needed and what kind of changes have you done.
Example: the variable rnd was not clear and therefore renamed to fl_round. 
-->
The decentralized metrics ( _metrics_distributed_ -  https://github.com/adap/flower/blob/main/src/py/flwr/server/app.py#L152) are not logged since _metrics_aggregated_ is always empty (https://github.com/adap/flower/blob/main/src/py/flwr/server/server.py#L231-L248, https://github.com/adap/flower/blob/main/src/py/flwr/server/strategy/qfedavg.py#L214-L239).

What I propose here is just a quick workaround to output the decentralized metrics, because I am not sure what the role of _metrics_aggregated_ is here and if there is a reason for this.

#### Comments
The log message should probably be changed, as the client {i} would be wrong in case not all clients are evaluated. 
<!--
Please be aware that it may take some time until we can check this PR. 
If you have an urgent request or question please use the Flower Slack channel.
The Slack channel is really active and contributors respond pretty fast. 

We value your contribution and are aware of the time you put into this PR.
Therefore, thank you for your contribution. 
-->