### PR TITLE
Add reference doc page for Flower binaries

### DIFF
--- a/doc/source/apiref-binaries.rst
+++ b/doc/source/apiref-binaries.rst
@@ -4,11 +4,11 @@ API Reference - Flower binaries
 .. _flower-driver-apiref:
 
 flower-driver-api
------------------
+~~~~~~~~~~~~~~~~~
 
 .. argparse::
-   :filename: flwr.server
-   :func:  _parse_args_driver
+   :module: flwr.server.app
+   :func: _parse_args_driver
    :prog: flower-driver-api
 
 .. _flower-fleet-apiref:
@@ -17,10 +17,9 @@ flower-fleet-api
 ~~~~~~~~~~~~~~~~
 
 .. argparse::
-   :filename: flwr.server
+   :module: flwr.server.app
    :func:  _parse_args_fleet
    :prog: flower-fleet-api
-
 
 .. _flower-server-apiref:
 
@@ -28,10 +27,9 @@ flower-server
 ~~~~~~~~~~~~~
 
 .. argparse::
-   :filename: flwr.server
+   :module: flwr.server.app
    :func:  _parse_args_server
    :prog: flower-server
-
 
 .. .. _flower-client-apiref:
 

--- a/doc/source/apiref-binaries.rst
+++ b/doc/source/apiref-binaries.rst
@@ -1,0 +1,44 @@
+API Reference - Flower binaries
+===============================
+
+.. _flower-driver-apiref:
+
+flower-driver-api
+-----------------
+
+.. argparse::
+   :filename: flwr.server
+   :func:  _parse_args_driver
+   :prog: flower-driver-api
+
+.. _flower-fleet-apiref:
+
+flower-fleet-api
+~~~~~~~~~~~~~~~~
+
+.. argparse::
+   :filename: flwr.server
+   :func:  _parse_args_fleet
+   :prog: flower-fleet-api
+
+
+.. _flower-server-apiref:
+
+flower-server
+~~~~~~~~~~~~~
+
+.. argparse::
+   :filename: flwr.server
+   :func:  _parse_args_server
+   :prog: flower-server
+
+
+.. .. _flower-client-apiref:
+
+.. flower-client
+.. ~~~~~~~~~~~~~
+
+    .. argparse::
+..    :filename: flwr.client
+..    :func: run_client
+..    :prog: flower-client

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -48,6 +48,7 @@ extensions = [
     "sphinx.ext.mathjax",
     "sphinx.ext.viewcode",
     "sphinx.ext.graphviz",
+    "sphinxarg.ext",
     "myst_parser",
     "sphinx_copybutton",
     "sphinx_design",

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -54,7 +54,7 @@ A learning-oriented series of federated learning tutorials, the best place to st
    quickstart-scikitlearn
    quickstart-xgboost
 
-QUICKSTART TUTORIALS: :ref:`PyTorch <quickstart-pytorch>` | :ref:`TensorFlow <quickstart-tensorflow>` | :ref:`🤗 Transformers <quickstart-huggingface>` | :ref:`JAX <quickstart-jax>` | :ref:`Pandas <quickstart-pandas>` | :ref:`fastai <quickstart-fastai>` | :ref:`PyTorch Lightning <quickstart-pytorch-lightning>` | :ref:`MXNet <quickstart-mxnet>` | :ref:`scikit-learn <quickstart-scikitlearn>` | :ref:`XGBoost <_quickstart-xgboost>`
+QUICKSTART TUTORIALS: :ref:`PyTorch <quickstart-pytorch>` | :ref:`TensorFlow <quickstart-tensorflow>` | :ref:`🤗 Transformers <quickstart-huggingface>` | :ref:`JAX <quickstart-jax>` | :ref:`Pandas <quickstart-pandas>` | :ref:`fastai <quickstart-fastai>` | :ref:`PyTorch Lightning <quickstart-pytorch-lightning>` | :ref:`MXNet <quickstart-mxnet>` | :ref:`scikit-learn <quickstart-scikitlearn>` | :ref:`XGBoost <quickstart-xgboost>`
 
 How-to guides
 ~~~~~~~~~~~~~

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -103,6 +103,7 @@ Information-oriented API reference and other reference material.
    :caption: API reference
 
    flwr <apiref-flwr>
+   binaries <apiref-binaries>
 
 .. toctree::
    :maxdepth: 1

--- a/doc/source/quickstart-xgboost.rst
+++ b/doc/source/quickstart-xgboost.rst
@@ -2,7 +2,7 @@
 
 
 Quickstart XGBoost
-=================
+==================
 
 Let's build a horizontal federated learning system using XGBoost and Flower!
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,7 @@ furo = "==2022.12.7"
 sphinx-reredirects = "==0.1.1"
 nbsphinx = "==0.8.12"
 nbstripout = "==0.6.1"
+sphinx-argparse = "==0.4.0"
 
 [tool.isort]
 line_length = 88

--- a/src/py/flwr/server/app.py
+++ b/src/py/flwr/server/app.py
@@ -221,7 +221,7 @@ def run_driver_api() -> None:
 
     log(INFO, "Starting Flower server (Driver API)")
     event(EventType.RUN_DRIVER_API_ENTER)
-    args = _parse_args_driver()
+    args = _parse_args_driver().parse_args()
 
     # Initialize StateFactory
     state_factory = StateFactory(args.database)
@@ -248,7 +248,7 @@ def run_fleet_api() -> None:
 
     log(INFO, "Starting Flower server (Fleet API)")
     event(EventType.RUN_FLEET_API_ENTER)
-    args = _parse_args_fleet()
+    args = _parse_args_fleet().parse_args()
 
     # Initialize StateFactory
     state_factory = StateFactory(args.database)
@@ -292,7 +292,7 @@ def run_server() -> None:
 
     log(INFO, "Starting Flower server")
     event(EventType.RUN_SERVER_ENTER)
-    args = _parse_args_server()
+    args = _parse_args_server().parse_args()
 
     # Initialize StateFactory
     state_factory = StateFactory(args.database)
@@ -469,7 +469,7 @@ def _run_fleet_api_rest(
     )
 
 
-def _parse_args_driver() -> argparse.Namespace:
+def _parse_args_driver() -> argparse.ArgumentParser:
     """Parse command line arguments for Driver API."""
     parser = argparse.ArgumentParser(
         description="Start Flower server (Driver API)",
@@ -478,10 +478,10 @@ def _parse_args_driver() -> argparse.Namespace:
     _add_args_common(parser=parser)
     _add_args_driver_api(parser=parser)
 
-    return parser.parse_args()
+    return parser
 
 
-def _parse_args_fleet() -> argparse.Namespace:
+def _parse_args_fleet() -> argparse.ArgumentParser:
     """Parse command line arguments for Fleet API."""
     parser = argparse.ArgumentParser(
         description="Start Flower server (Fleet API)",
@@ -490,10 +490,10 @@ def _parse_args_fleet() -> argparse.Namespace:
     _add_args_common(parser=parser)
     _add_args_fleet_api(parser=parser)
 
-    return parser.parse_args()
+    return parser
 
 
-def _parse_args_server() -> argparse.Namespace:
+def _parse_args_server() -> argparse.ArgumentParser:
     """Parse command line arguments for both Driver API and Fleet API."""
     parser = argparse.ArgumentParser(
         description="Start Flower server (Driver API and Fleet API)",
@@ -503,7 +503,7 @@ def _parse_args_server() -> argparse.Namespace:
     _add_args_driver_api(parser=parser)
     _add_args_fleet_api(parser=parser)
 
-    return parser.parse_args()
+    return parser
 
 
 def _add_args_common(parser: argparse.ArgumentParser) -> None:


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Adds an automated doc reference page for Flower binaries: `flower-server`, `flower-driver`, `flower-fleet`. It also fixes some syntax errors for the `xgboost` example doc.