### PR TITLE
Fix scripts

### DIFF
--- a/baselines/dev/bootstrap.sh
+++ b/baselines/dev/bootstrap.sh
@@ -2,9 +2,11 @@
 set -e
 cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"/../
 
+version=${1:-3.7.12}
+
 # Destroy and recreate the venv
-./dev/venv-delete.sh
-./dev/venv-create.sh
+./dev/venv-delete.sh $version
+./dev/venv-create.sh $version
 
 # Remove caches
 ./dev/rm-caches.sh

--- a/baselines/dev/setup-defaults.sh
+++ b/baselines/dev/setup-defaults.sh
@@ -1,10 +1,16 @@
 #!/bin/bash
 set -e
 
+# To install pyenv and virtualenv plugin
+function install_pyenv(){
+        curl https://pyenv.run | bash
+}
+
 if [ ! -d $HOME/.pyenv ]
 then
     # Install pyenv with the virtualenv plugin
-    curl https://pyenv.run | bash 
+    echo 'Installing pyenv...'
+    install_pyenv &>/dev/null
 
     # To add the config to the right file (depends on the shell used)
     rcfile=$HOME/.$(basename $SHELL)rc
@@ -12,29 +18,37 @@ then
     # Add $PYENV_ROOT environmnet variable
     echo 'export PYENV_ROOT="$HOME/.pyenv"' >> $rcfile
     # Add pyenv to $PATH
-    echo 'export PATH="$HOME/.pyenv/bin:$PATH"' >> $rcfile
+    echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> $rcfile
 
     # Init pyenv with the shell
     echo 'eval "$(pyenv init -)"' >> $rcfile
     echo 'eval "$(pyenv virtualenv-init -)"' >> $rcfile
-    
-    exec "$SHELL"
 else
+	[[ ! $PYENV_ROOT ]] && echo "You must restart your shell for env variables to be set" && exit
+
     # If pyenv is already installed, check for a newer version
+    echo 'Pyenv already installed, updating it...'
 
     # If the pyenv-update plugin isn't installed do the update manually
     if [ ! -d $HOME/.pyenv/plugins/pyenv-update ]
     then
-        git -C $HOME/.pyenv pull
-        git -C $HOME/.pyenv/plugins/pyenv-virtualenv pull
+        git -C $HOME/.pyenv pull &>/dev/null
+        git -C $HOME/.pyenv/plugins/pyenv-virtualenv pull &>/dev/null
     else
-        pyenv update
+        pyenv update &>/dev/null
     fi
 fi
 
-export PYENV_ROOT="$HOME/.pyenv"
 # Create the virtual environment for Flower baselines
-$( dirname "${BASH_SOURCE[0]}" )/venv-create.sh
+function create_venv(){
+        export PYENV_ROOT="$HOME/.pyenv"
+        export PATH="$PYENV_ROOT/bin:$PATH"
+        $( dirname "${BASH_SOURCE[0]}" )/venv-create.sh
+}
+echo 'Creating the virtual environment for Flower baselines...'
+create_venv &>/dev/null
 
-# Install the dependencies inside the virtual environment
-$( dirname "${BASH_SOURCE[0]}" )/bootstrap.sh
+echo "$(tput bold)Virtual env baselines-3.7.12 created, you must now run baselines/dev/bootstrap.sh to install all dependencies.$(tput sgr0)"
+
+exec "$SHELL"
+

--- a/baselines/dev/setup-defaults.sh
+++ b/baselines/dev/setup-defaults.sh
@@ -9,13 +9,16 @@ then
     # To add the config to the right file (depends on the shell used)
     rcfile=$HOME/.$(basename $SHELL)rc
 
+    # Add $PYENV_ROOT environmnet variable
+    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> $rcfile
     # Add pyenv to $PATH
     echo 'export PATH="$HOME/.pyenv/bin:$PATH"' >> $rcfile
 
     # Init pyenv with the shell
     echo 'eval "$(pyenv init -)"' >> $rcfile
     echo 'eval "$(pyenv virtualenv-init -)"' >> $rcfile
-    source $rcfile
+    
+    exec "$SHELL"
 else
     # If pyenv is already installed, check for a newer version
 
@@ -29,6 +32,7 @@ else
     fi
 fi
 
+export PYENV_ROOT="$HOME/.pyenv"
 # Create the virtual environment for Flower baselines
 $( dirname "${BASH_SOURCE[0]}" )/venv-create.sh
 

--- a/baselines/dev/setup-defaults.sh
+++ b/baselines/dev/setup-defaults.sh
@@ -3,7 +3,7 @@ set -e
 
 # To install pyenv and virtualenv plugin
 function install_pyenv(){
-        curl https://pyenv.run | bash
+    curl https://pyenv.run | bash
 }
 
 if [ ! -d $HOME/.pyenv ]
@@ -24,7 +24,7 @@ then
     echo 'eval "$(pyenv init -)"' >> $rcfile
     echo 'eval "$(pyenv virtualenv-init -)"' >> $rcfile
 else
-	[[ ! $PYENV_ROOT ]] && echo "You must restart your shell for env variables to be set" && exit
+    [[ ! $PYENV_ROOT ]] && echo "You must restart your shell for env variables to be set" && exit
 
     # If pyenv is already installed, check for a newer version
     echo 'Pyenv already installed, updating it...'
@@ -41,12 +41,20 @@ fi
 
 # Create the virtual environment for Flower baselines
 function create_venv(){
-        export PYENV_ROOT="$HOME/.pyenv"
-        export PATH="$PYENV_ROOT/bin:$PATH"
-        $( dirname "${BASH_SOURCE[0]}" )/venv-create.sh
+    export PYENV_ROOT="$HOME/.pyenv"
+    export PATH="$PYENV_ROOT/bin:$PATH"
+    $( dirname "${BASH_SOURCE[0]}" )/venv-create.sh
 }
-echo 'Creating the virtual environment for Flower baselines...'
-create_venv &>/dev/null
+
+if [ ! -d $HOME/.pyenv/versions/baseline-3.7.12 ]
+then
+    echo 'Creating the virtual environment for Flower baselines...'
+    create_venv &>/dev/null
+else
+    echo 'Virtual env already installed, nothing to do.'
+    echo 'If not already done, you must run baselines/dev/bootstrap.sh to install all the dependencies'
+    exit
+fi
 
 echo "$(tput bold)Virtual env baselines-3.7.12 created, you must now run baselines/dev/bootstrap.sh to install all dependencies.$(tput sgr0)"
 

--- a/baselines/dev/setup-defaults.sh
+++ b/baselines/dev/setup-defaults.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+version=${1:-3.7.12}
+
 # To install pyenv and virtualenv plugin
 function install_pyenv(){
     curl https://pyenv.run | bash
@@ -27,15 +29,25 @@ else
     [[ ! $PYENV_ROOT ]] && echo "You must restart your shell for env variables to be set" && exit
 
     # If pyenv is already installed, check for a newer version
-    echo 'Pyenv already installed, updating it...'
+    read -p 'Pyenv already installed, do you want to updating it y/[n]? ' update
+    update="${update:-"n"}"
+    update="${update,,}"
 
-    # If the pyenv-update plugin isn't installed do the update manually
-    if [ ! -d $HOME/.pyenv/plugins/pyenv-update ]
+    if [ $update == "y" ]
     then
-        git -C $HOME/.pyenv pull &>/dev/null
-        git -C $HOME/.pyenv/plugins/pyenv-virtualenv pull &>/dev/null
-    else
-        pyenv update &>/dev/null
+        # If the pyenv-update plugin isn't installed do the update manually
+        if [ ! -d $HOME/.pyenv/plugins/pyenv-update ]
+        then
+            if [ ! -d $HOME/.pyenv/.git ]
+            then
+                echo "Couldn't perform the update, continuing..."
+            else
+                git -C $HOME/.pyenv pull &>/dev/null
+                git -C $HOME/.pyenv/plugins/pyenv-virtualenv pull &>/dev/null
+            fi
+        else
+            pyenv update &>/dev/null
+        fi
     fi
 fi
 
@@ -43,20 +55,22 @@ fi
 function create_venv(){
     export PYENV_ROOT="$HOME/.pyenv"
     export PATH="$PYENV_ROOT/bin:$PATH"
-    $( dirname "${BASH_SOURCE[0]}" )/venv-create.sh
+    $( dirname "${BASH_SOURCE[0]}" )/venv-create.sh $version
 }
 
-if [ ! -d $HOME/.pyenv/versions/baseline-3.7.12 ]
+if [ ! -d $HOME/.pyenv/versions/baseline-$version ]
 then
     echo 'Creating the virtual environment for Flower baselines...'
     create_venv &>/dev/null
 else
     echo 'Virtual env already installed, nothing to do.'
-    echo 'If not already done, you must run baselines/dev/bootstrap.sh to install all the dependencies'
+    echo "If not already done, "\
+    "you must run baselines/dev/bootstrap.sh $version to install all the dependencies"
     exit
 fi
 
-echo "$(tput bold)Virtual env baselines-3.7.12 created, you must now run baselines/dev/bootstrap.sh to install all dependencies.$(tput sgr0)"
+echo "$(tput bold)Virtual env baselines-$version created, "\
+"you must now run baselines/dev/bootstrap.sh $version to install all dependencies.$(tput sgr0)"
 
 exec "$SHELL"
 

--- a/dev/setup-defaults.sh
+++ b/dev/setup-defaults.sh
@@ -1,10 +1,16 @@
 #!/bin/bash
 set -e
 
+# To install pyenv and virtualenv plugin
+function install_pyenv(){
+	curl https://pyenv.run | bash
+}
+
 if [ ! -d $HOME/.pyenv ]
 then
     # Install pyenv with the virtualenv plugin
-    curl https://pyenv.run | bash 
+    echo 'Installing pyenv...'
+    install_pyenv &>/dev/null
 
     # To add the config to the right file (depends on the shell used)
     rcfile=$HOME/.$(basename $SHELL)rc
@@ -12,29 +18,34 @@ then
     # Add $PYENV_ROOT environmnet variable
     echo 'export PYENV_ROOT="$HOME/.pyenv"' >> $rcfile
     # Add pyenv to $PATH
-    echo 'export PATH="$HOME/.pyenv/bin:$PATH"' >> $rcfile
+    echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> $rcfile
 
     # Init pyenv with the shell
     echo 'eval "$(pyenv init -)"' >> $rcfile
     echo 'eval "$(pyenv virtualenv-init -)"' >> $rcfile
-    
-    exec "$SHELL"
 else
     # If pyenv is already installed, check for a newer version
+    echo 'Pyenv already installed, updating it...'
 
     # If the pyenv-update plugin isn't installed do the update manually
     if [ ! -d $HOME/.pyenv/plugins/pyenv-update ]
     then
-        git -C $HOME/.pyenv pull
-        git -C $HOME/.pyenv/plugins/pyenv-virtualenv pull
+        git -C $HOME/.pyenv pull &>/dev/null
+        git -C $HOME/.pyenv/plugins/pyenv-virtualenv pull &>/dev/null
     else
-        pyenv update
+        pyenv update &>/dev/null
     fi
 fi
 
-export PYENV_ROOT="$HOME/.pyenv"
 # Create the virtual environment for Flower
-$( dirname "${BASH_SOURCE[0]}" )/venv-create.sh
+function create_venv(){
+	export PYENV_ROOT="$HOME/.pyenv"
+	export PATH="$PYENV_ROOT/bin:$PATH"
+	$( dirname "${BASH_SOURCE[0]}" )/venv-create.sh
+}
+echo 'Creating the virtual environment for Flower...'
+create_venv &>/dev/null
 
-# Install the dependencies inside the virtual environment
-$( dirname "${BASH_SOURCE[0]}" )/bootstrap.sh
+echo "$(tput bold)Virtual env flower-3.7.12 created, you must now run dev/bootstrap.sh to install all dependencies.$(tput sgr0)"
+
+exec "$SHELL"

--- a/dev/setup-defaults.sh
+++ b/dev/setup-defaults.sh
@@ -9,13 +9,16 @@ then
     # To add the config to the right file (depends on the shell used)
     rcfile=$HOME/.$(basename $SHELL)rc
 
+    # Add $PYENV_ROOT environmnet variable
+    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> $rcfile
     # Add pyenv to $PATH
     echo 'export PATH="$HOME/.pyenv/bin:$PATH"' >> $rcfile
 
     # Init pyenv with the shell
     echo 'eval "$(pyenv init -)"' >> $rcfile
     echo 'eval "$(pyenv virtualenv-init -)"' >> $rcfile
-    source $rcfile
+    
+    exec "$SHELL"
 else
     # If pyenv is already installed, check for a newer version
 
@@ -29,6 +32,7 @@ else
     fi
 fi
 
+export PYENV_ROOT="$HOME/.pyenv"
 # Create the virtual environment for Flower
 $( dirname "${BASH_SOURCE[0]}" )/venv-create.sh
 

--- a/dev/setup-defaults.sh
+++ b/dev/setup-defaults.sh
@@ -3,7 +3,7 @@ set -e
 
 # To install pyenv and virtualenv plugin
 function install_pyenv(){
-	curl https://pyenv.run | bash
+    curl https://pyenv.run | bash
 }
 
 if [ ! -d $HOME/.pyenv ]
@@ -24,6 +24,8 @@ then
     echo 'eval "$(pyenv init -)"' >> $rcfile
     echo 'eval "$(pyenv virtualenv-init -)"' >> $rcfile
 else
+    [[ ! $PYENV_ROOT ]] && echo "You must restart your shell for env variables to be set" && exit
+
     # If pyenv is already installed, check for a newer version
     echo 'Pyenv already installed, updating it...'
 
@@ -39,12 +41,20 @@ fi
 
 # Create the virtual environment for Flower
 function create_venv(){
-	export PYENV_ROOT="$HOME/.pyenv"
-	export PATH="$PYENV_ROOT/bin:$PATH"
-	$( dirname "${BASH_SOURCE[0]}" )/venv-create.sh
+    export PYENV_ROOT="$HOME/.pyenv"
+    export PATH="$PYENV_ROOT/bin:$PATH"
+    $( dirname "${BASH_SOURCE[0]}" )/venv-create.sh
 }
-echo 'Creating the virtual environment for Flower...'
-create_venv &>/dev/null
+
+if [ ! -d $HOME/.pyenv/versions/flower-3.7.12 ]
+then
+    echo 'Creating the virtual environment for Flower...'
+    create_venv &>/dev/null
+else
+    echo 'Virtual env already installed, nothing to do.'
+    echo 'If not already done, you must run dev/bootstrap.sh to install all the dependencies'
+    exit
+fi
 
 echo "$(tput bold)Virtual env flower-3.7.12 created, you must now run dev/bootstrap.sh to install all dependencies.$(tput sgr0)"
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

<!--
Explain why this PR is needed and what kind of changes have you done.

Example: The variable `rnd` could be interpreted as an abbreviation of *random*, to improve clarity it was renamed to `server_round`.
-->

After thorough testing the install script now works completely, before the environment variables were not set which caused errors when trying to run the `venv-create.sh` and `bootstrap.sh` scripts.
The user now has to run the `bootstrap.sh` script themselves after `setup-defaults.sh`, this is because the shell needs to be changed between the execution of the two scripts. This was not taken into account before.  


#### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
If you have an urgent request or question please use the Flower Slack channel.
The Slack channel is really active and contributors respond pretty fast. 

We value your contribution and are aware of the time you put into this PR.
Therefore, thank you for your contribution. 
-->

I will be adding info in the docs after this branch is merged into main.
