### PR TITLE
Add baselines to good first contributions doc

### DIFF
--- a/doc/source/good-first-contributions.rst
+++ b/doc/source/good-first-contributions.rst
@@ -15,8 +15,20 @@ they only touch non-core areas of the codebase. Good candidates to get started
 are:
 
 - Documentation: What's missing? What could be expressed more clearly? 
+- Baselines: See below.
 - Examples: See below.
 
+
+Request for Baselines
+---------------------
+
+If you are not familiar with baselines, you should probably check-out our `contributing guide for baselines <https://flower.dev/docs/contributing-baselines.html>`_.
+
+You should then check out the open 
+`issues <https://github.com/adap/flower/issues?q=is%3Aopen+is%3Aissue+label%3A%22new+baseline%22>`_ for baseline requests.
+If you find a baseline that you'd like to work on and that has no assignes, feel free to assign it to yourself and start working on it!
+
+Otherwise, if you don't find a baseline you'd like to work on, be sure to open a new issue with the baseline request template!
 
 Request for Examples
 --------------------

--- a/doc/source/good-first-contributions.rst
+++ b/doc/source/good-first-contributions.rst
@@ -22,7 +22,7 @@ are:
 Request for Baselines
 ---------------------
 
-If you are not familiar with baselines, you should probably check-out our `contributing guide for baselines <https://flower.dev/docs/contributing-baselines.html>`_.
+If you are not familiar with Flower Baselines, you should probably check-out our `contributing guide for baselines <https://flower.dev/docs/contributing-baselines.html>`_.
 
 You should then check out the open 
 `issues <https://github.com/adap/flower/issues?q=is%3Aopen+is%3Aissue+label%3A%22new+baseline%22>`_ for baseline requests.


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Mention baselines in the [`Good First Contributions`](https://flower.dev/docs/good-first-contributions.html) doc.
