### PR TITLE
Fix formatting for iOS example

### DIFF
--- a/examples/ios/scenarios.ipynb
+++ b/examples/ios/scenarios.ipynb
@@ -34,7 +34,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "686c227b",
    "metadata": {},
    "outputs": [],
@@ -51,7 +51,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "a4fa8ecc",
    "metadata": {},
    "outputs": [],
@@ -68,7 +68,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "f222f213",
    "metadata": {},
    "outputs": [],
@@ -85,7 +85,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "16564122",
    "metadata": {},
    "outputs": [],
@@ -107,7 +107,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "b374140e",
    "metadata": {},
    "outputs": [],
@@ -118,7 +118,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "2ec8ec27",
    "metadata": {},
    "outputs": [],
@@ -129,7 +129,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "c306ca04",
    "metadata": {},
    "outputs": [],
@@ -150,7 +150,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "398f4550",
    "metadata": {},
    "outputs": [],
@@ -162,7 +162,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "8dac2e0b",
    "metadata": {},
    "outputs": [],
@@ -196,7 +196,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "7fefc1fe",
    "metadata": {},
    "outputs": [],
@@ -213,7 +213,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "2f1c7d5a",
    "metadata": {},
    "outputs": [],
@@ -225,7 +225,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "d212252d",
    "metadata": {},
    "outputs": [],
@@ -237,7 +237,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": null,
    "id": "8f2c53e0",
    "metadata": {},
    "outputs": [],
@@ -253,18 +253,6 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.9.16"
   }
  },
  "nbformat": 4,

--- a/examples/ios/server.py
+++ b/examples/ios/server.py
@@ -2,6 +2,7 @@ import flwr
 import argparse
 import numpy as np
 
+
 # https://github.com/adap/flower/pull/488/files#diff-206567616f04a829972d62974a49c3b5769e331dd544233f180182c088c18ebfR30
 class SaveModelStrategy(flwr.server.strategy.FedAvg):
     def aggregate_fit(
@@ -17,25 +18,31 @@ class SaveModelStrategy(flwr.server.strategy.FedAvg):
             np.savez(f"round-{rnd}-weights.npz", *weights)
         return weights
 
-def main(num_clients = 1, num_rounds = 1) -> None:
-    
+
+def main(num_clients=1, num_rounds=1) -> None:
     strategy = SaveModelStrategy(
         min_fit_clients=num_clients,
         min_evaluate_clients=num_clients,
         min_available_clients=num_clients,
     )
-    
+
     # Start Flower server
     hist = flwr.server.start_server(
-        server_address="[::]:8080", 
+        server_address="[::]:8080",
         config=flwr.server.ServerConfig(num_rounds=num_rounds),
         strategy=strategy,
     )
     return hist
-    
+
+
 if __name__ == "__main__":
     argParser = argparse.ArgumentParser()
-    argParser.add_argument("-c", "--clients", type=int, help="minimum number of clients", default=1)
-    argParser.add_argument("-r", "--rounds", type=int, help="number of rounds", default=1)
+    argParser.add_argument(
+        "-c", "--clients", type=int, help="minimum number of clients", default=1
+    )
+    argParser.add_argument(
+        "-r", "--rounds", type=int, help="number of rounds", default=1
+    )
     args = argParser.parse_args()
     hist = main(args.clients, args.rounds)
+


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Applies formatting to the Python files of the iOS example and strips the notebook of its metadata
