### PR TITLE
Change docs title to 'Configure Clients'

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -68,6 +68,7 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 # To prevent 404 errors and redirect to the new pages.
 redirects = {
     # Renamed pages
+    "configuring-clients.html": "configure-clients.html",
     "quickstart_mxnet": "quickstart-mxnet.html",
     "quickstart_pytorch_lightning": "quickstart-pytorch-lightning.html",
     "example_walkthrough_pytorch_mnist": "example-walkthrough-pytorch-mnist.html",

--- a/doc/source/configure-clients.rst
+++ b/doc/source/configure-clients.rst
@@ -1,5 +1,5 @@
-Configuring Clients
-===================
+Configure Clients
+=================
 
 Along with model parameters, Flower can send configuration values to clients. Configuration values can be used for various purposes. They are, for example, a popular way to control client-side hyperparameters from the server.
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

For our documentation, we’ve started to use the Diàtaxis framework: [https://diataxis.fr/](https://diataxis.fr/)

Our “How to” guides should have titles that continue the sencence “How to …”, for example, “How to upgrade to Flower 1.0”.

Most of our guides do not follow this new format yet, and changing their title is (unfortunately) more involved than one might think.

This issue is about changing the title “Configuring Clients” to “****Configure Clients****”. Does this pass our check?

Before: ”How to c****onfiguring clients****” ❌

After: ”How to c****onfigure clients****” ✅