### PR TITLE
Restless change to POST for the HTTP stack.

### DIFF
--- a/src/py/flwr/client/rest_client/connection.py
+++ b/src/py/flwr/client/rest_client/connection.py
@@ -21,7 +21,7 @@ from typing import Callable, Iterator, Optional, Tuple
 import requests
 
 from flwr.common import GRPC_MAX_MESSAGE_LENGTH
-from flwr.proto.fleet_pb2 import CreateResultsRequest, GetTasksResponse, TokenizedResult
+from flwr.proto.fleet_pb2 import GetTasksRequest, CreateResultsRequest, GetTasksResponse, TokenizedResult
 from flwr.proto.transport_pb2 import ClientMessage, ServerMessage
 
 
@@ -62,13 +62,17 @@ def rest_not_a_connection(
 
     def receive() -> Optional[ServerMessage]:
         """Receive next task from server."""
+       # Serialize ProtoBuf to bytes
+        get_tasks_req_msg = GetTasksRequest()
+        get_tasks_req_msg_bytes = get_tasks_req_msg.SerializeToString()
 
         # Request instructions (task) from server
-        r = requests.get(
-            f"{base_url}/api/1.1/tasks/",
-            params={"client_id": client_id},
+        r = requests.post(
+            f"{base_url}/api/1.1/tasks",
+            headers={"Content-Type": "application/protobuf"},
+            data=get_tasks_req_msg_bytes,
         )
-        print(f"[C-{client_id}] GET /api/1.1/tasks/:", r.status_code, r.headers)
+        print(f"[C-{client_id}] POST /api/1.1/tasks:", r.status_code, r.headers)
         if r.status_code != 200:
             return None
 
@@ -99,11 +103,11 @@ def rest_not_a_connection(
 
         # Send ClientMessage to server
         r = requests.post(
-            f"{base_url}/api/1.1/result/",
+            f"{base_url}/api/1.1/result",
             headers={"Content-Type": "application/protobuf"},
             data=results_req_msg_bytes,
         )
-        print(f"[C-{client_id}] POST /api/1.1/result/:", r.status_code, r.headers)
+        print(f"[C-{client_id}] POST /api/1.1/result:", r.status_code, r.headers)
 
     # yield methods
     try:

--- a/src/py/flwr/client/rest_client/connection.py
+++ b/src/py/flwr/client/rest_client/connection.py
@@ -103,7 +103,7 @@ def rest_not_a_connection(
 
         # Send ClientMessage to server
         r = requests.post(
-            f"{base_url}/api/1.1/result",
+            f"{base_url}/api/1.1/results",
             headers={"Content-Type": "application/protobuf"},
             data=results_req_msg_bytes,
         )

--- a/src/py/flwr/client/rest_client/connection.py
+++ b/src/py/flwr/client/rest_client/connection.py
@@ -107,7 +107,7 @@ def rest_not_a_connection(
             headers={"Content-Type": "application/protobuf"},
             data=results_req_msg_bytes,
         )
-        print(f"[C-{client_id}] POST /api/1.1/result:", r.status_code, r.headers)
+        print(f"[C-{client_id}] POST /api/1.1/results:", r.status_code, r.headers)
 
     # yield methods
     try:

--- a/src/py/flwr/client/rest_client/connection.py
+++ b/src/py/flwr/client/rest_client/connection.py
@@ -62,7 +62,7 @@ def rest_not_a_connection(
 
     def receive() -> Optional[ServerMessage]:
         """Receive next task from server."""
-       # Serialize ProtoBuf to bytes
+        # Serialize ProtoBuf to bytes
         get_tasks_req_msg = GetTasksRequest()
         get_tasks_req_msg_bytes = get_tasks_req_msg.SerializeToString()
 

--- a/src/py/flwr/server/rest_server/rest_api.py
+++ b/src/py/flwr/server/rest_server/rest_api.py
@@ -63,7 +63,7 @@ async def tasks(request: Request) -> Response:
     task_resp_msg = GetTasksResponse()
     task_resp_msg.tokenized_tasks.tokenized_tasks.append(tokenized_task)
     task_resp_bytes = task_resp_msg.SerializeToString()
-    print(f"POST - Sending GetTaskResponse {message_being_sent}:")
+    print(f"POST - Sending GetTasksResponse {message_being_sent}:")
     print(task_resp_msg)
     return Response(
         status_code=200,

--- a/src/py/flwr/server/rest_server/rest_api.py
+++ b/src/py/flwr/server/rest_server/rest_api.py
@@ -73,7 +73,7 @@ async def tasks(request: Request) -> Response:
 
 
 @app.post("/api/1.1/result")
-async def result(request: Request) -> Response:  # Check if token is needed here
+async def results(request: Request) -> Response:  # Check if token is needed here
     # This is required to get the request body as raw bytes
     create_results_req_msg_bytes: bytes = await request.body()
 

--- a/src/py/flwr/server/rest_server/rest_api.py
+++ b/src/py/flwr/server/rest_server/rest_api.py
@@ -73,7 +73,7 @@ async def tasks(request: Request) -> Response:
     )
 
 
-@app.post("/api/1.1/result")
+@app.post("/api/1.1/results")
 async def results(request: Request) -> Response:  # Check if token is needed here
     # This is required to get the request body as raw bytes
     create_results_req_msg_bytes: bytes = await request.body()

--- a/src/py/flwr/server/rest_server/rest_api.py
+++ b/src/py/flwr/server/rest_server/rest_api.py
@@ -21,6 +21,7 @@ from fastapi import FastAPI, Request, Response
 from flwr.proto.fleet_pb2 import (
     CreateResultsRequest,
     CreateResultsResponse,
+    GetTasksRequest,
     GetTasksResponse,
     TokenizedTask,
 )
@@ -48,7 +49,7 @@ async def tasks(request: Request) -> Response:
     get_tasks_req_msg_bytes: bytes = await request.body()
 
     # Deserialize ProtoBuf
-    get_tasks_req_msg = CreateResultsRequest()
+    get_tasks_req_msg = GetTasksRequest()
     get_tasks_req_msg.ParseFromString(get_tasks_req_msg_bytes)
 
     # Print received message


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Change GET tasks to POST so that we can in the future include data in the GetTaskRequest without leaking anything through the URL