### PR TITLE
Make check-requirements-txt.sh optional

### DIFF
--- a/.github/workflows/flower.yml
+++ b/.github/workflows/flower.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Check if protos need recompilation
         run: ./dev/check-protos.sh
       - name: Check if example requirements.txt files need regeneration
+        continue-on-error: true
         run: ./dev/check-requirements-txt.sh
       - name: Lint + Test (isort/black/docformatter/mypy/pylint/flake8/pytest)
         run: ./dev/test.sh


### PR DESCRIPTION
The check-requirements-txt.sh is unstable so it needs to be made optional for the time being.
