### PR TITLE
add python 3.7 deprecation in changelog.md

### DIFF
--- a/doc/source/changelog.md
+++ b/doc/source/changelog.md
@@ -6,7 +6,7 @@
 
 - **Deprecate Python 3.7**
 
-  Since Python 3.7 reached its end of life (EOL), support for Python 3.7 is now deprecated and will be removed in the next release.
+  Since Python 3.7 reached its end of life (EOL) on 2023-06-27, support for Python 3.7 is now deprecated and will be removed in an upcoming release.
 
 -  **Add new** `FedTrimmedAvg` **strategy** ([#1769](https://github.com/adap/flower/pull/1769), [#1853](https://github.com/adap/flower/pull/1853))
 

--- a/doc/source/changelog.md
+++ b/doc/source/changelog.md
@@ -4,6 +4,10 @@
 
 ### What's new?
 
+- **Deprecate Python 3.7**
+
+  Since Python 3.7 reached its end of life (EOL), support for Python 3.7 is now deprecated and will be removed in the next release.
+
 -  **Add new** `FedTrimmedAvg` **strategy** ([#1769](https://github.com/adap/flower/pull/1769), [#1853](https://github.com/adap/flower/pull/1853))
 
   The new `FedTrimmedAvg` strategy implements Trimmed Mean by [Dong Yin, 2018](https://arxiv.org/abs/1803.01498)


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->
Python 3.7 reached its end of life, therefore support for it needs to be deprecated in the next release.

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

Add deprecation of Python 3.7 to the changelog.
