### PR TITLE
Fix behavior with null loss

### DIFF
--- a/src/py/flwr/server/server.py
+++ b/src/py/flwr/server/server.py
@@ -104,7 +104,7 @@ class Server:
         for current_round in range(1, num_rounds + 1):
             # Train model and replace previous global model
             res_fit = self.fit_round(server_round=current_round, timeout=timeout)
-            if res_fit:
+            if res_fit is not None:
                 parameters_prime, fit_metrics, _ = res_fit  # fit_metrics_aggregated
                 if parameters_prime:
                     self.parameters = parameters_prime
@@ -131,9 +131,9 @@ class Server:
 
             # Evaluate model on a sample of available clients
             res_fed = self.evaluate_round(server_round=current_round, timeout=timeout)
-            if res_fed:
+            if res_fed is not None:
                 loss_fed, evaluate_metrics_fed, _ = res_fed
-                if loss_fed:
+                if loss_fed is not None:
                     history.add_loss_distributed(
                         server_round=current_round, loss=loss_fed
                     )


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Currently when a loss is `0.0` it won't be stored in the `History` object. 

The PR also makes the check for `None` objects consistent.