### PR TITLE
Fixes Colab link for simulation_tensorflow example

### DIFF
--- a/examples/simulation_tensorflow/README.md
+++ b/examples/simulation_tensorflow/README.md
@@ -4,7 +4,7 @@ This introductory example uses the simulation capabilities of Flower to simulate
 
 ## Running the example (via Jupyter Notebook)
 
-Run the example on Google Colab: [![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/adap/flower/blob/main/examples/quickstart_simulation/sim.ipynb)
+Run the example on Google Colab: [![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/adap/flower/blob/main/examples/simulation_tensorflow/sim.ipynb)
 
 Alternatively, you can run `sim.ipynb` locally or in any other Jupyter environment.
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

The Colab links were not correctly updated when the example names changed.