### PR TITLE
Remove small spelling error in tutorial 2 🌱

### DIFF
--- a/doc/source/tutorial/Flower-2-Strategies-in-FL-PyTorch.ipynb
+++ b/doc/source/tutorial/Flower-2-Strategies-in-FL-PyTorch.ipynb
@@ -617,7 +617,7 @@
         "id": "b6Z3N_svyCFt"
       },
       "source": [
-        "We now have 1000 partitions, each holding 45 training and 5 validation examples. Given that the number of training examples on each client is quite small, we should probably traing the model a bit longer, so we configure the clients to perform 3 local training epochs. We should also adjust the fraction of clients selected for training during each round (we don't want all 1000 clients participating in every round), so we adjust `fraction_fit` to `0.05`, which means that only 5% of available clients (so 50 clients) will be selected for training each round:\n"
+        "We now have 1000 partitions, each holding 45 training and 5 validation examples. Given that the number of training examples on each client is quite small, we should probably train the model a bit longer, so we configure the clients to perform 3 local training epochs. We should also adjust the fraction of clients selected for training during each round (we don't want all 1000 clients participating in every round), so we adjust `fraction_fit` to `0.05`, which means that only 5% of available clients (so 50 clients) will be selected for training each round:\n"
       ]
     },
     {


### PR DESCRIPTION
#### Reference Issues/PRs

No issue mentions this.

#### What does this implement/fix? Explain your changes.

Spelling mistake, train was spelled traing. 

#### Any other comments?

Nah 🌱
