### PR TITLE
* Add Headerinjector based on https://github.com/grpc/grpc/tree/2d4f3…

### DIFF
--- a/src/py/flwr/client/app.py
+++ b/src/py/flwr/client/app.py
@@ -17,7 +17,7 @@
 
 import time
 from logging import INFO
-from typing import Callable, Dict, Optional, Union
+from typing import Callable, Dict, List, Optional, Tuple, Union
 
 from flwr.common import (
     GRPC_MAX_MESSAGE_LENGTH,
@@ -84,6 +84,7 @@ def start_client(
     client: Client,
     grpc_max_message_length: int = GRPC_MAX_MESSAGE_LENGTH,
     root_certificates: Optional[bytes] = None,
+    metadata: List[Tuple[str,str]] = []
 ) -> None:
     """Start a Flower Client which connects to a gRPC server.
 
@@ -105,7 +106,10 @@ def start_client(
             The PEM-encoded root certificates as a byte string. If provided, a secure
             connection using the certificates will be established to a
             SSL-enabled Flower server.
-
+        metadata: List[Tuple[str,str]] (default: [])
+            A List of metadata that should be send together with gRPC calls.
+            Entries should be a (key,value) Tuple.
+            The entries will be sent as http-headers to the gRPC endpoint.
     Returns
     -------
         None
@@ -127,6 +131,18 @@ def start_client(
     >>>     client=FlowerClient(),
     >>>     root_certificates=Path("/crts/root.pem").read_bytes(),
     >>> )
+
+    Starting a trusted SSL-enabled client with authorization metadata:
+
+    >>> from pathlib import Path
+    >>> start_client(
+    >>>     server_address=localhost:8080,
+    >>>     client=FlowerClient(),
+    >>>     root_certificates=Path("/etc/ssl/certs/ca-certificates.crt").read_bytes(),
+    >>>     metadata=[("authorization":"Bearer ey...")]
+    >>> )
+        
+
     """
     while True:
         sleep_duration: int = 0
@@ -134,6 +150,7 @@ def start_client(
             server_address,
             max_message_length=grpc_max_message_length,
             root_certificates=root_certificates,
+            metadata=metadata
         ) as conn:
             receive, send = conn
 
@@ -163,6 +180,8 @@ def start_numpy_client(
     client: NumPyClient,
     grpc_max_message_length: int = GRPC_MAX_MESSAGE_LENGTH,
     root_certificates: Optional[bytes] = None,
+    metadata: List[Tuple[str,str]] = []
+
 ) -> None:
     """Start a Flower NumPyClient which connects to a gRPC server.
 
@@ -184,6 +203,10 @@ def start_numpy_client(
         The PEM-encoded root certificates a byte string. If provided, a secure
         connection using the certificates will be established to a
         SSL-enabled Flower server.
+    metadata: List[Tuple[str,str]] (default: [])
+        A List of metadata that should be send together with gRPC calls.
+        Entries should be a (key,value) Tuple.
+        The entries will be sent as http-headers to the gRPC endpoint.
 
     Examples
     --------
@@ -202,6 +225,17 @@ def start_numpy_client(
     >>>     client=FlowerClient(),
     >>>     root_certificates=Path("/crts/root.pem").read_bytes(),
     >>> )
+
+    Starting a trusted SSL-enabled client with authorization:
+
+    >>> from pathlib import Path
+    >>> start_client(
+    >>>     server_address=localhost:8080,
+    >>>     client=FlowerClient(),
+    >>>     root_certificates=Path("/etc/ssl/certs/ca-certificates.crt").read_bytes(),
+    >>>     metadata=[("authorization":"Bearer ey...")],
+    >>> )
+    
     """
 
     # Start
@@ -210,6 +244,7 @@ def start_numpy_client(
         client=_wrap_numpy_client(client=client),
         grpc_max_message_length=grpc_max_message_length,
         root_certificates=root_certificates,
+        metadata=metadata
     )
 
 

--- a/src/py/flwr/client/grpc_client/connection.py
+++ b/src/py/flwr/client/grpc_client/connection.py
@@ -15,10 +15,12 @@
 """Contextmanager managing a gRPC channel to the Flower server."""
 
 
+import collections
 from contextlib import contextmanager
 from logging import DEBUG
 from queue import Queue
-from typing import Callable, Iterator, Optional, Tuple
+from typing import Callable, Iterator, Optional, Tuple, List
+import grpc
 
 from flwr.common import GRPC_MAX_MESSAGE_LENGTH
 from flwr.common.grpc import create_channel
@@ -32,7 +34,79 @@ from flwr.proto.transport_pb2_grpc import FlowerServiceStub
 # os.environ["GRPC_VERBOSITY"] = "debug"
 # os.environ["GRPC_TRACE"] = "tcp,http"
 
+class _GenericClientInterceptor(grpc.UnaryUnaryClientInterceptor,
+                                grpc.UnaryStreamClientInterceptor,
+                                grpc.StreamUnaryClientInterceptor,
+                                grpc.StreamStreamClientInterceptor):
 
+    def __init__(self, interceptor_function):
+        self._fn = interceptor_function
+
+    def intercept_unary_unary(self, continuation, client_call_details, request):
+        new_details, new_request_iterator, postprocess = self._fn(
+            client_call_details, iter((request,)), False, False)
+        response = continuation(new_details, next(new_request_iterator))
+        return postprocess(response) if postprocess else response
+
+    def intercept_unary_stream(self, continuation, client_call_details,
+                               request):
+        new_details, new_request_iterator, postprocess = self._fn(
+            client_call_details, iter((request,)), False, True)
+        response_it = continuation(new_details, next(new_request_iterator))
+        return postprocess(response_it) if postprocess else response_it
+
+    def intercept_stream_unary(self, continuation, client_call_details,
+                               request_iterator):
+        new_details, new_request_iterator, postprocess = self._fn(
+            client_call_details, request_iterator, True, False)
+        response = continuation(new_details, new_request_iterator)
+        return postprocess(response) if postprocess else response
+
+    def intercept_stream_stream(self, continuation, client_call_details,
+                                request_iterator):
+        new_details, new_request_iterator, postprocess = self._fn(
+            client_call_details, request_iterator, True, True)
+        response_it = continuation(new_details, new_request_iterator)
+        return postprocess(response_it) if postprocess else response_it
+
+
+def create_intercepter(intercept_call):
+    return _GenericClientInterceptor(intercept_call)
+    
+    
+def _unary_unary_rpc_terminator(code, details):
+
+    def terminate(ignored_request, context):
+        context.abort(code, details)
+
+    return grpc.unary_unary_rpc_method_handler(terminate)
+
+class _ClientCallDetails(
+        collections.namedtuple(
+            '_ClientCallDetails',
+            ('method', 'timeout', 'metadata', 'credentials')),
+        grpc.ClientCallDetails):
+    pass
+
+
+def header_adder_interceptor(header, value):
+
+    def intercept_call(client_call_details, request_iterator, request_streaming,
+                       response_streaming):
+        metadata = []
+        if client_call_details.metadata is not None:
+            metadata = list(client_call_details.metadata)
+        metadata.append((
+            header,
+            value,
+        ))
+        client_call_details = _ClientCallDetails(
+            client_call_details.method, client_call_details.timeout, metadata,
+            client_call_details.credentials)
+        return client_call_details, request_iterator, None
+
+    return create_intercepter(intercept_call)
+    
 def on_channel_state_change(channel_connectivity: str) -> None:
     """Log channel connectivity."""
     log(DEBUG, channel_connectivity)
@@ -43,6 +117,7 @@ def grpc_connection(
     server_address: str,
     max_message_length: int = GRPC_MAX_MESSAGE_LENGTH,
     root_certificates: Optional[bytes] = None,
+    metadata: List[Tuple[str,str]] = []
 ) -> Iterator[Tuple[Callable[[], ServerMessage], Callable[[ClientMessage], None]]]:
     """Establish a gRPC connection to a gRPC server.
 
@@ -64,7 +139,10 @@ def grpc_connection(
         The PEM-encoded root certificates as a byte string. If provided, a secure
         connection using the certificates will be established to a SSL-enabled
         Flower server.
-
+    metadata: List[Tuple[str,str]] (default: [])
+        A List of metadata that should be send together with gRPC calls.
+        Entries should be a (key,value) Tuple.
+        The entries will be sent as http-headers to the gRPC endpoint.
     Returns
     -------
     receive, send : Callable, Callable
@@ -83,12 +161,29 @@ def grpc_connection(
     >>>     server_message = receive()
     >>>     # do something here
     >>>     send(client_message)
+
+    Establishing a trusted SSL-enabled connection to the server with an auth token:
+
+    >>> from pathlib import Path
+    >>> with grpc_connection(
+    >>>     server_address,
+    >>>     max_message_length=max_message_length,
+    >>>     root_certificates=Path("/etc/ssl/certs/ca-certificates.crt").read_bytes(),
+    >>>     metadata=[("authorization":"Bearer ey...")]
+    >>> ) as conn:
+    >>>     receive, send = conn
+    >>>     server_message = receive()
+    >>>     # do something here
+    >>>     send(client_message)
     """
     channel = create_channel(
         server_address=server_address,
         root_certificates=root_certificates,
         max_message_length=max_message_length,
     )
+    for k,v in metadata:
+        channel = grpc.intercept_channel(channel,header_adder_interceptor(k,v))
+
     channel.subscribe(on_channel_state_change)
 
     queue: Queue[ClientMessage] = Queue(  # pylint: disable=unsubscriptable-object


### PR DESCRIPTION
#### Changelog

* Add Headerinjector based on https://github.com/grpc/grpc/tree/2d4f3c56001cd1e1f85734b2f7c5ce5f2797c38a/examples/python/interceptors/headers to grpc_connection.py
 * Add metadata to start_numpy_client, start_client and grpc_connection


#### What does this implement/fix? Explain your changes.

This PR implements an easy way to add metadata / HTTP-headers to the gRPC connection.


#### Any other comments?

We needed a way to add authorization headers to the gRPC connection (authorization and/or client-id&client-secret). and since it seems like a valid expansion to flower I created this PR.

It is very basic, and I'm very open to corrections.







