### PR TITLE
Fix access to the interator and display a better plot

### DIFF
--- a/doc/source/tutorial/Flower-1-Intro-to-FL-PyTorch.ipynb
+++ b/doc/source/tutorial/Flower-1-Intro-to-FL-PyTorch.ipynb
@@ -1,715 +1,718 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "cz71fPGrpRiQ"
-   },
-   "source": [
-    "# An Introduction to Federated Learning\n",
-    "\n",
-    "Welcome to the Flower federated learning tutorial!\n",
-    "\n",
-    "In this notebook, we'll build a federated learning system using Flower and PyTorch. In part 1, we use PyTorch for the model training pipeline and data loading. In part 2, we continue to federate the PyTorch-based pipeline using Flower.\n",
-    "\n",
-    "> Join the Flower community on Slack to connect, ask questions, and get help: [Join Slack](https://flower.dev/join-slack) 🌻 We'd love to hear from you in the `#introductions` channel! If anything is unclear, head over to the `#questions` channel.\n",
-    "\n",
-    "Let's get stated!"
-   ]
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "cz71fPGrpRiQ"
+      },
+      "source": [
+        "# An Introduction to Federated Learning\n",
+        "\n",
+        "Welcome to the Flower federated learning tutorial!\n",
+        "\n",
+        "In this notebook, we'll build a federated learning system using Flower and PyTorch. In part 1, we use PyTorch for the model training pipeline and data loading. In part 2, we continue to federate the PyTorch-based pipeline using Flower.\n",
+        "\n",
+        "> Join the Flower community on Slack to connect, ask questions, and get help: [Join Slack](https://flower.dev/join-slack) 🌻 We'd love to hear from you in the `#introductions` channel! If anything is unclear, head over to the `#questions` channel.\n",
+        "\n",
+        "Let's get stated!"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "mBu1HRRY6bwX"
+      },
+      "source": [
+        "## Step 0: Preparation\n",
+        "\n",
+        "Before we begin with any actual code, let's make sure that we have everything we need."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "D4KiTMTpiort"
+      },
+      "source": [
+        "### Installing dependencies\n",
+        "\n",
+        "Next, we install the necessary packages for PyTorch (`torch` and `torchvision`) and Flower (`flwr`):"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "eTrCL2FmC5U5"
+      },
+      "outputs": [],
+      "source": [
+        "!pip install -q flwr[simulation] torch torchvision matplotlib"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "3UFT3_A3iz76"
+      },
+      "source": [
+        "Now that we have all dependencies installed, we can import everything we need for this tutorial:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "Tja2N6l-qH-e"
+      },
+      "outputs": [],
+      "source": [
+        "from collections import OrderedDict\n",
+        "from typing import List, Tuple\n",
+        "\n",
+        "import flwr as fl\n",
+        "import numpy as np\n",
+        "import matplotlib.pyplot as plt\n",
+        "import torch\n",
+        "import torch.nn as nn\n",
+        "import torchvision\n",
+        "import torch.nn.functional as F\n",
+        "import torchvision.transforms as transforms\n",
+        "from flwr.common import Metrics\n",
+        "from torch.utils.data import DataLoader, random_split\n",
+        "from torchvision.datasets import CIFAR10\n",
+        "\n",
+        "DEVICE = torch.device(\"cpu\")  # Try \"cuda\" to train on GPU\n",
+        "print(f\"Training on {DEVICE} using PyTorch {torch.__version__} and Flower {fl.__version__}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "8D2bnPKG58Gx"
+      },
+      "source": [
+        "It is possible to switch to a runtime that has GPU acceleration enabled (on Google Colab: `Runtime > Change runtime type > Hardware acclerator: GPU > Save`). Note, however, that Google Colab is not always able to offer GPU acceleration. If you see an error related to GPU availability in one of the following sections, consider switching back to CPU-based execution by setting `DEVICE = torch.device(\"cpu\")`. If the runtime has GPU acceleration enabled, you should see the output `Training on cuda:0`, otherwise it'll say `Training on cpu`."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "JVcgAAiaihnx"
+      },
+      "source": [
+        "\n",
+        "### Loading the data\n",
+        "\n",
+        "Federated learning can be applied to many different types of tasks across different domains. In this tutorial, we introduce federated learning by training a simple convolutional neural network (CNN) on the popular CIFAR-10 dataset. CIFAR-10 can be used to train image classifiers that distinguish between images from ten different classes:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "-tpk_Zv37ONm"
+      },
+      "outputs": [],
+      "source": [
+        "CLASSES = ('plane', 'car', 'bird', 'cat', 'deer', 'dog', 'frog', 'horse', 'ship', 'truck')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "toxAoOq6fS2h"
+      },
+      "source": [
+        "We simulate having multiple datasets from multiple organizations (also called the \"cross-silo\" setting in federated learning) by splitting the original CIFAR-10 dataset into multiple partitions. Each partition will represent the data from a single organization. We're doing this purely for experimentation purposes, in the real world there's no need for data splitting because each organization already has their own data (so the data is naturally partitioned).\n",
+        "\n",
+        "Each organization will act as a client in the federated learning system. So having ten organizations participate in a federation means having ten clients connected to the federated learning server:\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "q9LhPFDh0S5c"
+      },
+      "outputs": [],
+      "source": [
+        "NUM_CLIENTS = 10"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "01Zy7yjBPhQd"
+      },
+      "source": [
+        "\n",
+        "Let's now load the CIFAR-10 training and test set, partition them into ten smaller datasets (each split into training and validation set), and wrap the resulting partitions by creating a PyTorch `DataLoader` for each of them:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "J4Em7BPNTXeX"
+      },
+      "outputs": [],
+      "source": [
+        "BATCH_SIZE = 32\n",
+        "\n",
+        "def load_datasets():\n",
+        "    # Download and transform CIFAR-10 (train and test)\n",
+        "    transform = transforms.Compose(\n",
+        "      [transforms.ToTensor(), transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))]\n",
+        "    )\n",
+        "    trainset = CIFAR10(\"./dataset\", train=True, download=True, transform=transform)\n",
+        "    testset = CIFAR10(\"./dataset\", train=False, download=True, transform=transform)\n",
+        "\n",
+        "    # Split training set into 10 partitions to simulate the individual dataset\n",
+        "    partition_size = len(trainset) // NUM_CLIENTS\n",
+        "    lengths = [partition_size] * NUM_CLIENTS\n",
+        "    datasets = random_split(trainset, lengths, torch.Generator().manual_seed(42))\n",
+        "\n",
+        "    # Split each partition into train/val and create DataLoader\n",
+        "    trainloaders = []\n",
+        "    valloaders = []\n",
+        "    for ds in datasets:\n",
+        "        len_val = len(ds) // 10  # 10 % validation set\n",
+        "        len_train = len(ds) - len_val\n",
+        "        lengths = [len_train, len_val]\n",
+        "        ds_train, ds_val = random_split(ds, lengths, torch.Generator().manual_seed(42))\n",
+        "        trainloaders.append(DataLoader(ds_train, batch_size=BATCH_SIZE, shuffle=True))\n",
+        "        valloaders.append(DataLoader(ds_val, batch_size=BATCH_SIZE))\n",
+        "    testloader = DataLoader(testset, batch_size=BATCH_SIZE)\n",
+        "    return trainloaders, valloaders, testloader\n",
+        "\n",
+        "trainloaders, valloaders, testloader = load_datasets()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "OBp7kB4G0sPB"
+      },
+      "source": [
+        "We now have a list of ten training sets and ten validation sets (`trainloaders` and `valloaders`) representing the data of ten different organizations. Each `trainloader`/`valloader` pair contains 4500 training examples and 500 validation examples. There's also a single `testloader` (we did not split the test set). Again, this is only necessary for building research or educational systems, actual federated learning systems have their data naturally distributed across multiple partitions.\n",
+        "\n",
+        "Let's take a look at the first batch of images and labels in the first training set (i.e., `trainloaders[0]`) before we move on:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "E3dag9WeT9VH"
+      },
+      "outputs": [],
+      "source": [
+        "images, labels = next(iter(trainloaders[0]))\n",
+        "# Reshape and convert images to a NumPy array\n",
+        "# matplotlib requires images with the shape (height, width, 3)\n",
+        "images = images.permute(0, 2, 3, 1).numpy()\n",
+        "# Denormalize\n",
+        "images = images/2 + 0.5\n",
+        "\n",
+        "# Create a figure and a grid of subplots\n",
+        "fig, axs = plt.subplots(4, 8, figsize=(12, 6))\n",
+        "\n",
+        "# Loop over the images and plot them\n",
+        "for i, ax in enumerate(axs.flat):\n",
+        "    ax.imshow(images[i])\n",
+        "    ax.set_title(CLASSES[labels[i]])\n",
+        "    ax.axis('off')\n",
+        "\n",
+        "# Show the plot\n",
+        "fig.tight_layout()\n",
+        "plt.show()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "ZGVGbRZ_yEA2"
+      },
+      "source": [
+        "The output above shows a random batch of images from the first `trainloader` in our list of ten `trainloaders`. It also prints the labels associated with each image (i.e., one of the ten possible labels we've seen above). If you run the cell again, you should see another batch of images."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "4TW4Pzb7p1F9"
+      },
+      "source": [
+        "## Step 1: Centralized Training with PyTorch\n",
+        "\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "cTjCmmBtqPgM"
+      },
+      "source": [
+        "Next, we're going to use PyTorch to define a simple convolutional neural network. This introduction assumes basic familiarity with PyTorch, so it doesn't cover the PyTorch-related aspects in full detail. If you want to dive deeper into PyTorch, we recommend [*DEEP LEARNING WITH PYTORCH: A 60 MINUTE BLITZ*](https://pytorch.org/tutorials/beginner/deep_learning_60min_blitz.html).\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "XYks8IpJL6iK"
+      },
+      "source": [
+        "### Defining the model\n",
+        "\n",
+        "We use the simple CNN described in the [PyTorch tutorial](https://pytorch.org/tutorials/beginner/blitz/cifar10_tutorial.html#define-a-convolutional-neural-network):"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "2X3cVBXMpP6w"
+      },
+      "outputs": [],
+      "source": [
+        "class Net(nn.Module):\n",
+        "    def __init__(self) -> None:\n",
+        "        super(Net, self).__init__()\n",
+        "        self.conv1 = nn.Conv2d(3, 6, 5)\n",
+        "        self.pool = nn.MaxPool2d(2, 2)\n",
+        "        self.conv2 = nn.Conv2d(6, 16, 5)\n",
+        "        self.fc1 = nn.Linear(16 * 5 * 5, 120)\n",
+        "        self.fc2 = nn.Linear(120, 84)\n",
+        "        self.fc3 = nn.Linear(84, 10)\n",
+        "\n",
+        "    def forward(self, x: torch.Tensor) -> torch.Tensor:\n",
+        "        x = self.pool(F.relu(self.conv1(x)))\n",
+        "        x = self.pool(F.relu(self.conv2(x)))\n",
+        "        x = x.view(-1, 16 * 5 * 5)\n",
+        "        x = F.relu(self.fc1(x))\n",
+        "        x = F.relu(self.fc2(x))\n",
+        "        x = self.fc3(x)\n",
+        "        return x"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "tCRhau5cr2Gd"
+      },
+      "source": [
+        "Let's continue with the usual training and test functions:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "xIl8NfAFpyam"
+      },
+      "outputs": [],
+      "source": [
+        "def train(net, trainloader, epochs: int, verbose=False):\n",
+        "    \"\"\"Train the network on the training set.\"\"\"\n",
+        "    criterion = torch.nn.CrossEntropyLoss()\n",
+        "    optimizer = torch.optim.Adam(net.parameters())\n",
+        "    net.train()\n",
+        "    for epoch in range(epochs):\n",
+        "        correct, total, epoch_loss = 0, 0, 0.0\n",
+        "        for images, labels in trainloader:\n",
+        "            images, labels = images.to(DEVICE), labels.to(DEVICE)\n",
+        "            optimizer.zero_grad()\n",
+        "            outputs = net(images)\n",
+        "            loss = criterion(net(images), labels)\n",
+        "            loss.backward()\n",
+        "            optimizer.step()\n",
+        "            # Metrics\n",
+        "            epoch_loss += loss\n",
+        "            total += labels.size(0)\n",
+        "            correct += (torch.max(outputs.data, 1)[1] == labels).sum().item()\n",
+        "        epoch_loss /= len(trainloader.dataset)\n",
+        "        epoch_acc = correct / total\n",
+        "        if verbose:\n",
+        "            print(f\"Epoch {epoch+1}: train loss {epoch_loss}, accuracy {epoch_acc}\")\n",
+        "\n",
+        "\n",
+        "def test(net, testloader):\n",
+        "    \"\"\"Evaluate the network on the entire test set.\"\"\"\n",
+        "    criterion = torch.nn.CrossEntropyLoss()\n",
+        "    correct, total, loss = 0, 0, 0.0\n",
+        "    net.eval()\n",
+        "    with torch.no_grad():\n",
+        "        for images, labels in testloader:\n",
+        "            images, labels = images.to(DEVICE), labels.to(DEVICE)\n",
+        "            outputs = net(images)\n",
+        "            loss += criterion(outputs, labels).item()\n",
+        "            _, predicted = torch.max(outputs.data, 1)\n",
+        "            total += labels.size(0)\n",
+        "            correct += (predicted == labels).sum().item()\n",
+        "    loss /= len(testloader.dataset)\n",
+        "    accuracy = correct / total\n",
+        "    return loss, accuracy"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "GDDxh73Sszck"
+      },
+      "source": [
+        "### Training the model\n",
+        "\n",
+        "We now have all the basic building blocks we need: a dataset, a model, a training function, and a test function. Let's put them together to train the model on the dataset of one of our organizations (`trainloaders[0]`). This simulates the reality of most machine learning projects today: each organization has their own data and trains models only on this internal data: "
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "WdUTb8WgtRMz"
+      },
+      "outputs": [],
+      "source": [
+        "trainloader = trainloaders[0]\n",
+        "valloader = valloaders[0]\n",
+        "net = Net().to(DEVICE)\n",
+        "\n",
+        "for epoch in range(5):\n",
+        "    train(net, trainloader, 1)\n",
+        "    loss, accuracy = test(net, valloader)\n",
+        "    print(f\"Epoch {epoch+1}: validation loss {loss}, accuracy {accuracy}\")\n",
+        "\n",
+        "loss, accuracy = test(net, testloader)\n",
+        "print(f\"Final test set performance:\\n\\tloss {loss}\\n\\taccuracy {accuracy}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "DhLGLdmhOhVr"
+      },
+      "source": [
+        "Training the simple CNN on our CIFAR-10 split for 5 epochs should result in a test set accuracy of about 41%, which is not good, but at the same time, it doesn't really matter for the purposes of this tutorial. The intent was just to show a simplistic centralized training pipeline that sets the stage for what comes next - federated learning!"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "a6HP2cYCsqxD"
+      },
+      "source": [
+        "## Step 2: Federated Learning with Flower\n",
+        "\n",
+        "Step 1 demonstrated a simple centralized training pipeline. All data was in one place (i.e., a single `trainloader` and a single `valloader`). Next, we'll simulate a situation where we have multiple datasets in multiple organizations and where we train a model over these organizations using federated learning."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "mf-cW093MzeT"
+      },
+      "source": [
+        "### Updating model parameters\n",
+        "\n",
+        "In federated learning, the server sends the global model parameters to the client, and the client updates the local model with the parameters received from the server. It then trains the model on the local data (which changes the model parameters locally) and sends the updated/changed model parameters back to the server (or, alternatively, it sends just the gradients back to the server, not the full model parameters).\n",
+        "\n",
+        "We need two helper functions to update the local model with parameters received from the server and to get the updated model parameters from the local model: `set_parameters` and `get_parameters`. The following two functions do just that for the PyTorch model above.\n",
+        "\n",
+        "The details of how this works are not really important here (feel free to consult the PyTorch documentation if you want to learn more). In essence, we use `state_dict` to access PyTorch model parameter tensors. The parameter tensors are then converted to/from a list of NumPy ndarray's (which Flower knows how to serialize/deserialize):"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "1ZxGk6AMNvvV"
+      },
+      "outputs": [],
+      "source": [
+        "def get_parameters(net) -> List[np.ndarray]:\n",
+        "    return [val.cpu().numpy() for _, val in net.state_dict().items()]\n",
+        "\n",
+        "def set_parameters(net, parameters: List[np.ndarray]):\n",
+        "    params_dict = zip(net.state_dict().keys(), parameters)\n",
+        "    state_dict = OrderedDict({k: torch.Tensor(v) for k, v in params_dict})\n",
+        "    net.load_state_dict(state_dict, strict=True)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "1lCf3oljdClM"
+      },
+      "source": [
+        "### Implementing a Flower client\n",
+        "\n",
+        "With that out of the way, let's move on to the interesting part. Federated learning systems consist of a server and multiple clients. In Flower, we create clients by implementing subclasses of `flwr.client.Client` or `flwr.client.NumPyClient`. We use `NumPyClient` in this tutorial because it is easier to implement and requires us to write less boilerplate.\n",
+        "\n",
+        "To implement the Flower client, we create a subclass of `flwr.client.NumPyClient` and implement the three methods `get_parameters`, `fit`, and `evaluate`:\n",
+        "\n",
+        "* `get_parameters`: Return the current local model parameters\n",
+        "* `fit`: Receive model parameters from the server, train the model parameters on the local data, and return the (updated) model parameters to the server\n",
+        "* `evaluate`: Receive model parameters from the server, evaluate the model parameters on the local data, and return the evaluation result to the server\n",
+        "\n",
+        "We mentioned that our clients will use the previously defined PyTorch components for model training and evaluation. Let's see a simple Flower client implementation that brings everything together:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "ye6Jt5p3LWtF"
+      },
+      "outputs": [],
+      "source": [
+        "class FlowerClient(fl.client.NumPyClient):\n",
+        "    def __init__(self, net, trainloader, valloader):\n",
+        "        self.net = net\n",
+        "        self.trainloader = trainloader\n",
+        "        self.valloader = valloader\n",
+        "\n",
+        "    def get_parameters(self, config):\n",
+        "        return get_parameters(self.net)\n",
+        "\n",
+        "    def fit(self, parameters, config):\n",
+        "        set_parameters(self.net, parameters)\n",
+        "        train(self.net, self.trainloader, epochs=1)\n",
+        "        return get_parameters(self.net), len(self.trainloader), {}\n",
+        "\n",
+        "    def evaluate(self, parameters, config):\n",
+        "        set_parameters(self.net, parameters)\n",
+        "        loss, accuracy = test(self.net, self.valloader)\n",
+        "        return float(loss), len(self.valloader), {\"accuracy\": float(accuracy)}"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Heyxd9MfHOTe"
+      },
+      "source": [
+        "Our class `FlowerClient` defines how local training/evaluation will be performed and allows Flower to call the local training/evaluation through `fit` and `evaluate`. Each instance of `FlowerClient` represents a *single client* in our federated learning system. Federated learning systems have multiple clients (otherwise, there's not much to federate), so each client will be represented by its own instance of `FlowerClient`. If we have, for example, three clients in our workload, then we'd have three instances of `FlowerClient`. Flower calls `FlowerClient.fit` on the respective instance when the server selects a particular client for training (and `FlowerClient.evaluate` for evaluation).\n",
+        "\n",
+        "### Using the Virtual Client Engine\n",
+        "\n",
+        "In this notebook, we want to simulate a federated learning system with 10 clients on a single machine. This means that the server and all 10 clients will live on a single machine and share resources such as CPU, GPU, and memory. Having 10 clients would mean having 10 instances of `FlowerClient` in memory. Doing this on a single machine can quickly exhaust the available memory resources, even if only a subset of these clients participates in a single round of federated learning.\n",
+        "\n",
+        "In addition to the regular capabilities where server and clients run on multiple machines, Flower, therefore, provides special simulation capabilities that create `FlowerClient` instances only when they are actually necessary for training or evaluation. To enable the Flower framework to create clients when necessary, we need to implement a function called `client_fn` that creates a `FlowerClient` instance on demand. Flower calls `client_fn` whenever it needs an instance of one particular client to call `fit` or `evaluate` (those instances are usually discarded after use, so they should not keep any local state). Clients are identified by a client ID, or short `cid`. The `cid` can be used, for example, to load different local data partitions for different clients, as can be seen below:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "qkcwggRYOwWN"
+      },
+      "outputs": [],
+      "source": [
+        "def client_fn(cid: str) -> FlowerClient:\n",
+        "    \"\"\"Create a Flower client representing a single organization.\"\"\"\n",
+        "\n",
+        "    # Load model\n",
+        "    net = Net().to(DEVICE)\n",
+        "\n",
+        "    # Load data (CIFAR-10)\n",
+        "    # Note: each client gets a different trainloader/valloader, so each client\n",
+        "    # will train and evaluate on their own unique data\n",
+        "    trainloader = trainloaders[int(cid)]\n",
+        "    valloader = valloaders[int(cid)]\n",
+        "\n",
+        "    # Create a  single Flower client representing a single organization\n",
+        "    return FlowerClient(net, trainloader, valloader)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "axzXSMtlfhXU"
+      },
+      "source": [
+        "### Starting the training\n",
+        "\n",
+        "We now have the class `FlowerClient` which defines client-side training/evaluation and `client_fn` which allows Flower to create `FlowerClient` instances whenever it needs to call `fit` or `evaluate` on one particular client. The last step is to start the actual simulation using `flwr.simulation.start_simulation`. \n",
+        "\n",
+        "The function `start_simulation` accepts a number of arguments, amongst them the `client_fn` used to create `FlowerClient` instances, the number of clients to simulate (`num_clients`), the number of federated learning rounds (`num_rounds`), and the strategy. The strategy encapsulates the federated learning approach/algorithm, for example, *Federated Averaging* (FedAvg).\n",
+        "\n",
+        "Flower has a number of built-in strategies, but we can also use our own strategy implementations to customize nearly all aspects of the federated learning approach. For this example, we use the built-in `FedAvg` implementation and customize it using a few basic parameters. The last step is the actual call to `start_simulation` which - you guessed it - starts the simulation:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "ELNy0-0nfyI2"
+      },
+      "outputs": [],
+      "source": [
+        "# Create FedAvg strategy\n",
+        "strategy = fl.server.strategy.FedAvg(\n",
+        "        fraction_fit=1.0,  # Sample 100% of available clients for training\n",
+        "        fraction_evaluate=0.5,  # Sample 50% of available clients for evaluation\n",
+        "        min_fit_clients=10,  # Never sample less than 10 clients for training\n",
+        "        min_evaluate_clients=5,  # Never sample less than 5 clients for evaluation\n",
+        "        min_available_clients=10,  # Wait until all 10 clients are available\n",
+        ")\n",
+        "\n",
+        "# Start simulation\n",
+        "fl.simulation.start_simulation(\n",
+        "    client_fn=client_fn,\n",
+        "    num_clients=NUM_CLIENTS,\n",
+        "    config=fl.server.ServerConfig(num_rounds=5),\n",
+        "    strategy=strategy,\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "e_lIXlErb9qN"
+      },
+      "source": [
+        "### Behind the scenes\n",
+        "\n",
+        "So how does this work? How does Flower execute this simulation?\n",
+        "\n",
+        "When we call `start_simulation`, we tell Flower that there are 10 clients (`num_clients=10`). Flower then goes ahead an asks the `FedAvg` strategy to select clients. `FedAvg` knows that it should select 100% of the available clients (`fraction_fit=1.0`), so it goes ahead and selects 10 random clients (i.e., 100% of 10).\n",
+        "\n",
+        "Flower then asks the selected 10 clients to train the model. When the server receives the model parameter updates from the clients, it hands those updates over to the strategy (*FedAvg*) for aggregation. The strategy aggregates those updates and returns the new global model, which then gets used in the next round of federated learning."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "713CIPfZ0egy"
+      },
+      "source": [
+        "### Where's the accuracy?\n",
+        "\n",
+        "You may have noticed that all metrics except for `losses_distributed` are empty. Where did the `{\"accuracy\": float(accuracy)}` go?\n",
+        "\n",
+        "Flower can automatically aggregate losses returned by individual clients, but it cannot do the same for metrics in the generic metrics dictionary (the one with the `accuracy` key). Metrics dictionaries can contain very different kinds of metrics and even key/value pairs that are not metrics at all, so the framework does not (and can not) know how to handle these automatically.\n",
+        "\n",
+        "As users, we need to tell the framework how to handle/aggregate these custom metrics, and we do so by passing metric aggregation functions to the strategy. The strategy will then call these functions whenever it receives fit or evaluate metrics from clients. The two possible functions are `fit_metrics_aggregation_fn` and `evaluate_metrics_aggregation_fn`.\n",
+        "\n",
+        "Let's create a simple weighted averaging function to aggregate the `accuracy` metric we return from `evaluate`:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "gQZ7mINF0egy"
+      },
+      "outputs": [],
+      "source": [
+        "def weighted_average(metrics: List[Tuple[int, Metrics]]) -> Metrics:\n",
+        "    # Multiply accuracy of each client by number of examples used\n",
+        "    accuracies = [num_examples * m[\"accuracy\"] for num_examples, m in metrics]\n",
+        "    examples = [num_examples for num_examples, _ in metrics]\n",
+        "    \n",
+        "    # Aggregate and return custom metric (weighted average)\n",
+        "    return {\"accuracy\": sum(accuracies) / sum(examples)}"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Gfn2l-OV0egz"
+      },
+      "source": [
+        "The only thing left to do is to tell the strategy to call this function whenever it receives evaluation metric dictionaries from the clients:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "yed1AI6x0egz"
+      },
+      "outputs": [],
+      "source": [
+        "# Create FedAvg strategy\n",
+        "strategy = fl.server.strategy.FedAvg(\n",
+        "        fraction_fit=1.0,\n",
+        "        fraction_evaluate=0.5,\n",
+        "        min_fit_clients=10,\n",
+        "        min_evaluate_clients=5,\n",
+        "        min_available_clients=10,\n",
+        "        evaluate_metrics_aggregation_fn=weighted_average,  # <-- pass the metric aggregation function\n",
+        ")\n",
+        "\n",
+        "# Start simulation\n",
+        "fl.simulation.start_simulation(\n",
+        "    client_fn=client_fn,\n",
+        "    num_clients=NUM_CLIENTS,\n",
+        "    config=fl.server.ServerConfig(num_rounds=5),\n",
+        "    strategy=strategy,\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "dhS5mDVt0egz"
+      },
+      "source": [
+        "We now have a full system that performs federated training and federated evaluation. It uses the `weighted_average` function to aggregate custom evaluation metrics and calculates a single `accuracy` metric across all clients on the server side.\n",
+        "\n",
+        "The other two categories of metrics (`losses_centralized` and `metrics_centralized`) are still empty because they only apply when centralized evaluation is being used. Part two of the Flower tutorial will cover centralized evaluation."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "umvwX56Of3Cr"
+      },
+      "source": [
+        "## Final remarks\n",
+        "\n",
+        "Congratulations, you just trained a convolutional neural network, federated over 10 clients! With that, you understand the basics of federated learning with Flower. The same approach you've seen can be used with other machine learning frameworks (not just PyTorch) and tasks (not just CIFAR-10 images classification), for example NLP with Hugging Face Transformers or speech with SpeechBrain.\n",
+        "\n",
+        "In the next notebook, we're going to cover some more advanced concepts. Want to customize your strategy? Initialize parameters on the server side? Or evaluate the aggregated model on the server side? We'll cover all this and more in the next tutorial."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "kFiBpTmI0egz"
+      },
+      "source": [
+        "## Next steps\n",
+        "\n",
+        "Before you continue, make sure to join the Flower community on Slack: [Join Slack](https://flower.dev/join-slack/)\n",
+        "\n",
+        "There's a dedicated `#questions` channel if you need help, but we'd also love to hear who you are in `#introductions`!\n",
+        "\n",
+        "The [Flower Federated Learning Tutorial - Part 2](https://flower.dev/docs/tutorial/Flower-2-Strategies-in-FL-PyTorch.html) goes into more depth about strategies and all the advanced things you can build with them."
+      ]
+    }
+  ],
+  "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "name": "Flower-1-Intro-to-FL-PyTorch.ipynb",
+      "provenance": [],
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "display_name": "Python 3.7.12 64-bit ('flower-3.7.12')",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.7.12"
+    },
+    "vscode": {
+      "interpreter": {
+        "hash": "a6202d1482f480674d090d9d9b5c400c9026d296d041bf38196c7cb6353a393f"
+      }
+    }
   },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "mBu1HRRY6bwX"
-   },
-   "source": [
-    "## Step 0: Preparation\n",
-    "\n",
-    "Before we begin with any actual code, let's make sure that we have everything we need."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "D4KiTMTpiort"
-   },
-   "source": [
-    "### Installing dependencies\n",
-    "\n",
-    "Next, we install the necessary packages for PyTorch (`torch` and `torchvision`) and Flower (`flwr`):"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "eTrCL2FmC5U5"
-   },
-   "outputs": [],
-   "source": [
-    "!pip install -q flwr[simulation] torch torchvision matplotlib"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "3UFT3_A3iz76"
-   },
-   "source": [
-    "Now that we have all dependencies installed, we can import everything we need for this tutorial:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "Tja2N6l-qH-e"
-   },
-   "outputs": [],
-   "source": [
-    "from collections import OrderedDict\n",
-    "from typing import List, Tuple\n",
-    "\n",
-    "import flwr as fl\n",
-    "import numpy as np\n",
-    "import matplotlib.pyplot as plt\n",
-    "import torch\n",
-    "import torch.nn as nn\n",
-    "import torchvision\n",
-    "import torch.nn.functional as F\n",
-    "import torchvision.transforms as transforms\n",
-    "from flwr.common import Metrics\n",
-    "from torch.utils.data import DataLoader, random_split\n",
-    "from torchvision.datasets import CIFAR10\n",
-    "\n",
-    "DEVICE = torch.device(\"cpu\")  # Try \"cuda\" to train on GPU\n",
-    "print(f\"Training on {DEVICE} using PyTorch {torch.__version__} and Flower {fl.__version__}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "8D2bnPKG58Gx"
-   },
-   "source": [
-    "It is possible to switch to a runtime that has GPU acceleration enabled (on Google Colab: `Runtime > Change runtime type > Hardware acclerator: GPU > Save`). Note, however, that Google Colab is not always able to offer GPU acceleration. If you see an error related to GPU availability in one of the following sections, consider switching back to CPU-based execution by setting `DEVICE = torch.device(\"cpu\")`. If the runtime has GPU acceleration enabled, you should see the output `Training on cuda:0`, otherwise it'll say `Training on cpu`."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "JVcgAAiaihnx"
-   },
-   "source": [
-    "\n",
-    "### Loading the data\n",
-    "\n",
-    "Federated learning can be applied to many different types of tasks across different domains. In this tutorial, we introduce federated learning by training a simple convolutional neural network (CNN) on the popular CIFAR-10 dataset. CIFAR-10 can be used to train image classifiers that distinguish between images from ten different classes:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "-tpk_Zv37ONm"
-   },
-   "outputs": [],
-   "source": [
-    "CLASSES = ('plane', 'car', 'bird', 'cat', 'deer', 'dog', 'frog', 'horse', 'ship', 'truck')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "toxAoOq6fS2h"
-   },
-   "source": [
-    "We simulate having multiple datasets from multiple organizations (also called the \"cross-silo\" setting in federated learning) by splitting the original CIFAR-10 dataset into multiple partitions. Each partition will represent the data from a single organization. We're doing this purely for experimentation purposes, in the real world there's no need for data splitting because each organization already has their own data (so the data is naturally partitioned).\n",
-    "\n",
-    "Each organization will act as a client in the federated learning system. So having ten organizations participate in a federation means having ten clients connected to the federated learning server:\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "q9LhPFDh0S5c"
-   },
-   "outputs": [],
-   "source": [
-    "NUM_CLIENTS = 10"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "01Zy7yjBPhQd"
-   },
-   "source": [
-    "\n",
-    "Let's now load the CIFAR-10 training and test set, partition them into ten smaller datasets (each split into training and validation set), and wrap the resulting partitions by creating a PyTorch `DataLoader` for each of them:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "J4Em7BPNTXeX"
-   },
-   "outputs": [],
-   "source": [
-    "BATCH_SIZE = 32\n",
-    "\n",
-    "def load_datasets():\n",
-    "    # Download and transform CIFAR-10 (train and test)\n",
-    "    transform = transforms.Compose(\n",
-    "      [transforms.ToTensor(), transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))]\n",
-    "    )\n",
-    "    trainset = CIFAR10(\"./dataset\", train=True, download=True, transform=transform)\n",
-    "    testset = CIFAR10(\"./dataset\", train=False, download=True, transform=transform)\n",
-    "\n",
-    "    # Split training set into 10 partitions to simulate the individual dataset\n",
-    "    partition_size = len(trainset) // NUM_CLIENTS\n",
-    "    lengths = [partition_size] * NUM_CLIENTS\n",
-    "    datasets = random_split(trainset, lengths, torch.Generator().manual_seed(42))\n",
-    "\n",
-    "    # Split each partition into train/val and create DataLoader\n",
-    "    trainloaders = []\n",
-    "    valloaders = []\n",
-    "    for ds in datasets:\n",
-    "        len_val = len(ds) // 10  # 10 % validation set\n",
-    "        len_train = len(ds) - len_val\n",
-    "        lengths = [len_train, len_val]\n",
-    "        ds_train, ds_val = random_split(ds, lengths, torch.Generator().manual_seed(42))\n",
-    "        trainloaders.append(DataLoader(ds_train, batch_size=BATCH_SIZE, shuffle=True))\n",
-    "        valloaders.append(DataLoader(ds_val, batch_size=BATCH_SIZE))\n",
-    "    testloader = DataLoader(testset, batch_size=BATCH_SIZE)\n",
-    "    return trainloaders, valloaders, testloader\n",
-    "\n",
-    "trainloaders, valloaders, testloader = load_datasets()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "OBp7kB4G0sPB"
-   },
-   "source": [
-    "We now have a list of ten training sets and ten validation sets (`trainloaders` and `valloaders`) representing the data of ten different organizations. Each `trainloader`/`valloader` pair contains 4500 training examples and 500 validation examples. There's also a single `testloader` (we did not split the test set). Again, this is only necessary for building research or educational systems, actual federated learning systems have their data naturally distributed across multiple partitions.\n",
-    "\n",
-    "Let's take a look at the first batch of images and labels in the first training set (i.e., `trainloaders[0]`) before we move on:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "E3dag9WeT9VH"
-   },
-   "outputs": [],
-   "source": [
-    "images, labels = next(iter(trainloaders[0]))\n",
-    "# Reshape and convert images to a NumPy array\n",
-    "# matplotlib requires images with the shape (height, width, 3)\n",
-    "images = images.permute(0, 2, 3, 1).numpy()\n",
-    "# Denormalize\n",
-    "images = images/2 + 0.5\n",
-    "\n",
-    "# Create a figure and a grid of subplots\n",
-    "fig, axs = plt.subplots(4, 8, figsize=(12, 6))\n",
-    "\n",
-    "# Loop over the images and plot them\n",
-    "for i, ax in enumerate(axs.flat):\n",
-    "    ax.imshow(images[i])\n",
-    "    ax.set_title(CLASSES[labels[i]])\n",
-    "    ax.axis('off')\n",
-    "\n",
-    "# Show the plot\n",
-    "fig.tight_layout()\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "ZGVGbRZ_yEA2"
-   },
-   "source": [
-    "The output above shows a random batch of images from the first `trainloader` in our list of ten `trainloaders`. It also prints the labels associated with each image (i.e., one of the ten possible labels we've seen above). If you run the cell again, you should see another batch of images."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "4TW4Pzb7p1F9"
-   },
-   "source": [
-    "## Step 1: Centralized Training with PyTorch\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "cTjCmmBtqPgM"
-   },
-   "source": [
-    "Next, we're going to use PyTorch to define a simple convolutional neural network. This introduction assumes basic familiarity with PyTorch, so it doesn't cover the PyTorch-related aspects in full detail. If you want to dive deeper into PyTorch, we recommend [*DEEP LEARNING WITH PYTORCH: A 60 MINUTE BLITZ*](https://pytorch.org/tutorials/beginner/deep_learning_60min_blitz.html).\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "XYks8IpJL6iK"
-   },
-   "source": [
-    "### Defining the model\n",
-    "\n",
-    "We use the simple CNN described in the [PyTorch tutorial](https://pytorch.org/tutorials/beginner/blitz/cifar10_tutorial.html#define-a-convolutional-neural-network):"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "2X3cVBXMpP6w"
-   },
-   "outputs": [],
-   "source": [
-    "class Net(nn.Module):\n",
-    "    def __init__(self) -> None:\n",
-    "        super(Net, self).__init__()\n",
-    "        self.conv1 = nn.Conv2d(3, 6, 5)\n",
-    "        self.pool = nn.MaxPool2d(2, 2)\n",
-    "        self.conv2 = nn.Conv2d(6, 16, 5)\n",
-    "        self.fc1 = nn.Linear(16 * 5 * 5, 120)\n",
-    "        self.fc2 = nn.Linear(120, 84)\n",
-    "        self.fc3 = nn.Linear(84, 10)\n",
-    "\n",
-    "    def forward(self, x: torch.Tensor) -> torch.Tensor:\n",
-    "        x = self.pool(F.relu(self.conv1(x)))\n",
-    "        x = self.pool(F.relu(self.conv2(x)))\n",
-    "        x = x.view(-1, 16 * 5 * 5)\n",
-    "        x = F.relu(self.fc1(x))\n",
-    "        x = F.relu(self.fc2(x))\n",
-    "        x = self.fc3(x)\n",
-    "        return x"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "tCRhau5cr2Gd"
-   },
-   "source": [
-    "Let's continue with the usual training and test functions:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "xIl8NfAFpyam"
-   },
-   "outputs": [],
-   "source": [
-    "def train(net, trainloader, epochs: int, verbose=False):\n",
-    "    \"\"\"Train the network on the training set.\"\"\"\n",
-    "    criterion = torch.nn.CrossEntropyLoss()\n",
-    "    optimizer = torch.optim.Adam(net.parameters())\n",
-    "    net.train()\n",
-    "    for epoch in range(epochs):\n",
-    "        correct, total, epoch_loss = 0, 0, 0.0\n",
-    "        for images, labels in trainloader:\n",
-    "            images, labels = images.to(DEVICE), labels.to(DEVICE)\n",
-    "            optimizer.zero_grad()\n",
-    "            outputs = net(images)\n",
-    "            loss = criterion(net(images), labels)\n",
-    "            loss.backward()\n",
-    "            optimizer.step()\n",
-    "            # Metrics\n",
-    "            epoch_loss += loss\n",
-    "            total += labels.size(0)\n",
-    "            correct += (torch.max(outputs.data, 1)[1] == labels).sum().item()\n",
-    "        epoch_loss /= len(trainloader.dataset)\n",
-    "        epoch_acc = correct / total\n",
-    "        if verbose:\n",
-    "            print(f\"Epoch {epoch+1}: train loss {epoch_loss}, accuracy {epoch_acc}\")\n",
-    "\n",
-    "\n",
-    "def test(net, testloader):\n",
-    "    \"\"\"Evaluate the network on the entire test set.\"\"\"\n",
-    "    criterion = torch.nn.CrossEntropyLoss()\n",
-    "    correct, total, loss = 0, 0, 0.0\n",
-    "    net.eval()\n",
-    "    with torch.no_grad():\n",
-    "        for images, labels in testloader:\n",
-    "            images, labels = images.to(DEVICE), labels.to(DEVICE)\n",
-    "            outputs = net(images)\n",
-    "            loss += criterion(outputs, labels).item()\n",
-    "            _, predicted = torch.max(outputs.data, 1)\n",
-    "            total += labels.size(0)\n",
-    "            correct += (predicted == labels).sum().item()\n",
-    "    loss /= len(testloader.dataset)\n",
-    "    accuracy = correct / total\n",
-    "    return loss, accuracy"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "GDDxh73Sszck"
-   },
-   "source": [
-    "### Training the model\n",
-    "\n",
-    "We now have all the basic building blocks we need: a dataset, a model, a training function, and a test function. Let's put them together to train the model on the dataset of one of our organizations (`trainloaders[0]`). This simulates the reality of most machine learning projects today: each organization has their own data and trains models only on this internal data: "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "WdUTb8WgtRMz"
-   },
-   "outputs": [],
-   "source": [
-    "trainloader = trainloaders[0]\n",
-    "valloader = valloaders[0]\n",
-    "net = Net().to(DEVICE)\n",
-    "\n",
-    "for epoch in range(5):\n",
-    "    train(net, trainloader, 1)\n",
-    "    loss, accuracy = test(net, valloader)\n",
-    "    print(f\"Epoch {epoch+1}: validation loss {loss}, accuracy {accuracy}\")\n",
-    "\n",
-    "loss, accuracy = test(net, testloader)\n",
-    "print(f\"Final test set performance:\\n\\tloss {loss}\\n\\taccuracy {accuracy}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "DhLGLdmhOhVr"
-   },
-   "source": [
-    "Training the simple CNN on our CIFAR-10 split for 5 epochs should result in a test set accuracy of about 41%, which is not good, but at the same time, it doesn't really matter for the purposes of this tutorial. The intent was just to show a simplistic centralized training pipeline that sets the stage for what comes next - federated learning!"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "a6HP2cYCsqxD"
-   },
-   "source": [
-    "## Step 2: Federated Learning with Flower\n",
-    "\n",
-    "Step 1 demonstrated a simple centralized training pipeline. All data was in one place (i.e., a single `trainloader` and a single `valloader`). Next, we'll simulate a situation where we have multiple datasets in multiple organizations and where we train a model over these organizations using federated learning."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "mf-cW093MzeT"
-   },
-   "source": [
-    "### Updating model parameters\n",
-    "\n",
-    "In federated learning, the server sends the global model parameters to the client, and the client updates the local model with the parameters received from the server. It then trains the model on the local data (which changes the model parameters locally) and sends the updated/changed model parameters back to the server (or, alternatively, it sends just the gradients back to the server, not the full model parameters).\n",
-    "\n",
-    "We need two helper functions to update the local model with parameters received from the server and to get the updated model parameters from the local model: `set_parameters` and `get_parameters`. The following two functions do just that for the PyTorch model above.\n",
-    "\n",
-    "The details of how this works are not really important here (feel free to consult the PyTorch documentation if you want to learn more). In essence, we use `state_dict` to access PyTorch model parameter tensors. The parameter tensors are then converted to/from a list of NumPy ndarray's (which Flower knows how to serialize/deserialize):"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "1ZxGk6AMNvvV"
-   },
-   "outputs": [],
-   "source": [
-    "def get_parameters(net) -> List[np.ndarray]:\n",
-    "    return [val.cpu().numpy() for _, val in net.state_dict().items()]\n",
-    "\n",
-    "def set_parameters(net, parameters: List[np.ndarray]):\n",
-    "    params_dict = zip(net.state_dict().keys(), parameters)\n",
-    "    state_dict = OrderedDict({k: torch.Tensor(v) for k, v in params_dict})\n",
-    "    net.load_state_dict(state_dict, strict=True)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "1lCf3oljdClM"
-   },
-   "source": [
-    "### Implementing a Flower client\n",
-    "\n",
-    "With that out of the way, let's move on to the interesting part. Federated learning systems consist of a server and multiple clients. In Flower, we create clients by implementing subclasses of `flwr.client.Client` or `flwr.client.NumPyClient`. We use `NumPyClient` in this tutorial because it is easier to implement and requires us to write less boilerplate.\n",
-    "\n",
-    "To implement the Flower client, we create a subclass of `flwr.client.NumPyClient` and implement the three methods `get_parameters`, `fit`, and `evaluate`:\n",
-    "\n",
-    "* `get_parameters`: Return the current local model parameters\n",
-    "* `fit`: Receive model parameters from the server, train the model parameters on the local data, and return the (updated) model parameters to the server\n",
-    "* `evaluate`: Receive model parameters from the server, evaluate the model parameters on the local data, and return the evaluation result to the server\n",
-    "\n",
-    "We mentioned that our clients will use the previously defined PyTorch components for model training and evaluation. Let's see a simple Flower client implementation that brings everything together:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "ye6Jt5p3LWtF"
-   },
-   "outputs": [],
-   "source": [
-    "class FlowerClient(fl.client.NumPyClient):\n",
-    "    def __init__(self, net, trainloader, valloader):\n",
-    "        self.net = net\n",
-    "        self.trainloader = trainloader\n",
-    "        self.valloader = valloader\n",
-    "\n",
-    "    def get_parameters(self, config):\n",
-    "        return get_parameters(self.net)\n",
-    "\n",
-    "    def fit(self, parameters, config):\n",
-    "        set_parameters(self.net, parameters)\n",
-    "        train(self.net, self.trainloader, epochs=1)\n",
-    "        return get_parameters(self.net), len(self.trainloader), {}\n",
-    "\n",
-    "    def evaluate(self, parameters, config):\n",
-    "        set_parameters(self.net, parameters)\n",
-    "        loss, accuracy = test(self.net, self.valloader)\n",
-    "        return float(loss), len(self.valloader), {\"accuracy\": float(accuracy)}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "Heyxd9MfHOTe"
-   },
-   "source": [
-    "Our class `FlowerClient` defines how local training/evaluation will be performed and allows Flower to call the local training/evaluation through `fit` and `evaluate`. Each instance of `FlowerClient` represents a *single client* in our federated learning system. Federated learning systems have multiple clients (otherwise there's not much to federate), so each client will be represented by its own instance of `FlowerClient`. If we have, for example, three clients in our workload, then we'd have three instances of `FlowerClient`. Flower calls `FlowerClient.fit` on the respective instance when the server selects a particular client for training (and `FlowerClient.evaluate` for evaluation).\n",
-    "\n",
-    "### Using the Virtual Client Engine\n",
-    "\n",
-    "In this notebook, we want to simulate a federated learning system with 10 clients on a single machine. This means that the server and all 10 clients will live on a single machine and share resources such as CPU, GPU, and memory. Having 10 clients would mean having 10 instances of `FlowerClient` im memory. Doing this on a single machine can quickly exhaust the available memory resources, even if only a subset of these clients participates in a single round of federated learning.\n",
-    "\n",
-    "In addition to the regular capabilities where server and clients run on multiple machines, Flower therefore provides special simulation capabilities that create `FlowerClient` instances only when they are actually necessary for training or evaluation. To enable the Flower framework to create clients when necessary, we need to implement a function called `client_fn` that creates a `FlowerClient` instance on demand. Flower calls `client_fn` whenever it needs an instance of one particular client to call `fit` or `evaluate` (those instances are usually discarded after use, so they should not keep any local state). Clients are identified by a client ID, or short `cid`. The `cid` can be used, for example, to load different local data partitions for different clients, as can be seen below:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "qkcwggRYOwWN"
-   },
-   "outputs": [],
-   "source": [
-    "def client_fn(cid: str) -> FlowerClient:\n",
-    "    \"\"\"Create a Flower client representing a single organization.\"\"\"\n",
-    "\n",
-    "    # Load model\n",
-    "    net = Net().to(DEVICE)\n",
-    "\n",
-    "    # Load data (CIFAR-10)\n",
-    "    # Note: each client gets a different trainloader/valloader, so each client\n",
-    "    # will train and evaluate on their own unique data\n",
-    "    trainloader = trainloaders[int(cid)]\n",
-    "    valloader = valloaders[int(cid)]\n",
-    "\n",
-    "    # Create a  single Flower client representing a single organization\n",
-    "    return FlowerClient(net, trainloader, valloader)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "axzXSMtlfhXU"
-   },
-   "source": [
-    "### Starting the training\n",
-    "\n",
-    "We now have the class `FlowerClient` which defines client-side training/evaluation and `client_fn` which allows Flower to create `FlowerClient` instances whenever it needs to call `fit` or `evaluate` on one particular client. The last step is to start the actual simulation using `flwr.simulation.start_simulation`. \n",
-    "\n",
-    "The function `start_simulation` accepts a number of arguments, amongst them the `client_fn` used to create `FlowerClient` instances, the number of clients to simulate (`num_clients`), the number of federated learning rounds (`num_rounds`), and the strategy. The strategy encapsulates the federated learning approach/algorithm, for example, *Federated Averaging* (FedAvg).\n",
-    "\n",
-    "Flower has a number of built-in strategies, but we can also use our own strategy implementations to customize nearly all aspects of the federated learning approach. For this example, we use the built-in `FedAvg` implementation and customize it using a few basic parameters. The last step is the actual call to `start_simulation` which - you guessed it - starts the simulation:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "ELNy0-0nfyI2"
-   },
-   "outputs": [],
-   "source": [
-    "# Create FedAvg strategy\n",
-    "strategy = fl.server.strategy.FedAvg(\n",
-    "        fraction_fit=1.0,  # Sample 100% of available clients for training\n",
-    "        fraction_evaluate=0.5,  # Sample 50% of available clients for evaluation\n",
-    "        min_fit_clients=10,  # Never sample less than 10 clients for training\n",
-    "        min_evaluate_clients=5,  # Never sample less than 5 clients for evaluation\n",
-    "        min_available_clients=10,  # Wait until all 10 clients are available\n",
-    ")\n",
-    "\n",
-    "# Start simulation\n",
-    "fl.simulation.start_simulation(\n",
-    "    client_fn=client_fn,\n",
-    "    num_clients=NUM_CLIENTS,\n",
-    "    config=fl.server.ServerConfig(num_rounds=5),\n",
-    "    strategy=strategy,\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "e_lIXlErb9qN"
-   },
-   "source": [
-    "### Behind the scenes\n",
-    "\n",
-    "So how does this work? How does Flower execute this simulation?\n",
-    "\n",
-    "When we call `start_simulation`, we tell Flower that there are 10 clients (`num_clients=10`). Flower then goes ahead an asks the `FedAvg` strategy to select clients. `FedAvg` knows that it should select 100% of the available clients (`fraction_fit=1.0`), so it goes ahead and selects 10 random clients (i.e., 100% of 10).\n",
-    "\n",
-    "Flower then asks the selected 10 clients to train the model. When the server receives the model parameter updates from the clients, it hands those updates over to the strategy (*FedAvg*) for aggregation. The strategy aggregates those updates and returns the new global model, which then gets used in the next round of federated learning."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Where's the accuracy?\n",
-    "\n",
-    "You may have noticed that all metrics except for `losses_distributed` are empty. Where did the `{\"accuracy\": float(accuracy)}` go?\n",
-    "\n",
-    "Flower can automatically aggregate losses returned by individual clients, but it cannot do the same for metrics in the generic metrics dictionary (the one with the `accuracy` key). Metrics dictionaries can contain very different kinds of metrics and even key/value pairs that are not metrics at all, so the framework does not (and can not) know how to handle these automatically.\n",
-    "\n",
-    "As users, we need to tell the framework how to handle/aggregate these custom metrics, and we do so by passing metric aggregation functions to the strategy. The strategy will then call these functions whenever it receives fit or evaluate metrics from clients. The two possible functions are `fit_metrics_aggregation_fn` and `evaluate_metrics_aggregation_fn`.\n",
-    "\n",
-    "Let's create a simple weighted averaging function to aggregate the `accuracy` metric we return from `evaluate`:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def weighted_average(metrics: List[Tuple[int, Metrics]]) -> Metrics:\n",
-    "    # Multiply accuracy of each client by number of examples used\n",
-    "    accuracies = [num_examples * m[\"accuracy\"] for num_examples, m in metrics]\n",
-    "    examples = [num_examples for num_examples, _ in metrics]\n",
-    "    \n",
-    "    # Aggregate and return custom metric (weighted average)\n",
-    "    return {\"accuracy\": sum(accuracies) / sum(examples)}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The only thing left to do is to tell the strategy to call this function whenever it receives evaluation metric dictionaries from the clients:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Create FedAvg strategy\n",
-    "strategy = fl.server.strategy.FedAvg(\n",
-    "        fraction_fit=1.0,\n",
-    "        fraction_evaluate=0.5,\n",
-    "        min_fit_clients=10,\n",
-    "        min_evaluate_clients=5,\n",
-    "        min_available_clients=10,\n",
-    "        evaluate_metrics_aggregation_fn=weighted_average,  # <-- pass the metric aggregation function\n",
-    ")\n",
-    "\n",
-    "# Start simulation\n",
-    "fl.simulation.start_simulation(\n",
-    "    client_fn=client_fn,\n",
-    "    num_clients=NUM_CLIENTS,\n",
-    "    config=fl.server.ServerConfig(num_rounds=5),\n",
-    "    strategy=strategy,\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We now have a full system that performs federated training and federated evaluation. It uses the `weighted_average` function to aggregate custom evaluation metrics and calculates a single `accuracy` metric across all clients on the server side.\n",
-    "\n",
-    "The other two categories of metrics (`losses_centralized` and `metrics_centralized`) are still empty because they only apply when centralized evaluation is being used. Part two of the Flower tutorial will cover centralized evaluation."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "umvwX56Of3Cr"
-   },
-   "source": [
-    "## Final remarks\n",
-    "\n",
-    "Congratulations, you just trained a convolutional neural network, federated over 10 clients! With that, you understand the basics of federated learning with Flower. The same approach you've seen can be used with other machine learning frameworks (not just PyTorch) and tasks (not just CIFAR-10 images classification), for example NLP with Hugging Face Transformers or speech with SpeechBrain.\n",
-    "\n",
-    "In the next notebook, we're going to cover some more advanced concepts. Want to customize your strategy? Initialize parameters on the server side? Or evaluate the aggregated model on the server side? We'll cover all this and more in the next tutorial."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Next steps\n",
-    "\n",
-    "Before you continue, make sure to join the Flower community on Slack: [Join Slack](https://flower.dev/join-slack/)\n",
-    "\n",
-    "There's a dedicated `#questions` channel if you need help, but we'd also love to hear who you are in `#introductions`!\n",
-    "\n",
-    "The [Flower Federated Learning Tutorial - Part 2](https://flower.dev/docs/tutorial/Flower-2-Strategies-in-FL-PyTorch.html) goes into more depth about strategies and all the advanced things you can build with them."
-   ]
-  }
- ],
- "metadata": {
-  "accelerator": "GPU",
-  "colab": {
-   "collapsed_sections": [],
-   "name": "Flower-1-Intro-to-FL-PyTorch.ipynb",
-   "provenance": [],
-   "toc_visible": true
-  },
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.7.12"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "a6202d1482f480674d090d9d9b5c400c9026d296d041bf38196c7cb6353a393f"
-   }
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 1
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/doc/source/tutorial/Flower-1-Intro-to-FL-PyTorch.ipynb
+++ b/doc/source/tutorial/Flower-1-Intro-to-FL-PyTorch.ipynb
@@ -1,696 +1,715 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "cz71fPGrpRiQ"
-      },
-      "source": [
-        "# An Introduction to Federated Learning\n",
-        "\n",
-        "Welcome to the Flower federated learning tutorial!\n",
-        "\n",
-        "In this notebook, we'll build a federated learning system using Flower and PyTorch. In part 1, we use PyTorch for the model training pipeline and data loading. In part 2, we continue to federate the PyTorch-based pipeline using Flower.\n",
-        "\n",
-        "> Join the Flower community on Slack to connect, ask questions, and get help: [Join Slack](https://flower.dev/join-slack) 🌻 We'd love to hear from you in the `#introductions` channel! If anything is unclear, head over to the `#questions` channel.\n",
-        "\n",
-        "Let's get stated!"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "mBu1HRRY6bwX"
-      },
-      "source": [
-        "## Step 0: Preparation\n",
-        "\n",
-        "Before we begin with any actual code, let's make sure that we have everything we need."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "D4KiTMTpiort"
-      },
-      "source": [
-        "### Installing dependencies\n",
-        "\n",
-        "Next, we install the necessary packages for PyTorch (`torch` and `torchvision`) and Flower (`flwr`):"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "eTrCL2FmC5U5"
-      },
-      "outputs": [],
-      "source": [
-        "!pip install -q flwr[simulation] torch torchvision matplotlib"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "3UFT3_A3iz76"
-      },
-      "source": [
-        "Now that we have all dependencies installed, we can import everything we need for this tutorial:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "Tja2N6l-qH-e"
-      },
-      "outputs": [],
-      "source": [
-        "from collections import OrderedDict\n",
-        "from typing import List, Tuple\n",
-        "\n",
-        "import flwr as fl\n",
-        "import numpy as np\n",
-        "import matplotlib.pyplot as plt\n",
-        "import torch\n",
-        "import torch.nn as nn\n",
-        "import torchvision\n",
-        "import torch.nn.functional as F\n",
-        "import torchvision.transforms as transforms\n",
-        "from flwr.common import Metrics\n",
-        "from torch.utils.data import DataLoader, random_split\n",
-        "from torchvision.datasets import CIFAR10\n",
-        "\n",
-        "DEVICE = torch.device(\"cpu\")  # Try \"cuda\" to train on GPU\n",
-        "print(f\"Training on {DEVICE} using PyTorch {torch.__version__} and Flower {fl.__version__}\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "8D2bnPKG58Gx"
-      },
-      "source": [
-        "It is possible to switch to a runtime that has GPU acceleration enabled (on Google Colab: `Runtime > Change runtime type > Hardware acclerator: GPU > Save`). Note, however, that Google Colab is not always able to offer GPU acceleration. If you see an error related to GPU availability in one of the following sections, consider switching back to CPU-based execution by setting `DEVICE = torch.device(\"cpu\")`. If the runtime has GPU acceleration enabled, you should see the output `Training on cuda:0`, otherwise it'll say `Training on cpu`."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "JVcgAAiaihnx"
-      },
-      "source": [
-        "\n",
-        "### Loading the data\n",
-        "\n",
-        "Federated learning can be applied to many different types of tasks across different domains. In this tutorial, we introduce federated learning by training a simple convolutional neural network (CNN) on the popular CIFAR-10 dataset. CIFAR-10 can be used to train image classifiers that distinguish between images from ten different classes:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "-tpk_Zv37ONm"
-      },
-      "outputs": [],
-      "source": [
-        "CLASSES = ('plane', 'car', 'bird', 'cat', 'deer', 'dog', 'frog', 'horse', 'ship', 'truck')"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "toxAoOq6fS2h"
-      },
-      "source": [
-        "We simulate having multiple datasets from multiple organizations (also called the \"cross-silo\" setting in federated learning) by splitting the original CIFAR-10 dataset into multiple partitions. Each partition will represent the data from a single organization. We're doing this purely for experimentation purposes, in the real world there's no need for data splitting because each organization already has their own data (so the data is naturally partitioned).\n",
-        "\n",
-        "Each organization will act as a client in the federated learning system. So having ten organizations participate in a federation means having ten clients connected to the federated learning server:\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "q9LhPFDh0S5c"
-      },
-      "outputs": [],
-      "source": [
-        "NUM_CLIENTS = 10"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "01Zy7yjBPhQd"
-      },
-      "source": [
-        "\n",
-        "Let's now load the CIFAR-10 training and test set, partition them into ten smaller datasets (each split into training and validation set), and wrap the resulting partitions by creating a PyTorch `DataLoader` for each of them:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "J4Em7BPNTXeX"
-      },
-      "outputs": [],
-      "source": [
-        "BATCH_SIZE = 32\n",
-        "\n",
-        "def load_datasets():\n",
-        "    # Download and transform CIFAR-10 (train and test)\n",
-        "    transform = transforms.Compose(\n",
-        "      [transforms.ToTensor(), transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))]\n",
-        "    )\n",
-        "    trainset = CIFAR10(\"./dataset\", train=True, download=True, transform=transform)\n",
-        "    testset = CIFAR10(\"./dataset\", train=False, download=True, transform=transform)\n",
-        "\n",
-        "    # Split training set into 10 partitions to simulate the individual dataset\n",
-        "    partition_size = len(trainset) // NUM_CLIENTS\n",
-        "    lengths = [partition_size] * NUM_CLIENTS\n",
-        "    datasets = random_split(trainset, lengths, torch.Generator().manual_seed(42))\n",
-        "\n",
-        "    # Split each partition into train/val and create DataLoader\n",
-        "    trainloaders = []\n",
-        "    valloaders = []\n",
-        "    for ds in datasets:\n",
-        "        len_val = len(ds) // 10  # 10 % validation set\n",
-        "        len_train = len(ds) - len_val\n",
-        "        lengths = [len_train, len_val]\n",
-        "        ds_train, ds_val = random_split(ds, lengths, torch.Generator().manual_seed(42))\n",
-        "        trainloaders.append(DataLoader(ds_train, batch_size=BATCH_SIZE, shuffle=True))\n",
-        "        valloaders.append(DataLoader(ds_val, batch_size=BATCH_SIZE))\n",
-        "    testloader = DataLoader(testset, batch_size=BATCH_SIZE)\n",
-        "    return trainloaders, valloaders, testloader\n",
-        "\n",
-        "trainloaders, valloaders, testloader = load_datasets()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "OBp7kB4G0sPB"
-      },
-      "source": [
-        "We now have a list of ten training sets and ten validation sets (`trainloaders` and `valloaders`) representing the data of ten different organizations. Each `trainloader`/`valloader` pair contains 4500 training examples and 500 validation examples. There's also a single `testloader` (we did not split the test set). Again, this is only necessary for building research or educational systems, actual federated learning systems have their data naturally distributed across multiple partitions.\n",
-        "\n",
-        "Let's take a look at the first batch of images and labels in the first training set (i.e., `trainloaders[0]`) before we move on:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "E3dag9WeT9VH"
-      },
-      "outputs": [],
-      "source": [
-        "def imshow(img):\n",
-        "    img = img / 2 + 0.5  # unnormalize\n",
-        "    plt.imshow(np.transpose(img.numpy(), (1, 2, 0)))\n",
-        "    plt.show()\n",
-        "\n",
-        "images, labels = iter(trainloaders[0]).next()\n",
-        "imshow(torchvision.utils.make_grid(images))\n",
-        "print(' '.join('%5s' % CLASSES[labels[j]] for j in range(32)))"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "ZGVGbRZ_yEA2"
-      },
-      "source": [
-        "The output above shows a random batch of images from the first `trainloader` in our list of ten `trainloaders`. It also prints the labels associated with each image (i.e., one of the ten possible labels we've seen above). If you run the cell again, you should see another batch of images."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "4TW4Pzb7p1F9"
-      },
-      "source": [
-        "## Step 1: Centralized Training with PyTorch\n",
-        "\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "cTjCmmBtqPgM"
-      },
-      "source": [
-        "Next, we're going to use PyTorch to define a simple convolutional neural network. This introduction assumes basic familiarity with PyTorch, so it doesn't cover the PyTorch-related aspects in full detail. If you want to dive deeper into PyTorch, we recommend [*DEEP LEARNING WITH PYTORCH: A 60 MINUTE BLITZ*](https://pytorch.org/tutorials/beginner/deep_learning_60min_blitz.html).\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "XYks8IpJL6iK"
-      },
-      "source": [
-        "### Defining the model\n",
-        "\n",
-        "We use the simple CNN described in the [PyTorch tutorial](https://pytorch.org/tutorials/beginner/blitz/cifar10_tutorial.html#define-a-convolutional-neural-network):"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "2X3cVBXMpP6w"
-      },
-      "outputs": [],
-      "source": [
-        "class Net(nn.Module):\n",
-        "    def __init__(self) -> None:\n",
-        "        super(Net, self).__init__()\n",
-        "        self.conv1 = nn.Conv2d(3, 6, 5)\n",
-        "        self.pool = nn.MaxPool2d(2, 2)\n",
-        "        self.conv2 = nn.Conv2d(6, 16, 5)\n",
-        "        self.fc1 = nn.Linear(16 * 5 * 5, 120)\n",
-        "        self.fc2 = nn.Linear(120, 84)\n",
-        "        self.fc3 = nn.Linear(84, 10)\n",
-        "\n",
-        "    def forward(self, x: torch.Tensor) -> torch.Tensor:\n",
-        "        x = self.pool(F.relu(self.conv1(x)))\n",
-        "        x = self.pool(F.relu(self.conv2(x)))\n",
-        "        x = x.view(-1, 16 * 5 * 5)\n",
-        "        x = F.relu(self.fc1(x))\n",
-        "        x = F.relu(self.fc2(x))\n",
-        "        x = self.fc3(x)\n",
-        "        return x"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "tCRhau5cr2Gd"
-      },
-      "source": [
-        "Let's continue with the usual training and test functions:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "xIl8NfAFpyam"
-      },
-      "outputs": [],
-      "source": [
-        "def train(net, trainloader, epochs: int, verbose=False):\n",
-        "    \"\"\"Train the network on the training set.\"\"\"\n",
-        "    criterion = torch.nn.CrossEntropyLoss()\n",
-        "    optimizer = torch.optim.Adam(net.parameters())\n",
-        "    net.train()\n",
-        "    for epoch in range(epochs):\n",
-        "        correct, total, epoch_loss = 0, 0, 0.0\n",
-        "        for images, labels in trainloader:\n",
-        "            images, labels = images.to(DEVICE), labels.to(DEVICE)\n",
-        "            optimizer.zero_grad()\n",
-        "            outputs = net(images)\n",
-        "            loss = criterion(net(images), labels)\n",
-        "            loss.backward()\n",
-        "            optimizer.step()\n",
-        "            # Metrics\n",
-        "            epoch_loss += loss\n",
-        "            total += labels.size(0)\n",
-        "            correct += (torch.max(outputs.data, 1)[1] == labels).sum().item()\n",
-        "        epoch_loss /= len(trainloader.dataset)\n",
-        "        epoch_acc = correct / total\n",
-        "        if verbose:\n",
-        "            print(f\"Epoch {epoch+1}: train loss {epoch_loss}, accuracy {epoch_acc}\")\n",
-        "\n",
-        "\n",
-        "def test(net, testloader):\n",
-        "    \"\"\"Evaluate the network on the entire test set.\"\"\"\n",
-        "    criterion = torch.nn.CrossEntropyLoss()\n",
-        "    correct, total, loss = 0, 0, 0.0\n",
-        "    net.eval()\n",
-        "    with torch.no_grad():\n",
-        "        for images, labels in testloader:\n",
-        "            images, labels = images.to(DEVICE), labels.to(DEVICE)\n",
-        "            outputs = net(images)\n",
-        "            loss += criterion(outputs, labels).item()\n",
-        "            _, predicted = torch.max(outputs.data, 1)\n",
-        "            total += labels.size(0)\n",
-        "            correct += (predicted == labels).sum().item()\n",
-        "    loss /= len(testloader.dataset)\n",
-        "    accuracy = correct / total\n",
-        "    return loss, accuracy"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "GDDxh73Sszck"
-      },
-      "source": [
-        "### Training the model\n",
-        "\n",
-        "We now have all the basic building blocks we need: a dataset, a model, a training function, and a test function. Let's put them together to train the model on the dataset of one of our organizations (`trainloaders[0]`). This simulates the reality of most machine learning projects today: each organization has their own data and trains models only on this internal data: "
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "WdUTb8WgtRMz"
-      },
-      "outputs": [],
-      "source": [
-        "trainloader = trainloaders[0]\n",
-        "valloader = valloaders[0]\n",
-        "net = Net().to(DEVICE)\n",
-        "\n",
-        "for epoch in range(5):\n",
-        "    train(net, trainloader, 1)\n",
-        "    loss, accuracy = test(net, valloader)\n",
-        "    print(f\"Epoch {epoch+1}: validation loss {loss}, accuracy {accuracy}\")\n",
-        "\n",
-        "loss, accuracy = test(net, testloader)\n",
-        "print(f\"Final test set performance:\\n\\tloss {loss}\\n\\taccuracy {accuracy}\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "DhLGLdmhOhVr"
-      },
-      "source": [
-        "Training the simple CNN on our CIFAR-10 split for 5 epochs should result in a test set accuracy of about 41%, which is not good, but at the same time, it doesn't really matter for the purposes of this tutorial. The intent was just to show a simplistic centralized training pipeline that sets the stage for what comes next - federated learning!"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "a6HP2cYCsqxD"
-      },
-      "source": [
-        "## Step 2: Federated Learning with Flower\n",
-        "\n",
-        "Step 1 demonstrated a simple centralized training pipeline. All data was in one place (i.e., a single `trainloader` and a single `valloader`). Next, we'll simulate a situation where we have multiple datasets in multiple organizations and where we train a model over these organizations using federated learning."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "mf-cW093MzeT"
-      },
-      "source": [
-        "### Updating model parameters\n",
-        "\n",
-        "In federated learning, the server sends the global model parameters to the client, and the client updates the local model with the parameters received from the server. It then trains the model on the local data (which changes the model parameters locally) and sends the updated/changed model parameters back to the server (or, alternatively, it sends just the gradients back to the server, not the full model parameters).\n",
-        "\n",
-        "We need two helper functions to update the local model with parameters received from the server and to get the updated model parameters from the local model: `set_parameters` and `get_parameters`. The following two functions do just that for the PyTorch model above.\n",
-        "\n",
-        "The details of how this works are not really important here (feel free to consult the PyTorch documentation if you want to learn more). In essence, we use `state_dict` to access PyTorch model parameter tensors. The parameter tensors are then converted to/from a list of NumPy ndarray's (which Flower knows how to serialize/deserialize):"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "1ZxGk6AMNvvV"
-      },
-      "outputs": [],
-      "source": [
-        "def get_parameters(net) -> List[np.ndarray]:\n",
-        "    return [val.cpu().numpy() for _, val in net.state_dict().items()]\n",
-        "\n",
-        "def set_parameters(net, parameters: List[np.ndarray]):\n",
-        "    params_dict = zip(net.state_dict().keys(), parameters)\n",
-        "    state_dict = OrderedDict({k: torch.Tensor(v) for k, v in params_dict})\n",
-        "    net.load_state_dict(state_dict, strict=True)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "1lCf3oljdClM"
-      },
-      "source": [
-        "### Implementing a Flower client\n",
-        "\n",
-        "With that out of the way, let's move on to the interesting part. Federated learning systems consist of a server and multiple clients. In Flower, we create clients by implementing subclasses of `flwr.client.Client` or `flwr.client.NumPyClient`. We use `NumPyClient` in this tutorial because it is easier to implement and requires us to write less boilerplate.\n",
-        "\n",
-        "To implement the Flower client, we create a subclass of `flwr.client.NumPyClient` and implement the three methods `get_parameters`, `fit`, and `evaluate`:\n",
-        "\n",
-        "* `get_parameters`: Return the current local model parameters\n",
-        "* `fit`: Receive model parameters from the server, train the model parameters on the local data, and return the (updated) model parameters to the server\n",
-        "* `evaluate`: Receive model parameters from the server, evaluate the model parameters on the local data, and return the evaluation result to the server\n",
-        "\n",
-        "We mentioned that our clients will use the previously defined PyTorch components for model training and evaluation. Let's see a simple Flower client implementation that brings everything together:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "ye6Jt5p3LWtF"
-      },
-      "outputs": [],
-      "source": [
-        "class FlowerClient(fl.client.NumPyClient):\n",
-        "    def __init__(self, net, trainloader, valloader):\n",
-        "        self.net = net\n",
-        "        self.trainloader = trainloader\n",
-        "        self.valloader = valloader\n",
-        "\n",
-        "    def get_parameters(self, config):\n",
-        "        return get_parameters(self.net)\n",
-        "\n",
-        "    def fit(self, parameters, config):\n",
-        "        set_parameters(self.net, parameters)\n",
-        "        train(self.net, self.trainloader, epochs=1)\n",
-        "        return get_parameters(self.net), len(self.trainloader), {}\n",
-        "\n",
-        "    def evaluate(self, parameters, config):\n",
-        "        set_parameters(self.net, parameters)\n",
-        "        loss, accuracy = test(self.net, self.valloader)\n",
-        "        return float(loss), len(self.valloader), {\"accuracy\": float(accuracy)}"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Heyxd9MfHOTe"
-      },
-      "source": [
-        "Our class `FlowerClient` defines how local training/evaluation will be performed and allows Flower to call the local training/evaluation through `fit` and `evaluate`. Each instance of `FlowerClient` represents a *single client* in our federated learning system. Federated learning systems have multiple clients (otherwise there's not much to federate), so each client will be represented by its own instance of `FlowerClient`. If we have, for example, three clients in our workload, then we'd have three instances of `FlowerClient`. Flower calls `FlowerClient.fit` on the respective instance when the server selects a particular client for training (and `FlowerClient.evaluate` for evaluation).\n",
-        "\n",
-        "### Using the Virtual Client Engine\n",
-        "\n",
-        "In this notebook, we want to simulate a federated learning system with 10 clients on a single machine. This means that the server and all 10 clients will live on a single machine and share resources such as CPU, GPU, and memory. Having 10 clients would mean having 10 instances of `FlowerClient` im memory. Doing this on a single machine can quickly exhaust the available memory resources, even if only a subset of these clients participates in a single round of federated learning.\n",
-        "\n",
-        "In addition to the regular capabilities where server and clients run on multiple machines, Flower therefore provides special simulation capabilities that create `FlowerClient` instances only when they are actually necessary for training or evaluation. To enable the Flower framework to create clients when necessary, we need to implement a function called `client_fn` that creates a `FlowerClient` instance on demand. Flower calls `client_fn` whenever it needs an instance of one particular client to call `fit` or `evaluate` (those instances are usually discarded after use, so they should not keep any local state). Clients are identified by a client ID, or short `cid`. The `cid` can be used, for example, to load different local data partitions for different clients, as can be seen below:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "qkcwggRYOwWN"
-      },
-      "outputs": [],
-      "source": [
-        "def client_fn(cid: str) -> FlowerClient:\n",
-        "    \"\"\"Create a Flower client representing a single organization.\"\"\"\n",
-        "\n",
-        "    # Load model\n",
-        "    net = Net().to(DEVICE)\n",
-        "\n",
-        "    # Load data (CIFAR-10)\n",
-        "    # Note: each client gets a different trainloader/valloader, so each client\n",
-        "    # will train and evaluate on their own unique data\n",
-        "    trainloader = trainloaders[int(cid)]\n",
-        "    valloader = valloaders[int(cid)]\n",
-        "\n",
-        "    # Create a  single Flower client representing a single organization\n",
-        "    return FlowerClient(net, trainloader, valloader)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "axzXSMtlfhXU"
-      },
-      "source": [
-        "### Starting the training\n",
-        "\n",
-        "We now have the class `FlowerClient` which defines client-side training/evaluation and `client_fn` which allows Flower to create `FlowerClient` instances whenever it needs to call `fit` or `evaluate` on one particular client. The last step is to start the actual simulation using `flwr.simulation.start_simulation`. \n",
-        "\n",
-        "The function `start_simulation` accepts a number of arguments, amongst them the `client_fn` used to create `FlowerClient` instances, the number of clients to simulate (`num_clients`), the number of federated learning rounds (`num_rounds`), and the strategy. The strategy encapsulates the federated learning approach/algorithm, for example, *Federated Averaging* (FedAvg).\n",
-        "\n",
-        "Flower has a number of built-in strategies, but we can also use our own strategy implementations to customize nearly all aspects of the federated learning approach. For this example, we use the built-in `FedAvg` implementation and customize it using a few basic parameters. The last step is the actual call to `start_simulation` which - you guessed it - starts the simulation:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "ELNy0-0nfyI2"
-      },
-      "outputs": [],
-      "source": [
-        "# Create FedAvg strategy\n",
-        "strategy = fl.server.strategy.FedAvg(\n",
-        "        fraction_fit=1.0,  # Sample 100% of available clients for training\n",
-        "        fraction_evaluate=0.5,  # Sample 50% of available clients for evaluation\n",
-        "        min_fit_clients=10,  # Never sample less than 10 clients for training\n",
-        "        min_evaluate_clients=5,  # Never sample less than 5 clients for evaluation\n",
-        "        min_available_clients=10,  # Wait until all 10 clients are available\n",
-        ")\n",
-        "\n",
-        "# Start simulation\n",
-        "fl.simulation.start_simulation(\n",
-        "    client_fn=client_fn,\n",
-        "    num_clients=NUM_CLIENTS,\n",
-        "    config=fl.server.ServerConfig(num_rounds=5),\n",
-        "    strategy=strategy,\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "e_lIXlErb9qN"
-      },
-      "source": [
-        "### Behind the scenes\n",
-        "\n",
-        "So how does this work? How does Flower execute this simulation?\n",
-        "\n",
-        "When we call `start_simulation`, we tell Flower that there are 10 clients (`num_clients=10`). Flower then goes ahead an asks the `FedAvg` strategy to select clients. `FedAvg` knows that it should select 100% of the available clients (`fraction_fit=1.0`), so it goes ahead and selects 10 random clients (i.e., 100% of 10).\n",
-        "\n",
-        "Flower then asks the selected 10 clients to train the model. When the server receives the model parameter updates from the clients, it hands those updates over to the strategy (*FedAvg*) for aggregation. The strategy aggregates those updates and returns the new global model, which then gets used in the next round of federated learning."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "### Where's the accuracy?\n",
-        "\n",
-        "You may have noticed that all metrics except for `losses_distributed` are empty. Where did the `{\"accuracy\": float(accuracy)}` go?\n",
-        "\n",
-        "Flower can automatically aggregate losses returned by individual clients, but it cannot do the same for metrics in the generic metrics dictionary (the one with the `accuracy` key). Metrics dictionaries can contain very different kinds of metrics and even key/value pairs that are not metrics at all, so the framework does not (and can not) know how to handle these automatically.\n",
-        "\n",
-        "As users, we need to tell the framework how to handle/aggregate these custom metrics, and we do so by passing metric aggregation functions to the strategy. The strategy will then call these functions whenever it receives fit or evaluate metrics from clients. The two possible functions are `fit_metrics_aggregation_fn` and `evaluate_metrics_aggregation_fn`.\n",
-        "\n",
-        "Let's create a simple weighted averaging function to aggregate the `accuracy` metric we return from `evaluate`:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "def weighted_average(metrics: List[Tuple[int, Metrics]]) -> Metrics:\n",
-        "    # Multiply accuracy of each client by number of examples used\n",
-        "    accuracies = [num_examples * m[\"accuracy\"] for num_examples, m in metrics]\n",
-        "    examples = [num_examples for num_examples, _ in metrics]\n",
-        "    \n",
-        "    # Aggregate and return custom metric (weighted average)\n",
-        "    return {\"accuracy\": sum(accuracies) / sum(examples)}"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "The only thing left to do is to tell the strategy to call this function whenever it receives evaluation metric dictionaries from the clients:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "# Create FedAvg strategy\n",
-        "strategy = fl.server.strategy.FedAvg(\n",
-        "        fraction_fit=1.0,\n",
-        "        fraction_evaluate=0.5,\n",
-        "        min_fit_clients=10,\n",
-        "        min_evaluate_clients=5,\n",
-        "        min_available_clients=10,\n",
-        "        evaluate_metrics_aggregation_fn=weighted_average,  # <-- pass the metric aggregation function\n",
-        ")\n",
-        "\n",
-        "# Start simulation\n",
-        "fl.simulation.start_simulation(\n",
-        "    client_fn=client_fn,\n",
-        "    num_clients=NUM_CLIENTS,\n",
-        "    config=fl.server.ServerConfig(num_rounds=5),\n",
-        "    strategy=strategy,\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "We now have a full system that performs federated training and federated evaluation. It uses the `weighted_average` function to aggregate custom evaluation metrics and calculates a single `accuracy` metric across all clients on the server side.\n",
-        "\n",
-        "The other two categories of metrics (`losses_centralized` and `metrics_centralized`) are still empty because they only apply when centralized evaluation is being used. Part two of the Flower tutorial will cover centralized evaluation."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "umvwX56Of3Cr"
-      },
-      "source": [
-        "## Final remarks\n",
-        "\n",
-        "Congratulations, you just trained a convolutional neural network, federated over 10 clients! With that, you understand the basics of federated learning with Flower. The same approach you've seen can be used with other machine learning frameworks (not just PyTorch) and tasks (not just CIFAR-10 images classification), for example NLP with Hugging Face Transformers or speech with SpeechBrain.\n",
-        "\n",
-        "In the next notebook, we're going to cover some more advanced concepts. Want to customize your strategy? Initialize parameters on the server side? Or evaluate the aggregated model on the server side? We'll cover all this and more in the next tutorial."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Next steps\n",
-        "\n",
-        "Before you continue, make sure to join the Flower community on Slack: [Join Slack](https://flower.dev/join-slack/)\n",
-        "\n",
-        "There's a dedicated `#questions` channel if you need help, but we'd also love to hear who you are in `#introductions`!\n",
-        "\n",
-        "The [Flower Federated Learning Tutorial - Part 2](https://flower.dev/docs/tutorial/Flower-2-Strategies-in-FL-PyTorch.html) goes into more depth about strategies and all the advanced things you can build with them."
-      ]
-    }
-  ],
-  "metadata": {
-    "accelerator": "GPU",
-    "colab": {
-      "collapsed_sections": [],
-      "name": "Flower-1-Intro-to-FL-PyTorch.ipynb",
-      "provenance": [],
-      "toc_visible": true
-    },
-    "kernelspec": {
-      "display_name": "Python 3.7.12 64-bit ('flower-3.7.12')",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "name": "python",
-      "version": "3.7.12"
-    },
-    "vscode": {
-      "interpreter": {
-        "hash": "a6202d1482f480674d090d9d9b5c400c9026d296d041bf38196c7cb6353a393f"
-      }
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "cz71fPGrpRiQ"
+   },
+   "source": [
+    "# An Introduction to Federated Learning\n",
+    "\n",
+    "Welcome to the Flower federated learning tutorial!\n",
+    "\n",
+    "In this notebook, we'll build a federated learning system using Flower and PyTorch. In part 1, we use PyTorch for the model training pipeline and data loading. In part 2, we continue to federate the PyTorch-based pipeline using Flower.\n",
+    "\n",
+    "> Join the Flower community on Slack to connect, ask questions, and get help: [Join Slack](https://flower.dev/join-slack) 🌻 We'd love to hear from you in the `#introductions` channel! If anything is unclear, head over to the `#questions` channel.\n",
+    "\n",
+    "Let's get stated!"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "mBu1HRRY6bwX"
+   },
+   "source": [
+    "## Step 0: Preparation\n",
+    "\n",
+    "Before we begin with any actual code, let's make sure that we have everything we need."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "D4KiTMTpiort"
+   },
+   "source": [
+    "### Installing dependencies\n",
+    "\n",
+    "Next, we install the necessary packages for PyTorch (`torch` and `torchvision`) and Flower (`flwr`):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "eTrCL2FmC5U5"
+   },
+   "outputs": [],
+   "source": [
+    "!pip install -q flwr[simulation] torch torchvision matplotlib"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "3UFT3_A3iz76"
+   },
+   "source": [
+    "Now that we have all dependencies installed, we can import everything we need for this tutorial:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "Tja2N6l-qH-e"
+   },
+   "outputs": [],
+   "source": [
+    "from collections import OrderedDict\n",
+    "from typing import List, Tuple\n",
+    "\n",
+    "import flwr as fl\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import torch\n",
+    "import torch.nn as nn\n",
+    "import torchvision\n",
+    "import torch.nn.functional as F\n",
+    "import torchvision.transforms as transforms\n",
+    "from flwr.common import Metrics\n",
+    "from torch.utils.data import DataLoader, random_split\n",
+    "from torchvision.datasets import CIFAR10\n",
+    "\n",
+    "DEVICE = torch.device(\"cpu\")  # Try \"cuda\" to train on GPU\n",
+    "print(f\"Training on {DEVICE} using PyTorch {torch.__version__} and Flower {fl.__version__}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "8D2bnPKG58Gx"
+   },
+   "source": [
+    "It is possible to switch to a runtime that has GPU acceleration enabled (on Google Colab: `Runtime > Change runtime type > Hardware acclerator: GPU > Save`). Note, however, that Google Colab is not always able to offer GPU acceleration. If you see an error related to GPU availability in one of the following sections, consider switching back to CPU-based execution by setting `DEVICE = torch.device(\"cpu\")`. If the runtime has GPU acceleration enabled, you should see the output `Training on cuda:0`, otherwise it'll say `Training on cpu`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "JVcgAAiaihnx"
+   },
+   "source": [
+    "\n",
+    "### Loading the data\n",
+    "\n",
+    "Federated learning can be applied to many different types of tasks across different domains. In this tutorial, we introduce federated learning by training a simple convolutional neural network (CNN) on the popular CIFAR-10 dataset. CIFAR-10 can be used to train image classifiers that distinguish between images from ten different classes:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "-tpk_Zv37ONm"
+   },
+   "outputs": [],
+   "source": [
+    "CLASSES = ('plane', 'car', 'bird', 'cat', 'deer', 'dog', 'frog', 'horse', 'ship', 'truck')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "toxAoOq6fS2h"
+   },
+   "source": [
+    "We simulate having multiple datasets from multiple organizations (also called the \"cross-silo\" setting in federated learning) by splitting the original CIFAR-10 dataset into multiple partitions. Each partition will represent the data from a single organization. We're doing this purely for experimentation purposes, in the real world there's no need for data splitting because each organization already has their own data (so the data is naturally partitioned).\n",
+    "\n",
+    "Each organization will act as a client in the federated learning system. So having ten organizations participate in a federation means having ten clients connected to the federated learning server:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "q9LhPFDh0S5c"
+   },
+   "outputs": [],
+   "source": [
+    "NUM_CLIENTS = 10"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "01Zy7yjBPhQd"
+   },
+   "source": [
+    "\n",
+    "Let's now load the CIFAR-10 training and test set, partition them into ten smaller datasets (each split into training and validation set), and wrap the resulting partitions by creating a PyTorch `DataLoader` for each of them:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "J4Em7BPNTXeX"
+   },
+   "outputs": [],
+   "source": [
+    "BATCH_SIZE = 32\n",
+    "\n",
+    "def load_datasets():\n",
+    "    # Download and transform CIFAR-10 (train and test)\n",
+    "    transform = transforms.Compose(\n",
+    "      [transforms.ToTensor(), transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))]\n",
+    "    )\n",
+    "    trainset = CIFAR10(\"./dataset\", train=True, download=True, transform=transform)\n",
+    "    testset = CIFAR10(\"./dataset\", train=False, download=True, transform=transform)\n",
+    "\n",
+    "    # Split training set into 10 partitions to simulate the individual dataset\n",
+    "    partition_size = len(trainset) // NUM_CLIENTS\n",
+    "    lengths = [partition_size] * NUM_CLIENTS\n",
+    "    datasets = random_split(trainset, lengths, torch.Generator().manual_seed(42))\n",
+    "\n",
+    "    # Split each partition into train/val and create DataLoader\n",
+    "    trainloaders = []\n",
+    "    valloaders = []\n",
+    "    for ds in datasets:\n",
+    "        len_val = len(ds) // 10  # 10 % validation set\n",
+    "        len_train = len(ds) - len_val\n",
+    "        lengths = [len_train, len_val]\n",
+    "        ds_train, ds_val = random_split(ds, lengths, torch.Generator().manual_seed(42))\n",
+    "        trainloaders.append(DataLoader(ds_train, batch_size=BATCH_SIZE, shuffle=True))\n",
+    "        valloaders.append(DataLoader(ds_val, batch_size=BATCH_SIZE))\n",
+    "    testloader = DataLoader(testset, batch_size=BATCH_SIZE)\n",
+    "    return trainloaders, valloaders, testloader\n",
+    "\n",
+    "trainloaders, valloaders, testloader = load_datasets()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "OBp7kB4G0sPB"
+   },
+   "source": [
+    "We now have a list of ten training sets and ten validation sets (`trainloaders` and `valloaders`) representing the data of ten different organizations. Each `trainloader`/`valloader` pair contains 4500 training examples and 500 validation examples. There's also a single `testloader` (we did not split the test set). Again, this is only necessary for building research or educational systems, actual federated learning systems have their data naturally distributed across multiple partitions.\n",
+    "\n",
+    "Let's take a look at the first batch of images and labels in the first training set (i.e., `trainloaders[0]`) before we move on:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "E3dag9WeT9VH"
+   },
+   "outputs": [],
+   "source": [
+    "images, labels = next(iter(trainloaders[0]))\n",
+    "# Reshape and convert images to a NumPy array\n",
+    "# matplotlib requires images with the shape (height, width, 3)\n",
+    "images = images.permute(0, 2, 3, 1).numpy()\n",
+    "# Denormalize\n",
+    "images = images/2 + 0.5\n",
+    "\n",
+    "# Create a figure and a grid of subplots\n",
+    "fig, axs = plt.subplots(4, 8, figsize=(12, 6))\n",
+    "\n",
+    "# Loop over the images and plot them\n",
+    "for i, ax in enumerate(axs.flat):\n",
+    "    ax.imshow(images[i])\n",
+    "    ax.set_title(CLASSES[labels[i]])\n",
+    "    ax.axis('off')\n",
+    "\n",
+    "# Show the plot\n",
+    "fig.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "ZGVGbRZ_yEA2"
+   },
+   "source": [
+    "The output above shows a random batch of images from the first `trainloader` in our list of ten `trainloaders`. It also prints the labels associated with each image (i.e., one of the ten possible labels we've seen above). If you run the cell again, you should see another batch of images."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "4TW4Pzb7p1F9"
+   },
+   "source": [
+    "## Step 1: Centralized Training with PyTorch\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "cTjCmmBtqPgM"
+   },
+   "source": [
+    "Next, we're going to use PyTorch to define a simple convolutional neural network. This introduction assumes basic familiarity with PyTorch, so it doesn't cover the PyTorch-related aspects in full detail. If you want to dive deeper into PyTorch, we recommend [*DEEP LEARNING WITH PYTORCH: A 60 MINUTE BLITZ*](https://pytorch.org/tutorials/beginner/deep_learning_60min_blitz.html).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "XYks8IpJL6iK"
+   },
+   "source": [
+    "### Defining the model\n",
+    "\n",
+    "We use the simple CNN described in the [PyTorch tutorial](https://pytorch.org/tutorials/beginner/blitz/cifar10_tutorial.html#define-a-convolutional-neural-network):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "2X3cVBXMpP6w"
+   },
+   "outputs": [],
+   "source": [
+    "class Net(nn.Module):\n",
+    "    def __init__(self) -> None:\n",
+    "        super(Net, self).__init__()\n",
+    "        self.conv1 = nn.Conv2d(3, 6, 5)\n",
+    "        self.pool = nn.MaxPool2d(2, 2)\n",
+    "        self.conv2 = nn.Conv2d(6, 16, 5)\n",
+    "        self.fc1 = nn.Linear(16 * 5 * 5, 120)\n",
+    "        self.fc2 = nn.Linear(120, 84)\n",
+    "        self.fc3 = nn.Linear(84, 10)\n",
+    "\n",
+    "    def forward(self, x: torch.Tensor) -> torch.Tensor:\n",
+    "        x = self.pool(F.relu(self.conv1(x)))\n",
+    "        x = self.pool(F.relu(self.conv2(x)))\n",
+    "        x = x.view(-1, 16 * 5 * 5)\n",
+    "        x = F.relu(self.fc1(x))\n",
+    "        x = F.relu(self.fc2(x))\n",
+    "        x = self.fc3(x)\n",
+    "        return x"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "tCRhau5cr2Gd"
+   },
+   "source": [
+    "Let's continue with the usual training and test functions:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "xIl8NfAFpyam"
+   },
+   "outputs": [],
+   "source": [
+    "def train(net, trainloader, epochs: int, verbose=False):\n",
+    "    \"\"\"Train the network on the training set.\"\"\"\n",
+    "    criterion = torch.nn.CrossEntropyLoss()\n",
+    "    optimizer = torch.optim.Adam(net.parameters())\n",
+    "    net.train()\n",
+    "    for epoch in range(epochs):\n",
+    "        correct, total, epoch_loss = 0, 0, 0.0\n",
+    "        for images, labels in trainloader:\n",
+    "            images, labels = images.to(DEVICE), labels.to(DEVICE)\n",
+    "            optimizer.zero_grad()\n",
+    "            outputs = net(images)\n",
+    "            loss = criterion(net(images), labels)\n",
+    "            loss.backward()\n",
+    "            optimizer.step()\n",
+    "            # Metrics\n",
+    "            epoch_loss += loss\n",
+    "            total += labels.size(0)\n",
+    "            correct += (torch.max(outputs.data, 1)[1] == labels).sum().item()\n",
+    "        epoch_loss /= len(trainloader.dataset)\n",
+    "        epoch_acc = correct / total\n",
+    "        if verbose:\n",
+    "            print(f\"Epoch {epoch+1}: train loss {epoch_loss}, accuracy {epoch_acc}\")\n",
+    "\n",
+    "\n",
+    "def test(net, testloader):\n",
+    "    \"\"\"Evaluate the network on the entire test set.\"\"\"\n",
+    "    criterion = torch.nn.CrossEntropyLoss()\n",
+    "    correct, total, loss = 0, 0, 0.0\n",
+    "    net.eval()\n",
+    "    with torch.no_grad():\n",
+    "        for images, labels in testloader:\n",
+    "            images, labels = images.to(DEVICE), labels.to(DEVICE)\n",
+    "            outputs = net(images)\n",
+    "            loss += criterion(outputs, labels).item()\n",
+    "            _, predicted = torch.max(outputs.data, 1)\n",
+    "            total += labels.size(0)\n",
+    "            correct += (predicted == labels).sum().item()\n",
+    "    loss /= len(testloader.dataset)\n",
+    "    accuracy = correct / total\n",
+    "    return loss, accuracy"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "GDDxh73Sszck"
+   },
+   "source": [
+    "### Training the model\n",
+    "\n",
+    "We now have all the basic building blocks we need: a dataset, a model, a training function, and a test function. Let's put them together to train the model on the dataset of one of our organizations (`trainloaders[0]`). This simulates the reality of most machine learning projects today: each organization has their own data and trains models only on this internal data: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "WdUTb8WgtRMz"
+   },
+   "outputs": [],
+   "source": [
+    "trainloader = trainloaders[0]\n",
+    "valloader = valloaders[0]\n",
+    "net = Net().to(DEVICE)\n",
+    "\n",
+    "for epoch in range(5):\n",
+    "    train(net, trainloader, 1)\n",
+    "    loss, accuracy = test(net, valloader)\n",
+    "    print(f\"Epoch {epoch+1}: validation loss {loss}, accuracy {accuracy}\")\n",
+    "\n",
+    "loss, accuracy = test(net, testloader)\n",
+    "print(f\"Final test set performance:\\n\\tloss {loss}\\n\\taccuracy {accuracy}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "DhLGLdmhOhVr"
+   },
+   "source": [
+    "Training the simple CNN on our CIFAR-10 split for 5 epochs should result in a test set accuracy of about 41%, which is not good, but at the same time, it doesn't really matter for the purposes of this tutorial. The intent was just to show a simplistic centralized training pipeline that sets the stage for what comes next - federated learning!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "a6HP2cYCsqxD"
+   },
+   "source": [
+    "## Step 2: Federated Learning with Flower\n",
+    "\n",
+    "Step 1 demonstrated a simple centralized training pipeline. All data was in one place (i.e., a single `trainloader` and a single `valloader`). Next, we'll simulate a situation where we have multiple datasets in multiple organizations and where we train a model over these organizations using federated learning."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "mf-cW093MzeT"
+   },
+   "source": [
+    "### Updating model parameters\n",
+    "\n",
+    "In federated learning, the server sends the global model parameters to the client, and the client updates the local model with the parameters received from the server. It then trains the model on the local data (which changes the model parameters locally) and sends the updated/changed model parameters back to the server (or, alternatively, it sends just the gradients back to the server, not the full model parameters).\n",
+    "\n",
+    "We need two helper functions to update the local model with parameters received from the server and to get the updated model parameters from the local model: `set_parameters` and `get_parameters`. The following two functions do just that for the PyTorch model above.\n",
+    "\n",
+    "The details of how this works are not really important here (feel free to consult the PyTorch documentation if you want to learn more). In essence, we use `state_dict` to access PyTorch model parameter tensors. The parameter tensors are then converted to/from a list of NumPy ndarray's (which Flower knows how to serialize/deserialize):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "1ZxGk6AMNvvV"
+   },
+   "outputs": [],
+   "source": [
+    "def get_parameters(net) -> List[np.ndarray]:\n",
+    "    return [val.cpu().numpy() for _, val in net.state_dict().items()]\n",
+    "\n",
+    "def set_parameters(net, parameters: List[np.ndarray]):\n",
+    "    params_dict = zip(net.state_dict().keys(), parameters)\n",
+    "    state_dict = OrderedDict({k: torch.Tensor(v) for k, v in params_dict})\n",
+    "    net.load_state_dict(state_dict, strict=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "1lCf3oljdClM"
+   },
+   "source": [
+    "### Implementing a Flower client\n",
+    "\n",
+    "With that out of the way, let's move on to the interesting part. Federated learning systems consist of a server and multiple clients. In Flower, we create clients by implementing subclasses of `flwr.client.Client` or `flwr.client.NumPyClient`. We use `NumPyClient` in this tutorial because it is easier to implement and requires us to write less boilerplate.\n",
+    "\n",
+    "To implement the Flower client, we create a subclass of `flwr.client.NumPyClient` and implement the three methods `get_parameters`, `fit`, and `evaluate`:\n",
+    "\n",
+    "* `get_parameters`: Return the current local model parameters\n",
+    "* `fit`: Receive model parameters from the server, train the model parameters on the local data, and return the (updated) model parameters to the server\n",
+    "* `evaluate`: Receive model parameters from the server, evaluate the model parameters on the local data, and return the evaluation result to the server\n",
+    "\n",
+    "We mentioned that our clients will use the previously defined PyTorch components for model training and evaluation. Let's see a simple Flower client implementation that brings everything together:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "ye6Jt5p3LWtF"
+   },
+   "outputs": [],
+   "source": [
+    "class FlowerClient(fl.client.NumPyClient):\n",
+    "    def __init__(self, net, trainloader, valloader):\n",
+    "        self.net = net\n",
+    "        self.trainloader = trainloader\n",
+    "        self.valloader = valloader\n",
+    "\n",
+    "    def get_parameters(self, config):\n",
+    "        return get_parameters(self.net)\n",
+    "\n",
+    "    def fit(self, parameters, config):\n",
+    "        set_parameters(self.net, parameters)\n",
+    "        train(self.net, self.trainloader, epochs=1)\n",
+    "        return get_parameters(self.net), len(self.trainloader), {}\n",
+    "\n",
+    "    def evaluate(self, parameters, config):\n",
+    "        set_parameters(self.net, parameters)\n",
+    "        loss, accuracy = test(self.net, self.valloader)\n",
+    "        return float(loss), len(self.valloader), {\"accuracy\": float(accuracy)}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Heyxd9MfHOTe"
+   },
+   "source": [
+    "Our class `FlowerClient` defines how local training/evaluation will be performed and allows Flower to call the local training/evaluation through `fit` and `evaluate`. Each instance of `FlowerClient` represents a *single client* in our federated learning system. Federated learning systems have multiple clients (otherwise there's not much to federate), so each client will be represented by its own instance of `FlowerClient`. If we have, for example, three clients in our workload, then we'd have three instances of `FlowerClient`. Flower calls `FlowerClient.fit` on the respective instance when the server selects a particular client for training (and `FlowerClient.evaluate` for evaluation).\n",
+    "\n",
+    "### Using the Virtual Client Engine\n",
+    "\n",
+    "In this notebook, we want to simulate a federated learning system with 10 clients on a single machine. This means that the server and all 10 clients will live on a single machine and share resources such as CPU, GPU, and memory. Having 10 clients would mean having 10 instances of `FlowerClient` im memory. Doing this on a single machine can quickly exhaust the available memory resources, even if only a subset of these clients participates in a single round of federated learning.\n",
+    "\n",
+    "In addition to the regular capabilities where server and clients run on multiple machines, Flower therefore provides special simulation capabilities that create `FlowerClient` instances only when they are actually necessary for training or evaluation. To enable the Flower framework to create clients when necessary, we need to implement a function called `client_fn` that creates a `FlowerClient` instance on demand. Flower calls `client_fn` whenever it needs an instance of one particular client to call `fit` or `evaluate` (those instances are usually discarded after use, so they should not keep any local state). Clients are identified by a client ID, or short `cid`. The `cid` can be used, for example, to load different local data partitions for different clients, as can be seen below:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "qkcwggRYOwWN"
+   },
+   "outputs": [],
+   "source": [
+    "def client_fn(cid: str) -> FlowerClient:\n",
+    "    \"\"\"Create a Flower client representing a single organization.\"\"\"\n",
+    "\n",
+    "    # Load model\n",
+    "    net = Net().to(DEVICE)\n",
+    "\n",
+    "    # Load data (CIFAR-10)\n",
+    "    # Note: each client gets a different trainloader/valloader, so each client\n",
+    "    # will train and evaluate on their own unique data\n",
+    "    trainloader = trainloaders[int(cid)]\n",
+    "    valloader = valloaders[int(cid)]\n",
+    "\n",
+    "    # Create a  single Flower client representing a single organization\n",
+    "    return FlowerClient(net, trainloader, valloader)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "axzXSMtlfhXU"
+   },
+   "source": [
+    "### Starting the training\n",
+    "\n",
+    "We now have the class `FlowerClient` which defines client-side training/evaluation and `client_fn` which allows Flower to create `FlowerClient` instances whenever it needs to call `fit` or `evaluate` on one particular client. The last step is to start the actual simulation using `flwr.simulation.start_simulation`. \n",
+    "\n",
+    "The function `start_simulation` accepts a number of arguments, amongst them the `client_fn` used to create `FlowerClient` instances, the number of clients to simulate (`num_clients`), the number of federated learning rounds (`num_rounds`), and the strategy. The strategy encapsulates the federated learning approach/algorithm, for example, *Federated Averaging* (FedAvg).\n",
+    "\n",
+    "Flower has a number of built-in strategies, but we can also use our own strategy implementations to customize nearly all aspects of the federated learning approach. For this example, we use the built-in `FedAvg` implementation and customize it using a few basic parameters. The last step is the actual call to `start_simulation` which - you guessed it - starts the simulation:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "ELNy0-0nfyI2"
+   },
+   "outputs": [],
+   "source": [
+    "# Create FedAvg strategy\n",
+    "strategy = fl.server.strategy.FedAvg(\n",
+    "        fraction_fit=1.0,  # Sample 100% of available clients for training\n",
+    "        fraction_evaluate=0.5,  # Sample 50% of available clients for evaluation\n",
+    "        min_fit_clients=10,  # Never sample less than 10 clients for training\n",
+    "        min_evaluate_clients=5,  # Never sample less than 5 clients for evaluation\n",
+    "        min_available_clients=10,  # Wait until all 10 clients are available\n",
+    ")\n",
+    "\n",
+    "# Start simulation\n",
+    "fl.simulation.start_simulation(\n",
+    "    client_fn=client_fn,\n",
+    "    num_clients=NUM_CLIENTS,\n",
+    "    config=fl.server.ServerConfig(num_rounds=5),\n",
+    "    strategy=strategy,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "e_lIXlErb9qN"
+   },
+   "source": [
+    "### Behind the scenes\n",
+    "\n",
+    "So how does this work? How does Flower execute this simulation?\n",
+    "\n",
+    "When we call `start_simulation`, we tell Flower that there are 10 clients (`num_clients=10`). Flower then goes ahead an asks the `FedAvg` strategy to select clients. `FedAvg` knows that it should select 100% of the available clients (`fraction_fit=1.0`), so it goes ahead and selects 10 random clients (i.e., 100% of 10).\n",
+    "\n",
+    "Flower then asks the selected 10 clients to train the model. When the server receives the model parameter updates from the clients, it hands those updates over to the strategy (*FedAvg*) for aggregation. The strategy aggregates those updates and returns the new global model, which then gets used in the next round of federated learning."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Where's the accuracy?\n",
+    "\n",
+    "You may have noticed that all metrics except for `losses_distributed` are empty. Where did the `{\"accuracy\": float(accuracy)}` go?\n",
+    "\n",
+    "Flower can automatically aggregate losses returned by individual clients, but it cannot do the same for metrics in the generic metrics dictionary (the one with the `accuracy` key). Metrics dictionaries can contain very different kinds of metrics and even key/value pairs that are not metrics at all, so the framework does not (and can not) know how to handle these automatically.\n",
+    "\n",
+    "As users, we need to tell the framework how to handle/aggregate these custom metrics, and we do so by passing metric aggregation functions to the strategy. The strategy will then call these functions whenever it receives fit or evaluate metrics from clients. The two possible functions are `fit_metrics_aggregation_fn` and `evaluate_metrics_aggregation_fn`.\n",
+    "\n",
+    "Let's create a simple weighted averaging function to aggregate the `accuracy` metric we return from `evaluate`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def weighted_average(metrics: List[Tuple[int, Metrics]]) -> Metrics:\n",
+    "    # Multiply accuracy of each client by number of examples used\n",
+    "    accuracies = [num_examples * m[\"accuracy\"] for num_examples, m in metrics]\n",
+    "    examples = [num_examples for num_examples, _ in metrics]\n",
+    "    \n",
+    "    # Aggregate and return custom metric (weighted average)\n",
+    "    return {\"accuracy\": sum(accuracies) / sum(examples)}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The only thing left to do is to tell the strategy to call this function whenever it receives evaluation metric dictionaries from the clients:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create FedAvg strategy\n",
+    "strategy = fl.server.strategy.FedAvg(\n",
+    "        fraction_fit=1.0,\n",
+    "        fraction_evaluate=0.5,\n",
+    "        min_fit_clients=10,\n",
+    "        min_evaluate_clients=5,\n",
+    "        min_available_clients=10,\n",
+    "        evaluate_metrics_aggregation_fn=weighted_average,  # <-- pass the metric aggregation function\n",
+    ")\n",
+    "\n",
+    "# Start simulation\n",
+    "fl.simulation.start_simulation(\n",
+    "    client_fn=client_fn,\n",
+    "    num_clients=NUM_CLIENTS,\n",
+    "    config=fl.server.ServerConfig(num_rounds=5),\n",
+    "    strategy=strategy,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We now have a full system that performs federated training and federated evaluation. It uses the `weighted_average` function to aggregate custom evaluation metrics and calculates a single `accuracy` metric across all clients on the server side.\n",
+    "\n",
+    "The other two categories of metrics (`losses_centralized` and `metrics_centralized`) are still empty because they only apply when centralized evaluation is being used. Part two of the Flower tutorial will cover centralized evaluation."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "umvwX56Of3Cr"
+   },
+   "source": [
+    "## Final remarks\n",
+    "\n",
+    "Congratulations, you just trained a convolutional neural network, federated over 10 clients! With that, you understand the basics of federated learning with Flower. The same approach you've seen can be used with other machine learning frameworks (not just PyTorch) and tasks (not just CIFAR-10 images classification), for example NLP with Hugging Face Transformers or speech with SpeechBrain.\n",
+    "\n",
+    "In the next notebook, we're going to cover some more advanced concepts. Want to customize your strategy? Initialize parameters on the server side? Or evaluate the aggregated model on the server side? We'll cover all this and more in the next tutorial."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Next steps\n",
+    "\n",
+    "Before you continue, make sure to join the Flower community on Slack: [Join Slack](https://flower.dev/join-slack/)\n",
+    "\n",
+    "There's a dedicated `#questions` channel if you need help, but we'd also love to hear who you are in `#introductions`!\n",
+    "\n",
+    "The [Flower Federated Learning Tutorial - Part 2](https://flower.dev/docs/tutorial/Flower-2-Strategies-in-FL-PyTorch.html) goes into more depth about strategies and all the advanced things you can build with them."
+   ]
+  }
+ ],
+ "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "collapsed_sections": [],
+   "name": "Flower-1-Intro-to-FL-PyTorch.ipynb",
+   "provenance": [],
+   "toc_visible": true
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.12"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "a6202d1482f480674d090d9d9b5c400c9026d296d041bf38196c7cb6353a393f"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
 }

--- a/doc/source/tutorial/Flower-1-Intro-to-FL-PyTorch.ipynb
+++ b/doc/source/tutorial/Flower-1-Intro-to-FL-PyTorch.ipynb
@@ -209,6 +209,7 @@
       "outputs": [],
       "source": [
         "images, labels = next(iter(trainloaders[0]))\n",
+        "\n",
         "# Reshape and convert images to a NumPy array\n",
         "# matplotlib requires images with the shape (height, width, 3)\n",
         "images = images.permute(0, 2, 3, 1).numpy()\n",


### PR DESCRIPTION
It fixes access to the trainloader required to display a batch of CIFAR10 images.
Before:
```python
images, labels = iter(trainloaders[0]).next()
```
Gives: AttributeError: '_SingleProcessDataLoaderIter' object has no attribute 'next'

Now:
```python
images, labels = next(iter(trainloaders[0]))
```

Additionally, it creates a more appealing plot of images (bigger plot, space between images, labels directly above the images).
Before (with the iterator access fix):
<img width="1026" alt="Screen Shot 2022-12-30 at 11 14 42" src="https://user-images.githubusercontent.com/51029327/210060466-b67f9bc1-f0d9-4881-ab6e-b5b8aeb7050f.png">
After:
<img width="1029" alt="Screen Shot 2022-12-30 at 11 13 51" src="https://user-images.githubusercontent.com/51029327/210060490-e4e29fd1-e1b4-4070-ae51-c395d7bad99f.png">


