### PR TITLE
Add Ruff linter for docstring checks

### DIFF
--- a/dev/format.sh
+++ b/dev/format.sh
@@ -7,6 +7,7 @@ python -m isort --skip src/py/flwr/proto src/py
 python -m black -q --exclude src/py/flwr/proto src/py
 python -m docformatter -i -r src/py/flwr -e src/py/flwr/proto
 python -m docformatter -i -r src/py/flwr_tool
+python -m ruff check --fix src/py/flwr
 
 # Protos
 find src/proto/flwr/proto -name *.proto | grep "\.proto" | xargs clang-format -i

--- a/dev/test.sh
+++ b/dev/test.sh
@@ -25,7 +25,7 @@ python -m docformatter -c -r src/py/flwr -e src/py/flwr/proto &&
 echo "- docformatter:  done" &&
 
 echo "- ruff: start" &&
-python -m ruff src/py/flwr &&
+python -m ruff check src/py/flwr &&
 echo "- ruff: done" &&
 
 echo "- mypy: start" &&

--- a/dev/test.sh
+++ b/dev/test.sh
@@ -24,6 +24,10 @@ echo "- docformatter: start" &&
 python -m docformatter -c -r src/py/flwr -e src/py/flwr/proto &&
 echo "- docformatter:  done" &&
 
+echo "- ruff: start" &&
+python -m ruff src/py/flwr &&
+echo "- ruff: done" &&
+
 echo "- mypy: start" &&
 python -m mypy src/py &&
 echo "- mypy: done" &&

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,7 @@ furo = "==2022.12.7"
 sphinx-reredirects = "==0.1.2"
 nbsphinx = "==0.9.2"
 nbstripout = "==0.6.1"
+ruff = "==0.0.272"
 sphinx-argparse = "==0.4.0"
 pipreqs = "==0.4.13"
 
@@ -156,3 +157,35 @@ follow_imports_for_stubs = true
 [tool.docformatter]
 wrap-summaries = 88
 wrap-descriptions = 88
+
+[tool.ruff]
+line-length = 88
+select = ["D"]
+fixable = ["D"]
+
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".hg",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "venv",
+    "proto",
+]
+
+[tool.ruff.pydocstyle]
+convention = "numpy"


### PR DESCRIPTION
CAUTION: Please review this PR in the order mentioned https://github.com/adap/flower/pull/1920 for your easy review process.
## Issue

### Description

The current checks for the docstrings are not exhaustive enough. 

### Related issues/PRs

https://github.com/adap/flower/pull/1702 (it builds on top of it - test.sh, format.sh, pyproject.toml with a few minor changes)

## Proposal

Add ruff linter to the `test.sh` and `format.sh` and the settings and download to `pyproject.toml`.

### Explanation

`format.sh` the `--fix` flag enables some to automate some easy fixes (check out which ones https://beta.ruff.rs/docs/rules/#pydocstyle-d)

`pyproject.toml` - the version is fixed because the update might add some new rule that the code would fail (manual version updates should be applied). The `exclude = [` adds proto `proto` to the defaults. The convention of the docstrings the checks are performed against is "numpy".
