### PR TITLE
Isolate ClientManager in the streaming gRPC stack

### DIFF
--- a/src/py/flwr/server/app.py
+++ b/src/py/flwr/server/app.py
@@ -224,7 +224,7 @@ def run_server() -> None:
     )
 
     # Start Driver API
-    driver_server = _run_driver_api_grpc(driver_state, driver_client_manager)
+    driver_server = _run_driver_api_grpc(driver_state)
 
     # Start Fleet API
     fleet_server = _run_fleet_api_grpc_legacy(driver_client_manager)
@@ -267,14 +267,12 @@ def run_server() -> None:
 
 def _run_driver_api_grpc(
     driver_state: DriverState,
-    driver_client_manager: DriverClientManager,
 ) -> grpc.Server:
     """Run Driver API (gRPC-based)."""
 
     # Create Driver API gRPC server
     address: str = DEFAULT_SERVER_ADDRESS_DRIVER
     driver_servicer = DriverServicer(
-        driver_client_manager=driver_client_manager,
         driver_state=driver_state,
     )
     driver_add_servicer_to_server_fn = add_DriverServicer_to_server

--- a/src/py/flwr/server/driver/driver_client_manager.py
+++ b/src/py/flwr/server/driver/driver_client_manager.py
@@ -107,7 +107,7 @@ class DriverClientManager(ClientManager):
             ins_scheduler.stop()
 
             # Unregister node_id in with DriverState
-            self.driver_state.register_node(node_id=node_id)
+            self.driver_state.unregister_node(node_id=node_id)
 
             with self._cv:
                 self._cv.notify_all()

--- a/src/py/flwr/server/driver/driver_client_manager.py
+++ b/src/py/flwr/server/driver/driver_client_manager.py
@@ -74,6 +74,9 @@ class DriverClientManager(ClientManager):
         random_node_id: int = uuid.uuid1().int >> 64
         client.node_id = random_node_id
 
+        # Register node_id in with DriverState
+        self.driver_state.register_node(node_id=random_node_id)
+
         # Create and start the instruction scheduler
         ins_scheduler = InsScheduler(
             client_proxy=client,
@@ -99,9 +102,12 @@ class DriverClientManager(ClientManager):
         client : flwr.server.client_proxy.ClientProxy
         """
         if client.cid in self.nodes:
-            _, ins_scheduler = self.nodes[client.cid]
+            node_id, ins_scheduler = self.nodes[client.cid]
             del self.nodes[client.cid]
             ins_scheduler.stop()
+
+            # Unregister node_id in with DriverState
+            self.driver_state.register_node(node_id=node_id)
 
             with self._cv:
                 self._cv.notify_all()

--- a/src/py/flwr/server/driver/driver_servicer.py
+++ b/src/py/flwr/server/driver/driver_servicer.py
@@ -32,7 +32,6 @@ from flwr.proto.driver_pb2 import (
     PushTaskInsResponse,
 )
 from flwr.proto.task_pb2 import Task, TaskIns, TaskRes
-from flwr.server.driver.driver_client_manager import DriverClientManager
 from flwr.server.driver.state import DriverState
 
 
@@ -41,10 +40,8 @@ class DriverServicer(driver_pb2_grpc.DriverServicer):
 
     def __init__(
         self,
-        driver_client_manager: DriverClientManager,
         driver_state: DriverState,
     ) -> None:
-        self.driver_client_manager = driver_client_manager
         self.driver_state = driver_state
 
     def GetNodes(
@@ -52,7 +49,7 @@ class DriverServicer(driver_pb2_grpc.DriverServicer):
     ) -> GetNodesResponse:
         """Get available nodes."""
         log(INFO, "DriverServicer.GetNodes")
-        all_ids: Set[int] = self.driver_client_manager.all_ids()
+        all_ids: Set[int] = self.driver_state.get_nodes()
         return GetNodesResponse(node_ids=list(all_ids))
 
     def PushTaskIns(

--- a/src/py/flwr/server/driver/state.py
+++ b/src/py/flwr/server/driver/state.py
@@ -26,6 +26,7 @@ class DriverState:
     """DriverState."""
 
     def __init__(self) -> None:
+        self.node_ids: Set[int] = set()
         self.task_ins_store: Dict[UUID, TaskIns] = {}
         self.task_res_store: Dict[UUID, TaskRes] = {}
 
@@ -126,6 +127,22 @@ class DriverState:
 
         # Return TaskRes
         return task_res_list
+
+    def register_node(self, node_id: int) -> None:
+        """Register a client node."""
+        if node_id in self.node_ids:
+            raise ValueError(f"Node {node_id} is already registered")
+        self.node_ids.add(node_id)
+
+    def unregister_node(self, node_id: int) -> None:
+        """Unregister a client node."""
+        if node_id not in self.node_ids:
+            raise ValueError(f"Node {node_id} is not registered")
+        self.node_ids.remove(node_id)
+
+    def get_nodes(self) -> Set[int]:
+        """Return all available client nodes."""
+        return self.node_ids
 
 
 def _now() -> datetime:


### PR DESCRIPTION
With this PR, the Driver API dependency on the `ClientManager` is dropped. Going forward, the streaming gRPC stack is the only component that relies on `ClientManager`, other transport stacks (e.g. REST) will be able to run without it.

The dependency on `ClientManager` is dropped by keeping a record about available client nodes (node IDs) in the `DriverState` (instead of having the `DriverServicer` read this directly from the `DriverClientManager`). Other transport stacks (e.g., REST) will be able to register client nodes with the `DriverState` in the same way.

Disentangling Driver API (`DriverServicer`) and `DriverClientManager` is an important step to eventually have Driver API and Fleet API run in different processes, maybe even on different machines.