### PR TITLE
Fix docformatter docstrings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,3 +155,4 @@ follow_imports_for_stubs = true
 
 [tool.docformatter]
 wrap-summaries = 88
+wrap-descriptions = 88

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,3 +152,6 @@ disallow_untyped_calls = false
 module = "torch.*"
 follow_imports = "skip"
 follow_imports_for_stubs = true
+
+[tool.docformatter]
+wrap-summaries = 88

--- a/src/py/flwr/client/grpc_client/connection_test.py
+++ b/src/py/flwr/client/grpc_client/connection_test.py
@@ -77,8 +77,8 @@ def mock_join(  # type: ignore # pylint: disable=invalid-name
 def test_integration_connection() -> None:
     """Create a server and establish a connection to it.
 
-    Purpose of this integration test is to simulate multiple clients
-    with multiple roundtrips between server and client.
+    Purpose of this integration test is to simulate multiple clients with multiple
+    roundtrips between server and client.
     """
     # Prepare
     port = unused_tcp_port()

--- a/src/py/flwr/common/dp.py
+++ b/src/py/flwr/common/dp.py
@@ -31,8 +31,7 @@ def _get_update_norm(update: NDArrays) -> float:
 
 
 def add_gaussian_noise(update: NDArrays, std_dev: float) -> NDArrays:
-    """Adds iid Gaussian noise of the given standard deviation to each floating
-    point value in the update."""
+    """Add iid Gaussian noise to each floating point value in the update."""
     update_noised = [
         layer + np.random.normal(0, std_dev, layer.shape) for layer in update
     ]

--- a/src/py/flwr/common/telemetry_test.py
+++ b/src/py/flwr/common/telemetry_test.py
@@ -74,8 +74,7 @@ class TelemetryTest(unittest.TestCase):
     def test_get_source_id(self) -> None:
         """Test if _get_source_id returns an ID successfully.
 
-        This test might fail if the UNIX user invoking the test has no
-        home directory.
+        This test might fail if the UNIX user invoking the test has no home directory.
         """
         # Prepare
         # nothing to prepare

--- a/src/py/flwr/server/app.py
+++ b/src/py/flwr/server/app.py
@@ -66,8 +66,8 @@ DATABASE = ":flwr-in-memory-state:"
 class ServerConfig:
     """Flower server config.
 
-    All attributes have default values which allows users to configure
-    just the ones they care about.
+    All attributes have default values which allows users to configure just the ones
+    they care about.
     """
 
     num_rounds: int = 1
@@ -462,8 +462,8 @@ def _register_exit_handlers(
     ) -> None:
         """Exit handler to be registered with signal.signal.
 
-        When called will reset signal handler to original signal handler
-        from default_handlers.
+        When called will reset signal handler to original signal handler from
+        default_handlers.
         """
 
         # Reset to default handler

--- a/src/py/flwr/server/criterion.py
+++ b/src/py/flwr/server/criterion.py
@@ -21,8 +21,7 @@ from .client_proxy import ClientProxy
 
 
 class Criterion(ABC):
-    """Abstract class which allows subclasses to implement criterion
-    sampling."""
+    """Abstract class which allows subclasses to implement criterion sampling."""
 
     @abstractmethod
     def select(self, client: ClientProxy) -> bool:

--- a/src/py/flwr/server/fleet/grpc_bidi/grpc_bridge.py
+++ b/src/py/flwr/server/fleet/grpc_bidi/grpc_bridge.py
@@ -80,8 +80,7 @@ class GrpcBridge:
     def _transition(self, next_status: Status) -> None:
         """Validate status transition and set next status.
 
-        The caller of the transition method will have to aquire
-        conditional variable.
+        The caller of the transition method will have to aquire conditional variable.
         """
         if next_status == Status.CLOSED:
             self._status = next_status

--- a/src/py/flwr/server/state/sqlite_state.py
+++ b/src/py/flwr/server/state/sqlite_state.py
@@ -471,8 +471,7 @@ def dict_factory(
 ) -> Dict[str, Any]:
     """Used to turn SQLite results into dicts.
 
-    Less efficent for retrival of large amounts of data but easier to
-    use.
+    Less efficent for retrival of large amounts of data but easier to use.
     """
     fields = [column[0] for column in cursor.description]
     return dict(zip(fields, row))

--- a/src/py/flwr/server/state/state_test.py
+++ b/src/py/flwr/server/state/state_test.py
@@ -311,8 +311,7 @@ class StateTest(unittest.TestCase):
         assert len(retrieved_node_ids) == 0
 
     def test_num_task_ins(self) -> None:
-        """Test if num_tasks returns correct number of not delivered
-        task_ins."""
+        """Test if num_tasks returns correct number of not delivered task_ins."""
         # Prepare
         state: State = self.state_factory()
         task_0 = create_task_ins(consumer_node_id=0, anonymous=True)
@@ -329,8 +328,7 @@ class StateTest(unittest.TestCase):
         assert num == 2
 
     def test_num_task_res(self) -> None:
-        """Test if num_tasks returns correct number of not delivered
-        task_res."""
+        """Test if num_tasks returns correct number of not delivered task_res."""
         # Prepare
         state: State = self.state_factory()
         task_0 = create_task_res(producer_node_id=0, anonymous=True, ancestry=["1"])

--- a/src/py/flwr/server/strategy/fedadagrad.py
+++ b/src/py/flwr/server/strategy/fedadagrad.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Adaptive Federated Optimization using Adagrad (FedAdagrad) [Reddi et al.,
-2020] strategy.
+"""Adaptive Federated Optimization using Adagrad (FedAdagrad) [Reddi et al., 2020]
+strategy.
 
 Paper: arxiv.org/abs/2003.00295
 """
@@ -39,8 +39,8 @@ from .fedopt import FedOpt
 
 # flake8: noqa: E501
 class FedAdagrad(FedOpt):
-    """Adaptive Federated Optimization using Adagrad (FedAdagrad) [Reddi et
-    al., 2020] strategy.
+    """Adaptive Federated Optimization using Adagrad (FedAdagrad) [Reddi et al., 2020]
+    strategy.
 
     Paper: https://arxiv.org/abs/2003.00295
     """

--- a/src/py/flwr/server/strategy/fedadam.py
+++ b/src/py/flwr/server/strategy/fedadam.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Adaptive Federated Optimization using Adam (FedAdam) [Reddi et al., 2020]
-strategy.
+"""Adaptive Federated Optimization using Adam (FedAdam) [Reddi et al., 2020] strategy.
 
 Paper: arxiv.org/abs/2003.00295
 """
@@ -39,8 +38,8 @@ from .fedopt import FedOpt
 
 # flake8: noqa: E501
 class FedAdam(FedOpt):
-    """Adaptive Federated Optimization using Adam (FedAdam) [Reddi et al.,
-    2020] strategy.
+    """Adaptive Federated Optimization using Adam (FedAdam) [Reddi et al., 2020]
+    strategy.
 
     Paper: https://arxiv.org/abs/2003.00295
     """

--- a/src/py/flwr/server/strategy/fedavg.py
+++ b/src/py/flwr/server/strategy/fedavg.py
@@ -135,8 +135,7 @@ class FedAvg(Strategy):
         return rep
 
     def num_fit_clients(self, num_available_clients: int) -> Tuple[int, int]:
-        """Return the sample size and the required number of available
-        clients."""
+        """Return the sample size and the required number of available clients."""
         num_clients = int(num_available_clients * self.fraction_fit)
         return max(num_clients, self.min_fit_clients), self.min_available_clients
 

--- a/src/py/flwr/server/strategy/fedavg_android.py
+++ b/src/py/flwr/server/strategy/fedavg_android.py
@@ -109,8 +109,7 @@ class FedAvgAndroid(Strategy):
         return rep
 
     def num_fit_clients(self, num_available_clients: int) -> Tuple[int, int]:
-        """Return the sample size and the required number of available
-        clients."""
+        """Return the sample size and the required number of available clients."""
         num_clients = int(num_available_clients * self.fraction_fit)
         return max(num_clients, self.min_fit_clients), self.min_available_clients
 

--- a/src/py/flwr/server/strategy/fedopt.py
+++ b/src/py/flwr/server/strategy/fedopt.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Adaptive Federated Optimization (FedOpt) [Reddi et al., 2020] abstract
-strategy.
+"""Adaptive Federated Optimization (FedOpt) [Reddi et al., 2020] abstract strategy.
 
 Paper: arxiv.org/abs/2003.00295
 """

--- a/src/py/flwr/server/strategy/fedxgb_nn_avg.py
+++ b/src/py/flwr/server/strategy/fedxgb_nn_avg.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Federated XGBoost in the horizontal setting based on building Neural Network
-and averaging on prediction outcomes [Ma et al., 2023].
+"""Federated XGBoost in the horizontal setting based on building Neural Network and
+averaging on prediction outcomes [Ma et al., 2023].
 
 Paper: Coming
 """

--- a/src/py/flwr/server/strategy/fedyogi.py
+++ b/src/py/flwr/server/strategy/fedyogi.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Adaptive Federated Optimization using Yogi (FedYogi) [Reddi et al., 2020]
-strategy.
+"""Adaptive Federated Optimization using Yogi (FedYogi) [Reddi et al., 2020] strategy.
 
 Paper: arxiv.org/abs/2003.00295
 """
@@ -39,8 +38,8 @@ from .fedopt import FedOpt
 
 # flake8: noqa: E501
 class FedYogi(FedOpt):
-    """Adaptive Federated Optimization using Yogi (FedYogi) [Reddi et al.,
-    2020] strategy.
+    """Adaptive Federated Optimization using Yogi (FedYogi) [Reddi et al., 2020]
+    strategy.
 
     Paper: https://arxiv.org/abs/2003.00295
     """

--- a/src/py/flwr/server/strategy/qfedavg.py
+++ b/src/py/flwr/server/strategy/qfedavg.py
@@ -96,8 +96,7 @@ class QFedAvg(FedAvg):
         return rep
 
     def num_fit_clients(self, num_available_clients: int) -> Tuple[int, int]:
-        """Return the sample size and the required number of available
-        clients."""
+        """Return the sample size and the required number of available clients."""
         num_clients = int(num_available_clients * self.fraction_fit)
         return max(num_clients, self.min_fit_clients), self.min_available_clients
 

--- a/src/py/flwr/server/utils/tensorboard.py
+++ b/src/py/flwr/server/utils/tensorboard.py
@@ -82,8 +82,7 @@ def tensorboard(logdir: str) -> Callable[[Strategy], Strategy]:
                 results: List[Tuple[ClientProxy, EvaluateRes]],
                 failures: List[Union[Tuple[ClientProxy, EvaluateRes], BaseException]],
             ) -> Tuple[Optional[float], Dict[str, Scalar]]:
-                """Hooks into aggregate_evaluate for TensorBoard logging
-                purpose."""
+                """Hooks into aggregate_evaluate for TensorBoard logging purpose."""
                 # Execute decorated function and extract results for logging
                 # They will be returned at the end of this function but also
                 # used for logging


### PR DESCRIPTION
Change the docformatter (used in the tests) wrap summaries and descriptions of the docstrings to 88 from 72 chars (the default).

Why?
* Our line width is 88
* The ruff linter with pydocstyle checks if the docstrings summary is in one line (which was not the case). This change is required otherwise we would have conflicting requirements - docstrings formatted wrapping the summaries too early not allowing a single line summary and ruff that requires a single line summary.