### PR TITLE
Remove VSCode metadata from notebooks

### DIFF
--- a/dev/format.sh
+++ b/dev/format.sh
@@ -17,6 +17,6 @@ python -m docformatter -i -r examples
 
 
 # Notebooks
-KEYS="metadata.celltoolbar metadata.language_info metadata.toc metadata.notify_time metadata.varInspector metadata.accelerator metadata.vscode cell.metadata.id cell.metadata.heading_collapsed cell.metadata.hidden cell.metadata.code_folding cell.metadata.tags cell.metadata.init_cell"
+KEYS="metadata.celltoolbar metadata.language_info metadata.toc metadata.notify_time metadata.varInspector metadata.accelerator metadata.vscode cell.metadata.id cell.metadata.heading_collapsed cell.metadata.hidden cell.metadata.code_folding cell.metadata.tags cell.metadata.init_cell cell.metadata.vscode"
 python -m nbstripout doc/source/tutorial/*.ipynb --extra-keys "$KEYS"
 python -m nbstripout examples/*/*.ipynb --extra-keys "$KEYS"

--- a/doc/source/tutorial/Flower-1-Intro-to-FL-PyTorch.ipynb
+++ b/doc/source/tutorial/Flower-1-Intro-to-FL-PyTorch.ipynb
@@ -37,11 +37,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "!pip install -q flwr[simulation] torch torchvision matplotlib"
@@ -57,11 +53,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from collections import OrderedDict\n",
@@ -106,11 +98,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "CLASSES = (\n",
@@ -139,11 +127,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "NUM_CLIENTS = 10"
@@ -160,11 +144,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "BATCH_SIZE = 32\n",
@@ -212,11 +192,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "images, labels = next(iter(trainloaders[0]))\n",
@@ -275,11 +251,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "class Net(nn.Module):\n",
@@ -312,11 +284,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def train(net, trainloader, epochs: int, verbose=False):\n",
@@ -373,11 +341,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "trainloader = trainloaders[0]\n",
@@ -425,11 +389,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def get_parameters(net) -> List[np.ndarray]:\n",
@@ -462,11 +422,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "class FlowerClient(fl.client.NumPyClient):\n",
@@ -505,11 +461,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def client_fn(cid: str) -> FlowerClient:\n",
@@ -544,11 +496,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Create FedAvg strategy\n",
@@ -606,11 +554,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def weighted_average(metrics: List[Tuple[int, Metrics]]) -> Metrics:\n",
@@ -632,11 +576,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Create FedAvg strategy\n",

--- a/doc/source/tutorial/Flower-3-Building-a-Strategy-PyTorch.ipynb
+++ b/doc/source/tutorial/Flower-3-Building-a-Strategy-PyTorch.ipynb
@@ -37,11 +37,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "!pip install -q flwr[simulation] torch torchvision"
@@ -57,11 +53,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from collections import OrderedDict\n",
@@ -102,11 +94,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "NUM_CLIENTS = 10\n",
@@ -154,11 +142,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "class Net(nn.Module):\n",
@@ -244,11 +228,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "class FlowerClient(fl.client.NumPyClient):\n",
@@ -292,11 +272,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Specify client resources if you need GPU (defaults to 1 CPU and 0 GPU)\n",
@@ -324,11 +300,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from typing import Callable, Union\n",
@@ -490,11 +462,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fl.simulation.start_simulation(\n",


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Currently the `format.sh` script is not removing the metadata generated by VSCode in notebooks.