### PR TITLE
Align scripts from baselines to scripts on root

### DIFF
--- a/baselines/dev/bootstrap.sh
+++ b/baselines/dev/bootstrap.sh
@@ -11,5 +11,4 @@ python -m pip install -U setuptools==63.2.0
 python -m pip install -U poetry==1.1.14
 
 # Use `poetry` to install project dependencies
-python -m poetry install \
-  --extras "simulation"
+python -m poetry install

--- a/baselines/dev/bootstrap.sh
+++ b/baselines/dev/bootstrap.sh
@@ -2,17 +2,8 @@
 set -e
 cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"/../
 
-version=${1:-3.7.12}
-
-# Destroy and recreate the venv
-./dev/venv-delete.sh $version
-./dev/venv-create.sh $version
-
 # Remove caches
 ./dev/rm-caches.sh
-
-# Remove poetry.lock file
-rm -f poetry.lock
 
 # Upgrade/install spcific versions of `pip`, `setuptools`, and `poetry`
 python -m pip install -U pip==22.2
@@ -20,4 +11,5 @@ python -m pip install -U setuptools==63.2.0
 python -m pip install -U poetry==1.1.14
 
 # Use `poetry` to install project dependencies
-python -m poetry install
+python -m poetry install \
+  --extras "simulation"


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Before the `bootstrap.sh` in `baselines/` was resetting the virtual environment, which was not the case in the root `dev/bootstrap.sh` script. Resetting the virtual environment is now left to `venv-reset.sh` and the 2 bootstrapping scripts have the same behavior.  

