### PR TITLE
disabling mypy `type: ignore` comments

### DIFF
--- a/src/py/flwr/server/fleet/rest_rere/rest_api.py
+++ b/src/py/flwr/server/fleet/rest_rere/rest_api.py
@@ -32,7 +32,7 @@ except ModuleNotFoundError:
 app: FastAPI = FastAPI()
 
 
-@app.post("/api/v0/fleet/pull-task-ins", response_class=Response)  # type: ignore
+@app.post("/api/v0/fleet/pull-task-ins", response_class=Response)
 async def pull_task_ins(request: Request) -> Response:
     """Pull TaskIns."""
     _check_headers(request.headers)
@@ -62,7 +62,7 @@ async def pull_task_ins(request: Request) -> Response:
     )
 
 
-@app.post("/api/v0/fleet/push-task-res", response_class=Response)  # type: ignore
+@app.post("/api/v0/fleet/push-task-res", response_class=Response)
 async def push_task_res(request: Request) -> Response:  # Check if token is needed here
     """Push TaskRes."""
     _check_headers(request.headers)


### PR DESCRIPTION
removing `mypy` `type: ignore` from a couple of lines. Breaks `mypy` tests otherwise. Will it work?