### PR TITLE
Rename Weights to NDArrays and use it more consistently

### DIFF
--- a/src/py/flwr/client/app.py
+++ b/src/py/flwr/client/app.py
@@ -17,9 +17,7 @@
 
 import time
 from logging import INFO
-from typing import Callable, Dict, List, Optional, Union
-
-import numpy as np
+from typing import Callable, Dict, Optional, Union
 
 from flwr.common import (
     GRPC_MAX_MESSAGE_LENGTH,
@@ -37,6 +35,7 @@ from flwr.common.typing import (
     GetParametersRes,
     GetPropertiesIns,
     GetPropertiesRes,
+    NDArrays,
     Status,
 )
 
@@ -53,7 +52,7 @@ EXCEPTION_MESSAGE_WRONG_RETURN_TYPE_FIT = """
 NumPyClient.fit did not return a tuple with 3 elements.
 The returned values should have the following type signature:
 
-    Tuple[List[np.ndarray], int, Dict[str, Scalar]]
+    Tuple[NDArrays, int, Dict[str, Scalar]]
 
 Example
 -------
@@ -248,7 +247,7 @@ def _get_parameters(self: Client, ins: GetParametersIns) -> GetParametersRes:
 def _fit(self: Client, ins: FitIns) -> FitRes:
     """Refine the provided weights using the locally held dataset."""
     # Deconstruct FitIns
-    parameters: List[np.ndarray] = parameters_to_weights(ins.parameters)
+    parameters: NDArrays = parameters_to_weights(ins.parameters)
 
     # Train
     results = self.numpy_client.fit(parameters, ins.config)  # type: ignore
@@ -273,7 +272,7 @@ def _fit(self: Client, ins: FitIns) -> FitRes:
 
 def _evaluate(self: Client, ins: EvaluateIns) -> EvaluateRes:
     """Evaluate the provided parameters using the locally held dataset."""
-    parameters: List[np.ndarray] = parameters_to_weights(ins.parameters)
+    parameters: NDArrays = parameters_to_weights(ins.parameters)
 
     results = self.numpy_client.evaluate(parameters, ins.config)  # type: ignore
     if not (

--- a/src/py/flwr/client/app_test.py
+++ b/src/py/flwr/client/app_test.py
@@ -15,9 +15,7 @@
 """Flower Client app tests."""
 
 
-from typing import Dict, List, Tuple
-
-import numpy as np
+from typing import Dict, Tuple
 
 from flwr.common import (
     Config,
@@ -29,6 +27,7 @@ from flwr.common import (
     GetParametersRes,
     GetPropertiesIns,
     GetPropertiesRes,
+    NDArrays,
     Scalar,
 )
 
@@ -64,18 +63,18 @@ class NeedsWrappingClient(NumPyClient):
         # This method is not expected to be called
         raise Exception()
 
-    def get_parameters(self, config: Config) -> List[np.ndarray]:
+    def get_parameters(self, config: Config) -> NDArrays:
         # This method is not expected to be called
         raise Exception()
 
     def fit(
-        self, parameters: List[np.ndarray], config: Config
-    ) -> Tuple[List[np.ndarray], int, Dict[str, Scalar]]:
+        self, parameters: NDArrays, config: Config
+    ) -> Tuple[NDArrays, int, Dict[str, Scalar]]:
         # This method is not expected to be called
         raise Exception()
 
     def evaluate(
-        self, parameters: List[np.ndarray], config: Config
+        self, parameters: NDArrays, config: Config
     ) -> Tuple[float, int, Dict[str, Scalar]]:
         # This method is not expected to be called
         raise Exception()

--- a/src/py/flwr/client/numpy_client.py
+++ b/src/py/flwr/client/numpy_client.py
@@ -16,11 +16,9 @@
 
 
 from abc import ABC
-from typing import Dict, List, Tuple
+from typing import Dict, Tuple
 
-import numpy as np
-
-from flwr.common import Config, Scalar
+from flwr.common import Config, NDArrays, Scalar
 
 
 class NumPyClient(ABC):
@@ -44,7 +42,7 @@ class NumPyClient(ABC):
             arbitrary property values back to the server.
         """
 
-    def get_parameters(self, config: Dict[str, Scalar]) -> List[np.ndarray]:
+    def get_parameters(self, config: Dict[str, Scalar]) -> NDArrays:
         """Return the current local model parameters.
 
         Parameters
@@ -56,18 +54,18 @@ class NumPyClient(ABC):
 
         Returns
         -------
-        parameters : List[numpy.ndarray]
+        parameters : NDArrays
             The local model parameters as a list of NumPy ndarrays.
         """
 
     def fit(
-        self, parameters: List[np.ndarray], config: Dict[str, Scalar]
-    ) -> Tuple[List[np.ndarray], int, Dict[str, Scalar]]:
+        self, parameters: NDArrays, config: Dict[str, Scalar]
+    ) -> Tuple[NDArrays, int, Dict[str, Scalar]]:
         """Train the provided parameters using the locally held dataset.
 
         Parameters
         ----------
-        parameters : List[numpy.ndarray]
+        parameters : NDArrays
             The current (global) model parameters.
         config : Dict[str, Scalar]
             Configuration parameters which allow the
@@ -77,7 +75,7 @@ class NumPyClient(ABC):
 
         Returns
         -------
-        parameters : List[numpy.ndarray]
+        parameters : NDArrays
             The locally updated model parameters.
         num_examples : int
             The number of examples used for training.
@@ -88,13 +86,13 @@ class NumPyClient(ABC):
         """
 
     def evaluate(
-        self, parameters: List[np.ndarray], config: Dict[str, Scalar]
+        self, parameters: NDArrays, config: Dict[str, Scalar]
     ) -> Tuple[float, int, Dict[str, Scalar]]:
-        """Evaluate the provided weights using the locally held dataset.
+        """Evaluate the provided parameters using the locally held dataset.
 
         Parameters
         ----------
-        parameters : List[np.ndarray]
+        parameters : NDArrays
             The current (global) model parameters.
         config : Dict[str, Scalar]
             Configuration parameters which allow the server to influence

--- a/src/py/flwr/client/numpy_client_test.py
+++ b/src/py/flwr/client/numpy_client_test.py
@@ -15,11 +15,9 @@
 """Flower NumPyClient tests."""
 
 
-from typing import Dict, List, Tuple
+from typing import Dict, Tuple
 
-import numpy as np
-
-from flwr.common import Config, Properties, Scalar
+from flwr.common import Config, NDArrays, Properties, Scalar
 
 from .numpy_client import (
     NumPyClient,
@@ -36,16 +34,16 @@ class OverridingClient(NumPyClient):
     def get_properties(self, config: Config) -> Properties:
         return Properties()
 
-    def get_parameters(self, config: Config) -> List[np.ndarray]:
+    def get_parameters(self, config: Config) -> NDArrays:
         return []
 
     def fit(
-        self, parameters: List[np.ndarray], config: Dict[str, Scalar]
-    ) -> Tuple[List[np.ndarray], int, Dict[str, Scalar]]:
+        self, parameters: NDArrays, config: Dict[str, Scalar]
+    ) -> Tuple[NDArrays, int, Dict[str, Scalar]]:
         return [], 0, {}
 
     def evaluate(
-        self, parameters: List[np.ndarray], config: Dict[str, Scalar]
+        self, parameters: NDArrays, config: Dict[str, Scalar]
     ) -> Tuple[float, int, Dict[str, Scalar]]:
         return 0.0, 0, {}
 

--- a/src/py/flwr/common/__init__.py
+++ b/src/py/flwr/common/__init__.py
@@ -32,12 +32,12 @@ from .typing import GetPropertiesIns as GetPropertiesIns
 from .typing import GetPropertiesRes as GetPropertiesRes
 from .typing import Metrics as Metrics
 from .typing import MetricsAggregationFn as MetricsAggregationFn
+from .typing import NDArrays as NDArrays
 from .typing import Parameters as Parameters
 from .typing import Properties as Properties
 from .typing import ReconnectIns as ReconnectIns
 from .typing import Scalar as Scalar
 from .typing import Status as Status
-from .typing import Weights as Weights
 
 GRPC_MAX_MESSAGE_LENGTH: int = 536_870_912  # == 512 * 1024 * 1024
 
@@ -57,6 +57,7 @@ __all__ = [
     "GRPC_MAX_MESSAGE_LENGTH",
     "Metrics",
     "MetricsAggregationFn",
+    "NDArrays",
     "ndarray_to_bytes",
     "Parameters",
     "parameters_to_weights",
@@ -64,6 +65,5 @@ __all__ = [
     "ReconnectIns",
     "Scalar",
     "Status",
-    "Weights",
     "weights_to_parameters",
 ]

--- a/src/py/flwr/common/parameter.py
+++ b/src/py/flwr/common/parameter.py
@@ -20,16 +20,16 @@ from typing import cast
 
 import numpy as np
 
-from .typing import Parameters, Weights
+from .typing import NDArrays, Parameters
 
 
-def weights_to_parameters(weights: Weights) -> Parameters:
+def weights_to_parameters(weights: NDArrays) -> Parameters:
     """Convert NumPy weights to parameters object."""
     tensors = [ndarray_to_bytes(ndarray) for ndarray in weights]
     return Parameters(tensors=tensors, tensor_type="numpy.ndarray")
 
 
-def parameters_to_weights(parameters: Parameters) -> Weights:
+def parameters_to_weights(parameters: Parameters) -> NDArrays:
     """Convert parameters object to NumPy weights."""
     return [bytes_to_ndarray(tensor) for tensor in parameters.tensors]
 
@@ -49,6 +49,6 @@ def bytes_to_ndarray(tensor: bytes) -> np.ndarray:
     bytes_io = BytesIO(tensor)
     # WARNING: NEVER set allow_pickle to true.
     # Reason: loading pickled data can execute arbitrary code
-    # Source: https://numpy.org/doc/stable/reference/generated/numpy.save.html
+    # Source: https://numpy.org/doc/stable/reference/generated/numpy.load.html
     ndarray_deserialized = np.load(bytes_io, allow_pickle=False)
     return cast(np.ndarray, ndarray_deserialized)

--- a/src/py/flwr/common/parameter_test.py
+++ b/src/py/flwr/common/parameter_test.py
@@ -25,8 +25,7 @@ from .parameter import bytes_to_ndarray, ndarray_to_bytes
 
 
 def test_serialisation_deserialisation() -> None:
-    """Test if after serialization/deserialisation the np.ndarray is
-    identical."""
+    """Test if the np.ndarray is identical after (de-)serialization."""
     arr = np.array([[1, 2], [3, 4], [5, 6]])
 
     arr_serialized = ndarray_to_bytes(arr)

--- a/src/py/flwr/common/serde_test.py
+++ b/src/py/flwr/common/serde_test.py
@@ -29,8 +29,7 @@ from .serde import (
 
 
 def test_serialisation_deserialisation() -> None:
-    """Test if after serialization/deserialisation the np.ndarray is
-    identical."""
+    """Test if the np.ndarray is identical after (de-)serialization."""
 
     # Prepare
     scalars = [True, b"bytestr", 3.14, 9000, "Hello"]

--- a/src/py/flwr/common/typing.py
+++ b/src/py/flwr/common/typing.py
@@ -21,7 +21,7 @@ from typing import Callable, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 
-Weights = List[np.ndarray]
+NDArrays = List[np.ndarray]
 
 # The following union type contains Python types corresponding to ProtoBuf types that
 # ProtoBuf considers to be "Scalar Value Types", even though some of them arguably do

--- a/src/py/flwr/server/strategy/aggregate.py
+++ b/src/py/flwr/server/strategy/aggregate.py
@@ -20,10 +20,10 @@ from typing import List, Tuple
 
 import numpy as np
 
-from flwr.common import Weights
+from flwr.common import NDArrays
 
 
-def aggregate(results: List[Tuple[Weights, int]]) -> Weights:
+def aggregate(results: List[Tuple[NDArrays, int]]) -> NDArrays:
     """Compute weighted average."""
     # Calculate the total number of examples used during training
     num_examples_total = sum([num_examples for _, num_examples in results])
@@ -34,7 +34,7 @@ def aggregate(results: List[Tuple[Weights, int]]) -> Weights:
     ]
 
     # Compute average weights of each layer
-    weights_prime: Weights = [
+    weights_prime: NDArrays = [
         reduce(np.add, layer_updates) / num_examples_total
         for layer_updates in zip(*weighted_weights)
     ]
@@ -49,8 +49,8 @@ def weighted_loss_avg(results: List[Tuple[int, float]]) -> float:
 
 
 def aggregate_qffl(
-    weights: Weights, deltas: List[Weights], hs_fll: List[Weights]
-) -> Weights:
+    weights: NDArrays, deltas: List[NDArrays], hs_fll: List[NDArrays]
+) -> NDArrays:
     """Compute weighted average based on  Q-FFL paper."""
     demominator = np.sum(np.asarray(hs_fll))
     scaled_deltas = []

--- a/src/py/flwr/server/strategy/fault_tolerant_fedavg.py
+++ b/src/py/flwr/server/strategy/fault_tolerant_fedavg.py
@@ -22,9 +22,9 @@ from flwr.common import (
     EvaluateRes,
     FitRes,
     MetricsAggregationFn,
+    NDArrays,
     Parameters,
     Scalar,
-    Weights,
     parameters_to_weights,
     weights_to_parameters,
 )
@@ -47,7 +47,7 @@ class FaultTolerantFedAvg(FedAvg):
         min_eval_clients: int = 1,
         min_available_clients: int = 1,
         eval_fn: Optional[
-            Callable[[Weights], Optional[Tuple[float, Dict[str, Scalar]]]]
+            Callable[[NDArrays], Optional[Tuple[float, Dict[str, Scalar]]]]
         ] = None,
         on_fit_config_fn: Optional[Callable[[int], Dict[str, Scalar]]] = None,
         on_evaluate_config_fn: Optional[Callable[[int], Dict[str, Scalar]]] = None,

--- a/src/py/flwr/server/strategy/fault_tolerant_fedavg_test.py
+++ b/src/py/flwr/server/strategy/fault_tolerant_fedavg_test.py
@@ -22,9 +22,9 @@ from flwr.common import (
     Code,
     EvaluateRes,
     FitRes,
+    NDArrays,
     Parameters,
     Status,
-    Weights,
     parameters_to_weights,
 )
 from flwr.server.client_proxy import ClientProxy
@@ -103,7 +103,7 @@ def test_aggregate_fit_just_enough_results() -> None:
         )
     ]
     failures: List[BaseException] = [Exception()]
-    expected: Optional[Weights] = []
+    expected: Optional[NDArrays] = []
 
     # Execute
     actual, _ = strategy.aggregate_fit(1, results, failures)
@@ -129,7 +129,7 @@ def test_aggregate_fit_no_failures() -> None:
         )
     ]
     failures: List[BaseException] = []
-    expected: Optional[Weights] = []
+    expected: Optional[NDArrays] = []
 
     # Execute
     actual, _ = strategy.aggregate_fit(1, results, failures)

--- a/src/py/flwr/server/strategy/fedadagrad.py
+++ b/src/py/flwr/server/strategy/fedadagrad.py
@@ -26,9 +26,9 @@ import numpy as np
 from flwr.common import (
     FitRes,
     MetricsAggregationFn,
+    NDArrays,
     Parameters,
     Scalar,
-    Weights,
     parameters_to_weights,
     weights_to_parameters,
 )
@@ -55,7 +55,7 @@ class FedAdagrad(FedOpt):
         min_eval_clients: int = 2,
         min_available_clients: int = 2,
         eval_fn: Optional[
-            Callable[[Weights], Optional[Tuple[float, Dict[str, Scalar]]]]
+            Callable[[NDArrays], Optional[Tuple[float, Dict[str, Scalar]]]]
         ] = None,
         on_fit_config_fn: Optional[Callable[[int], Dict[str, Scalar]]] = None,
         on_evaluate_config_fn: Optional[Callable[[int], Dict[str, Scalar]]] = None,
@@ -82,7 +82,7 @@ class FedAdagrad(FedOpt):
                 during validation. Defaults to 2.
             min_available_clients (int, optional): Minimum number of total
                 clients in the system. Defaults to 2.
-            eval_fn (Callable[[Weights], Optional[Tuple[float, float]]], optional):
+            eval_fn (Callable[[NDArrays], Optional[Tuple[float, float]]], optional):
                 Function used for validation. Defaults to None.
             on_fit_config_fn (Callable[[int], Dict[str, str]], optional):
                 Function used to configure training. Defaults to None.

--- a/src/py/flwr/server/strategy/fedadagrad_test.py
+++ b/src/py/flwr/server/strategy/fedadagrad_test.py
@@ -23,9 +23,9 @@ from numpy import array, float32
 from flwr.common import (
     Code,
     FitRes,
+    NDArrays,
     Parameters,
     Status,
-    Weights,
     parameters_to_weights,
     weights_to_parameters,
 )
@@ -38,7 +38,7 @@ from .fedadagrad import FedAdagrad
 def test_aggregate_fit() -> None:
     """Tests if adagrad function is aggregating correctly."""
     # Prepare
-    previous_weights: Weights = [array([0.1, 0.1, 0.1, 0.1], dtype=float32)]
+    previous_weights: NDArrays = [array([0.1, 0.1, 0.1, 0.1], dtype=float32)]
     strategy = FedAdagrad(
         eta=0.1,
         eta_l=0.316,
@@ -74,7 +74,7 @@ def test_aggregate_fit() -> None:
             ),
         ),
     ]
-    expected: Weights = [array([0.15, 0.15, 0.15, 0.15], dtype=float32)]
+    expected: NDArrays = [array([0.15, 0.15, 0.15, 0.15], dtype=float32)]
 
     # Execute
     actual_aggregated, _ = strategy.aggregate_fit(rnd=1, results=results, failures=[])

--- a/src/py/flwr/server/strategy/fedadam.py
+++ b/src/py/flwr/server/strategy/fedadam.py
@@ -26,9 +26,9 @@ import numpy as np
 from flwr.common import (
     FitRes,
     MetricsAggregationFn,
+    NDArrays,
     Parameters,
     Scalar,
-    Weights,
     parameters_to_weights,
     weights_to_parameters,
 )
@@ -54,7 +54,7 @@ class FedAdam(FedOpt):
         min_eval_clients: int = 2,
         min_available_clients: int = 2,
         eval_fn: Optional[
-            Callable[[Weights], Optional[Tuple[float, Dict[str, Scalar]]]]
+            Callable[[NDArrays], Optional[Tuple[float, Dict[str, Scalar]]]]
         ] = None,
         on_fit_config_fn: Optional[Callable[[int], Dict[str, Scalar]]] = None,
         on_evaluate_config_fn: Optional[Callable[[int], Dict[str, Scalar]]] = None,
@@ -83,7 +83,7 @@ class FedAdam(FedOpt):
                 during validation. Defaults to 2.
             min_available_clients (int, optional): Minimum number of total
                 clients in the system. Defaults to 2.
-            eval_fn (Callable[[Weights], Optional[Tuple[float, float]]], optional):
+            eval_fn (Callable[[NDArrays], Optional[Tuple[float, float]]], optional):
                 Function used for validation. Defaults to None.
             on_fit_config_fn (Callable[[int], Dict[str, str]], optional):
                 Function used to configure training. Defaults to None.

--- a/src/py/flwr/server/strategy/fedavg.py
+++ b/src/py/flwr/server/strategy/fedavg.py
@@ -27,9 +27,9 @@ from flwr.common import (
     FitIns,
     FitRes,
     MetricsAggregationFn,
+    NDArrays,
     Parameters,
     Scalar,
-    Weights,
     parameters_to_weights,
     weights_to_parameters,
 )
@@ -60,7 +60,7 @@ class FedAvg(Strategy):
         min_eval_clients: int = 2,
         min_available_clients: int = 2,
         eval_fn: Optional[
-            Callable[[Weights], Optional[Tuple[float, Dict[str, Scalar]]]]
+            Callable[[NDArrays], Optional[Tuple[float, Dict[str, Scalar]]]]
         ] = None,
         on_fit_config_fn: Optional[Callable[[int], Dict[str, Scalar]]] = None,
         on_evaluate_config_fn: Optional[Callable[[int], Dict[str, Scalar]]] = None,
@@ -85,7 +85,7 @@ class FedAvg(Strategy):
             Minimum number of clients used during validation. Defaults to 2.
         min_available_clients : int, optional
             Minimum number of total clients in the system. Defaults to 2.
-        eval_fn : Callable[[Weights], Optional[Tuple[float, Dict[str, Scalar]]]]
+        eval_fn : Callable[[NDArrays], Optional[Tuple[float, Dict[str, Scalar]]]]
             Optional function used for validation. Defaults to None.
         on_fit_config_fn : Callable[[int], Dict[str, Scalar]], optional
             Function used to configure training. Defaults to None.

--- a/src/py/flwr/server/strategy/fedavg_android.py
+++ b/src/py/flwr/server/strategy/fedavg_android.py
@@ -28,9 +28,9 @@ from flwr.common import (
     EvaluateRes,
     FitIns,
     FitRes,
+    NDArrays,
     Parameters,
     Scalar,
-    Weights,
 )
 from flwr.server.client_manager import ClientManager
 from flwr.server.client_proxy import ClientProxy
@@ -51,7 +51,7 @@ class FedAvgAndroid(Strategy):
         min_eval_clients: int = 2,
         min_available_clients: int = 2,
         eval_fn: Optional[
-            Callable[[Weights], Optional[Tuple[float, Dict[str, Scalar]]]]
+            Callable[[NDArrays], Optional[Tuple[float, Dict[str, Scalar]]]]
         ] = None,
         on_fit_config_fn: Optional[Callable[[int], Dict[str, Scalar]]] = None,
         on_evaluate_config_fn: Optional[Callable[[int], Dict[str, Scalar]]] = None,
@@ -73,7 +73,7 @@ class FedAvgAndroid(Strategy):
                 during validation. Defaults to 2.
             min_available_clients (int, optional): Minimum number of total
                 clients in the system. Defaults to 2.
-            eval_fn : Callable[[Weights], Optional[Tuple[float, Dict[str, Scalar]]]]
+            eval_fn : Callable[[NDArrays], Optional[Tuple[float, Dict[str, Scalar]]]]
                 Optional function used for validation. Defaults to None.
             on_fit_config_fn (Callable[[int], Dict[str, Scalar]], optional):
                 Function used to configure training. Defaults to None.
@@ -221,12 +221,12 @@ class FedAvgAndroid(Strategy):
         )
         return loss_aggregated, {}
 
-    def weights_to_parameters(self, weights: Weights) -> Parameters:
+    def weights_to_parameters(self, weights: NDArrays) -> Parameters:
         """Convert NumPy weights to parameters object."""
         tensors = [self.ndarray_to_bytes(ndarray) for ndarray in weights]
         return Parameters(tensors=tensors, tensor_type="numpy.nda")
 
-    def parameters_to_weights(self, parameters: Parameters) -> Weights:
+    def parameters_to_weights(self, parameters: Parameters) -> NDArrays:
         """Convert parameters object to NumPy weights."""
         return [self.bytes_to_ndarray(tensor) for tensor in parameters.tensors]
 

--- a/src/py/flwr/server/strategy/fedavgm.py
+++ b/src/py/flwr/server/strategy/fedavgm.py
@@ -24,9 +24,9 @@ from typing import Callable, Dict, List, Optional, Tuple
 from flwr.common import (
     FitRes,
     MetricsAggregationFn,
+    NDArrays,
     Parameters,
     Scalar,
-    Weights,
     parameters_to_weights,
     weights_to_parameters,
 )
@@ -58,7 +58,7 @@ class FedAvgM(FedAvg):
         min_eval_clients: int = 2,
         min_available_clients: int = 2,
         eval_fn: Optional[
-            Callable[[Weights], Optional[Tuple[float, Dict[str, Scalar]]]]
+            Callable[[NDArrays], Optional[Tuple[float, Dict[str, Scalar]]]]
         ] = None,
         on_fit_config_fn: Optional[Callable[[int], Dict[str, Scalar]]] = None,
         on_evaluate_config_fn: Optional[Callable[[int], Dict[str, Scalar]]] = None,
@@ -85,7 +85,7 @@ class FedAvgM(FedAvg):
             Minimum number of clients used during validation. Defaults to 2.
         min_available_clients : int, optional
             Minimum number of total clients in the system. Defaults to 2.
-        eval_fn : Callable[[Weights], Optional[Tuple[float, Dict[str, Scalar]]]]
+        eval_fn : Callable[[NDArrays], Optional[Tuple[float, Dict[str, Scalar]]]]
             Optional function used for validation. Defaults to None.
         on_fit_config_fn : Callable[[int], Dict[str, Scalar]], optional
             Function used to configure training. Defaults to None.
@@ -127,7 +127,7 @@ class FedAvgM(FedAvg):
         self.server_opt: bool = (self.server_momentum != 0.0) or (
             self.server_learning_rate != 1.0
         )
-        self.momentum_vector: Optional[Weights] = None
+        self.momentum_vector: Optional[NDArrays] = None
         self.fit_metrics_aggregation_fn = fit_metrics_aggregation_fn
         self.evaluate_metrics_aggregation_fn = evaluate_metrics_aggregation_fn
 

--- a/src/py/flwr/server/strategy/fedavgm_test.py
+++ b/src/py/flwr/server/strategy/fedavgm_test.py
@@ -20,7 +20,7 @@ from unittest.mock import MagicMock
 from numpy import array, float32
 from numpy.testing import assert_almost_equal
 
-from flwr.common import Code, FitRes, Status, Weights, parameters_to_weights
+from flwr.common import Code, FitRes, NDArrays, Status, parameters_to_weights
 from flwr.common.parameter import weights_to_parameters
 from flwr.server.client_proxy import ClientProxy
 
@@ -35,7 +35,7 @@ def test_aggregate_fit_using_near_one_server_lr_and_no_momentum() -> None:
     weights1_0 = array([[1, 2, 3], [4, 5, 6]], dtype=float32)
     weights1_1 = array([7, 8, 9, 10], dtype=float32)
 
-    initial_weights: Weights = [
+    initial_weights: NDArrays = [
         array([[0, 0, 0], [0, 0, 0]], dtype=float32),
         array([0, 0, 0, 0], dtype=float32),
     ]
@@ -61,7 +61,7 @@ def test_aggregate_fit_using_near_one_server_lr_and_no_momentum() -> None:
         ),
     ]
     failures: List[BaseException] = []
-    expected: Weights = [
+    expected: NDArrays = [
         array([[1, 2, 3], [4, 5, 6]], dtype=float32),
         array([7, 8, 9, 10], dtype=float32),
     ]
@@ -88,7 +88,7 @@ def test_aggregate_fit_server_learning_rate_and_momentum() -> None:
     weights1_0 = array([[1, 2, 3], [4, 5, 6]], dtype=float32)
     weights1_1 = array([7, 8, 9, 10], dtype=float32)
 
-    initial_weights: Weights = [
+    initial_weights: NDArrays = [
         array([[0, 0, 0], [0, 0, 0]], dtype=float32),
         array([0, 0, 0, 0], dtype=float32),
     ]
@@ -114,7 +114,7 @@ def test_aggregate_fit_server_learning_rate_and_momentum() -> None:
         ),
     ]
     failures: List[BaseException] = []
-    expected: Weights = [
+    expected: NDArrays = [
         array([[1, 2, 3], [4, 5, 6]], dtype=float32),
         array([7, 8, 9, 10], dtype=float32),
     ]

--- a/src/py/flwr/server/strategy/fedopt.py
+++ b/src/py/flwr/server/strategy/fedopt.py
@@ -23,9 +23,9 @@ from typing import Callable, Dict, Optional, Tuple
 
 from flwr.common import (
     MetricsAggregationFn,
+    NDArrays,
     Parameters,
     Scalar,
-    Weights,
     parameters_to_weights,
 )
 
@@ -45,7 +45,7 @@ class FedOpt(FedAvg):
         min_eval_clients: int = 2,
         min_available_clients: int = 2,
         eval_fn: Optional[
-            Callable[[Weights], Optional[Tuple[float, Dict[str, Scalar]]]]
+            Callable[[NDArrays], Optional[Tuple[float, Dict[str, Scalar]]]]
         ] = None,
         on_fit_config_fn: Optional[Callable[[int], Dict[str, Scalar]]] = None,
         on_evaluate_config_fn: Optional[Callable[[int], Dict[str, Scalar]]] = None,
@@ -75,7 +75,7 @@ class FedOpt(FedAvg):
             during validation. Defaults to 2.
         min_available_clients (int, optional): Minimum number of total
             clients in the system. Defaults to 2.
-        eval_fn (Callable[[Weights], Optional[Tuple[float, float]]], optional):
+        eval_fn (Callable[[NDArrays], Optional[Tuple[float, float]]], optional):
             Function used for validation. Defaults to None.
         on_fit_config_fn (Callable[[int], Dict[str, str]], optional):
             Function used to configure training. Defaults to None.
@@ -115,8 +115,8 @@ class FedOpt(FedAvg):
         self.tau = tau
         self.beta_1 = beta_1
         self.beta_2 = beta_2
-        self.m_t: Optional[Weights] = None
-        self.v_t: Optional[Weights] = None
+        self.m_t: Optional[NDArrays] = None
+        self.v_t: Optional[NDArrays] = None
 
     def __repr__(self) -> str:
         rep = f"FedOpt(accept_failures={self.accept_failures})"

--- a/src/py/flwr/server/strategy/fedyogi.py
+++ b/src/py/flwr/server/strategy/fedyogi.py
@@ -26,9 +26,9 @@ import numpy as np
 from flwr.common import (
     FitRes,
     MetricsAggregationFn,
+    NDArrays,
     Parameters,
     Scalar,
-    Weights,
     parameters_to_weights,
     weights_to_parameters,
 )
@@ -54,7 +54,7 @@ class FedYogi(FedOpt):
         min_eval_clients: int = 2,
         min_available_clients: int = 2,
         eval_fn: Optional[
-            Callable[[Weights], Optional[Tuple[float, Dict[str, Scalar]]]]
+            Callable[[NDArrays], Optional[Tuple[float, Dict[str, Scalar]]]]
         ] = None,
         on_fit_config_fn: Optional[Callable[[int], Dict[str, Scalar]]] = None,
         on_evaluate_config_fn: Optional[Callable[[int], Dict[str, Scalar]]] = None,
@@ -83,7 +83,7 @@ class FedYogi(FedOpt):
                 during validation. Defaults to 2.
             min_available_clients (int, optional): Minimum number of total
                 clients in the system. Defaults to 2.
-            eval_fn (Callable[[Weights], Optional[Tuple[float, float]]], optional):
+            eval_fn (Callable[[NDArrays], Optional[Tuple[float, float]]], optional):
                 Function used for validation. Defaults to None.
             on_fit_config_fn (Callable[[int], Dict[str, str]], optional):
                 Function used to configure training. Defaults to None.

--- a/src/py/flwr/server/strategy/qfedavg.py
+++ b/src/py/flwr/server/strategy/qfedavg.py
@@ -29,9 +29,9 @@ from flwr.common import (
     FitIns,
     FitRes,
     MetricsAggregationFn,
+    NDArrays,
     Parameters,
     Scalar,
-    Weights,
     parameters_to_weights,
     weights_to_parameters,
 )
@@ -58,7 +58,7 @@ class QFedAvg(FedAvg):
         min_eval_clients: int = 1,
         min_available_clients: int = 1,
         eval_fn: Optional[
-            Callable[[Weights], Optional[Tuple[float, Dict[str, Scalar]]]]
+            Callable[[NDArrays], Optional[Tuple[float, Dict[str, Scalar]]]]
         ] = None,
         on_fit_config_fn: Optional[Callable[[int], Dict[str, Scalar]]] = None,
         on_evaluate_config_fn: Optional[Callable[[int], Dict[str, Scalar]]] = None,
@@ -92,7 +92,7 @@ class QFedAvg(FedAvg):
         self.accept_failures = accept_failures
         self.learning_rate = qffl_learning_rate
         self.q_param = q_param
-        self.pre_weights: Optional[Weights] = None
+        self.pre_weights: Optional[NDArrays] = None
         self.fit_metrics_aggregation_fn = fit_metrics_aggregation_fn
         self.evaluate_metrics_aggregation_fn = evaluate_metrics_aggregation_fn
 
@@ -177,7 +177,7 @@ class QFedAvg(FedAvg):
             return None, {}
         # Convert results
 
-        def norm_grad(grad_list: List[Weights]) -> float:
+        def norm_grad(grad_list: List[NDArrays]) -> float:
             # input: nested gradients
             # output: square of the L-2 norm
             client_grads = grad_list[0]
@@ -219,7 +219,7 @@ class QFedAvg(FedAvg):
                 * np.float_power(loss + 1e-10, self.q_param)
             )
 
-        weights_aggregated: Weights = aggregate_qffl(weights_before, deltas, hs_ffl)
+        weights_aggregated: NDArrays = aggregate_qffl(weights_before, deltas, hs_ffl)
         parameters_aggregated = weights_to_parameters(weights_aggregated)
 
         # Aggregate custom metrics if aggregation fn was provided


### PR DESCRIPTION
The PR
1. Renames `Weights` to `NDArrays`
2. Uses it more consistently (instead of mixing `Weights` and `List[np.ndarray` across the codebase)