### PR TITLE
Rename the recently changed how guides in index.rst (toctree)

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -61,10 +61,10 @@ Problem-oriented how-to guides show step-by-step how to achieve a specific goal.
    :caption: How-to guides
 
    installation
-   configuring-clients
+   configure-clients
    strategies
    implementing-strategies
-   saving-progress
+   save-progress
    saving-and-loading-pytorch-checkpoints
    ssl-enabled-connections
    example-walkthrough-pytorch-mnist


### PR DESCRIPTION
Problem:
There are two recently renamed how-to guides missing from the website.
Explanation:
The newly changed names of how-to guides (names of files in docs/source/\*.rst) were changed but left the same in index.rst in the toctree structure. 
Solution:
The names in the index.rst were changed to reflect the names in the docs/source/\*.rst.
