### PR TITLE
dynamically decorate function with ray.remote to fix GPU OOM

### DIFF
--- a/src/py/flwr/simulation/ray_transport/ray_client_proxy.py
+++ b/src/py/flwr/simulation/ray_transport/ray_client_proxy.py
@@ -46,8 +46,8 @@ class RayClientProxy(ClientProxy):
         self, ins: common.GetPropertiesIns, timeout: Optional[float]
     ) -> common.GetPropertiesRes:
         """Return client's properties."""
-        future_get_properties_res = launch_and_get_properties.options(
-            **self.resources,
+        future_get_properties_res = _ray_actor_factory(
+            launch_and_get_properties, self.resources
         ).remote(self.client_fn, self.cid, ins)
         try:
             res = ray.get(future_get_properties_res, timeout=timeout)  # type: ignore
@@ -63,11 +63,12 @@ class RayClientProxy(ClientProxy):
         self, ins: common.GetParametersIns, timeout: Optional[float]
     ) -> common.GetParametersRes:
         """Return the current local model parameters."""
-        future_paramseters_res = launch_and_get_parameters.options(
-            **self.resources,
+        future_parameters_res = _ray_actor_factory(
+            launch_and_get_parameters, self.resources
         ).remote(self.client_fn, self.cid, ins)
+
         try:
-            res = ray.get(future_paramseters_res, timeout=timeout)  # type: ignore
+            res = ray.get(future_parameters_res, timeout=timeout)  # type: ignore
         except Exception as ex:
             log(ERROR, ex)
             raise ex
@@ -78,8 +79,8 @@ class RayClientProxy(ClientProxy):
 
     def fit(self, ins: common.FitIns, timeout: Optional[float]) -> common.FitRes:
         """Train model parameters on the locally held dataset."""
-        future_fit_res = launch_and_fit.options(
-            **self.resources,
+        future_fit_res = _ray_actor_factory(
+            launch_and_fit, self.resources
         ).remote(self.client_fn, self.cid, ins)
         try:
             res = ray.get(future_fit_res, timeout=timeout)  # type: ignore
@@ -95,8 +96,8 @@ class RayClientProxy(ClientProxy):
         self, ins: common.EvaluateIns, timeout: Optional[float]
     ) -> common.EvaluateRes:
         """Evaluate model parameters on the locally held dataset."""
-        future_evaluate_res = launch_and_evaluate.options(
-            **self.resources,
+        future_evaluate_res = _ray_actor_factory(
+            launch_and_evaluate, self.resources
         ).remote(self.client_fn, self.cid, ins)
         try:
             res = ray.get(future_evaluate_res, timeout=timeout)  # type: ignore
@@ -115,7 +116,6 @@ class RayClientProxy(ClientProxy):
         return common.DisconnectRes(reason="")  # Nothing to do here (yet)
 
 
-@ray.remote  # type: ignore
 def launch_and_get_properties(
     client_fn: ClientFn, cid: str, get_properties_ins: common.GetPropertiesIns
 ) -> common.GetPropertiesRes:
@@ -127,7 +127,6 @@ def launch_and_get_properties(
     )
 
 
-@ray.remote  # type: ignore
 def launch_and_get_parameters(
     client_fn: ClientFn, cid: str, get_parameters_ins: common.GetParametersIns
 ) -> common.GetParametersRes:
@@ -139,7 +138,6 @@ def launch_and_get_parameters(
     )
 
 
-@ray.remote  # type: ignore
 def launch_and_fit(
     client_fn: ClientFn, cid: str, fit_ins: common.FitIns
 ) -> common.FitRes:
@@ -151,7 +149,6 @@ def launch_and_fit(
     )
 
 
-@ray.remote  # type: ignore
 def launch_and_evaluate(
     client_fn: ClientFn, cid: str, evaluate_ins: common.EvaluateIns
 ) -> common.EvaluateRes:
@@ -167,3 +164,9 @@ def _create_client(client_fn: ClientFn, cid: str) -> Client:
     """Create a client instance."""
     client_like: ClientLike = client_fn(cid)
     return to_client(client_like=client_like)
+
+def _ray_actor_factory(base_fn, options: Dict[str, float]):
+    """
+        Dynamical decorate ray actor to set up `max_calls` parameters
+    """
+    return ray.remote(**options)(base_fn)


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description
According to [ray doc](https://docs.ray.io/en/latest/ray-core/api/doc/ray.remote.html), without setting ``max_calls=1``, using GPUs with ray may lead to memory leakage issue. Because ray actor process might be reused multiple times and the resources allocated to it won't be reclaimed until the process terminates.
There are two simple fixes I could think of

- Statically decorate all relevant functions with ``@ray.remote(max_calls=1)``. But this fix might be suboptimal, because in other settings you might need ``max_calls`` to be large for better performance.
- Use ``{max_calls : 1}`` as one of the key-value pair of ``client_resources`` passed to ``flwr.simulation.start_simulation``. In the [source code](https://github.com/adap/flower/blob/main/src/py/flwr/simulation/ray_transport/ray_client_proxy.py), ``client_resources`` is then passed to ray actor through ``.options()``. But due to constraints imposed by ray, ``max_calls`` is the only exception, which can not be overwritten is ``.options()``. Check the response by ray team [here](https://discuss.ray.io/t/behavior-of-max-calls-of-ray-remote-by-default/11088)

Therefore, I am using a function factory kind of thing to dynamically decorate ray actors. User is then able to pass ``{max_calls : 1}`` as one of the configuration for ray.remote through ``client_resources``. If this PR gets merged, the doc probably needs to be updated to reflect this.
<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->


### Related issues/PRs

- GPU OOM problem related to this fix has been elaborated in my previous [issue post](https://github.com/adap/flower/issues/1942).
- There is [another PR](https://github.com/adap/flower/pull/1384) related to this.


<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

### Checklist

- [x] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.dev/docs/writing-documentation.html)
- [ ] Update [changelog](https://github.com/adap/flower/blob/main/doc/source/changelog.rst)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.dev/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
