### PR TITLE
Removing deprecated `get_resource_ids()

### DIFF
--- a/baselines/flwr_baselines/publications/adaptive_federated_optimization/cifar/client.py
+++ b/baselines/flwr_baselines/publications/adaptive_federated_optimization/cifar/client.py
@@ -71,15 +71,12 @@ class RayClient(fl.client.NumPyClient):
         """
         net = self.set_parameters(parameters)
         net.to(self.device)
-        num_workers = len(ray.worker.get_resource_ids()["CPU"])
         trainset = ClientDataset(
             path_to_data=Path(self.fed_dir) / f"{self.cid}" / "train.pt",
             transform=get_transforms(self.num_classes)["train"],
         )
 
-        trainloader = DataLoader(
-            trainset, batch_size=int(config["batch_size"]), num_workers=num_workers
-        )
+        trainloader = DataLoader(trainset, batch_size=int(config["batch_size"]))
         # train
         train(net, trainloader, epochs=int(config["epochs"]), device=self.device)
 
@@ -103,12 +100,11 @@ class RayClient(fl.client.NumPyClient):
         """
         net = self.set_parameters(parameters)
         # load data for this client and get trainloader
-        num_workers = len(ray.worker.get_resource_ids()["CPU"])
         validationset = ClientDataset(
             path_to_data=Path(self.fed_dir) / self.cid / "test.pt",
             transform=get_transforms()["test"],
         )
-        valloader = DataLoader(validationset, batch_size=50, num_workers=num_workers)
+        valloader = DataLoader(validationset, batch_size=50)
 
         # send model to device
         net.to(self.device)

--- a/baselines/flwr_baselines/publications/adaptive_federated_optimization/cifar/client.py
+++ b/baselines/flwr_baselines/publications/adaptive_federated_optimization/cifar/client.py
@@ -5,7 +5,6 @@ from typing import Callable, Dict, Tuple
 
 import flwr as fl
 import numpy as np
-import ray
 import torch
 from flwr.common.typing import Scalar, Weights
 from torch.utils.data import DataLoader

--- a/src/py/flwr/simulation/ray_transport/ray_client_proxy.py
+++ b/src/py/flwr/simulation/ray_transport/ray_client_proxy.py
@@ -84,7 +84,7 @@ class RayClientProxy(ClientProxy):
         return common.Disconnect(reason="")  # Nothing to do here (yet)
 
 
-@ray.remote  # type: ignore
+@ray.remote
 def launch_and_get_properties(
     client_fn: ClientFn, cid: str, properties_ins: common.PropertiesIns
 ) -> common.PropertiesRes:
@@ -93,14 +93,14 @@ def launch_and_get_properties(
     return client.get_properties(properties_ins)
 
 
-@ray.remote  # type: ignore
+@ray.remote
 def launch_and_get_parameters(client_fn: ClientFn, cid: str) -> common.ParametersRes:
     """Exectue get_parameters remotely."""
     client: Client = _create_client(client_fn, cid)
     return client.get_parameters()
 
 
-@ray.remote  # type: ignore
+@ray.remote
 def launch_and_fit(
     client_fn: ClientFn, cid: str, fit_ins: common.FitIns
 ) -> common.FitRes:
@@ -109,7 +109,7 @@ def launch_and_fit(
     return client.fit(fit_ins)
 
 
-@ray.remote  # type: ignore
+@ray.remote
 def launch_and_evaluate(
     client_fn: ClientFn, cid: str, evaluate_ins: common.EvaluateIns
 ) -> common.EvaluateRes:

--- a/src/py/flwr/simulation/ray_transport/ray_client_proxy.py
+++ b/src/py/flwr/simulation/ray_transport/ray_client_proxy.py
@@ -37,8 +37,8 @@ class RayClientProxy(ClientProxy):
 
     def get_properties(self, ins: common.PropertiesIns) -> common.PropertiesRes:
         """Returns client's properties."""
-        future_properties_res = launch_and_get_properties.options(
-            **self.resources
+        future_properties_res = launch_and_get_properties.options(  # type: ignore
+            **self.resources,
         ).remote(self.client_fn, self.cid, ins)
         res = ray.worker.get(future_properties_res)
         return cast(
@@ -48,8 +48,8 @@ class RayClientProxy(ClientProxy):
 
     def get_parameters(self) -> common.ParametersRes:
         """Return the current local model parameters."""
-        future_paramseters_res = launch_and_get_parameters.options(
-            **self.resources
+        future_paramseters_res = launch_and_get_parameters.options(  # type: ignore
+            **self.resources,
         ).remote(self.client_fn, self.cid)
         res = ray.worker.get(future_paramseters_res)
         return cast(
@@ -59,9 +59,9 @@ class RayClientProxy(ClientProxy):
 
     def fit(self, ins: common.FitIns) -> common.FitRes:
         """Train model parameters on the locally held dataset."""
-        future_fit_res = launch_and_fit.options(**self.resources).remote(
-            self.client_fn, self.cid, ins
-        )
+        future_fit_res = launch_and_fit.options(  # type: ignore
+            **self.resources,
+        ).remote(self.client_fn, self.cid, ins)
         res = ray.worker.get(future_fit_res)
         return cast(
             common.FitRes,
@@ -70,9 +70,9 @@ class RayClientProxy(ClientProxy):
 
     def evaluate(self, ins: common.EvaluateIns) -> common.EvaluateRes:
         """Evaluate model parameters on the locally held dataset."""
-        future_evaluate_res = launch_and_evaluate.options(**self.resources).remote(
-            self.client_fn, self.cid, ins
-        )
+        future_evaluate_res = launch_and_evaluate.options(  # type: ignore
+            **self.resources,
+        ).remote(self.client_fn, self.cid, ins)
         res = ray.worker.get(future_evaluate_res)
         return cast(
             common.EvaluateRes,


### PR DESCRIPTION
`get_resource_ids()` is deprecated https://docs.ray.io/en/latest/_modules/ray/worker.html

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved.
-->

#### What does this implement/fix? Explain your changes.

<!--
Explain why this PR is needed and what kind of changes have you done.
Example: the variable rnd was not clear and therefore renamed to fl_round. 
-->

#### Any other comments?


<!--
Please be aware that it may take some time until we can check this PR. 
If you have an urgent request or question please use the Flower Slack channel.
The Slack channel is really active and contributors respond pretty fast. 

We value your contribution and are aware of the time you put into this PR.
Therefore, thank you for your contribution. 
-->