### PR TITLE
Remove unnecessary XGBoost dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,13 +64,10 @@ requests = { version = "^2.28.2", optional = true }
 fastapi = { version = "^0.95.0", optional = true }
 starlette = { version = "^0.26.1", optional = true }
 uvicorn = { version = "^0.21.1", extras = ["standard"], optional = true }
-# Optional dependency (xgboost)
-xgboost = { version = "^1.6.2", optional = true }
 
 [tool.poetry.extras]
 simulation = ["ray"]
 rest = ["fastapi", "requests", "starlette", "uvicorn"]
-xgboost = ["xgboost"]
 
 [tool.poetry.group.dev.dependencies]
 types-dataclasses = "==0.6.6"


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

The `XGBoost` optional dependency was actually not in use in the main project. It can therefore be removed.
