### PR TITLE
Add modularity to reset script

### DIFF
--- a/baselines/dev/venv-reset.sh
+++ b/baselines/dev/venv-reset.sh
@@ -2,11 +2,13 @@
 set -e
 cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"/../
 
+version=${1:-3.8.15}
+
 # Delete caches, venv, and lock file
 ./dev/rm-caches.sh
-./dev/venv-delete.sh
+./dev/venv-delete.sh $version
 [ ! -e poetry.lock ] || rm poetry.lock
 
 # Recreate
-./dev/venv-create.sh
+./dev/venv-create.sh $version
 ./dev/bootstrap.sh

--- a/dev/venv-reset.sh
+++ b/dev/venv-reset.sh
@@ -2,11 +2,13 @@
 set -e
 cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"/../
 
+version=${1:-3.7.15}
+
 # Delete caches, venv, and lock file
 ./dev/rm-caches.sh
-./dev/venv-delete.sh
+./dev/venv-delete.sh $version
 [ ! -e poetry.lock ] || rm poetry.lock
 
 # Recreate
-./dev/venv-create.sh
+./dev/venv-create.sh $version
 ./dev/bootstrap.sh


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

<!--
Explain why this PR is needed and what kind of changes have you done.

Example: The variable `rnd` could be interpreted as an abbreviation of *random*, to improve clarity it was renamed to `server_round`.
-->

Before the reset script was not modular like the other scripts with regards to the Python version. Now we can choose which venv to reset by providing a version.