### PR TITLE
Expose some server functions to other modules

### DIFF
--- a/src/py/flwr/server/app.py
+++ b/src/py/flwr/server/app.py
@@ -173,7 +173,7 @@ def start_server(  # pylint: disable=too-many-arguments,too-many-locals
     )
 
     # Start training
-    hist = fl(
+    hist = run_fl(
         server=initialized_server,
         config=initialized_config,
     )
@@ -192,7 +192,7 @@ def init_defaults(
     strategy: Optional[Strategy],
     client_manager: Optional[ClientManager],
 ) -> Tuple[Server, ServerConfig]:
-    # Create server instance if none was given
+    """Create server instance if none was given."""
     if server is None:
         if client_manager is None:
             client_manager = SimpleClientManager()
@@ -209,11 +209,11 @@ def init_defaults(
     return server, config
 
 
-def fl(
+def run_fl(
     server: Server,
     config: ServerConfig,
 ) -> History:
-    # Fit model
+    """Train a model on the given server and return the History object."""
     hist = server.fit(num_rounds=config.num_rounds, timeout=config.round_timeout)
     log(INFO, "app_fit: losses_distributed %s", str(hist.losses_distributed))
     log(INFO, "app_fit: metrics_distributed_fit %s", str(hist.metrics_distributed_fit))

--- a/src/py/flwr/server/app.py
+++ b/src/py/flwr/server/app.py
@@ -139,7 +139,7 @@ def start_server(  # pylint: disable=too-many-arguments,too-many-locals
     event(EventType.START_SERVER_ENTER)
 
     # Initialize server and server config
-    initialized_server, initialized_config = _init_defaults(
+    initialized_server, initialized_config = init_defaults(
         server=server,
         config=config,
         strategy=strategy,
@@ -173,7 +173,7 @@ def start_server(  # pylint: disable=too-many-arguments,too-many-locals
     )
 
     # Start training
-    hist = _fl(
+    hist = fl(
         server=initialized_server,
         config=initialized_config,
     )
@@ -186,7 +186,7 @@ def start_server(  # pylint: disable=too-many-arguments,too-many-locals
     return hist
 
 
-def _init_defaults(
+def init_defaults(
     server: Optional[Server],
     config: Optional[ServerConfig],
     strategy: Optional[Strategy],
@@ -209,7 +209,7 @@ def _init_defaults(
     return server, config
 
 
-def _fl(
+def fl(
     server: Server,
     config: ServerConfig,
 ) -> History:

--- a/src/py/flwr/simulation/app.py
+++ b/src/py/flwr/simulation/app.py
@@ -25,7 +25,7 @@ from flwr.client import ClientLike
 from flwr.common import EventType, event
 from flwr.common.logger import log
 from flwr.server import Server
-from flwr.server.app import ServerConfig, run_fl, init_defaults
+from flwr.server.app import ServerConfig, init_defaults, run_fl
 from flwr.server.client_manager import ClientManager
 from flwr.server.history import History
 from flwr.server.strategy import Strategy

--- a/src/py/flwr/simulation/app.py
+++ b/src/py/flwr/simulation/app.py
@@ -25,7 +25,7 @@ from flwr.client import ClientLike
 from flwr.common import EventType, event
 from flwr.common.logger import log
 from flwr.server import Server
-from flwr.server.app import ServerConfig, _fl, _init_defaults
+from flwr.server.app import ServerConfig, fl, init_defaults
 from flwr.server.client_manager import ClientManager
 from flwr.server.history import History
 from flwr.server.strategy import Strategy
@@ -137,7 +137,7 @@ def start_simulation(  # pylint: disable=too-many-arguments
     )
 
     # Initialize server and server config
-    initialized_server, initialized_config = _init_defaults(
+    initialized_server, initialized_config = init_defaults(
         server=server,
         config=config,
         strategy=strategy,
@@ -194,7 +194,7 @@ def start_simulation(  # pylint: disable=too-many-arguments
         initialized_server.client_manager().register(client=client_proxy)
 
     # Start training
-    hist = _fl(
+    hist = fl(
         server=initialized_server,
         config=initialized_config,
     )

--- a/src/py/flwr/simulation/app.py
+++ b/src/py/flwr/simulation/app.py
@@ -25,7 +25,7 @@ from flwr.client import ClientLike
 from flwr.common import EventType, event
 from flwr.common.logger import log
 from flwr.server import Server
-from flwr.server.app import ServerConfig, fl, init_defaults
+from flwr.server.app import ServerConfig, run_fl, init_defaults
 from flwr.server.client_manager import ClientManager
 from flwr.server.history import History
 from flwr.server.strategy import Strategy
@@ -194,7 +194,7 @@ def start_simulation(  # pylint: disable=too-many-arguments
         initialized_server.client_manager().register(client=client_proxy)
 
     # Start training
-    hist = fl(
+    hist = run_fl(
         server=initialized_server,
         config=initialized_config,
     )


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

The future `start_driver` function will need to use the `_fl` and `_init_defaults` from the `flwr.app.server.app` module, but those functions are prefixed with an underscore which conventionally indicate that the functions are private (not accessible from other modules).

### Related issues/PRs

#1697 

## Proposal

### Explanation

Rename `_fl` into `fl` and `_init_defaults` into `init_defaults`.

### Checklist

- [x] Implement proposed change
- [ ] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

N/A
