### PR TITLE
Support many uvicorn workers

### DIFF
--- a/src/py/flwr/server/app.py
+++ b/src/py/flwr/server/app.py
@@ -273,7 +273,7 @@ def run_fleet_api() -> None:
     state_factory = StateFactory(args.database)
 
     grpc_servers = []
-    bckg_threads = []
+    bckg_threads: List[threading.Thread] = []
 
     # Start Fleet API
     if args.fleet_api_type == "rest":
@@ -350,7 +350,7 @@ def run_server() -> None:
     )
 
     grpc_servers = [driver_server]
-    bckg_threads = []
+    bckg_threads: List[threading.Thread] = []
 
     # Start Fleet API
     if args.fleet_api_type == "rest":
@@ -518,7 +518,6 @@ def _run_fleet_api_rest(
     try:
         import uvicorn
 
-        from flwr.server.rest_server.rest_api import app as fast_api_app
     except ModuleNotFoundError:
         sys.exit(MISSING_EXTRA_REST)
     log(INFO, "Starting Flower REST server")

--- a/src/py/flwr/server/app.py
+++ b/src/py/flwr/server/app.py
@@ -290,13 +290,13 @@ def run_fleet_api() -> None:
             sys.exit(f"Fleet IP address ({address_arg}) cannot be parsed.")
         host, port, _ = parsed_address
         _run_fleet_api_rest(
-                host,
-                port,
-                args.ssl_keyfile,
-                args.ssl_certfile,
-                state_factory,
-                args.rest_fleet_api_workers,
-            )
+            host,
+            port,
+            args.ssl_keyfile,
+            args.ssl_certfile,
+            state_factory,
+            args.rest_fleet_api_workers,
+        )
     elif args.fleet_api_type == "grpc":
         address_arg = args.grpc_fleet_api_address
         parsed_address = parse_address(address_arg)

--- a/src/py/flwr/server/rest_server/rest_api.py
+++ b/src/py/flwr/server/rest_server/rest_api.py
@@ -13,8 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 """REST API server."""
-
-
+import os
 import sys
 from logging import INFO
 from typing import List, Optional
@@ -30,7 +29,7 @@ from flwr.proto.fleet_pb2 import (
     Reconnect,
 )
 from flwr.proto.task_pb2 import TaskIns, TaskRes
-from flwr.server.state import State
+from flwr.server.state import State, StateFactory
 
 try:
     from fastapi import FastAPI, HTTPException, Request, Response
@@ -40,6 +39,14 @@ except ModuleNotFoundError:
 
 
 app: FastAPI = FastAPI()
+
+
+@app.on_event("startup")
+async def startup_event():
+    database = os.environ.get("DATABASE")
+    if database is None:
+        raise KeyError(f"The DATABASE environment variable does not exist.")
+    app.state.STATE_FACTORY = StateFactory(database)
 
 
 @app.post("/api/v0/fleet/pull-task-ins", response_class=Response)  # type: ignore

--- a/src/py/flwr/server/rest_server/rest_api.py
+++ b/src/py/flwr/server/rest_server/rest_api.py
@@ -41,7 +41,7 @@ except ModuleNotFoundError:
 app: FastAPI = FastAPI()
 
 
-@app.on_event("startup")
+@app.on_event("startup")  # type: ignore
 async def startup_event() -> None:
     """Set StateFactory as an attribute of the FastAPI app."""
     database = os.environ.get("DATABASE")

--- a/src/py/flwr/server/rest_server/rest_api.py
+++ b/src/py/flwr/server/rest_server/rest_api.py
@@ -42,10 +42,11 @@ app: FastAPI = FastAPI()
 
 
 @app.on_event("startup")
-async def startup_event():
+async def startup_event() -> None:
+    """Set StateFactory as an attribute of the FastAPI app."""
     database = os.environ.get("DATABASE")
     if database is None:
-        raise KeyError(f"The DATABASE environment variable does not exist.")
+        raise KeyError("The DATABASE environment variable does not exist.")
     app.state.STATE_FACTORY = StateFactory(database)
 
 


### PR DESCRIPTION
* Add DATABASE environment variable
* Remove starting _run_fleet_api_rest from a thread (reason: Signal only works in main thread)
* Add on_startup  event for StateFactory creation with environment variable to the fastAPI app (rest_api.py file)