### PR TITLE
Fix FedProx proximal term

### DIFF
--- a/baselines/flwr_baselines/publications/fedprox_mnist/model.py
+++ b/baselines/flwr_baselines/publications/fedprox_mnist/model.py
@@ -77,7 +77,7 @@ def train(  # pylint: disable=too-many-arguments
     """
     criterion = torch.nn.CrossEntropyLoss()
     optimizer = torch.optim.SGD(net.parameters(), lr=learning_rate)
-    global_params = copy.deepcopy(net).parameters()
+    global_params = [val.detach().clone() for val in net.parameters()]
     net.train()
     for _ in range(epochs):
         net = _training_loop(


### PR DESCRIPTION
The FedProx proximal term always evaluated to 0, this fix builds detached copies of the parameters.

The attached outputs show the value of the proximal term up to sample 200 without the fix (output_default.txt) or with the fix (output_fixed.txt).

[output_default.txt](https://github.com/adap/flower/files/10684713/output_default.txt)
[output_fixed.txt](https://github.com/adap/flower/files/10684715/output_fixed.txt)
