### PR TITLE
Fix docs on mobile / switch to Furo theme

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -48,6 +48,7 @@ extensions = [
     "sphinx.ext.mathjax",
     "sphinx.ext.viewcode",
     "sphinx.ext.graphviz",
+    "sphinx_copybutton",
     "sphinx_panels",
     "sphinxcontrib.mermaid",
 ]
@@ -66,22 +67,30 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = "sphinx_book_theme"
+html_theme = "furo"
 html_title = f"Flower {release}"
 html_logo = "_static/flower-logo.png"
 html_favicon = "_static/favicon.ico"
 html_baseurl = "https://flower.dev/docs/"
 
-# https://sphinx-book-theme.readthedocs.io/en/latest/configure.html
 html_theme_options = {
-    # GitHub
-    "repository_url": "https://github.com/adap/flower",
-    "repository_branch": "main",
-    "path_to_docs": "doc/source/",
-    "home_page_in_toc": True,
-    "use_repository_button": True,
-    "use_issues_button": True,
-    "use_edit_page_button": True,
+    # Sphinx Book Theme
+    # https://sphinx-book-theme.readthedocs.io/en/latest/configure.html
+    # "repository_url": "https://github.com/adap/flower",
+    # "repository_branch": "main",
+    # "path_to_docs": "doc/source/",
+    # "home_page_in_toc": True,
+    # "use_repository_button": True,
+    # "use_issues_button": True,
+    # "use_edit_page_button": True,
+
+    # Furo
+    # https://pradyunsg.me/furo/customisation/
+    "light_css_variables": {
+        "color-brand-primary": "#292F36",
+        "color-brand-content": "#F2B705",
+    },
+    "announcement": "Flower Summit 2022 <a href=\"https://flower.dev/conf/flower-summit-2022/\">register now</a>",
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -86,10 +86,11 @@ html_theme_options = {
 
     # Furo
     # https://pradyunsg.me/furo/customisation/
-    "light_css_variables": {
-        "color-brand-primary": "#292F36",
-        "color-brand-content": "#F2B705",
-    },
+    # "light_css_variables": {
+    #     "color-brand-primary": "#292F36",
+    #     "color-brand-content": "#292F36",  
+    #     "color-admonition-background": "#F2B705",
+    # },
     "announcement": "Flower Summit 2022 <a href=\"https://flower.dev/conf/flower-summit-2022/\">register now</a>",
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,9 +73,10 @@ mypy-protobuf = "==3.2.0"
 rope = "==0.19.0"
 semver = "==2.13.0"
 sphinx = "==4.4.0"
-sphinx-book-theme = "==0.2.0"
+sphinx-copybutton = "==0.5.0"
 sphinx-panels = "==0.6.0"
 sphinxcontrib-mermaid = "==0.7.1"
+furo = "==2022.3.4"
 
 [tool.isort]
 line_length = 88


### PR DESCRIPTION
The current docs are broken on mobile (sidebar nav cannot be closed):

<img width="450" alt="image" src="https://user-images.githubusercontent.com/1245515/161657814-1191098f-ba59-45c5-a852-2880dd38643f.png">


This PR fixes the docs on mobile devices by switching to the Furo theme:

<img width="450" alt="image" src="https://user-images.githubusercontent.com/1245515/161658775-96202c9c-5e84-47ec-911d-c155a7c4a7b0.png">


By switching to Furo, we can also add an announcement banner at the top of the page:

<img width="1581" alt="image" src="https://user-images.githubusercontent.com/1245515/161658945-8cca0923-5041-430f-8baa-9edd4a3ad8b8.png">


The last change is a copy button on code blocks:

<img width="750" alt="image" src="https://user-images.githubusercontent.com/1245515/161658074-d8b88713-c396-45d7-aeac-4bc72376b1eb.png">

