### PR TITLE
Fix return value in get_properties in numpy_client_test

### DIFF
--- a/src/py/flwr/client/numpy_client_test.py
+++ b/src/py/flwr/client/numpy_client_test.py
@@ -32,7 +32,7 @@ class OverridingClient(NumPyClient):
     """Client overriding `get_properties`."""
 
     def get_properties(self, config: Config) -> Properties:
-        return Properties()
+        return {}
 
     def get_parameters(self, config: Config) -> NDArrays:
         return []


### PR DESCRIPTION
## Issue

### Description
The return value `Properties()` of `get_properties` would lead to an error if the method is called. 
Note that the test didn't fail because the has_get_properties function checks types only and didn't run the get_properties. Yet, it still might be misleading, and in the case of expanding on the test, it would lead to an error.

The `Properties` is a custom type and cannot be instantiated.
## Proposal
Return an empty dict `{}`.
### Explanation
The empty dict meets the Properties type and follows what other methods were mocking - the most straightforward implementation of NumPyClient.
