### PR TITLE
Change docs title to 'Save Progress'

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -75,6 +75,7 @@ redirects = {
     "quickstart_pytorch": "quickstart-pytorch.html",
     "quickstart_tensorflow": "quickstart-tensorflow.html",
     "release_process": "release-process.html",
+    "saving-progress": "save-progress.html",
     "quickstart_scikitlearn": "quickstart-scikitlearn.html",
     # Deleted pages
     "people": "index.html",

--- a/doc/source/save-progress.rst
+++ b/doc/source/save-progress.rst
@@ -1,5 +1,5 @@
 Save Progress
-===============
+=============
 
 The Flower server does not prescribe a way to persist model updates or evaluation results.
 Flower does not (yet) automatically save model updates on the server-side.

--- a/doc/source/save-progress.rst
+++ b/doc/source/save-progress.rst
@@ -1,4 +1,4 @@
-Saving Progress
+Save Progress
 ===============
 
 The Flower server does not prescribe a way to persist model updates or evaluation results.


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

For our documentation, we’ve started to use the Diátaxis framework: [https://diataxis.fr/](https://diataxis.fr/)

Our “How to” guides should have titles that continue the sencence “How to …”, for example, “How to upgrade to Flower 1.0”.

This PR is about changing the title “Saving Progress” to “Save Progress”. 

Before: ”How to saving progress” ❌

After: ”How to save progress” ✅

