### PR TITLE
Fix treating hint-types new lines as a new attributes

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,3 +2,5 @@
 max-line-length = 88
 exclude = src/py/flwr/proto
 ignore = E302,W503
+per-file-ignores =
+    src/py/flwr/server/strategy/*.py:E501

--- a/src/py/flwr/server/strategy/fedadagrad.py
+++ b/src/py/flwr/server/strategy/fedadagrad.py
@@ -44,7 +44,7 @@ class FedAdagrad(FedOpt):
     Paper: https://arxiv.org/abs/2003.00295
     """
 
-    # pylint: disable=too-many-arguments,too-many-locals,too-many-instance-attributes
+    # pylint: disable=too-many-arguments,too-many-locals,too-many-instance-attributes, line-too-long
     def __init__(
         self,
         *,
@@ -85,8 +85,7 @@ class FedAdagrad(FedOpt):
             Minimum number of clients used during validation. Defaults to 2.
         min_available_clients : int, optional
             Minimum number of total clients in the system. Defaults to 2.
-        evaluate_fn : Optional[Callable[[int, NDArrays, Dict[str, Scalar]],
-        Optional[Tuple[float, Dict[str, Scalar]]]]]
+        evaluate_fn : Optional[Callable[[int, NDArrays, Dict[str, Scalar]], Optional[Tuple[float, Dict[str, Scalar]]]]]
             Optional function used for validation. Defaults to None.
         on_fit_config_fn : Callable[[int], Dict[str, Scalar]], optional
             Function used to configure training. Defaults to None.

--- a/src/py/flwr/server/strategy/fedadam.py
+++ b/src/py/flwr/server/strategy/fedadam.py
@@ -43,7 +43,7 @@ class FedAdam(FedOpt):
     Paper: https://arxiv.org/abs/2003.00295
     """
 
-    # pylint: disable=too-many-arguments,too-many-instance-attributes,too-many-locals
+    # pylint: disable=too-many-arguments,too-many-instance-attributes,too-many-locals, line-too-long
     def __init__(
         self,
         *,
@@ -86,8 +86,7 @@ class FedAdam(FedOpt):
             Minimum number of clients used during validation. Defaults to 2.
         min_available_clients : int, optional
             Minimum number of total clients in the system. Defaults to 2.
-        evaluate_fn : Optional[Callable[[int, NDArrays, Dict[str, Scalar]],
-        Optional[Tuple[float, Dict[str, Scalar]]]]]
+        evaluate_fn : Optional[Callable[[int, NDArrays, Dict[str, Scalar]], Optional[Tuple[float, Dict[str, Scalar]]]]]
             Optional function used for validation. Defaults to None.
         on_fit_config_fn : Callable[[int], Dict[str, Scalar]], optional
             Function used to configure training. Defaults to None.

--- a/src/py/flwr/server/strategy/fedavg.py
+++ b/src/py/flwr/server/strategy/fedavg.py
@@ -51,7 +51,7 @@ than or equal to the values of `min_fit_clients` and `min_evaluate_clients`.
 class FedAvg(Strategy):
     """Configurable FedAvg strategy implementation."""
 
-    # pylint: disable=too-many-arguments,too-many-instance-attributes
+    # pylint: disable=too-many-arguments,too-many-instance-attributes, line-too-long
     def __init__(
         self,
         *,
@@ -93,8 +93,7 @@ class FedAvg(Strategy):
             Minimum number of clients used during validation. Defaults to 2.
         min_available_clients : int, optional
             Minimum number of total clients in the system. Defaults to 2.
-        evaluate_fn : Optional[Callable[[int, NDArrays, Dict[str, Scalar]],
-        Optional[Tuple[float, Dict[str, Scalar]]]]]
+        evaluate_fn : Optional[Callable[[int, NDArrays, Dict[str, Scalar]], Optional[Tuple[float, Dict[str, Scalar]]]]]
             Optional function used for validation. Defaults to None.
         on_fit_config_fn : Callable[[int], Dict[str, Scalar]], optional
             Function used to configure training. Defaults to None.

--- a/src/py/flwr/server/strategy/fedavg_android.py
+++ b/src/py/flwr/server/strategy/fedavg_android.py
@@ -43,7 +43,7 @@ from .strategy import Strategy
 class FedAvgAndroid(Strategy):
     """Configurable FedAvg strategy implementation."""
 
-    # pylint: disable=too-many-arguments,too-many-instance-attributes
+    # pylint: disable=too-many-arguments,too-many-instance-attributes, line-too-long
     def __init__(
         self,
         *,
@@ -79,8 +79,7 @@ class FedAvgAndroid(Strategy):
             Minimum number of clients used during validation. Defaults to 2.
         min_available_clients : Optional[int]
             Minimum number of total clients in the system. Defaults to 2.
-        evaluate_fn : Optional[Callable[[int, NDArrays, Dict[str, Scalar]],
-        Optional[Tuple[float, Dict[str, Scalar]]]]]
+        evaluate_fn : Optional[Callable[[int, NDArrays, Dict[str, Scalar]], Optional[Tuple[float, Dict[str, Scalar]]]]]
             Optional function used for validation. Defaults to None.
         on_fit_config_fn : Optional[Callable[[int], Dict[str, Scalar]]]
             Function used to configure training. Defaults to None.

--- a/src/py/flwr/server/strategy/fedavgm.py
+++ b/src/py/flwr/server/strategy/fedavgm.py
@@ -41,7 +41,7 @@ from .fedavg import FedAvg
 class FedAvgM(FedAvg):
     """Configurable FedAvg with Momentum strategy implementation."""
 
-    # pylint: disable=too-many-arguments,too-many-instance-attributes
+    # pylint: disable=too-many-arguments,too-many-instance-attributes, line-too-long
     def __init__(
         self,
         *,
@@ -81,8 +81,7 @@ class FedAvgM(FedAvg):
             Minimum number of clients used during validation. Defaults to 2.
         min_available_clients : int, optional
             Minimum number of total clients in the system. Defaults to 2.
-        evaluate_fn : Optional[Callable[[int, NDArrays, Dict[str, Scalar]],
-        Optional[Tuple[float, Dict[str, Scalar]]]]]
+        evaluate_fn : Optional[Callable[[int, NDArrays, Dict[str, Scalar]], Optional[Tuple[float, Dict[str, Scalar]]]]]
             Optional function used for validation. Defaults to None.
         on_fit_config_fn : Callable[[int], Dict[str, Scalar]], optional
             Function used to configure training. Defaults to None.

--- a/src/py/flwr/server/strategy/fedopt.py
+++ b/src/py/flwr/server/strategy/fedopt.py
@@ -34,7 +34,7 @@ from .fedavg import FedAvg
 class FedOpt(FedAvg):
     """Configurable FedAdagrad strategy implementation."""
 
-    # pylint: disable=too-many-arguments,too-many-instance-attributes,too-many-locals
+    # pylint: disable=too-many-arguments,too-many-instance-attributes,too-many-locals, line-too-long
     def __init__(
         self,
         *,
@@ -77,8 +77,7 @@ class FedOpt(FedAvg):
             Minimum number of clients used during validation. Defaults to 2.
         min_available_clients : int, optional
             Minimum number of total clients in the system. Defaults to 2.
-        evaluate_fn : Optional[Callable[[int, NDArrays, Dict[str, Scalar]],
-        Optional[Tuple[float, Dict[str, Scalar]]]]]
+        evaluate_fn : Optional[Callable[[int, NDArrays, Dict[str, Scalar]], Optional[Tuple[float, Dict[str, Scalar]]]]]
             Optional function used for validation. Defaults to None.
         on_fit_config_fn : Callable[[int], Dict[str, Scalar]], optional
             Function used to configure training. Defaults to None.

--- a/src/py/flwr/server/strategy/fedprox.py
+++ b/src/py/flwr/server/strategy/fedprox.py
@@ -30,7 +30,7 @@ from .fedavg import FedAvg
 class FedProx(FedAvg):
     """Configurable FedProx strategy implementation."""
 
-    # pylint: disable=too-many-arguments,too-many-instance-attributes
+    # pylint: disable=too-many-arguments,too-many-instance-attributes, line-too-long
     def __init__(
         self,
         *,
@@ -105,8 +105,7 @@ class FedProx(FedAvg):
             Minimum number of clients used during validation. Defaults to 2.
         min_available_clients : int, optional
             Minimum number of total clients in the system. Defaults to 2.
-        evaluate_fn : Optional[Callable[[int, NDArrays, Dict[str, Scalar]],
-        Optional[Tuple[float, Dict[str, Scalar]]]]]
+        evaluate_fn : Optional[Callable[[int, NDArrays, Dict[str, Scalar]], Optional[Tuple[float, Dict[str, Scalar]]]]]
             Optional function used for validation. Defaults to None.
         on_fit_config_fn : Callable[[int], Dict[str, Scalar]], optional
             Function used to configure training. Defaults to None.

--- a/src/py/flwr/server/strategy/fedtrimmedavg.py
+++ b/src/py/flwr/server/strategy/fedtrimmedavg.py
@@ -41,7 +41,7 @@ class FedTrimmedAvg(FedAvg):
     Paper: https://arxiv.org/abs/1803.01498
     """
 
-    # pylint: disable=too-many-arguments,too-many-instance-attributes
+    # pylint: disable=too-many-arguments,too-many-instance-attributes, line-too-long
     def __init__(
         self,
         *,
@@ -77,8 +77,7 @@ class FedTrimmedAvg(FedAvg):
             Minimum number of clients used during validation. Defaults to 2.
         min_available_clients : int, optional
             Minimum number of total clients in the system. Defaults to 2.
-        evaluate_fn : Optional[Callable[[int, NDArrays, Dict[str, Scalar]],
-            Optional[Tuple[float, Dict[str, Scalar]]]]]
+        evaluate_fn : Optional[Callable[[int, NDArrays, Dict[str, Scalar]], Optional[Tuple[float, Dict[str, Scalar]]]]]
             Optional function used for validation. Defaults to None.
         on_fit_config_fn : Callable[[int], Dict[str, Scalar]], optional
             Function used to configure training. Defaults to None.

--- a/src/py/flwr/server/strategy/fedyogi.py
+++ b/src/py/flwr/server/strategy/fedyogi.py
@@ -43,7 +43,7 @@ class FedYogi(FedOpt):
     Paper: https://arxiv.org/abs/2003.00295
     """
 
-    # pylint: disable=too-many-arguments,too-many-instance-attributes,too-many-locals
+    # pylint: disable=too-many-arguments,too-many-instance-attributes,too-many-locals, line-too-long
     def __init__(
         self,
         *,
@@ -86,8 +86,7 @@ class FedYogi(FedOpt):
             Minimum number of clients used during validation. Defaults to 2.
         min_available_clients : int, optional
             Minimum number of total clients in the system. Defaults to 2.
-        evaluate_fn : Optional[Callable[[int, NDArrays, Dict[str, Scalar]],
-        Optional[Tuple[float, Dict[str, Scalar]]]]]
+        evaluate_fn : Optional[Callable[[int, NDArrays, Dict[str, Scalar]], Optional[Tuple[float, Dict[str, Scalar]]]]]
             Optional function used for validation. Defaults to None.
         on_fit_config_fn : Callable[[int], Dict[str, Scalar]], optional
             Function used to configure training. Defaults to None.

--- a/src/py/flwr/server/strategy/krum.py
+++ b/src/py/flwr/server/strategy/krum.py
@@ -42,7 +42,7 @@ from .fedavg import FedAvg
 class Krum(FedAvg):
     """Configurable Krum strategy implementation."""
 
-    # pylint: disable=too-many-arguments,too-many-instance-attributes
+    # pylint: disable=too-many-arguments,too-many-instance-attributes, line-too-long
     def __init__(
         self,
         *,
@@ -85,8 +85,7 @@ class Krum(FedAvg):
         num_clients_to_keep : int, optional
             Number of clients to keep before averaging (MultiKrum). Defaults to 0, in
             that case classical Krum is applied.
-        evaluate_fn : Optional[Callable[[int, NDArrays, Dict[str, Scalar]],
-        Optional[Tuple[float, Dict[str, Scalar]]]]]
+        evaluate_fn : Optional[Callable[[int, NDArrays, Dict[str, Scalar]], Optional[Tuple[float, Dict[str, Scalar]]]]]
             Optional function used for validation. Defaults to None.
         on_fit_config_fn : Callable[[int], Dict[str, Scalar]], optional
             Function used to configure training. Defaults to None.


### PR DESCRIPTION
## Issue

### Description
The changes from https://github.com/adap/flower/pull/1934 broke the documentation - the new line in hint types was treated as a new attribute (I must have checked it wrong when I built if for testing in that PR), yet the changes introduced in that PR are necessary for Ruff linter to work.

<img width="596" alt="image" src="https://github.com/adap/flower/assets/51029327/11d6c664-fcfe-43b4-8cbf-c4736ac60049">

### Related issues/PRs

https://github.com/adap/flower/pull/1934

## Proposal

### Explanation

I bring back the pylint `line-too-long` to the code.
I fix the flake8 (and future ruff problems) by adding per-file specific type ignores (E501 = line too long) to the flake8 config (per file specific ignore is file is not possible for flake8).

<img width="653" alt="image" src="https://github.com/adap/flower/assets/51029327/5f028576-c220-44c6-a3c2-9eb77af33e5b">

