### PR TITLE
Fix tensorflow-cpu 2.11.1 dependency issue by limiting to 2.11.0

### DIFF
--- a/examples/advanced_tensorflow/pyproject.toml
+++ b/examples/advanced_tensorflow/pyproject.toml
@@ -11,4 +11,4 @@ authors = ["The Flower Authors <hello@flower.dev>"]
 [tool.poetry.dependencies]
 python = ">=3.7,<3.11"
 flwr = "^1.0.0"
-tensorflow-cpu = "^2.9.1"
+tensorflow-cpu = "<=2.11.0"

--- a/examples/android/pyproject.toml
+++ b/examples/android/pyproject.toml
@@ -12,4 +12,4 @@ authors = ["The Flower Authors <hello@flower.dev>"]
 python = ">=3.7,<3.11"
 flwr = "^1.0.0"
 # flwr = { path = "../../", develop = true }  # Development
-tensorflow-cpu = "^2.9.1"
+tensorflow-cpu = "<=2.11.0"

--- a/examples/quickstart_tensorflow/pyproject.toml
+++ b/examples/quickstart_tensorflow/pyproject.toml
@@ -11,4 +11,4 @@ authors = ["The Flower Authors <hello@flower.dev>"]
 [tool.poetry.dependencies]
 python = ">=3.7,<3.11"
 flwr = "^1.0.0"
-tensorflow-cpu = "^2.9.1"
+tensorflow-cpu = "<=2.11.0"

--- a/examples/simulation_tensorflow/pyproject.toml
+++ b/examples/simulation_tensorflow/pyproject.toml
@@ -11,4 +11,4 @@ authors = ["The Flower Authors <hello@flower.dev>"]
 [tool.poetry.dependencies]
 python = ">=3.7,<3.11"
 flwr = { extras = ["simulation"], version = "^1.0.0" }
-tensorflow-cpu = "^2.9.1"
+tensorflow-cpu = "<=2.11.0"


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Fixes an issue where the CI is breaking with TF-CPU 2.11.1