### PR TITLE
Update app.py

### DIFF
--- a/src/py/flwr/simulation/app.py
+++ b/src/py/flwr/simulation/app.py
@@ -69,7 +69,7 @@ def start_simulation(  # pylint: disable=too-many-arguments
     strategy: Optional[Strategy] = None,
     client_manager: Optional[ClientManager] = None,
     ray_init_args: Optional[Dict[str, Any]] = None,
-    keep_initialised: Optional[bool] = False,
+    keep_initialised: Optional[bool] = True,
 ) -> History:
     """Start a Ray-based Flower simulation server.
 
@@ -120,7 +120,7 @@ def start_simulation(  # pylint: disable=too-many-arguments
 
         An empty dictionary can be used (ray_init_args={}) to prevent any
         arguments from being passed to ray.init.
-    keep_initialised: Optional[bool] (default: False)
+    keep_initialised: Optional[bool] (default: True)
         Set to True to prevent `ray.shutdown()` in case `ray.is_initialized()=True`.
 
     Returns


### PR DESCRIPTION
Shutting down the `ray.init()` can cause problems if the head is started elsewhere. Setting the default value of `keep_initialized` to `True`.

<!--
Thank you for opening a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md

Does the documentation need to be updated?
See: https://flower.dev/docs/writing-documentation.html

Does the changelog need to be updated?
See: https://github.com/adap/flower/blob/main/doc/source/changelog.rst
-->

#### Reference Issues/PRs

NA

#### What does this implement/fix? Explain your changes.

This fixes the default behaviour of restarting the head node, not suitable for multi-node.

#### Any other comments?

NA