### PR TITLE
Update `grpcio` dependency version to more current one

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ numpy = [
     { version = ">=1.19.0,<1.21.0", python = "<3.10"},
     { version = "^1.21", python = "^3.10"},
 ]
-grpcio = "^1.41.0"
+grpcio = "^1.43.0"
 protobuf = "^3.19.0"
 importlib-metadata = { version = "^4.0.0", markers = "python_version < '3.8'" }
 iterators = "^0.0.2"
@@ -75,7 +75,7 @@ flake8 = "==3.9.2"
 pytest = "==7.1.2"
 pytest-cov = "==3.0.0"
 pytest-watch = "==4.2.0"
-grpcio-tools = "==1.41.0"
+grpcio-tools = "==1.43.0"
 mypy-protobuf = "==3.2.0"
 jupyterlab = "==3.3.2"
 rope = "==0.19.0"


### PR DESCRIPTION
#### Reference Issues/PRs

* Work toward Flower 1.0

#### What does this implement/fix? Explain your changes.

Update the minimum required version of `grpcio` and `grpcio-tools` to 1.43.0 (latest would be 1.47.0)

#### Any other comments?

Unfortunately upgrading to the latest version of `grpio` is not possible due to a conflict with Ray.

See:
```shell
Updating dependencies
Resolving dependencies... (1.1s)

  SolverProblemError

  Because ray (1.13.0) depends on grpcio (>=1.28.1,<=1.43.0)
   and no versions of ray match >1.13.0,<1.14.0, ray (>=1.13.0,<1.14.0) requires grpcio (>=1.28.1,<=1.43.0).
  So, because flwr depends on both grpcio (^1.47.0) and ray (~1.13.0), version solving failed.
```
