### PR TITLE
option to not shutdown ray if already initialised

### DIFF
--- a/src/py/flwr/simulation/app.py
+++ b/src/py/flwr/simulation/app.py
@@ -63,6 +63,7 @@ def start_simulation(  # pylint: disable=too-many-arguments
     num_rounds: int = 1,
     strategy: Optional[Strategy] = None,
     ray_init_args: Optional[Dict[str, Any]] = None,
+    keep_initialised: Optional[bool] = False,
 ) -> History:
     """Start a Ray-based Flower simulation server.
 
@@ -108,6 +109,8 @@ def start_simulation(  # pylint: disable=too-many-arguments
 
         An empty dictionary can be used (ray_init_args={}) to prevent any
         arguments from being passed to ray.init.
+    keep_initialised: Optional[bool] (default: False)
+        Set to True to prevent `ray.shutdown()` in case `ray.is_initialized()=True`.
 
     Returns:
         hist: flwr.server.history.History. Object containing metrics from training.
@@ -135,8 +138,8 @@ def start_simulation(  # pylint: disable=too-many-arguments
             "include_dashboard": False,
         }
 
-    # Shut down Ray if it has already been initialized
-    if ray.is_initialized():
+    # Shut down Ray if it has already been initialized (unless asked not to)
+    if ray.is_initialized() and not keep_initialised:
         ray.shutdown()
 
     # Initialize Ray


### PR DESCRIPTION
This a short PR enabling the user to decide whether `start_simulation` should do `ray.shutdown()` if an existing Ray runtime is already initialized. In some settings, we might want to have Ray already running before calling `start_simulation` if, for example, some other tasks have to run first before FL.