### PR TITLE
Taking care of get_properties() by catching an AttributeError.

### DIFF
--- a/src/py/flwr/client/app.py
+++ b/src/py/flwr/client/app.py
@@ -26,7 +26,6 @@ from .client import Client
 from .grpc_client.connection import grpc_connection
 from .grpc_client.message_handler import handle
 from .numpy_client import NumPyClient, NumPyClientWrapper
-from .numpy_client import has_get_properties as numpyclient_has_get_properties
 
 
 def start_client(
@@ -159,13 +158,6 @@ def start_numpy_client(
 
     # Wrap the NumPyClient
     flower_client = NumPyClientWrapper(client)
-
-    # Delete get_properties method from NumPyClientWrapper if the user-provided
-    # NumPyClient instance does not implement get_properties. This enables the
-    # following call to start_client to handle NumPyClientWrapper instances like any
-    # other Client instance (which might or might not implement get_properties).
-    if not numpyclient_has_get_properties(client=client):
-        del NumPyClientWrapper.get_properties
 
     # Start
     start_client(

--- a/src/py/flwr/client/client.py
+++ b/src/py/flwr/client/client.py
@@ -45,6 +45,7 @@ class Client(ABC):
         PropertiesRes
             Client's properties.
         """
+        raise AttributeError(f'\'{self.__class__.__name__}\' object has no attribute \'get_properties\'')
 
     @abstractmethod
     def get_parameters(self) -> ParametersRes:
@@ -92,8 +93,3 @@ class Client(ABC):
             other details such as the number of local data examples used for
             evaluation.
         """
-
-
-def has_get_properties(client: Client) -> bool:
-    """Check if Client implements get_properties."""
-    return type(client).get_properties != Client.get_properties

--- a/src/py/flwr/client/client_test.py
+++ b/src/py/flwr/client/client_test.py
@@ -27,7 +27,7 @@ from flwr.common import (
     Status,
 )
 
-from .client import Client, has_get_properties
+from .client import Client
 
 
 class OverridingClient(Client):
@@ -71,23 +71,27 @@ def test_has_get_properties_true() -> None:
     """Test fit_clients."""
     # Prepare
     client = OverridingClient()
-    expected = True
 
     # Execute
-    actual = has_get_properties(client=client)
-
-    # Assert
-    assert actual == expected
+    try:
+        client.get_properties(PropertiesIns(config={}))
+    except AttributeError:
+        assert False
+    else:
+        assert True
 
 
 def test_has_get_properties_false() -> None:
     """Test fit_clients."""
     # Prepare
     client = NotOverridingClient()
-    expected = False
 
     # Execute
-    actual = has_get_properties(client=client)
+    try:
+        client.get_properties(PropertiesIns(config={}))
+    except AttributeError:
+        assert True
+    else:
+        assert False
 
-    # Assert
-    assert actual == expected
+

--- a/src/py/flwr/client/numpy_client.py
+++ b/src/py/flwr/client/numpy_client.py
@@ -86,6 +86,7 @@ class NumPyClient(ABC):
             bool, bytes, float, int, or str. It can be used to communicate
             arbitrary property values back to the server.
         """
+        raise AttributeError(f'\'{self.__class__.__name__}\' object has no attribute \'get_properties\'')
 
     @abstractmethod
     def get_parameters(self) -> List[np.ndarray]:
@@ -158,11 +159,6 @@ class NumPyClient(ABC):
         extended format (int, float, float, Dict[str, Scalar]) have been
         deprecated and removed since Flower 0.19.
         """
-
-
-def has_get_properties(client: NumPyClient) -> bool:
-    """Check if NumPyClient implements get_properties."""
-    return type(client).get_properties != NumPyClient.get_properties
 
 
 class NumPyClientWrapper(Client):

--- a/src/py/flwr/client/numpy_client_test.py
+++ b/src/py/flwr/client/numpy_client_test.py
@@ -21,14 +21,14 @@ import numpy as np
 
 from flwr.common import Config, Properties, Scalar
 
-from .numpy_client import NumPyClient, has_get_properties
+from .numpy_client import NumPyClient
 
 
 class OverridingClient(NumPyClient):
     """Client overriding `get_properties`."""
 
     def get_properties(self, config: Config) -> Properties:
-        return Properties()
+        return {}
 
     def get_parameters(self) -> List[np.ndarray]:
         # This method is not expected to be called
@@ -71,23 +71,26 @@ def test_has_get_properties_true() -> None:
     """Test fit_clients."""
     # Prepare
     client = OverridingClient()
-    expected = True
 
     # Execute
-    actual = has_get_properties(client=client)
-
-    # Assert
-    assert actual == expected
+    try:
+        client.get_properties({})
+    except AttributeError:
+        assert False
+    else:
+        assert True
 
 
 def test_has_get_properties_false() -> None:
     """Test fit_clients."""
     # Prepare
     client = NotOverridingClient()
-    expected = False
 
     # Execute
-    actual = has_get_properties(client=client)
+    try:
+        client.get_properties({})
+    except AttributeError:
+        assert True
+    else:
+        assert False
 
-    # Assert
-    assert actual == expected


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs

This is meant to address #1113.

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved.
-->

#### What does this implement/fix? Explain your changes.

It is an improved attempt at dealing with the issue appropriately dealing with `get_properties` not being defined by a user implementation of `Client` or `NumPyClient`. In essence, the default implementation raises an `AttributeError`, which is caught and an appropriate response sent to the server.

<!--
Explain why this PR is needed and what kind of changes have you done.
Example: the variable rnd was not clear and therefore renamed to fl_round. 
-->

#### Any other comments?

This should allow a user to run multiple `Client`s in the same python process.

<!--
Please be aware that it may take some time until we can check this PR. 
If you have an urgent request or question please use the Flower Slack channel.
The Slack channel is really active and contributors respond pretty fast. 

We value your contribution and are aware of the time you put into this PR.
Therefore, thank you for your contribution. 
-->