### PR TITLE
Update sklearn example's server and client

### DIFF
--- a/examples/sklearn-logreg-mnist/client.py
+++ b/examples/sklearn-logreg-mnist/client.py
@@ -27,7 +27,7 @@ if __name__ == "__main__":
 
     # Define Flower client
     class MnistClient(fl.client.NumPyClient):
-        def get_parameters(self):  # type: ignore
+        def get_parameters(self, config):  # type: ignore
             return utils.get_model_parameters(model)
 
         def fit(self, parameters, config):  # type: ignore
@@ -46,4 +46,4 @@ if __name__ == "__main__":
             return loss, len(X_test), {"accuracy": accuracy}
 
     # Start Flower client
-    fl.client.start_numpy_client("0.0.0.0:8080", client=MnistClient())
+    fl.client.start_numpy_client(server_address="0.0.0.0:8080", client=MnistClient())

--- a/examples/sklearn-logreg-mnist/pyproject.toml
+++ b/examples/sklearn-logreg-mnist/pyproject.toml
@@ -15,7 +15,7 @@ authors = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-flwr = "^0.19.0"
+flwr = "^1.0.0"
 # flwr = { path = "../../", develop = true }  # Development
 scikit-learn = "^1.1.1"
 openml = "^0.12.2"

--- a/examples/sklearn-logreg-mnist/server.py
+++ b/examples/sklearn-logreg-mnist/server.py
@@ -17,7 +17,7 @@ def get_evaluate_fn(model: LogisticRegression):
     _, (X_test, y_test) = utils.load_mnist()
 
     # The `evaluate` function will be called after every round
-    def evaluate(parameters: fl.common.Weights):
+    def evaluate(server_round, parameters: fl.common.NDArrays, config):
         # Update model with the latest parameters
         utils.set_model_params(model, parameters)
         loss = log_loss(y_test, model.predict_proba(X_test))
@@ -39,5 +39,5 @@ if __name__ == "__main__":
     fl.server.start_server(
         server_address="0.0.0.0:8080",
         strategy=strategy,
-        config={"num_rounds": 5},
+        config=fl.server.ServerConfig(num_rounds=5),
     )


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md

Does the changelog need to be updated?
See: https://github.com/adap/flower/blob/main/doc/source/changelog.rst
-->

#### Reference Issues/PRs
Fixes #1346
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved.
-->

#### What does this implement/fix? Explain your changes.
Fixes both the server and the client implementations. 
Changes the evaluate_fn passed to built-in strategies like FedAvg to take the three parameters required by Flower 1.0.0.
Changes the naming of Weights to NDArrays.
Adds a configuration object of type flwr.server.ServerConfig in the start_server function, containing the num_rounds instead of the old config dictionary.

<!--
Explain why this PR is needed and what kind of changes have you done.
Example: the variable `rnd` could be interpreted as an abbreviation of *random*, to improve clarity it was renamed to `server_round`. 
-->

#### Any other comments?
I tested it with the run.sh script and it works now

<!--
Please be aware that it may take some time until we can check this PR. 
If you have an urgent request or question please use the Flower Slack channel.
The Slack channel is really active and contributors respond pretty fast. 

We value your contribution and are aware of the time you put into this PR.
Therefore, thank you for your contribution. 
-->
