### PR TITLE
Add FedTrimmedMean strategy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ xgboost = { version = "^1.6.2", optional = true }
 # Optional dependency (fedtrimmedavg)
 scipy = [
     {version = "<=1.6.3", markers = "python_version < '3.8'", optional = true},
-    {version = "^1.10.1", markers = "python_version >= '3.8'", optional = true}
+    {version = "^1.10.1", markers = "python_version >= '3.8' and python_version < '3.12'", optional = true}
 ]
 
 [tool.poetry.extras]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,11 +66,6 @@ starlette = { version = "^0.25.0", optional = true }
 uvicorn = { extras = ["standard"], version = "^0.20.0", optional = true }
 # Optional dependency (xgboost)
 xgboost = { version = "^1.6.2", optional = true }
-# Optional dependency (fedtrimmedavg)
-scipy = [
-    {version = "<=1.6.3", markers = "python_version < '3.8'", optional = true},
-    {version = "^1.10.1", markers = "python_version >= '3.8' and python_version < '3.12'", optional = true}
-]
 
 [tool.poetry.extras]
 simulation = ["ray"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,10 @@ uvicorn = { extras = ["standard"], version = "^0.20.0", optional = true }
 # Optional dependency (xgboost)
 xgboost = { version = "^1.6.2", optional = true }
 # Optional dependency (fedtrimmedavg)
-scipy = { version = "^1.10.1", optional = true }
+scipy = [
+    {version = "<=1.6.3", python = "<3.8"},
+    {version = "^1.10.1", python = ">=3.8"}
+]
 
 [tool.poetry.extras]
 simulation = ["ray"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,8 +68,8 @@ uvicorn = { extras = ["standard"], version = "^0.20.0", optional = true }
 xgboost = { version = "^1.6.2", optional = true }
 # Optional dependency (fedtrimmedavg)
 scipy = [
-    {version = "<=1.6.3", python = "<3.8"},
-    {version = "^1.10.1", python = ">=3.8"}
+    {version = "<=1.6.3", markers = "python_version < '3.8'", optional = true},
+    {version = "^1.10.1", markers = "python_version >= '3.8'", optional = true}
 ]
 
 [tool.poetry.extras]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,8 @@ starlette = { version = "^0.25.0", optional = true }
 uvicorn = { extras = ["standard"], version = "^0.20.0", optional = true }
 # Optional dependency (xgboost)
 xgboost = { version = "^1.6.2", optional = true }
+# Optional dependency (fedtrimmedavg)
+scipy = { version = "^1.10.1", optional = true }
 
 [tool.poetry.extras]
 simulation = ["ray"]

--- a/src/py/flwr/server/strategy/__init__.py
+++ b/src/py/flwr/server/strategy/__init__.py
@@ -28,6 +28,7 @@ from .fedxgb_nn_avg import FedXgbNnAvg as FedXgbNnAvg
 from .fedyogi import FedYogi as FedYogi
 from .qfedavg import QFedAvg as QFedAvg
 from .strategy import Strategy as Strategy
+from .fedtrimmedavg import FedTrimmedAvg as FedTrimmedAvg
 
 __all__ = [
     "FaultTolerantFedAvg",
@@ -42,5 +43,6 @@ __all__ = [
     "FedYogi",
     "QFedAvg",
     "FedMedian",
+    "FedTrimmedAvg",
     "Strategy",
 ]

--- a/src/py/flwr/server/strategy/__init__.py
+++ b/src/py/flwr/server/strategy/__init__.py
@@ -24,11 +24,11 @@ from .fedavgm import FedAvgM as FedAvgM
 from .fedmedian import FedMedian as FedMedian
 from .fedopt import FedOpt as FedOpt
 from .fedprox import FedProx as FedProx
+from .fedtrimmedavg import FedTrimmedAvg as FedTrimmedAvg
 from .fedxgb_nn_avg import FedXgbNnAvg as FedXgbNnAvg
 from .fedyogi import FedYogi as FedYogi
 from .qfedavg import QFedAvg as QFedAvg
 from .strategy import Strategy as Strategy
-from .fedtrimmedavg import FedTrimmedAvg as FedTrimmedAvg
 
 __all__ = [
     "FaultTolerantFedAvg",

--- a/src/py/flwr/server/strategy/aggregate.py
+++ b/src/py/flwr/server/strategy/aggregate.py
@@ -134,13 +134,17 @@ def _compute_distances(weights: List[NDArrays]) -> NDArray:
             distance_matrix[i, j] = norm**2
     return distance_matrix
 
-def aggregate_trimmed_avg(results: List[Tuple[NDArray, int]], proportiontocut: float) -> NDArray:
+
+def aggregate_trimmed_avg(
+    results: List[Tuple[NDArray, int]], proportiontocut: float
+) -> NDArray:
     """Compute trimmed average."""
     # Create a list of weights and ignore the number of examples
     weights = [weights for weights, _ in results]
 
     trimmed_w: NDArrays = [
-        stats.trim_mean(np.asarray(layer), axis=0, proportiontocut=proportiontocut) for layer in zip(*weights)
+        stats.trim_mean(np.asarray(layer), axis=0, proportiontocut=proportiontocut)
+        for layer in zip(*weights)
     ]
 
     return trimmed_w

--- a/src/py/flwr/server/strategy/aggregate.py
+++ b/src/py/flwr/server/strategy/aggregate.py
@@ -19,6 +19,7 @@ from functools import reduce
 from typing import List, Tuple
 
 import numpy as np
+from scipy import stats
 
 from flwr.common import NDArray, NDArrays
 
@@ -132,3 +133,14 @@ def _compute_distances(weights: List[NDArrays]) -> NDArray:
             norm = np.linalg.norm(delta)  # type: ignore
             distance_matrix[i, j] = norm**2
     return distance_matrix
+
+def aggregate_trimmed_avg(results: List[Tuple[NDArray, int]], proportiontocut: float) -> NDArray:
+    """Compute trimmed average."""
+    # Create a list of weights and ignore the number of examples
+    weights = [weights for weights, _ in results]
+
+    trimmed_w: NDArrays = [
+        stats.trim_mean(np.asarray(layer), axis=0, proportiontocut=proportiontocut) for layer in zip(*weights)
+    ]
+
+    return trimmed_w

--- a/src/py/flwr/server/strategy/aggregate.py
+++ b/src/py/flwr/server/strategy/aggregate.py
@@ -137,7 +137,7 @@ def _compute_distances(weights: List[NDArrays]) -> NDArray:
 
 def aggregate_trimmed_avg(
     results: List[Tuple[NDArray, int]], proportiontocut: float
-) -> NDArray:
+) -> NDArrays:
     """Compute trimmed average."""
     # Create a list of weights and ignore the number of examples
     weights = [weights for weights, _ in results]

--- a/src/py/flwr/server/strategy/aggregate.py
+++ b/src/py/flwr/server/strategy/aggregate.py
@@ -136,7 +136,7 @@ def _compute_distances(weights: List[NDArrays]) -> NDArray:
 
 
 def aggregate_trimmed_avg(
-    results: List[Tuple[NDArray, int]], proportiontocut: float
+    results: List[Tuple[NDArrays, int]], proportiontocut: float
 ) -> NDArrays:
     """Compute trimmed average."""
     # Create a list of weights and ignore the number of examples

--- a/src/py/flwr/server/strategy/fedmedian.py
+++ b/src/py/flwr/server/strategy/fedmedian.py
@@ -118,9 +118,6 @@ class FedMedian(FedAvg):
             fit_metrics_aggregation_fn=fit_metrics_aggregation_fn,
             evaluate_metrics_aggregation_fn=evaluate_metrics_aggregation_fn,
         )
-        # TODO Aren't these two lines below redundant?
-        self.fit_metrics_aggregation_fn = fit_metrics_aggregation_fn
-        self.evaluate_metrics_aggregation_fn = evaluate_metrics_aggregation_fn
 
     def __repr__(self) -> str:
         rep = f"FedMedian(accept_failures={self.accept_failures})"

--- a/src/py/flwr/server/strategy/fedtrimmedavg.py
+++ b/src/py/flwr/server/strategy/fedtrimmedavg.py
@@ -109,7 +109,7 @@ class FedTrimmedAvg(FedAvg):
         results: List[Tuple[ClientProxy, FitRes]],
         failures: List[Union[Tuple[ClientProxy, FitRes], BaseException]],
     ) -> Tuple[Optional[Parameters], Dict[str, Scalar]]:
-        """Aggregate fit results using median."""
+        """Aggregate fit results using trimmed average."""
         if not results:
             return None, {}
         # Do not aggregate if there are failures and failures are not accepted

--- a/src/py/flwr/server/strategy/fedtrimmedavg.py
+++ b/src/py/flwr/server/strategy/fedtrimmedavg.py
@@ -50,7 +50,7 @@ class FedTrimmedAvg(FedAvg):
         beta: float = 0.2,
     ) -> None:
         """Configurable FedTrimmedAvg strategy.
-         
+
         Implementation based on https://arxiv.org/pdf/1803.01498.pdf
 
         Parameters

--- a/src/py/flwr/server/strategy/fedtrimmedavg.py
+++ b/src/py/flwr/server/strategy/fedtrimmedavg.py
@@ -47,9 +47,11 @@ class FedTrimmedAvg(FedAvg):
         initial_parameters: Optional[Parameters] = None,
         fit_metrics_aggregation_fn: Optional[MetricsAggregationFn] = None,
         evaluate_metrics_aggregation_fn: Optional[MetricsAggregationFn] = None,
-        proportiontocut: float = 0.2,
+        beta: float = 0.2,
     ) -> None:
         """Configurable FedTrimmedAvg strategy.
+         
+        Implementation based on https://arxiv.org/pdf/1803.01498.pdf
 
         Parameters
         ----------
@@ -73,7 +75,7 @@ class FedTrimmedAvg(FedAvg):
             Whether or not accept rounds containing failures. Defaults to True.
         initial_parameters : Parameters, optional
             Initial global model parameters.
-        proportiontocut : float, optional
+        beta : float, optional
             Fraction to cut off of both tails of the distribution. Defaults to 0.2.
         """
 
@@ -97,7 +99,7 @@ class FedTrimmedAvg(FedAvg):
             fit_metrics_aggregation_fn=fit_metrics_aggregation_fn,
             evaluate_metrics_aggregation_fn=evaluate_metrics_aggregation_fn,
         )
-        self.proportiontocut = proportiontocut
+        self.beta = beta
 
     def __repr__(self) -> str:
         rep = f"FedTrimmedAvg(accept_failures={self.accept_failures})"
@@ -122,7 +124,7 @@ class FedTrimmedAvg(FedAvg):
             for _, fit_res in results
         ]
         parameters_aggregated = ndarrays_to_parameters(
-            aggregate_trimmed_avg(weights_results, self.proportiontocut)
+            aggregate_trimmed_avg(weights_results, self.beta)
         )
 
         # Aggregate custom metrics if aggregation fn was provided

--- a/src/py/flwr/server/strategy/fedtrimmedavg.py
+++ b/src/py/flwr/server/strategy/fedtrimmedavg.py
@@ -26,7 +26,6 @@ than or equal to the values of `min_fit_clients` and `min_evaluate_clients`.
 
 # flake8: noqa: E501
 class FedTrimmedAvg(FedAvg):
-
     # pylint: disable=too-many-arguments,too-many-instance-attributes,line-too-long
     def __init__(
         self,


### PR DESCRIPTION
<!--
Thank you for opening a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md

Does the documentation need to be updated?
See: https://flower.dev/docs/writing-documentation.html

Does the changelog need to be updated?
See: https://github.com/adap/flower/blob/main/doc/source/changelog.rst
-->

#### Reference Issues/PRs

#1610

#### What does this implement/fix? Explain your changes.

A strategy that removes the indicated percentage of the largest and smallest weights from the local models received by the server and finally averages their values to create a new global model

#### Any other comments?

Please check TODO comments and I would also need some guidance in fixing CI ;)