### PR TITLE
Fix the return type of client_fn in simulation

### DIFF
--- a/src/py/flwr/simulation/app.py
+++ b/src/py/flwr/simulation/app.py
@@ -79,7 +79,7 @@ def start_simulation(  # pylint: disable=too-many-arguments
     client_fn : Callable[[str], ClientLike]
         A function creating client instances. The function must take a single
         str argument called `cid`. It should return a single client instance
-        of type Client or ClientLike. Note that the created client instances
+        of type ClientLike. Note that the created client instances
         are ephemeral and will often be destroyed after a single method
         invocation. Since client instances are not long-lived, they should not
          attempt to carry state over method invocations. Any state required by

--- a/src/py/flwr/simulation/app.py
+++ b/src/py/flwr/simulation/app.py
@@ -21,7 +21,7 @@ from typing import Any, Callable, Dict, List, Optional
 
 import ray
 
-from flwr.client.client import Client
+from flwr.client import ClientLike
 from flwr.common import EventType, event
 from flwr.common.logger import log
 from flwr.server import Server
@@ -38,7 +38,7 @@ Invalid Arguments in method:
 
 `start_simulation(
     *,
-    client_fn: Callable[[str], Client],
+    client_fn: Callable[[str], ClientLike],
     num_clients: Optional[int] = None,
     clients_ids: Optional[List[str]] = None,
     client_resources: Optional[Dict[str, float]] = None,
@@ -61,7 +61,7 @@ REASON:
 
 def start_simulation(  # pylint: disable=too-many-arguments
     *,
-    client_fn: Callable[[str], Client],
+    client_fn: Callable[[str], ClientLike],
     num_clients: Optional[int] = None,
     clients_ids: Optional[List[str]] = None,
     client_resources: Optional[Dict[str, float]] = None,
@@ -76,16 +76,17 @@ def start_simulation(  # pylint: disable=too-many-arguments
 
     Parameters
     ----------
-    client_fn : Callable[[str], Client]
+    client_fn : Callable[[str], ClientLike]
         A function creating client instances. The function must take a single
-        str argument called `cid`. It should return a single client instance.
-        Note that the created client instances are ephemeral and will often be
-        destroyed after a single method invocation. Since client instances are
-        not long-lived, they should not attempt to carry state over method
-        invocations. Any state required by the instance (model, dataset,
-        hyperparameters, ...) should be (re-)created in either the call to
-        `client_fn` or the call to any of the client methods (e.g., load
-        evaluation data in the `evaluate` method itself).
+        str argument called `cid`. It should return a single client instance
+        of type Client or ClientLike. Note that the created client instances
+        are ephemeral and will often be destroyed after a single method
+        invocation. Since client instances are not long-lived, they should not
+         attempt to carry state over method invocations. Any state required by
+        the instance (model, dataset,hyperparameters, ...) should be
+        (re-)created in either the call to `client_fn` or the call to any of
+        the client methods (e.g., load evaluation data in the `evaluate`
+        method itself).
     num_clients : Optional[int]
         The total number of clients in this simulation. This must be set if
         `clients_ids` is not set and vice-versa.


### PR DESCRIPTION
Currently, the simulation requires client_fn of type `Callable[[str], Client]`; however, it works on both Client and NumpyClient (also, the example on the website show function with the return type of NumpyClient).
This PR changes the type to `ClientLike`, which is `Union[Client, NumPyClient]`.
The problem was mentioned in https://github.com/adap/flower/issues/1176

Both type work because the simulation uses `RayClientProxy` that calls this function
https://github.com/adap/flower/blob/57a4365f24727ecf7f0887bdaab9438c4b0142c8/src/py/flwr/client/app.py#L249-L253
