### PR TITLE
Fix an error in the quickstart_pytorch example on GPU.

### DIFF
--- a/examples/quickstart_pytorch/client.py
+++ b/examples/quickstart_pytorch/client.py
@@ -37,7 +37,8 @@ def test(net, testloader):
     with torch.no_grad():
         for images, labels in tqdm(testloader):
             outputs = net(images.to(DEVICE))
-            loss += criterion(outputs, labels.to(DEVICE)).item()
+            labels = labels.to(DEVICE)
+            loss += criterion(outputs, labels).item()
             total += labels.size(0)
             correct += (torch.max(outputs.data, 1)[1] == labels).sum().item()
     return loss / len(testloader.dataset), correct / total


### PR DESCRIPTION
Fix a problem where the label tensor was not properly converted to a CUDA tensor leading to an error.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved.
-->

#### What does this implement/fix? Explain your changes.

Running the `quickstart_pytorch/run.sh` with a CUDA-enabled GPU yields to an exception 

```
[...]
  File "/examples/quickstart_pytorch/client.py", line 42, in test
    correct += (torch.max(outputs.data, 1)[1] == labels).sum().item()
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!
```
This is due to `labels` not being on the CUDA device. This PR fixes this issue.

    

<!--
Explain why this PR is needed and what kind of changes have you done.
Example: the variable rnd was not clear and therefore renamed to fl_round. 
-->


<!--
Please be aware that it may take some time until we can check this PR. 
If you have an urgent request or question please use the Flower Slack channel.
The Slack channel is really active and contributors respond pretty fast. 

We value your contribution and are aware of the time you put into this PR.
Therefore, thank you for your contribution. 
-->