### PR TITLE
Add Python version modularity in venv scripts

### DIFF
--- a/baselines/dev/venv-create.sh
+++ b/baselines/dev/venv-create.sh
@@ -4,7 +4,8 @@ cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"/../
 
 version=${1:-3.7.12}
 
-# Check if the directory does not exist and if so, install python
+# Check if the directory for the Python version does not exist and if so, 
+# install the right Python version through pyenv
 [[ ! -d $PYENV_ROOT/versions/$version ]] && pyenv install $version
 
 pyenv virtualenv $version baselines-$version

--- a/baselines/dev/venv-create.sh
+++ b/baselines/dev/venv-create.sh
@@ -2,5 +2,9 @@
 set -e
 cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"/../
 
-pyenv virtualenv 3.7.12 baselines-3.7.12
-echo baselines-3.7.12 > .python-version
+version=${1:-3.7.12}
+
+[[ ! -d $PYENV_ROOT/versions/$version ]] && pyenv install $version
+
+pyenv virtualenv $version baselines-$version
+echo baselines-$version > .python-version

--- a/baselines/dev/venv-create.sh
+++ b/baselines/dev/venv-create.sh
@@ -4,6 +4,7 @@ cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"/../
 
 version=${1:-3.7.12}
 
+# Check if the directory does not exist and if so, install python
 [[ ! -d $PYENV_ROOT/versions/$version ]] && pyenv install $version
 
 pyenv virtualenv $version baselines-$version

--- a/baselines/dev/venv-delete.sh
+++ b/baselines/dev/venv-delete.sh
@@ -2,4 +2,6 @@
 set -e
 cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"/../
 
-pyenv uninstall -f baselines-3.7.12
+version=${1:-3.7.12}
+
+pyenv uninstall -f baselines-$version

--- a/dev/venv-create.sh
+++ b/dev/venv-create.sh
@@ -4,7 +4,8 @@ cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"/../
 
 version=${1:-3.7.12}
 
-# Check if the directory does not exist and if so, install python
+# Check if the directory for the Python version does not exist and if so, 
+# install the right Python version through pyenv
 [[ ! -d $PYENV_ROOT/versions/$version ]] && pyenv install $version
 
 pyenv virtualenv $version flower-$version

--- a/dev/venv-create.sh
+++ b/dev/venv-create.sh
@@ -4,6 +4,7 @@ cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"/../
 
 version=${1:-3.7.12}
 
+# Check if the directory does not exist and if so, install python
 [[ ! -d $PYENV_ROOT/versions/$version ]] && pyenv install $version
 
 pyenv virtualenv $version flower-$version

--- a/dev/venv-create.sh
+++ b/dev/venv-create.sh
@@ -2,5 +2,9 @@
 set -e
 cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"/../
 
-pyenv virtualenv 3.7.12 flower-3.7.12
-echo flower-3.7.12 > .python-version
+version=${1:-3.7.12}
+
+[[ ! -d $PYENV_ROOT/versions/$version ]] && pyenv install $version
+
+pyenv virtualenv $version flower-$version
+echo flower-$version > .python-version

--- a/dev/venv-delete.sh
+++ b/dev/venv-delete.sh
@@ -2,4 +2,6 @@
 set -e
 cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"/../
 
-pyenv uninstall -f flower-3.7.12
+version=${1:-3.7.12}
+
+pyenv uninstall -f flower-$version


### PR DESCRIPTION
<!--
Thank you for opening a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md

Does the documentation need to be updated?
See: https://flower.dev/docs/writing-documentation.html

Does the changelog need to be updated?
See: https://github.com/adap/flower/blob/main/doc/source/changelog.rst
-->

#### What does this implement/fix? Explain your changes.

<!--
Explain why this PR is needed and what kind of changes have you done.

Example: The variable `rnd` could be interpreted as an abbreviation of *random*, to improve clarity it was renamed to `server_round`.
-->

The `dev/venv-create.sh` and `baselines/dev/venv-create.sh` scripts didn't work with versions of Python that were not `3.7.12`.  Now the scripts will also install the right Python version through `pyenv install $version` before creating the virtual environment.

By default the Python version used is `3.7.12`, but an other version can be given as argument of the script, for example :

`./dev/create-venv.sh 3.8.10` will create the virtual environment `flower-3.8.10` using `Python 3.8.10`.

Note that the `dev/venv-delete.sh` and `baselines/dev/venv-delete.sh` will work in the same fashion. By default, it will delete the virtual environment that is using `Python 3.7.12` but an argument can be given to delete a virtual environment that uses another version. If we continue with our previous example, 

`./dev/delete-venv.sh 3.8.10` will delete the virtual environment `flower-3.8.10` that we created with the previous command.

#### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
If you have an urgent request or question please use the Flower Slack channel.
The Slack channel is really active and contributors respond pretty fast. 

We value your contribution and are aware of the time you put into this PR.
Therefore, thank you for your contribution. 
-->

This [page](https://flower.dev/docs/getting-started-for-contributors.html) of the docs would need to be updated accordingly (even though the changes shouldn't break the explained steps) .
