### PR TITLE
Proper gpu in tutorials

### DIFF
--- a/doc/source/tutorial/Flower-1-Intro-to-FL-PyTorch.ipynb
+++ b/doc/source/tutorial/Flower-1-Intro-to-FL-PyTorch.ipynb
@@ -92,7 +92,7 @@
         "id": "8D2bnPKG58Gx"
       },
       "source": [
-        "It is possible to switch to a runtime that has GPU acceleration enabled (on Google Colab: `Runtime > Change runtime type > Hardware acclerator: GPU > Save`). Note, however, that Google Colab is not always able to offer GPU acceleration. If you see an error related to GPU availability in one of the following sections, consider switching back to CPU-based execution by setting `DEVICE = torch.device(\"cpu\")`. If the runtime has GPU acceleration enabled, you should see the output `Training on cuda:0`, otherwise it'll say `Training on cpu`."
+        "It is possible to switch to a runtime that has GPU acceleration enabled (on Google Colab: `Runtime > Change runtime type > Hardware acclerator: GPU > Save`). Note, however, that Google Colab is not always able to offer GPU acceleration. If you see an error related to GPU availability in one of the following sections, consider switching back to CPU-based execution by setting `DEVICE = torch.device(\"cpu\")`. If the runtime has GPU acceleration enabled, you should see the output `Training on cuda`, otherwise it'll say `Training on cpu`."
       ]
     },
     {
@@ -558,12 +558,18 @@
         "        min_available_clients=10,  # Wait until all 10 clients are available\n",
         ")\n",
         "\n",
+        "# Specify client resources if you need GPU (defaults to 1 CPU and 0 GPU)\n",
+        "client_resources = None\n",
+        "if DEVICE.type == \"cuda\":\n",
+        "  client_resources = {\"num_gpus\": 1}\n",
+        "\n",
         "# Start simulation\n",
         "fl.simulation.start_simulation(\n",
         "    client_fn=client_fn,\n",
         "    num_clients=NUM_CLIENTS,\n",
         "    config=fl.server.ServerConfig(num_rounds=5),\n",
         "    strategy=strategy,\n",
+        "    client_resources=client_resources,\n",
         ")"
       ]
     },
@@ -649,6 +655,7 @@
         "    num_clients=NUM_CLIENTS,\n",
         "    config=fl.server.ServerConfig(num_rounds=5),\n",
         "    strategy=strategy,\n",
+        "    client_resources=client_resources,\n",
         ")"
       ]
     },

--- a/doc/source/tutorial/Flower-2-Strategies-in-FL-PyTorch.ipynb
+++ b/doc/source/tutorial/Flower-2-Strategies-in-FL-PyTorch.ipynb
@@ -89,7 +89,7 @@
         "id": "8D2bnPKG58Gx"
       },
       "source": [
-        "It is possible to switch to a runtime that has GPU acceleration enabled (on Google Colab: `Runtime > Change runtime type > Hardware acclerator: GPU > Save`). Note, however, that Google Colab is not always able to offer GPU acceleration. If you see an error related to GPU availability in one of the following sections, consider switching back to CPU-based execution by setting `DEVICE = torch.device(\"cpu\")`. If the runtime has GPU acceleration enabled, you should see the output `Training on cuda:0`, otherwise it'll say `Training on cpu`."
+        "It is possible to switch to a runtime that has GPU acceleration enabled (on Google Colab: `Runtime > Change runtime type > Hardware acclerator: GPU > Save`). Note, however, that Google Colab is not always able to offer GPU acceleration. If you see an error related to GPU availability in one of the following sections, consider switching back to CPU-based execution by setting `DEVICE = torch.device(\"cpu\")`. If the runtime has GPU acceleration enabled, you should see the output `Training on cuda`, otherwise it'll say `Training on cpu`."
       ]
     },
     {
@@ -325,12 +325,18 @@
         "    initial_parameters=fl.common.ndarrays_to_parameters(params),\n",
         ")\n",
         "\n",
+        "# Specify client resources if you need GPU (defaults to 1 CPU and 0 GPU)\n",
+        "client_resources = None\n",
+        "if DEVICE.type == \"cuda\":\n",
+        "  client_resources = {\"num_gpus\": 1}\n",
+        "\n",
         "# Start simulation\n",
         "fl.simulation.start_simulation(\n",
         "    client_fn=client_fn,\n",
         "    num_clients=NUM_CLIENTS,\n",
         "    config=fl.server.ServerConfig(num_rounds=3),  # Just three rounds\n",
         "    strategy=strategy,\n",
+        "    client_resources=client_resources,\n",
         ")"
       ]
     },
@@ -380,6 +386,7 @@
         "    num_clients=NUM_CLIENTS,\n",
         "    config=fl.server.ServerConfig(num_rounds=3),  # Just three rounds\n",
         "    strategy=strategy,\n",
+        "    client_resources=client_resources,\n",
         ")"
       ]
     },
@@ -412,7 +419,7 @@
         "def evaluate(\n",
         "    server_round: int, parameters: fl.common.NDArrays, config: Dict[str, fl.common.Scalar]\n",
         ") -> Optional[Tuple[float, Dict[str, fl.common.Scalar]]]:\n",
-        "    net = Net()\n",
+        "    net = Net().to(DEVICE)\n",
         "    valloader = valloaders[0]\n",
         "    set_parameters(net, parameters)  # Update model with the latest parameters\n",
         "    loss, accuracy = test(net, valloader)\n",
@@ -443,6 +450,7 @@
         "    num_clients=NUM_CLIENTS,\n",
         "    config=fl.server.ServerConfig(num_rounds=3),  # Just three rounds\n",
         "    strategy=strategy,\n",
+        "    client_resources=client_resources,\n",
         ")"
       ]
     },
@@ -564,6 +572,7 @@
         "    num_clients=NUM_CLIENTS,\n",
         "    config=fl.server.ServerConfig(num_rounds=3),  # Just three rounds\n",
         "    strategy=strategy,\n",
+        "    client_resources=client_resources,\n",
         ")"
       ]
     },
@@ -641,6 +650,7 @@
         "    num_clients=NUM_CLIENTS,\n",
         "    config=fl.server.ServerConfig(num_rounds=3),  # Just three rounds\n",
         "    strategy=strategy,\n",
+        "    client_resources=client_resources,\n",
         ")"
       ]
     },
@@ -659,7 +669,9 @@
     },
     {
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "id": "97Jmk3QbuAIs"
+      },
       "source": [
         "## Next steps\n",
         "\n",
@@ -674,7 +686,6 @@
   "metadata": {
     "accelerator": "GPU",
     "colab": {
-      "collapsed_sections": [],
       "name": "Flower-2-Strategies-in-FL-PyTorch.ipynb",
       "provenance": [],
       "toc_visible": true

--- a/doc/source/tutorial/Flower-3-Building-a-Strategy-PyTorch.ipynb
+++ b/doc/source/tutorial/Flower-3-Building-a-Strategy-PyTorch.ipynb
@@ -89,7 +89,7 @@
         "id": "8D2bnPKG58Gx"
       },
       "source": [
-        "It is possible to switch to a runtime that has GPU acceleration enabled (on Google Colab: `Runtime > Change runtime type > Hardware acclerator: GPU > Save`). Note, however, that Google Colab is not always able to offer GPU acceleration. If you see an error related to GPU availability in one of the following sections, consider switching back to CPU-based execution by setting `DEVICE = torch.device(\"cpu\")`. If the runtime has GPU acceleration enabled, you should see the output `Training on cuda:0`, otherwise it'll say `Training on cpu`."
+        "It is possible to switch to a runtime that has GPU acceleration enabled (on Google Colab: `Runtime > Change runtime type > Hardware acclerator: GPU > Save`). Note, however, that Google Colab is not always able to offer GPU acceleration. If you see an error related to GPU availability in one of the following sections, consider switching back to CPU-based execution by setting `DEVICE = torch.device(\"cpu\")`. If the runtime has GPU acceleration enabled, you should see the output `Training on cuda`, otherwise it'll say `Training on cpu`."
       ]
     },
     {
@@ -284,7 +284,9 @@
     },
     {
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "id": "YqnRgtiMvI-f"
+      },
       "source": [
         "Let's test what we have so far before we continue:"
       ]
@@ -292,13 +294,21 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {},
+      "metadata": {
+        "id": "9enZUOD1vI-f"
+      },
       "outputs": [],
       "source": [
+        "# Specify client resources if you need GPU (defaults to 1 CPU and 0 GPU)\n",
+        "client_resources = None\n",
+        "if DEVICE.type == \"cuda\":\n",
+        "  client_resources = {\"num_gpus\": 1}\n",
+        "\n",
         "fl.simulation.start_simulation(\n",
         "    client_fn=client_fn,\n",
         "    num_clients=2,\n",
         "    config=fl.server.ServerConfig(num_rounds=3),\n",
+        "    client_resources=client_resources,\n",
         ")"
       ]
     },
@@ -316,7 +326,9 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {},
+      "metadata": {
+        "id": "MwEvqdupvI-g"
+      },
       "outputs": [],
       "source": [
         "from typing import Callable, Union\n",
@@ -403,7 +415,9 @@
     },
     {
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "id": "sz4Zdja7vI-g"
+      },
       "source": [
         "[WIP - add description]"
       ]
@@ -411,7 +425,9 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {},
+      "metadata": {
+        "id": "8FVhnXIYvI-h"
+      },
       "outputs": [],
       "source": [
         "fl.simulation.start_simulation(\n",
@@ -419,12 +435,15 @@
         "    num_clients=2,\n",
         "    config=fl.server.ServerConfig(num_rounds=3),\n",
         "    strategy=FedCustom(),  # <-- pass the new strategy here\n",
+        "    client_resources=client_resources,\n",
         ")"
       ]
     },
     {
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "id": "UWhGFuEQvI-h"
+      },
       "source": [
         "## Recap\n",
         "\n",
@@ -433,7 +452,9 @@
     },
     {
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "id": "K5YowGXMvI-h"
+      },
       "source": [
         "## Next steps\n",
         "\n",
@@ -448,7 +469,6 @@
   "metadata": {
     "accelerator": "GPU",
     "colab": {
-      "collapsed_sections": [],
       "name": "Flower-2-Strategies-in-FL-PyTorch.ipynb",
       "provenance": [],
       "toc_visible": true

--- a/doc/source/tutorial/Flower-4-Client-and-NumPyClient-PyTorch.ipynb
+++ b/doc/source/tutorial/Flower-4-Client-and-NumPyClient-PyTorch.ipynb
@@ -89,7 +89,7 @@
         "id": "8D2bnPKG58Gx"
       },
       "source": [
-        "It is possible to switch to a runtime that has GPU acceleration enabled (on Google Colab: `Runtime > Change runtime type > Hardware acclerator: GPU > Save`). Note, however, that Google Colab is not always able to offer GPU acceleration. If you see an error related to GPU availability in one of the following sections, consider switching back to CPU-based execution by setting `DEVICE = torch.device(\"cpu\")`. If the runtime has GPU acceleration enabled, you should see the output `Training on cuda:0`, otherwise it'll say `Training on cpu`."
+        "It is possible to switch to a runtime that has GPU acceleration enabled (on Google Colab: `Runtime > Change runtime type > Hardware acclerator: GPU > Save`). Note, however, that Google Colab is not always able to offer GPU acceleration. If you see an error related to GPU availability in one of the following sections, consider switching back to CPU-based execution by setting `DEVICE = torch.device(\"cpu\")`. If the runtime has GPU acceleration enabled, you should see the output `Training on cuda`, otherwise it'll say `Training on cpu`."
       ]
     },
     {
@@ -284,7 +284,9 @@
     },
     {
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "id": "HhKrncxswb6d"
+      },
       "source": [
         "We've seen this before, there's nothing new so far. The only *tiny* difference compared to the previous notebook is naming, we've changed `FlowerClient` to `FlowerNumPyClient` and `client_fn` to `numpyclient_fn`. Let's run it to see the output we get:"
       ]
@@ -292,19 +294,29 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {},
+      "metadata": {
+        "id": "BGOSdG7wwb6d"
+      },
       "outputs": [],
       "source": [
+        "# Specify client resources if you need GPU (defaults to 1 CPU and 0 GPU)\n",
+        "client_resources = None\n",
+        "if DEVICE.type == \"cuda\":\n",
+        "  client_resources = {\"num_gpus\": 1}\n",
+        "\n",
         "fl.simulation.start_simulation(\n",
         "    client_fn=numpyclient_fn,\n",
         "    num_clients=2,\n",
         "    config=fl.server.ServerConfig(num_rounds=3),\n",
+        "    client_resources=client_resources,\n",
         ")"
       ]
     },
     {
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "id": "kvt28QgLwb6e"
+      },
       "source": [
         "This works as expected, two clients are training for three rounds of federated learning.\n",
         "\n",
@@ -329,7 +341,9 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {},
+      "metadata": {
+        "id": "syYrxOT7wb6e"
+      },
       "outputs": [],
       "source": [
         "from flwr.common import Code, EvaluateIns, EvaluateRes, FitIns, FitRes, GetParametersIns, GetParametersRes, Status\n",
@@ -413,7 +427,9 @@
     },
     {
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "id": "5JgcOe0Ywb6e"
+      },
       "source": [
         "Before we discuss the code in more detail, let's try to run it! Gotta make sure our new `Client`-based client works, right?"
       ]
@@ -421,19 +437,24 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {},
+      "metadata": {
+        "id": "5zUGX-Egwb6f"
+      },
       "outputs": [],
       "source": [
         "fl.simulation.start_simulation(\n",
         "    client_fn=numpyclient_fn,\n",
         "    num_clients=2,\n",
         "    config=fl.server.ServerConfig(num_rounds=3),\n",
+        "    client_resources=client_resources,\n",
         ")"
       ]
     },
     {
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "id": "dG8ilnaSwb6f"
+      },
       "source": [
         "That's it, we're now using `Client`. It probably looks similar to what we've done with `NumPyClient`. So what's the difference?\n",
         "\n",
@@ -446,7 +467,9 @@
     },
     {
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "id": "XcBXgXDrwb6f"
+      },
       "source": [
         "## Step 3: Custom serialization [WIP]\n",
         "\n",
@@ -455,7 +478,9 @@
     },
     {
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "id": "-4KdyOW3wb6f"
+      },
       "source": [
         "### Client-side\n",
         "\n",
@@ -464,7 +489,9 @@
     },
     {
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "id": "4k3afftYwb6f"
+      },
       "source": [
         "### Server-side\n",
         "\n",
@@ -473,7 +500,9 @@
     },
     {
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "id": "OEcDElvBwb6g"
+      },
       "source": [
         "## Recap\n",
         "\n",
@@ -482,7 +511,9 @@
     },
     {
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "id": "sFMY27Tiwb6g"
+      },
       "source": [
         "## Next steps\n",
         "\n",
@@ -502,7 +533,6 @@
   "metadata": {
     "accelerator": "GPU",
     "colab": {
-      "collapsed_sections": [],
       "name": "Flower-2-Strategies-in-FL-PyTorch.ipynb",
       "provenance": [],
       "toc_visible": true


### PR DESCRIPTION
Support GPU out-of-the-box GPU in simulations(when a user specifies "cuda" as the device) in the following tutorials:
* An Introduction to Federated Learning
* Strategies in Federated Learning
* Building a Strategy
* Client and NumPyClient

How:
Specify GPU in start_simulation, by giving client_resources argument with {num_gpus=1}, in case of using CUDA

Other changes:
Also adds .to(DEVICE) when it was missing (2nd tutorial)

