### PR TITLE
Fixed epoch_loss calculation in intro tutorial

### DIFF
--- a/doc/source/tutorial/Flower-1-Intro-to-FL-PyTorch.ipynb
+++ b/doc/source/tutorial/Flower-1-Intro-to-FL-PyTorch.ipynb
@@ -326,7 +326,7 @@
         "            epoch_loss += loss\n",
         "            total += labels.size(0)\n",
         "            correct += (torch.max(outputs.data, 1)[1] == labels).sum().item()\n",
-        "        epoch_loss /= len(testloader.dataset)\n",
+        "        epoch_loss /= len(trainloader.dataset)\n",
         "        epoch_acc = correct / total\n",
         "        if verbose:\n",
         "            print(f\"Epoch {epoch+1}: train loss {epoch_loss}, accuracy {epoch_acc}\")\n",


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

There seems to be a tiny bug in the tutorial notebook, the `train` function sums up the loss values for each value in the *train* dataset but then divides by the number of *test* samples.