### PR TITLE
Enable metric aggregation through user-provided functions

### DIFF
--- a/src/py/flwr/server/strategy/fast_and_slow.py
+++ b/src/py/flwr/server/strategy/fast_and_slow.py
@@ -354,6 +354,8 @@ class FastAndSlow(FedAvg):
                     num_examples_ceil,
                 )
                 self.durations.append(cid_duration)
+        
+        # FIXME use metrics aggregation fn
 
         return weights_to_parameters(weights_prime), {}
 
@@ -372,6 +374,8 @@ class FastAndSlow(FedAvg):
         if completion_rate < self.min_completion_rate_evaluate:
             # Not enough results for aggregation
             return None, {}
+
+        # FIXME use metrics aggregation fn
 
         return (
             weighted_loss_avg(

--- a/src/py/flwr/server/strategy/fault_tolerant_fedavg.py
+++ b/src/py/flwr/server/strategy/fault_tolerant_fedavg.py
@@ -84,11 +84,15 @@ class FaultTolerantFedAvg(FedAvg):
         if completion_rate < self.completion_rate_fit:
             # Not enough results for aggregation
             return None, {}
+        
         # Convert results
         weights_results = [
             (parameters_to_weights(fit_res.parameters), fit_res.num_examples)
             for client, fit_res in results
         ]
+
+        # FIXME use metrics aggregation fn
+
         return weights_to_parameters(aggregate(weights_results)), {}
 
     def aggregate_evaluate(
@@ -105,6 +109,9 @@ class FaultTolerantFedAvg(FedAvg):
         if completion_rate < self.completion_rate_evaluate:
             # Not enough results for aggregation
             return None, {}
+
+        # FIXME use metrics aggregation fn
+        
         return (
             weighted_loss_avg(
                 [

--- a/src/py/flwr/server/strategy/fedadagrad.py
+++ b/src/py/flwr/server/strategy/fedadagrad.py
@@ -108,6 +108,7 @@ class FedAdagrad(FedOpt):
             beta_1=0.0,
             beta_2=0.0,
             tau=tau,
+            # FIXME use metrics aggregation fn
         )
 
     def __repr__(self) -> str:

--- a/src/py/flwr/server/strategy/fedadam.py
+++ b/src/py/flwr/server/strategy/fedadam.py
@@ -112,6 +112,7 @@ class FedAdam(FedOpt):
             beta_1=beta_1,
             beta_2=beta_2,
             tau=tau,
+            # FIXME use metrics aggregation fn
         )
 
     def __repr__(self) -> str:

--- a/src/py/flwr/server/strategy/fedavgm.py
+++ b/src/py/flwr/server/strategy/fedavgm.py
@@ -191,4 +191,6 @@ class FedAvgM(FedAvg):
             # Update current weights
             self.initial_parameters = weights_to_parameters(fedavg_result)
 
+        # FIXME use metrics aggregation fn
+        
         return weights_to_parameters(fedavg_result), {}

--- a/src/py/flwr/server/strategy/fedfs_v0.py
+++ b/src/py/flwr/server/strategy/fedfs_v0.py
@@ -204,6 +204,8 @@ class FedFSv0(FedAvg):
                 self.contributions[cid] = []
             self.contributions[cid].append(contribution)
 
+        # FIXME use metrics aggregation fn
+
         return weights_to_parameters(weights_prime), {}
 
     def aggregate_evaluate(
@@ -222,6 +224,8 @@ class FedFSv0(FedAvg):
             # Not enough results for aggregation
             return None, {}
 
+        # FIXME use metrics aggregation fn
+        
         return (
             weighted_loss_avg(
                 [

--- a/src/py/flwr/server/strategy/fedfs_v1.py
+++ b/src/py/flwr/server/strategy/fedfs_v1.py
@@ -296,6 +296,8 @@ class FedFSv1(FedAvg):
             )
             self.durations.append(cid_duration)
 
+        # FIXME use metrics aggregation fn
+
         return weights_to_parameters(weights_prime), {}
 
     def aggregate_evaluate(
@@ -314,6 +316,8 @@ class FedFSv1(FedAvg):
             # Not enough results for aggregation
             return None, {}
 
+        # FIXME use metrics aggregation fn
+        
         return (
             weighted_loss_avg(
                 [

--- a/src/py/flwr/server/strategy/fedyogi.py
+++ b/src/py/flwr/server/strategy/fedyogi.py
@@ -112,6 +112,7 @@ class FedYogi(FedOpt):
             beta_1=beta_1,
             beta_2=beta_2,
             tau=tau,
+            # FIXME use metrics aggregation fn
         )
 
     def __repr__(self) -> str:

--- a/src/py/flwr/server/strategy/qfedavg.py
+++ b/src/py/flwr/server/strategy/qfedavg.py
@@ -210,6 +210,9 @@ class QFedAvg(FedAvg):
             )
 
         weights_aggregated: Weights = aggregate_qffl(weights_before, deltas, hs_ffl)
+
+        # FIXME use metrics aggregation fn
+
         return weights_to_parameters(weights_aggregated), {}
 
     def aggregate_evaluate(
@@ -224,6 +227,9 @@ class QFedAvg(FedAvg):
         # Do not aggregate if there are failures and failures are not accepted
         if not self.accept_failures and failures:
             return None, {}
+
+        # FIXME use metrics aggregation fn
+        
         return (
             weighted_loss_avg(
                 [


### PR DESCRIPTION
This PR enables users to customize metric aggregation in built-in strategies. This prevents users from having to customize the strategy just to customize the aggregation of metrics dicts.

Currently, users have to do this:

<img width="717" alt="image" src="https://user-images.githubusercontent.com/1245515/159764622-da450d50-ef93-444e-96f8-a4b64166878f.png">

With this PR, users can instead do this:

<img width="583" alt="image" src="https://user-images.githubusercontent.com/1245515/159764751-eacd0af3-81d7-4a2f-8045-33716dd9fad8.png">
