### PR TITLE
Fix the docstrings of the strategies

### DIFF
--- a/src/py/flwr/server/strategy/dpfedavg_adaptive.py
+++ b/src/py/flwr/server/strategy/dpfedavg_adaptive.py
@@ -67,6 +67,7 @@ class DPFedAvgAdaptive(DPFedAvgFixed):
             ) ** (-0.5)
 
     def __repr__(self) -> str:
+        """Compute a string representation of the strategy."""
         rep = "Strategy with DP with Adaptive Clipping enabled."
         return rep
 

--- a/src/py/flwr/server/strategy/dpfedavg_fixed.py
+++ b/src/py/flwr/server/strategy/dpfedavg_fixed.py
@@ -56,6 +56,7 @@ class DPFedAvgFixed(Strategy):
         self.server_side_noising = server_side_noising
 
     def __repr__(self) -> str:
+        """Compute a string representation of the strategy."""
         rep = "Strategy with DP with Fixed Clipping enabled."
         return rep
 

--- a/src/py/flwr/server/strategy/fault_tolerant_fedavg.py
+++ b/src/py/flwr/server/strategy/fault_tolerant_fedavg.py
@@ -79,6 +79,7 @@ class FaultTolerantFedAvg(FedAvg):
         self.completion_rate_evaluate = min_completion_rate_evaluate
 
     def __repr__(self) -> str:
+        """Compute a string representation of the strategy."""
         return "FaultTolerantFedAvg()"
 
     def aggregate_fit(

--- a/src/py/flwr/server/strategy/fedadagrad.py
+++ b/src/py/flwr/server/strategy/fedadagrad.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Adaptive Federated Optimization using Adagrad (FedAdagrad) [Reddi et al., 2020]
-strategy.
+"""FedAdagrad [Reddi et al., 2020] strategy.
+
+Adaptive Federated Optimization using Adagrad.
 
 Paper: arxiv.org/abs/2003.00295
 """
@@ -38,8 +39,7 @@ from .fedopt import FedOpt
 
 
 class FedAdagrad(FedOpt):
-    """Adaptive Federated Optimization using Adagrad (FedAdagrad) [Reddi et al., 2020]
-    strategy.
+    """FedAdagrad strategy - Adaptive Federated Optimization using Adagrad.
 
     Paper: https://arxiv.org/abs/2003.00295
     """
@@ -128,6 +128,7 @@ class FedAdagrad(FedOpt):
         )
 
     def __repr__(self) -> str:
+        """Compute a string representation of the strategy."""
         rep = f"FedAdagrad(accept_failures={self.accept_failures})"
         return rep
 

--- a/src/py/flwr/server/strategy/fedadam.py
+++ b/src/py/flwr/server/strategy/fedadam.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Adaptive Federated Optimization using Adam (FedAdam) [Reddi et al., 2020] strategy.
+"""Adaptive Federated Optimization using Adam (FedAdam) strategy.
+
+[Reddi et al., 2020]
 
 Paper: arxiv.org/abs/2003.00295
 """
@@ -37,8 +39,7 @@ from .fedopt import FedOpt
 
 
 class FedAdam(FedOpt):
-    """Adaptive Federated Optimization using Adam (FedAdam) [Reddi et al., 2020]
-    strategy.
+    """FedAdam - Adaptive Federated Optimization using Adam.
 
     Paper: https://arxiv.org/abs/2003.00295
     """
@@ -133,6 +134,7 @@ class FedAdam(FedOpt):
         )
 
     def __repr__(self) -> str:
+        """Compute a string representation of the strategy."""
         rep = f"FedAdam(accept_failures={self.accept_failures})"
         return rep
 

--- a/src/py/flwr/server/strategy/fedavg.py
+++ b/src/py/flwr/server/strategy/fedavg.py
@@ -131,6 +131,7 @@ class FedAvg(Strategy):
         self.evaluate_metrics_aggregation_fn = evaluate_metrics_aggregation_fn
 
     def __repr__(self) -> str:
+        """Compute a string representation of the strategy."""
         rep = f"FedAvg(accept_failures={self.accept_failures})"
         return rep
 

--- a/src/py/flwr/server/strategy/fedavg_android.py
+++ b/src/py/flwr/server/strategy/fedavg_android.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Federated Averaging (FedAvg) strategy with custom serialization for Android devices.
-
-[McMahan et al., 2016]
+"""FedAvg [McMahan et al., 2016] strategy with custom serialization for Android devices.
 
 Paper: arxiv.org/abs/1602.05629
 """

--- a/src/py/flwr/server/strategy/fedavg_android.py
+++ b/src/py/flwr/server/strategy/fedavg_android.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Federated Averaging (FedAvg) [McMahan et al., 2016] strategy with custom
-serialization for Android devices.
+"""Federated Averaging (FedAvg) strategy with custom serialization for Android devices.
+
+[McMahan et al., 2016]
 
 Paper: arxiv.org/abs/1602.05629
 """
@@ -105,6 +106,7 @@ class FedAvgAndroid(Strategy):
         self.initial_parameters = initial_parameters
 
     def __repr__(self) -> str:
+        """Compute a string representation of the strategy."""
         rep = f"FedAvg(accept_failures={self.accept_failures})"
         return rep
 

--- a/src/py/flwr/server/strategy/fedavgm.py
+++ b/src/py/flwr/server/strategy/fedavgm.py
@@ -98,7 +98,6 @@ class FedAvgM(FedAvg):
         server_momentum: float
             Server-side momentum factor used for FedAvgM. Defaults to 0.0.
         """
-
         super().__init__(
             fraction_fit=fraction_fit,
             fraction_evaluate=fraction_evaluate,
@@ -121,6 +120,7 @@ class FedAvgM(FedAvg):
         self.momentum_vector: Optional[NDArrays] = None
 
     def __repr__(self) -> str:
+        """Compute a string representation of the strategy."""
         rep = f"FedAvgM(accept_failures={self.accept_failures})"
         return rep
 

--- a/src/py/flwr/server/strategy/fedmedian.py
+++ b/src/py/flwr/server/strategy/fedmedian.py
@@ -39,6 +39,7 @@ class FedMedian(FedAvg):
     """Configurable FedAvg with Momentum strategy implementation."""
 
     def __repr__(self) -> str:
+        """Compute a string representation of the strategy."""
         rep = f"FedMedian(accept_failures={self.accept_failures})"
         return rep
 

--- a/src/py/flwr/server/strategy/fedopt.py
+++ b/src/py/flwr/server/strategy/fedopt.py
@@ -127,5 +127,6 @@ class FedOpt(FedAvg):
         self.v_t: Optional[NDArrays] = None
 
     def __repr__(self) -> str:
+        """Compute a string representation of the strategy."""
         rep = f"FedOpt(accept_failures={self.accept_failures})"
         return rep

--- a/src/py/flwr/server/strategy/fedprox.py
+++ b/src/py/flwr/server/strategy/fedprox.py
@@ -53,7 +53,7 @@ class FedProx(FedAvg):
         evaluate_metrics_aggregation_fn: Optional[MetricsAggregationFn] = None,
         proximal_mu: float,
     ) -> None:
-        """Federated Optimization strategy.
+        r"""Federated Optimization strategy.
 
         Implementation based on https://arxiv.org/abs/1812.06127
 
@@ -126,7 +126,6 @@ class FedProx(FedAvg):
             regularization will be used (that is, the client parameters will need to be
             closer to the server parameters during training).
         """
-
         super().__init__(
             fraction_fit=fraction_fit,
             fraction_evaluate=fraction_evaluate,
@@ -144,6 +143,7 @@ class FedProx(FedAvg):
         self.proximal_mu = proximal_mu
 
     def __repr__(self) -> str:
+        """Compute a string representation of the strategy."""
         rep = f"FedProx(accept_failures={self.accept_failures})"
         return rep
 

--- a/src/py/flwr/server/strategy/fedtrimmedavg.py
+++ b/src/py/flwr/server/strategy/fedtrimmedavg.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Federated Averaging with Trimmed Mean [Dong Yin, et al., 2021]
+"""Federated Averaging with Trimmed Mean [Dong Yin, et al., 2021].
 
 Paper: arxiv.org/abs/1803.01498
 """
@@ -36,7 +36,7 @@ from .fedavg import FedAvg
 
 
 class FedTrimmedAvg(FedAvg):
-    """Federated Averaging with Trimmed Mean [Dong Yin, et al., 2021]
+    """Federated Averaging with Trimmed Mean [Dong Yin, et al., 2021].
 
     Paper: https://arxiv.org/abs/1803.01498
     """
@@ -64,7 +64,8 @@ class FedTrimmedAvg(FedAvg):
         evaluate_metrics_aggregation_fn: Optional[MetricsAggregationFn] = None,
         beta: float = 0.2,
     ) -> None:
-        """
+        """Federated Averaging with Trimmed Mean [Dong Yin, et al., 2021].
+
         Parameters
         ----------
         fraction_fit : float, optional
@@ -91,7 +92,6 @@ class FedTrimmedAvg(FedAvg):
         beta : float, optional
             Fraction to cut off of both tails of the distribution. Defaults to 0.2.
         """
-
         super().__init__(
             fraction_fit=fraction_fit,
             fraction_evaluate=fraction_evaluate,
@@ -109,6 +109,7 @@ class FedTrimmedAvg(FedAvg):
         self.beta = beta
 
     def __repr__(self) -> str:
+        """Compute a string representation of the strategy."""
         rep = f"FedTrimmedAvg(accept_failures={self.accept_failures})"
         return rep
 

--- a/src/py/flwr/server/strategy/fedxgb_nn_avg.py
+++ b/src/py/flwr/server/strategy/fedxgb_nn_avg.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Federated XGBoost in the horizontal setting based on building Neural Network and
-averaging on prediction outcomes [Ma et al., 2023].
+"""Federated XGBoost [Ma et al., 2023] strategy.
+
+Strategy in the horizontal setting based on building Neural Network and averaging on
+prediction outcomes.
 
 Paper: Coming
 """
@@ -34,6 +36,7 @@ class FedXgbNnAvg(FedAvg):
     """Configurable FedXgbNnAvg strategy implementation."""
 
     def __repr__(self) -> str:
+        """Compute a string representation of the strategy."""
         rep = f"FedXgbNnAvg(accept_failures={self.accept_failures})"
         return rep
 

--- a/src/py/flwr/server/strategy/fedyogi.py
+++ b/src/py/flwr/server/strategy/fedyogi.py
@@ -37,8 +37,9 @@ from .fedopt import FedOpt
 
 
 class FedYogi(FedOpt):
-    """Adaptive Federated Optimization using Yogi (FedYogi) [Reddi et al., 2020]
-    strategy.
+    """FedYogi [Reddi et al., 2020] strategy.
+
+    Adaptive Federated Optimization using Yogi.
 
     Paper: https://arxiv.org/abs/2003.00295
     """
@@ -134,6 +135,7 @@ class FedYogi(FedOpt):
         )
 
     def __repr__(self) -> str:
+        """Compute a string representation of the strategy."""
         rep = f"FedYogi(accept_failures={self.accept_failures})"
         return rep
 

--- a/src/py/flwr/server/strategy/krum.py
+++ b/src/py/flwr/server/strategy/krum.py
@@ -66,7 +66,7 @@ class Krum(FedAvg):
         fit_metrics_aggregation_fn: Optional[MetricsAggregationFn] = None,
         evaluate_metrics_aggregation_fn: Optional[MetricsAggregationFn] = None,
     ) -> None:
-        """Configurable Krum strategy.
+        """Krum strategy.
 
         Parameters
         ----------
@@ -97,7 +97,6 @@ class Krum(FedAvg):
         initial_parameters : Parameters, optional
             Initial global model parameters.
         """
-
         super().__init__(
             fraction_fit=fraction_fit,
             fraction_evaluate=fraction_evaluate,
@@ -116,6 +115,7 @@ class Krum(FedAvg):
         self.num_clients_to_keep = num_clients_to_keep
 
     def __repr__(self) -> str:
+        """Compute a string representation of the strategy."""
         rep = f"Krum(accept_failures={self.accept_failures})"
         return rep
 

--- a/src/py/flwr/server/strategy/qfedavg.py
+++ b/src/py/flwr/server/strategy/qfedavg.py
@@ -90,7 +90,7 @@ class QFedAvg(FedAvg):
         self.pre_weights: Optional[NDArrays] = None
 
     def __repr__(self) -> str:
-        # pylint: disable=line-too-long
+        """Compute a string representation of the strategy."""
         rep = f"QffedAvg(learning_rate={self.learning_rate}, "
         rep += f"q_param={self.q_param}, pre_weights={self.pre_weights})"
         return rep


### PR DESCRIPTION
CAUTION: Please review this PR in the order mentioned https://github.com/adap/flower/pull/1920 for your easy review process.
Fix docstrings of the strategies:
* D105 Missing docstring in magic method
* D205 1 blank line required between summary line and description
D205 meant the summary didn't fit into single line and required shortening 
* D301 Use `r"""` if any backslashes in a docstring
I checked, and adding r""" didn't break anything in the documentation.
* D400 [*] First line should end with a period
* D202 [*] No blank lines allowed after function docstring (found 1)
