### PR TITLE
Upgrade Ray to `2.3.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ protobuf = "^3.19.0"
 importlib-metadata = { version = "^4.0.0", markers = "python_version < '3.8'" }
 iterators = "^0.0.2"
 # Optional dependencies (VCE)
-ray = { extras = ["default"], version = "~2.2.0", optional = true }
+ray = { extras = ["default"], version = "~2.3.0", optional = true }
 # Optional dependencies (REST transport layer)
 requests = "^2.28.2"
 fastapi = "^0.92.0"

--- a/src/py/flwr/simulation/app.py
+++ b/src/py/flwr/simulation/app.py
@@ -171,15 +171,15 @@ def start_simulation(  # pylint: disable=too-many-arguments
         }
 
     # Shut down Ray if it has already been initialized (unless asked not to)
-    if ray.is_initialized() and not keep_initialised:  # type: ignore
-        ray.shutdown()  # type: ignore
+    if ray.is_initialized() and not keep_initialised:
+        ray.shutdown()
 
     # Initialize Ray
-    ray.init(**ray_init_args)  # type: ignore
+    ray.init(**ray_init_args)
     log(
         INFO,
         "Flower VCE: Ray initialized with resources: %s",
-        ray.cluster_resources(),  # type: ignore
+        ray.cluster_resources(),
     )
 
     # Register one RayClientProxy object for each client with the ClientManager

--- a/src/py/flwr/simulation/ray_transport/ray_client_proxy.py
+++ b/src/py/flwr/simulation/ray_transport/ray_client_proxy.py
@@ -46,7 +46,7 @@ class RayClientProxy(ClientProxy):
         self, ins: common.GetPropertiesIns, timeout: Optional[float]
     ) -> common.GetPropertiesRes:
         """Returns client's properties."""
-        future_get_properties_res = launch_and_get_properties.options(
+        future_get_properties_res = launch_and_get_properties.options(  # type: ignore
             **self.resources,
         ).remote(self.client_fn, self.cid, ins)
         try:
@@ -63,7 +63,7 @@ class RayClientProxy(ClientProxy):
         self, ins: common.GetParametersIns, timeout: Optional[float]
     ) -> common.GetParametersRes:
         """Return the current local model parameters."""
-        future_paramseters_res = launch_and_get_parameters.options(
+        future_paramseters_res = launch_and_get_parameters.options(  # type: ignore
             **self.resources,
         ).remote(self.client_fn, self.cid, ins)
         try:
@@ -78,7 +78,7 @@ class RayClientProxy(ClientProxy):
 
     def fit(self, ins: common.FitIns, timeout: Optional[float]) -> common.FitRes:
         """Train model parameters on the locally held dataset."""
-        future_fit_res = launch_and_fit.options(
+        future_fit_res = launch_and_fit.options(  # type: ignore
             **self.resources,
         ).remote(self.client_fn, self.cid, ins)
         try:
@@ -95,7 +95,7 @@ class RayClientProxy(ClientProxy):
         self, ins: common.EvaluateIns, timeout: Optional[float]
     ) -> common.EvaluateRes:
         """Evaluate model parameters on the locally held dataset."""
-        future_evaluate_res = launch_and_evaluate.options(
+        future_evaluate_res = launch_and_evaluate.options(  # type: ignore
             **self.resources,
         ).remote(self.client_fn, self.cid, ins)
         try:

--- a/src/py/flwr/simulation/ray_transport/ray_client_proxy.py
+++ b/src/py/flwr/simulation/ray_transport/ray_client_proxy.py
@@ -50,7 +50,7 @@ class RayClientProxy(ClientProxy):
             **self.resources,
         ).remote(self.client_fn, self.cid, ins)
         try:
-            res = ray.get(future_get_properties_res, timeout=timeout)  # type: ignore
+            res = ray.get(future_get_properties_res, timeout=timeout)
         except Exception as ex:
             log(DEBUG, ex)
             raise ex
@@ -67,7 +67,7 @@ class RayClientProxy(ClientProxy):
             **self.resources,
         ).remote(self.client_fn, self.cid, ins)
         try:
-            res = ray.get(future_paramseters_res, timeout=timeout)  # type: ignore
+            res = ray.get(future_paramseters_res, timeout=timeout)
         except Exception as ex:
             log(DEBUG, ex)
             raise ex
@@ -82,7 +82,7 @@ class RayClientProxy(ClientProxy):
             **self.resources,
         ).remote(self.client_fn, self.cid, ins)
         try:
-            res = ray.get(future_fit_res, timeout=timeout)  # type: ignore
+            res = ray.get(future_fit_res, timeout=timeout)
         except Exception as ex:
             log(DEBUG, ex)
             raise ex
@@ -99,7 +99,7 @@ class RayClientProxy(ClientProxy):
             **self.resources,
         ).remote(self.client_fn, self.cid, ins)
         try:
-            res = ray.get(future_evaluate_res, timeout=timeout)  # type: ignore
+            res = ray.get(future_evaluate_res, timeout=timeout)
         except Exception as ex:
             log(DEBUG, ex)
             raise ex
@@ -115,7 +115,7 @@ class RayClientProxy(ClientProxy):
         return common.DisconnectRes(reason="")  # Nothing to do here (yet)
 
 
-@ray.remote  # type: ignore
+@ray.remote
 def launch_and_get_properties(
     client_fn: ClientFn, cid: str, get_properties_ins: common.GetPropertiesIns
 ) -> common.GetPropertiesRes:
@@ -127,7 +127,7 @@ def launch_and_get_properties(
     )
 
 
-@ray.remote  # type: ignore
+@ray.remote
 def launch_and_get_parameters(
     client_fn: ClientFn, cid: str, get_parameters_ins: common.GetParametersIns
 ) -> common.GetParametersRes:
@@ -139,7 +139,7 @@ def launch_and_get_parameters(
     )
 
 
-@ray.remote  # type: ignore
+@ray.remote
 def launch_and_fit(
     client_fn: ClientFn, cid: str, fit_ins: common.FitIns
 ) -> common.FitRes:
@@ -151,7 +151,7 @@ def launch_and_fit(
     )
 
 
-@ray.remote  # type: ignore
+@ray.remote
 def launch_and_evaluate(
     client_fn: ClientFn, cid: str, evaluate_ins: common.EvaluateIns
 ) -> common.EvaluateRes:


### PR DESCRIPTION
#### Reference Issues/PRs

#1516, #1394 

#### What does this implement/fix? Explain your changes.

Upgrade Ray to `2.3.0` in order to fix storage issues caused by object spilling.
