### PR TITLE
Add markdown tooling

### DIFF
--- a/dev/format.sh
+++ b/dev/format.sh
@@ -21,3 +21,6 @@ python -m black --ipynb -q doc/source/tutorial
 KEYS="metadata.celltoolbar metadata.language_info metadata.toc metadata.notify_time metadata.varInspector metadata.accelerator metadata.vscode cell.metadata.id cell.metadata.heading_collapsed cell.metadata.hidden cell.metadata.code_folding cell.metadata.tags cell.metadata.init_cell cell.metadata.vscode"
 python -m nbstripout doc/source/tutorial/*.ipynb --extra-keys "$KEYS"
 python -m nbstripout examples/*/*.ipynb --extra-keys "$KEYS"
+
+# Markdown
+python -m mdformat doc/source/tutorial examples

--- a/dev/test.sh
+++ b/dev/test.sh
@@ -4,6 +4,8 @@ cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"/../
 
 echo "=== test.sh ==="
 
+echo "- Start Python checks"
+
 echo "- clang-format:  start" &&
 clang-format --Werror --dry-run src/proto/flwr/proto/* &&
 echo "- clang-format:  done" &&
@@ -45,3 +47,11 @@ python -m pytest --cov=src/py/flwr &&
 echo "- pytest: done" &&
 
 echo "- All Python checks passed"
+
+echo "- Start Markdown checks"
+
+echo "- mdformat: start" &&
+python -m mdformat --check doc/source/tutorial examples &&
+echo "- mdformat: done" &&
+
+echo "- All Markdown checks passed"

--- a/examples/advanced_pytorch/README.md
+++ b/examples/advanced_pytorch/README.md
@@ -57,8 +57,8 @@ pip install -r requirements.txt
 
 # Run Federated Learning with PyTorch and Flower
 
-The included `run.sh` will start the Flower server (using `server.py`), 
-sleep for 2 seconds to ensure that the server is up, and then start 10 Flower clients (using `client.py`) with only a small subset of the data (in order to run on any machine), 
+The included `run.sh` will start the Flower server (using `server.py`),
+sleep for 2 seconds to ensure that the server is up, and then start 10 Flower clients (using `client.py`) with only a small subset of the data (in order to run on any machine),
 but this can be changed by removing the `--toy True` argument in the script. You can simply start everything in a terminal as follows:
 
 ```shell

--- a/examples/android/README.md
+++ b/examples/android/README.md
@@ -1,12 +1,11 @@
 # Flower Android Example (TensorFlowLite)
 
-This example demonstrates a federated learning setup with Android Clients. The training on Android is done on a CIFAR10 dataset using TensorFlow Lite. The setup is as follows: 
+This example demonstrates a federated learning setup with Android Clients. The training on Android is done on a CIFAR10 dataset using TensorFlow Lite. The setup is as follows:
 
 - The CIFAR10 dataset is randomly split across 10 clients. Each Android client holds a local dataset of 5000 training examples and 1000 test examples.
-- The FL server runs in Python but all the clients run on Android. 
-- We use a strategy called FedAvgAndroid for this example. 
-- The strategy is vanilla FedAvg with a custom serialization and deserialization to handle the Bytebuffers sent from Android clients to Python server.   
-
+- The FL server runs in Python but all the clients run on Android.
+- We use a strategy called FedAvgAndroid for this example.
+- The strategy is vanilla FedAvg with a custom serialization and deserialization to handle the Bytebuffers sent from Android clients to Python server.
 
 ## Project Setup
 
@@ -51,6 +50,6 @@ The included `run.sh` will start the Flower server (using `server.py`). You can 
 poetry run ./run.sh
 ```
 
-Download and install the `flwr_android_client.apk` on each Android device/emulator. The server currently expects a minimum of 4 Android clients, but it can be changed in the `server.py`. 
+Download and install the `flwr_android_client.apk` on each Android device/emulator. The server currently expects a minimum of 4 Android clients, but it can be changed in the `server.py`.
 
-When the Android app runs, add the client ID (between 1-10), the IP and port of your server, and press `Load Dataset`. This will load the local CIFAR10 dataset in memory. Then press `Setup Connection Channel` which will establish connection with the server. Finally, press `Train Federated!` which will start the federated training. 
+When the Android app runs, add the client ID (between 1-10), the IP and port of your server, and press `Load Dataset`. This will load the local CIFAR10 dataset in memory. Then press `Setup Connection Channel` which will establish connection with the server. Finally, press `Train Federated!` which will start the federated training.

--- a/examples/dp-sgd-mnist/README.md
+++ b/examples/dp-sgd-mnist/README.md
@@ -1,10 +1,9 @@
 # Flower Example Using Tensorflow/Keras and Tensorflow Privacy
 
-This example of Flower trains a federeated learning system where clients are free to choose 
-between non-private and private optimizers. Specifically, clients can choose to train Keras models using the standard SGD optimizer or __Differentially Private__ SGD (DPSGD) from [Tensorflow Privacy](https://github.com/tensorflow/privacy). For this task we use the MNIST dataset which is split artificially among clients. This causes the dataset to be i.i.d. The clients using DPSGD track the amount of privacy spent and display it at the end of the training. 
+This example of Flower trains a federeated learning system where clients are free to choose
+between non-private and private optimizers. Specifically, clients can choose to train Keras models using the standard SGD optimizer or __Differentially Private__ SGD (DPSGD) from [Tensorflow Privacy](https://github.com/tensorflow/privacy). For this task we use the MNIST dataset which is split artificially among clients. This causes the dataset to be i.i.d. The clients using DPSGD track the amount of privacy spent and display it at the end of the training.
 
 This example is adapted from https://github.com/tensorflow/privacy/blob/master/tutorials/mnist_dpsgd_tutorial_keras.py
-
 
 ## Project Setup
 
@@ -24,6 +23,7 @@ This will create a new directory called `dp-sgd-mnist` containing the following 
 -- common.py
 -- README.md
 ```
+
 ### Installing Dependencies
 
 Project dependencies (such as `tensorflow` and `tensorflow-privacy`) are defined in `pyproject.toml` and `requirements.txt`. We recommend [Poetry](https://python-poetry.org/docs/) to install those dependencies and manage your virtual environment ([Poetry installation](https://python-poetry.org/docs/#installation)) or [pip](https://pip.pypa.io/en/latest/development/), but feel free to use a different way of installing dependencies and managing virtual environments if you have other preferences.
@@ -66,6 +66,7 @@ Now you are ready to start the Flower clients which will participate in the lear
 # terminal 2
 poetry run python3 client.py --partition 0
 ```
+
 ```shell
 # terminal 3
 # We will set the second client to use `dpsgd`

--- a/examples/embedded_devices/README.md
+++ b/examples/embedded_devices/README.md
@@ -4,16 +4,17 @@ This demo will show you how Flower makes it very easy to run Federated Learning 
 
 ## Getting things ready
 
-This is a list of components that you'll need: 
+This is a list of components that you'll need:
 
-* For server: A machine running Linux/macOS.
-* For clients: either a Rapsberry Pi 3 B+ (RPi 4 would work too) or a Jetson Xavier-NX (or any other recent NVIDIA-Jetson device).
-* A 32GB uSD card and ideally UHS-1 or better. (not needed if you plan to use a Jetson TX2 instead)
-* Software to flash the images to a uSD card (e.g. [Etcher](https://www.balena.io/etcher/))
+- For server: A machine running Linux/macOS.
+- For clients: either a Rapsberry Pi 3 B+ (RPi 4 would work too) or a Jetson Xavier-NX (or any other recent NVIDIA-Jetson device).
+- A 32GB uSD card and ideally UHS-1 or better. (not needed if you plan to use a Jetson TX2 instead)
+- Software to flash the images to a uSD card (e.g. [Etcher](https://www.balena.io/etcher/))
 
 What follows is a step-by-step guide on how to setup your client/s and the server. In order to minimize the amount of setup and potential issues that might arise due to the hardware/software heterogenity between clients we'll be running the clients inside a Docker. We provide two docker images: one built for Jetson devices and make use of their GPU; and the other for CPU-only training suitable for Raspberry Pi (but would also work on Jetson devices). The following diagram illustrates the setup for this demo:
 
 <!-- jetson xavier-nx image borrowed from: https://developer.nvidia.com/embedded/jetson-xavier-nx-devkit -->
+
 ![alt text](media/diagram.png)
 
 ## Clone this repo
@@ -30,83 +31,87 @@ The only requirement for the server is to have flower installed. You can do so b
 
 ## Setting up a Jetson Xavier-NX
 
-> These steps have been validated for a Jetson Xavier-NX Dev Kit. An identical setup is needed for a Jetson Nano and Jetson TX2 once you get ssh access to them (i.e. jumping straight to point `4` below). For instructions on how to setup these devices please refer to the "getting started guides" for [Jetson Nano](https://developer.nvidia.com/embedded/learn/get-started-jetson-nano-devkit#intro) and [Jetson TX2](https://developer.nvidia.com/embedded/dlc/l4t-28-2-jetson-developer-kit-user-guide-ga). 
+> These steps have been validated for a Jetson Xavier-NX Dev Kit. An identical setup is needed for a Jetson Nano and Jetson TX2 once you get ssh access to them (i.e. jumping straight to point `4` below). For instructions on how to setup these devices please refer to the "getting started guides" for [Jetson Nano](https://developer.nvidia.com/embedded/learn/get-started-jetson-nano-devkit#intro) and [Jetson TX2](https://developer.nvidia.com/embedded/dlc/l4t-28-2-jetson-developer-kit-user-guide-ga).
 
 1. Download the Ubuntu 18.04 image from [NVIDIA-embedded](https://developer.nvidia.com/embedded/downloads), note that you'll need a NVIDIA developer account. This image comes with Docker pre-installed as well as PyTorch+Torchvision compiled with GPU support.
-2. Extract the imgae (~14GB) and flash it onto the uSD card using Etcher (or equivalent).
-3. Follow [the instructions](https://developer.nvidia.com/embedded/learn/get-started-jetson-xavier-nx-devkit) to setup the device.
-4. Installing Docker: Docker comes pre-installed with the Ubuntu image provided by NVIDIA. But for convinience we will create a new user group and add our user to it (with the idea of not having to use `sudo` for every command involving docker (e.g. `docker run`, `docker ps`, etc)). More details about what this entails can be found in the [Docker documentation](https://docs.docker.com/engine/install/linux-postinstall/). You can achieve this by doing:
 
-    ``` bash
-    $ sudo usermod -aG docker $USER
-    # apply changes to current shell (or logout/reboot)
-    $ newgrp docker
-    ```
+1. Extract the imgae (~14GB) and flash it onto the uSD card using Etcher (or equivalent).
 
-5. The minimal installation to run this example only requires an additional package, `git`, in order to clone this repo. Install `git` by:
+1. Follow [the instructions](https://developer.nvidia.com/embedded/learn/get-started-jetson-xavier-nx-devkit) to setup the device.
 
-    ```bash
-    $ sudo apt-get update && sudo apt-get install git -y
-    ```
+1. Installing Docker: Docker comes pre-installed with the Ubuntu image provided by NVIDIA. But for convinience we will create a new user group and add our user to it (with the idea of not having to use `sudo` for every command involving docker (e.g. `docker run`, `docker ps`, etc)). More details about what this entails can be found in the [Docker documentation](https://docs.docker.com/engine/install/linux-postinstall/). You can achieve this by doing:
 
-6. (optional) additional packages:
-        <img align="right" style="padding-top: 40px; padding-left: 15px" width="575" height="380" src="media/tmux_jtop_view.gif">
-     * [jtop](https://github.com/rbonghi/jetson_stats),  to monitor CPU/GPU utilization, power consumption and, many more.
+   ```bash
+   $ sudo usermod -aG docker $USER
+   # apply changes to current shell (or logout/reboot)
+   $ newgrp docker
+   ```
 
-        ```bash
-        # First we need to install pip3
-        $ sudo apt-get install python3-pip -y 
-        # updated pip3
-        $ sudo pip3 install -U pip
-        # finally, install jtop
-        $ sudo -H pip3 install -U jetson-stats
-        ```
+1. The minimal installation to run this example only requires an additional package, `git`, in order to clone this repo. Install `git` by:
 
-     * [TMUX](https://github.com/tmux/tmux/wiki), a terminal multiplexer.
+   ```bash
+   $ sudo apt-get update && sudo apt-get install git -y
+   ```
 
-        ```bash
-        # install tmux
-        $ sudo apt-get install tmux -y
-        # add mouse support
-        $ echo set -g mouse on > ~/.tmux.conf
-        ``` 
+1. (optional) additional packages:
+   <img align="right" style="padding-top: 40px; padding-left: 15px" width="575" height="380" src="media/tmux_jtop_view.gif">
 
-7. Power modes: The Jetson devices can operate at different power modes, each making use of more or less CPU cores clocked at different freqencies. The right power mode might very much depend on the application and scenario. When power consumption is not a limiting factor, we could use the highest 15W mode using all 6 CPU cores. On the other hand, if the devices are battery-powered we might want to make use of a low power mode using 10W and 2 CPU cores. All the details regarding the different power modes of a Jetson Xavier-NX can be found [here](https://docs.nvidia.com/jetson/l4t/index.html#page/Tegra%2520Linux%2520Driver%2520Package%2520Development%2520Guide%2Fpower_management_jetson_xavier.html%23wwpID0E0NO0HA). For this demo we'll be setting the device to the high performance mode:
+   - [jtop](https://github.com/rbonghi/jetson_stats),  to monitor CPU/GPU utilization, power consumption and, many more.
 
-    ```bash
-    $ sudo /usr/sbin/nvpmodel -m 2 # 15W with 6cpus @ 1.4GHz
-    ```
+     ```bash
+     # First we need to install pip3
+     $ sudo apt-get install python3-pip -y 
+     # updated pip3
+     $ sudo pip3 install -U pip
+     # finally, install jtop
+     $ sudo -H pip3 install -U jetson-stats
+     ```
+
+   - [TMUX](https://github.com/tmux/tmux/wiki), a terminal multiplexer.
+
+     ```bash
+     # install tmux
+     $ sudo apt-get install tmux -y
+     # add mouse support
+     $ echo set -g mouse on > ~/.tmux.conf
+     ```
+
+1. Power modes: The Jetson devices can operate at different power modes, each making use of more or less CPU cores clocked at different freqencies. The right power mode might very much depend on the application and scenario. When power consumption is not a limiting factor, we could use the highest 15W mode using all 6 CPU cores. On the other hand, if the devices are battery-powered we might want to make use of a low power mode using 10W and 2 CPU cores. All the details regarding the different power modes of a Jetson Xavier-NX can be found [here](https://docs.nvidia.com/jetson/l4t/index.html#page/Tegra%2520Linux%2520Driver%2520Package%2520Development%2520Guide%2Fpower_management_jetson_xavier.html%23wwpID0E0NO0HA). For this demo we'll be setting the device to the high performance mode:
+
+   ```bash
+   $ sudo /usr/sbin/nvpmodel -m 2 # 15W with 6cpus @ 1.4GHz
+   ```
 
 ## Setting up a Raspberry Pi (3B+ or 4B)
 
 1. Install Ubuntu server 20.04 LTS 64-bit for Rapsberry Pi. You can do this by using one of the images provided [by Ubuntu](https://ubuntu.com/download/raspberry-pi) and then use Etcher. Alternativelly, astep-by-step installation guide, showing how to download and flash the image onto a uSD card and, go throught the first boot process, can be found [here](https://ubuntu.com/tutorials/how-to-install-ubuntu-on-your-raspberry-pi#1-overview). Please note that the first time you boot your RPi it will automatically update the system (which will lock `sudo` and prevent running the commands below for a few minutes)
 
-2. Install docker (+ post-installation steps as in [Docker Docs](https://docs.docker.com/engine/install/linux-postinstall/)):
+1. Install docker (+ post-installation steps as in [Docker Docs](https://docs.docker.com/engine/install/linux-postinstall/)):
 
-    ```bash
-    # make sure your OS is up-to-date
-    $ sudo apt-get update
+   ```bash
+   # make sure your OS is up-to-date
+   $ sudo apt-get update
 
-    # get the installation script
-    $ curl -fsSL https://get.docker.com -o get-docker.sh
+   # get the installation script
+   $ curl -fsSL https://get.docker.com -o get-docker.sh
 
-    # install docker
-    $ sudo sh get-docker.sh
+   # install docker
+   $ sudo sh get-docker.sh
 
-    # add your user to the docker group
-    $ sudo usermod -aG docker $USER
+   # add your user to the docker group
+   $ sudo usermod -aG docker $USER
 
-    # apply changes to current shell (or logout/reboot)
-    $ newgrp docker
-    ```
+   # apply changes to current shell (or logout/reboot)
+   $ newgrp docker
+   ```
 
-3. (optional) additional packages: you could install `TMUX` (see point `6` above) and `htop` as a replacement for `jtop` (which is only available for Jetson devices). Htop can be installed via: `sudo apt-get install htop -y`.
+1. (optional) additional packages: you could install `TMUX` (see point `6` above) and `htop` as a replacement for `jtop` (which is only available for Jetson devices). Htop can be installed via: `sudo apt-get install htop -y`.
 
 # Running FL training with Flower
 
-For this demo we'll be using [CIFAR-10](https://www.cs.toronto.edu/~kriz/cifar.html), a popular dataset for image classification comprised of 10 classes (e.g. car, bird, airplane) and a total of 60K `32x32` RGB images. The training set contains 50K images. The server will automatically download the dataset should it not be found in `./data`. To keep the client side simple, the datasets will be downloaded when building the docker image. This will happen as the first stage in both `run_pi.sh` and `run_jetson.sh`. 
+For this demo we'll be using [CIFAR-10](https://www.cs.toronto.edu/~kriz/cifar.html), a popular dataset for image classification comprised of 10 classes (e.g. car, bird, airplane) and a total of 60K `32x32` RGB images. The training set contains 50K images. The server will automatically download the dataset should it not be found in `./data`. To keep the client side simple, the datasets will be downloaded when building the docker image. This will happen as the first stage in both `run_pi.sh` and `run_jetson.sh`.
 
->If you'd like to make use of your own dataset you could [mount it](https://docs.docker.com/storage/volumes/) to the client docker container when calling `docker run`. We leave this an other more advanced topics for a future example.
+> If you'd like to make use of your own dataset you could [mount it](https://docs.docker.com/storage/volumes/) to the client docker container when calling `docker run`. We leave this an other more advanced topics for a future example.
 
 ## Server
 
@@ -119,7 +124,7 @@ $ python server.py --server_address <YOUR_SERVER_IP:PORT> --rounds 3 --min_num_c
 
 ## Clients
 
-Asuming you have cloned this repo onto the device/s, then execute the appropiate script to run the docker image, connect with the server and proceed with the training. Note that you can use both a Jetson and a RPi simultaneously, just make sure you modify the script above when launching the server so it waits until 2 clients are online. 
+Asuming you have cloned this repo onto the device/s, then execute the appropiate script to run the docker image, connect with the server and proceed with the training. Note that you can use both a Jetson and a RPi simultaneously, just make sure you modify the script above when launching the server so it waits until 2 clients are online.
 
 ### For Jetson
 

--- a/examples/embedded_devices/base_images/README.md
+++ b/examples/embedded_devices/base_images/README.md
@@ -1,4 +1,3 @@
-
 ## Building the base Docker images
 
 We provide the base images used in the Dockerfile of the parent directory (i.e. `jafermarq/jetsonfederated_cpu` and `jafermarq/jetsonfederated_gpu`). To make the process of running the demo as seamsless as possible (i.e. without long Docker build times) we have pre-built these images and uploaded them to dockerhub. In that way, the Dockerfile in the parent directory only requires adding a couple of python scripts to the image. If you want to build these images by yourself, you can do so by running the `build.sh` script in each directory. Note that building these images might take around one hour, depending on your system's specs.

--- a/examples/opacus/README.md
+++ b/examples/opacus/README.md
@@ -8,7 +8,7 @@ This example contains code demonstrating how to include the Opacus library for t
 
 ## Requirements
 
-- **Flower** nightly release (or development version from `main` branch) for the simulation, otherwise normal Flower for the client 
+- **Flower** nightly release (or development version from `main` branch) for the simulation, otherwise normal Flower for the client
 - **PyTorch** 1.7.1 (but most likely will work with older versions)
 - **Ray** 1.4.1 (just for the simulation)
 - **Opacus** 0.14.0

--- a/examples/pytorch_federated_variational_autoencoder/README.md
+++ b/examples/pytorch_federated_variational_autoencoder/README.md
@@ -9,6 +9,7 @@ Start by cloning the example project. We prepared a single-line command that you
 ```shell
 git clone --depth=1 https://github.com/adap/flower.git && mv flower/examples/pytorch_federated_variational_autoencoder . && rm -rf flower && cd pytorch_federated_variational_autoencoder
 ```
+
 This will create a new directory called `pytorch_federated_variational_autoencoder` containing the following files:
 
 ```shell

--- a/examples/quickstart_cpp/README.md
+++ b/examples/quickstart_cpp/README.md
@@ -2,9 +2,10 @@
 
 In this example you will train a linear model on synthetic data using C++ clients.
 
-# Acknowledgements 
+# Acknowledgements
 
 Many thanks to the original contributors to this code:
+
 - Lekang Jiang (original author and main contributor)
 - Francisco José Solís (code re-organization)
 - Andreea Zaharia (training algorithm and data generation)
@@ -24,12 +25,14 @@ cmake --build build
 
 # Run the server and two clients in separate terminals
 
-```bash 
+```bash
 python server.py
 ```
+
 ```bash
 build/flwr_client 0 127.0.0.1:8080 
 ```
+
 ```bash
 build/flwr_client 1 127.0.0.1:8080
 ```

--- a/examples/quickstart_mlcube/README.md
+++ b/examples/quickstart_mlcube/README.md
@@ -59,4 +59,4 @@ Congrats! You have just run a Federated Learning experiment using TensorFlow/Ker
 
 ## Background
 
-Wondering how this works? Most of the interaction with MLCube happens in `mlcube_utils.py`, which reads and writes to the file system. It also provides a function called `run_task`, which invokes `mlcube_docker`` run ...` to execute the appropriate task. The custom client we have implemented in `client.py` will run the MLCube 'download' task when it's instantiated. Fit and evaluate also interface through the `mlcube_utils.py` helpers for reading and writing to disk and calling the appropriate MLCube tasks.
+Wondering how this works? Most of the interaction with MLCube happens in `mlcube_utils.py`, which reads and writes to the file system. It also provides a function called `run_task`, which invokes ``` mlcube_docker`` run ... ``` to execute the appropriate task. The custom client we have implemented in `client.py` will run the MLCube 'download' task when it's instantiated. Fit and evaluate also interface through the `mlcube_utils.py` helpers for reading and writing to disk and calling the appropriate MLCube tasks.

--- a/examples/quickstart_pytorch/README.md
+++ b/examples/quickstart_pytorch/README.md
@@ -20,6 +20,7 @@ This will create a new directory called `quickstart_pytorch` containing the foll
 -- server.py
 -- README.md
 ```
+
 ### Installing Dependencies
 
 Project dependencies (such as `torch` and `flwr`) are defined in `pyproject.toml` and `requirements.txt`. We recommend [Poetry](https://python-poetry.org/docs/) to install those dependencies and manage your virtual environment ([Poetry installation](https://python-poetry.org/docs/#installation)) or [pip](https://pip.pypa.io/en/latest/development/), but feel free to use a different way of installing dependencies and managing virtual environments if you have other preferences.

--- a/examples/quickstart_xgboost_horizontal/README.md
+++ b/examples/quickstart_xgboost_horizontal/README.md
@@ -6,7 +6,7 @@ This example demonstrates a federated XGBoost using Flower with PyTorch. This is
 
 - We aggregate and conduct federated learning on client tree’s prediction outcomes by sending clients' built XGBoost trees to the server and then sharing to the clients.
 - The exchange of privacy-sensitive information (gradients) is not needed.
-- The model is a CNN with 1D convolution kernel size = the number of XGBoost trees in the client tree ensembles. 
+- The model is a CNN with 1D convolution kernel size = the number of XGBoost trees in the client tree ensembles.
 - Using 1D convolution, we make the tree learning rate (a hyperparameter of XGBoost) learnable.
 
 ## Project Setup

--- a/examples/simulation_pytorch/README.md
+++ b/examples/simulation_pytorch/README.md
@@ -4,9 +4,9 @@ This code splits CIFAR-10 dataset into `pool_size` partitions (user defined) and
 
 ## Requirements
 
-*    Flower 0.18.0
-*    A recent version of PyTorch. This example has been tested with Pytorch 1.7.1, 1.8.2 (LTS) and 1.10.2.
-*    A recent version of Ray. This example has been tested with Ray 1.4.1, 1.6 and 1.9.2.
+- Flower 0.18.0
+- A recent version of PyTorch. This example has been tested with Pytorch 1.7.1, 1.8.2 (LTS) and 1.10.2.
+- A recent version of Ray. This example has been tested with Ray 1.4.1, 1.6 and 1.9.2.
 
 From a clean virtualenv or Conda environment with Python 3.7+, the following command will isntall all the dependencies needed:
 
@@ -19,11 +19,11 @@ $ pip install -r requirements.txt
 This example:
 
 1. Downloads CIFAR-10
-2. Partitions the dataset into N splits, where N is the total number of
+1. Partitions the dataset into N splits, where N is the total number of
    clients. We refere to this as `pool_size`. The partition can be IID or non-IID
-4. Starts a Ray-based simulation where a % of clients are sample each round.
+1. Starts a Ray-based simulation where a % of clients are sample each round.
    This example uses N=10, so 10 clients will be sampled each round.
-5. After the M rounds end, the global model is evaluated on the entire testset.
+1. After the M rounds end, the global model is evaluated on the entire testset.
    Also, the global model is evaluated on the valset partition residing in each
    client. This is useful to get a sense on how well the global model can generalise
    to each client's data.

--- a/examples/sklearn-logreg-mnist/README.md
+++ b/examples/sklearn-logreg-mnist/README.md
@@ -71,4 +71,4 @@ poetry run python3 client.py &
 poetry run python3 client.py
 ```
 
-You will see that Flower is starting a federated training. 
+You will see that Flower is starting a federated training.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,9 @@ nbstripout = "==0.6.1"
 ruff = "==0.0.272"
 sphinx-argparse = "==0.4.0"
 pipreqs = "==0.4.13"
+mdformat-gfm = "==0.3.5"
+mdformat-frontmatter = "==2.0.1"
+mdformat-footnote = "==0.1.1"
 
 [tool.isort]
 line_length = 88


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->

There are lack of tooling for markdown files, since the markdown files are planned to be published into Flower documentation website page it is important to establish a good tooling to maintain consistent style and improve quality and readability.

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

- Markdown: Auto-format using mdformat
    - Execute the tool inside `./dev/format.sh`
- Markdown: Lint script using mdformat
    - Execute the tool inside `./dev/test.sh`

### Checklist

- [ ] Implement proposed change
- [ ] Write tests
- [ ] Make CI checks pass