### PR TITLE
Updated minor error on the documentation, (3rd config dict print) ins…

### DIFF
--- a/doc/source/configure-clients.rst
+++ b/doc/source/configure-clients.rst
@@ -61,7 +61,7 @@ One the client side, we receive the configuration dictionary in ``fit``:
         def fit(parameters, config):
             print(config["batch_size"])  # Prints `32`
             print(config["current_round"])  # Prints `1`/`2`/`...`
-            print(config["batch_size"])  # Prints `2`
+            print(config["local_epochs"])  # Prints `2`
             # ... (rest of `fit` method)
 
 There is also an `on_evaluate_config_fn` to configure evaluation, which works the same way. They are separate functions because one might want to send different configuration values to `evaluate` (for example, to use a different batch size).


### PR DESCRIPTION
…tead of batch_size prints 2 to local_epochs prints 2

<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue
Just a minor error on the documentation (Configure Clients)

### Description
I updated a small error on the documentation, the strategy config dict is:
    config = {
        "batch_size": 32,
        "current_round": server_round,
        "local_epochs": 2,
    }

On the documentation I changed:
        print(config["batch_size"])  # Prints `32`
        print(config["current_round"])  # Prints `1`/`2`/`...`
        print(config["batch_size"])  # Prints `2`
to:
        print(config["batch_size"])  # Prints `32`
        print(config["current_round"])  # Prints `1`/`2`/`...`
        print(config["local_epochs"])  # Prints `2`

<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

### Checklist

- [ ] Implement proposed change
- [ ] Write tests
- [x] Update [documentation](https://flower.dev/docs/writing-documentation.html)
- [ ] Update [changelog](https://github.com/adap/flower/blob/main/doc/source/changelog.rst)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.dev/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
