### PR TITLE
Add a missing description to Flower-3-Building-a-Strategy-PyTorch

### DIFF
--- a/doc/source/tutorial/Flower-3-Building-a-Strategy-PyTorch.ipynb
+++ b/doc/source/tutorial/Flower-3-Building-a-Strategy-PyTorch.ipynb
@@ -485,7 +485,7 @@
         "id": "sz4Zdja7vI-g"
       },
       "source": [
-        "[WIP - add description]"
+        "The only thing left is to specify the newly created Custom Strategy."
       ]
     },
     {

--- a/doc/source/tutorial/Flower-3-Building-a-Strategy-PyTorch.ipynb
+++ b/doc/source/tutorial/Flower-3-Building-a-Strategy-PyTorch.ipynb
@@ -485,7 +485,7 @@
         "id": "sz4Zdja7vI-g"
       },
       "source": [
-        "The only thing left is to specify the newly created Custom Strategy."
+        "The only thing left is to use the newly created custom Strategy `FedCustom` when starting the experiment:"
       ]
     },
     {


### PR DESCRIPTION
I left one [wip] section unchanged in the tutorial, now it's fixed.