### PR TITLE
Fix code documentation in aggregate_krum()

### DIFF
--- a/src/py/flwr/server/strategy/aggregate.py
+++ b/src/py/flwr/server/strategy/aggregate.py
@@ -87,7 +87,7 @@ def aggregate_krum(
         best_results = [results[i] for i in best_indices]
         return aggregate(best_results)
 
-    # Return the model which minimizes the score (Krum)
+    # Return the model parameters that minimize the score (Krum)
     return weights[np.argmin(scores)]
 
 

--- a/src/py/flwr/server/strategy/aggregate.py
+++ b/src/py/flwr/server/strategy/aggregate.py
@@ -87,7 +87,7 @@ def aggregate_krum(
         best_results = [results[i] for i in best_indices]
         return aggregate(best_results)
 
-    # Return the index of the client which minimizes the score (Krum)
+    # Return the model which minimizes the score (Krum)
     return weights[np.argmin(scores)]
 
 


### PR DESCRIPTION
### Description

Just realized I wrote a wrong comment here. So, `aggregate_krum` does not return the index of the best model, but the best model itself.
