### PR TITLE
Downgrade Ray to fix the CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ protobuf = "^3.19.0"
 importlib-metadata = { version = "^4.0.0", markers = "python_version < '3.8'" }
 iterators = "^0.0.2"
 # Optional dependencies (VCE)
-ray = { version = "^2.4.0", extras = ["default"], optional = true }
+ray = { version = "<=2.4.0", extras = ["default"], optional = true }
 # Optional dependencies (REST transport layer)
 requests = { version = "^2.28.2", optional = true }
 fastapi = { version = "^0.95.0", optional = true }


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

The CI is breaking because of Ray 2.5.0, probably related to this: https://github.com/ray-project/ray/issues/36252. 

### Related issues/PRs

#1925 

## Proposal

### Explanation

We can fix Ray to use 2.4.0 until a patch is released.

### Checklist

- [x] Implement proposed change
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

N/A
