### PR TITLE
Log exceptions in VCE by default

### DIFF
--- a/doc/source/changelog.md
+++ b/doc/source/changelog.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- All Client exceptions happening in the VCE will now be logged by default and not just exposed through the strategies.
+
 ## v1.0.0 (2022-07-28)
 
 ### Highlights

--- a/src/py/flwr/simulation/ray_transport/ray_client_proxy.py
+++ b/src/py/flwr/simulation/ray_transport/ray_client_proxy.py
@@ -15,16 +15,15 @@
 """Ray-based Flower ClientProxy implementation."""
 
 
+from logging import DEBUG
 from typing import Callable, Dict, Optional, cast
 
 import ray
 
 from flwr import common
 from flwr.client import Client, ClientLike, to_client
-from flwr.server.client_proxy import ClientProxy
 from flwr.common.logger import log
-
-from logging import DEBUG
+from flwr.server.client_proxy import ClientProxy
 
 ClientFn = Callable[[str], ClientLike]
 

--- a/src/py/flwr/simulation/ray_transport/ray_client_proxy.py
+++ b/src/py/flwr/simulation/ray_transport/ray_client_proxy.py
@@ -22,6 +22,9 @@ import ray
 from flwr import common
 from flwr.client import Client, ClientLike, to_client
 from flwr.server.client_proxy import ClientProxy
+from flwr.common.logger import log
+
+from logging import DEBUG
 
 ClientFn = Callable[[str], ClientLike]
 
@@ -41,7 +44,11 @@ class RayClientProxy(ClientProxy):
         future_get_properties_res = launch_and_get_properties.options(  # type: ignore
             **self.resources,
         ).remote(self.client_fn, self.cid, ins)
-        res = ray.get(future_get_properties_res, timeout=timeout)
+        try:
+            res = ray.get(future_get_properties_res, timeout=timeout)
+        except Exception as ex:
+            log(DEBUG, ex)
+            raise ex
         return cast(
             common.GetPropertiesRes,
             res,
@@ -54,7 +61,11 @@ class RayClientProxy(ClientProxy):
         future_paramseters_res = launch_and_get_parameters.options(  # type: ignore
             **self.resources,
         ).remote(self.client_fn, self.cid, ins)
-        res = ray.get(future_paramseters_res, timeout=timeout)
+        try:
+            res = ray.get(future_paramseters_res, timeout=timeout)
+        except Exception as ex:
+            log(DEBUG, ex)
+            raise ex
         return cast(
             common.GetParametersRes,
             res,
@@ -65,7 +76,11 @@ class RayClientProxy(ClientProxy):
         future_fit_res = launch_and_fit.options(  # type: ignore
             **self.resources,
         ).remote(self.client_fn, self.cid, ins)
-        res = ray.get(future_fit_res, timeout=timeout)
+        try:
+            res = ray.get(future_fit_res, timeout=timeout)
+        except Exception as ex:
+            log(DEBUG, ex)
+            raise ex
         return cast(
             common.FitRes,
             res,
@@ -78,7 +93,11 @@ class RayClientProxy(ClientProxy):
         future_evaluate_res = launch_and_evaluate.options(  # type: ignore
             **self.resources,
         ).remote(self.client_fn, self.cid, ins)
-        res = ray.get(future_evaluate_res, timeout=timeout)
+        try:
+            res = ray.get(future_evaluate_res, timeout=timeout)
+        except Exception as ex:
+            log(DEBUG, ex)
+            raise ex
         return cast(
             common.EvaluateRes,
             res,


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

This change will ensure exceptions in the VCE are logged by default when using the `ray_client_proxy.py`