### PR TITLE
Correct testing loss in the quickstart_pytorch example

### DIFF
--- a/examples/quickstart_pytorch/client.py
+++ b/examples/quickstart_pytorch/client.py
@@ -42,7 +42,7 @@ class Net(nn.Module):
 
 def train(net, trainloader, epochs):
     """Train the model on the training set."""
-    criterion = torch.nn.CrossEntropyLoss()
+    criterion = torch.nn.CrossEntropyLoss(reduction='sum')
     optimizer = torch.optim.SGD(net.parameters(), lr=0.001, momentum=0.9)
     for _ in range(epochs):
         for images, labels in tqdm(trainloader):
@@ -53,16 +53,16 @@ def train(net, trainloader, epochs):
 
 def test(net, testloader):
     """Validate the model on the test set."""
-    criterion = torch.nn.CrossEntropyLoss()
-    correct, total, loss = 0, 0, 0.0
+    criterion = torch.nn.CrossEntropyLoss(reduction='sum')
+    correct, loss = 0, 0.0
     with torch.no_grad():
         for images, labels in tqdm(testloader):
             outputs = net(images.to(DEVICE))
             labels = labels.to(DEVICE)
             loss += criterion(outputs, labels).item()
-            total += labels.size(0)
             correct += (torch.max(outputs.data, 1)[1] == labels).sum().item()
-    return loss / len(testloader.dataset), correct / total
+    total = len(testloader.dataset)
+    return loss / total, correct / total
 
 
 def load_data():


### PR DESCRIPTION
#### Reference Issues/PRs

#1604 

#### What does this implement/fix? Explain your changes.

Makes the total testing loss in the `quickstart_pytorch` example more consistent by changing the reduction method of the criterion from `mean` to `sum`.
