### PR TITLE
Fix rest_server renaming

### DIFF
--- a/src/py/flwr/server/app.py
+++ b/src/py/flwr/server/app.py
@@ -527,7 +527,7 @@ def _run_fleet_api_rest(
     try:
         import uvicorn
 
-        from flwr.server.rest_server.rest_api import app as fast_api_app
+        from flwr.server.fleet.rest_rere.rest_api import app as fast_api_app
     except ModuleNotFoundError:
         sys.exit(MISSING_EXTRA_REST)
     if workers != 1:


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

A import error caused by a package that doesn't exist after a renaming.

### Related issues/PRs

#1863 

## Proposal

### Explanation

Rename `rest_server` into `fleet.rest_rere`

### Checklist

- [x] Implement proposed change
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

N/A
