### PR TITLE
Fix `ray` version to 2.5.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ protobuf = "^3.19.0"
 importlib-metadata = { version = "^4.0.0", markers = "python_version < '3.8'" }
 iterators = "^0.0.2"
 # Optional dependencies (VCE)
-ray = { version = "^2.4.0", extras = ["default"], optional = true }
+ray = { version = "==2.5.1", extras = ["default"], optional = true }
 # Optional dependencies (REST transport layer)
 requests = { version = "^2.28.2", optional = true }
 fastapi = { version = "^0.95.0", optional = true }


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

The version of `ray` impacts the typing checks made during the CI, therefore it would be better to use a fixed version and to update it manually when new versions come out.

### Related issues/PRs

N/A

## Proposal

### Explanation

Set a fixed version (`2.5.1`) of `ray` in `pyproject.toml`.

### Checklist

- [x] Implement proposed change
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

N/A
