### PR TITLE
Remove redundant attributes in strategies subclassing FedAvg

### DIFF
--- a/src/py/flwr/server/strategy/fault_tolerant_fedavg.py
+++ b/src/py/flwr/server/strategy/fault_tolerant_fedavg.py
@@ -77,8 +77,6 @@ class FaultTolerantFedAvg(FedAvg):
         )
         self.completion_rate_fit = min_completion_rate_fit
         self.completion_rate_evaluate = min_completion_rate_evaluate
-        self.fit_metrics_aggregation_fn = fit_metrics_aggregation_fn
-        self.evaluate_metrics_aggregation_fn = evaluate_metrics_aggregation_fn
 
     def __repr__(self) -> str:
         return "FaultTolerantFedAvg()"

--- a/src/py/flwr/server/strategy/fedavgm.py
+++ b/src/py/flwr/server/strategy/fedavgm.py
@@ -132,8 +132,6 @@ class FedAvgM(FedAvg):
             self.server_learning_rate != 1.0
         )
         self.momentum_vector: Optional[NDArrays] = None
-        self.fit_metrics_aggregation_fn = fit_metrics_aggregation_fn
-        self.evaluate_metrics_aggregation_fn = evaluate_metrics_aggregation_fn
 
     def __repr__(self) -> str:
         rep = f"FedAvgM(accept_failures={self.accept_failures})"

--- a/src/py/flwr/server/strategy/fedmedian.py
+++ b/src/py/flwr/server/strategy/fedmedian.py
@@ -118,8 +118,6 @@ class FedMedian(FedAvg):
             fit_metrics_aggregation_fn=fit_metrics_aggregation_fn,
             evaluate_metrics_aggregation_fn=evaluate_metrics_aggregation_fn,
         )
-        self.fit_metrics_aggregation_fn = fit_metrics_aggregation_fn
-        self.evaluate_metrics_aggregation_fn = evaluate_metrics_aggregation_fn
 
     def __repr__(self) -> str:
         rep = f"FedMedian(accept_failures={self.accept_failures})"

--- a/src/py/flwr/server/strategy/fedxgb_nn_avg.py
+++ b/src/py/flwr/server/strategy/fedxgb_nn_avg.py
@@ -127,8 +127,6 @@ class FedXgbNnAvg(FedAvg):
             fit_metrics_aggregation_fn=fit_metrics_aggregation_fn,
             evaluate_metrics_aggregation_fn=evaluate_metrics_aggregation_fn,
         )
-        self.fit_metrics_aggregation_fn = fit_metrics_aggregation_fn
-        self.evaluate_metrics_aggregation_fn = evaluate_metrics_aggregation_fn
 
     def __repr__(self) -> str:
         rep = f"FedXgbNnAvg(accept_failures={self.accept_failures})"

--- a/src/py/flwr/server/strategy/krum.py
+++ b/src/py/flwr/server/strategy/krum.py
@@ -124,8 +124,6 @@ class Krum(FedAvg):
             fit_metrics_aggregation_fn=fit_metrics_aggregation_fn,
             evaluate_metrics_aggregation_fn=evaluate_metrics_aggregation_fn,
         )
-        self.fit_metrics_aggregation_fn = fit_metrics_aggregation_fn
-        self.evaluate_metrics_aggregation_fn = evaluate_metrics_aggregation_fn
         self.num_malicious_clients = num_malicious_clients
         self.num_clients_to_keep = num_clients_to_keep
 

--- a/src/py/flwr/server/strategy/qfedavg.py
+++ b/src/py/flwr/server/strategy/qfedavg.py
@@ -97,8 +97,6 @@ class QFedAvg(FedAvg):
         self.learning_rate = qffl_learning_rate
         self.q_param = q_param
         self.pre_weights: Optional[NDArrays] = None
-        self.fit_metrics_aggregation_fn = fit_metrics_aggregation_fn
-        self.evaluate_metrics_aggregation_fn = evaluate_metrics_aggregation_fn
 
     def __repr__(self) -> str:
         # pylint: disable=line-too-long

--- a/src/py/flwr/server/strategy/qfedavg.py
+++ b/src/py/flwr/server/strategy/qfedavg.py
@@ -85,15 +85,6 @@ class QFedAvg(FedAvg):
             fit_metrics_aggregation_fn=fit_metrics_aggregation_fn,
             evaluate_metrics_aggregation_fn=evaluate_metrics_aggregation_fn,
         )
-        self.min_fit_clients = min_fit_clients
-        self.min_evaluate_clients = min_evaluate_clients
-        self.fraction_fit = fraction_fit
-        self.fraction_evaluate = fraction_evaluate
-        self.min_available_clients = min_available_clients
-        self.evaluate_fn = evaluate_fn
-        self.on_fit_config_fn = on_fit_config_fn
-        self.on_evaluate_config_fn = on_evaluate_config_fn
-        self.accept_failures = accept_failures
         self.learning_rate = qffl_learning_rate
         self.q_param = q_param
         self.pre_weights: Optional[NDArrays] = None


### PR DESCRIPTION
Strategies subclassing FedAvg still define `fit_metrics_aggregation_fn` and `evaluate_metrics_aggregation_fn` as attributes via self. 
Also, QFedAvg does the same with almost all attributes that are passed to the FedAvg subclass initializer.
The redundancy is removed.