### PR TITLE
Opacus example version compatibility

### DIFF
--- a/examples/opacus/dp_cifar_main.py
+++ b/examples/opacus/dp_cifar_main.py
@@ -94,7 +94,7 @@ class DPCifarClient(fl.client.NumPyClient):
             noise_multiplier=PRIVACY_PARAMS["noise_multiplier"],
         )
 
-    def get_parameters(self):
+    def get_parameters(self, config):
         return [val.cpu().numpy() for _, val in self.model.state_dict().items()]
 
     def set_parameters(self, parameters):
@@ -108,7 +108,7 @@ class DPCifarClient(fl.client.NumPyClient):
             self.model, self.trainloader, self.privacy_engine, PARAMS["local_epochs"]
         )
         print(f"epsilon = {epsilon:.2f}")
-        return self.get_parameters(), len(self.trainloader), {"epsilon": epsilon}
+        return self.get_parameters(config={}), len(self.trainloader), {"epsilon": epsilon}
 
     def evaluate(self, parameters, config):
         self.set_parameters(parameters)

--- a/examples/opacus/server.py
+++ b/examples/opacus/server.py
@@ -2,5 +2,5 @@ import flwr as fl
 
 fl.server.start_server(
     server_address="0.0.0.0:8080",
-    config={"num_rounds": 3},
+    config=flwr.server.ServerConfig(num_rounds=3),
 )


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Makes this example compatible with the versions `>=1.0.0` of `flwr`.

<!--
Explain why this PR is needed and what kind of changes have you done.

Example: The variable `rnd` could be interpreted as an abbreviation of *random*, to improve clarity it was renamed to `server_round`.
-->

