### PR TITLE
simulation, add max_calls arg to ray.remote to avoid rayidle in gpus

### DIFF
--- a/src/py/flwr/simulation/ray_transport/ray_client_proxy.py
+++ b/src/py/flwr/simulation/ray_transport/ray_client_proxy.py
@@ -91,7 +91,7 @@ class RayClientProxy(ClientProxy):
         return common.DisconnectRes(reason="")  # Nothing to do here (yet)
 
 
-@ray.remote
+@ray.remote(max_calls=1)
 def launch_and_get_properties(
     client_fn: ClientFn, cid: str, get_properties_ins: common.GetPropertiesIns
 ) -> common.GetPropertiesRes:
@@ -100,7 +100,7 @@ def launch_and_get_properties(
     return client.get_properties(get_properties_ins)
 
 
-@ray.remote
+@ray.remote(max_calls=1)
 def launch_and_get_parameters(
     client_fn: ClientFn, cid: str, get_parameters_ins: common.GetParametersIns
 ) -> common.GetParametersRes:
@@ -109,7 +109,7 @@ def launch_and_get_parameters(
     return client.get_parameters(get_parameters_ins)
 
 
-@ray.remote
+@ray.remote(max_calls=1)
 def launch_and_fit(
     client_fn: ClientFn, cid: str, fit_ins: common.FitIns
 ) -> common.FitRes:
@@ -118,7 +118,7 @@ def launch_and_fit(
     return client.fit(fit_ins)
 
 
-@ray.remote
+@ray.remote(max_calls=1)
 def launch_and_evaluate(
     client_fn: ClientFn, cid: str, evaluate_ins: common.EvaluateIns
 ) -> common.EvaluateRes:


### PR DESCRIPTION
<!--
Thank you for opening a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md

Does the documentation need to be updated?
See: https://flower.dev/docs/writing-documentation.html

Does the changelog need to be updated?
See: https://github.com/adap/flower/blob/main/doc/source/changelog.rst
-->

#### Reference Issues/PRs
Fixes #1152 and #1376 
<!--
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved.

Example: Fixes #123. See also #456 and #789.
-->

#### What does this implement/fix? Explain your changes.
Issue: `@ray.remote` in [ray_client_proxy.py](https://github.com/adap/flower/blob/main/src/py/flwr/simulation/ray_transport/ray_client_proxy.py#L113) is repeatedly called when running simulation. By default, after each client finishes its training, the ray worker still rests in GPUs as `Ray::IDLE`. This accumulates and causes CUDA memory to run out. 

Change: By adding one argument `@ray.remote(max_calls=1)`, each ray worker will be removed after every client finishes.

<!--
Explain why this PR is needed and what kind of changes have you done.

Example: The variable `rnd` could be interpreted as an abbreviation of *random*, to improve clarity it was renamed to `server_round`.
-->

#### Any other comments?
None
<!--
Please be aware that it may take some time until the maintainers can review the PR.
If you have an urgent request or question please use the Flower Slack channel.
The Slack channel is really active and contributors respond pretty fast. 

We value your contribution and are aware of the time you put into this PR.
Therefore, thank you for your contribution. 
-->
