### PR TITLE
Avoid CI job to marked as failure if requirements.txt check fails

### DIFF
--- a/.github/workflows/flower.yml
+++ b/.github/workflows/flower.yml
@@ -33,8 +33,5 @@ jobs:
         run: python -m poetry install --extras "simulation"
       - name: Check if protos need recompilation
         run: ./dev/check-protos.sh
-      - name: Check if example requirements.txt files need regeneration
-        continue-on-error: true
-        run: ./dev/check-requirements-txt.sh
       - name: Lint + Test (isort/black/docformatter/mypy/pylint/flake8/pytest)
         run: ./dev/test.sh


### PR DESCRIPTION
### Description

It seems continue-on-error will still mark the test as failed. I missed that in the review of the previous PR which made it optional.

### Related issues/PRs

* #1905 

