### PR TITLE
Add GetParametersIns to getParameters() in SwiftSDK

### DIFF
--- a/src/swift/flwr/Sources/Flower/Client/Client.swift
+++ b/src/swift/flwr/Sources/Flower/Client/Client.swift
@@ -13,14 +13,14 @@ import Foundation
 ///
 /// ### Functionalities
 ///
-/// - ``getParameters()``
+/// - ``getParameters(ins:)``
 /// - ``getProperties(ins:)-4u0tf``
 /// - ``fit(ins:)``
 /// - ``evaluate(ins:)``
 public protocol Client {
     
     /// Return the current local model parameters.
-    func getParameters() -> GetParametersRes
+    func getParameters(ins: GetParametersIns) -> GetParametersRes
     
     /// Return set of client properties.
     func getProperties(ins: GetPropertiesIns) -> GetPropertiesRes

--- a/src/swift/flwr/Sources/Flower/Common/Serde.swift
+++ b/src/swift/flwr/Sources/Flower/Common/Serde.swift
@@ -72,6 +72,7 @@ func disconnectFromProto(msg: Flwr_Proto_ClientMessage.DisconnectRes) -> Disconn
     }
 }
 
+func getParametersInsToProto(ins: )
 func getParametersToProto() -> Flwr_Proto_ServerMessage.GetParametersIns {
     return Flwr_Proto_ServerMessage.GetParametersIns()
 }

--- a/src/swift/flwr/Sources/Flower/Common/Typing.swift
+++ b/src/swift/flwr/Sources/Flower/Common/Typing.swift
@@ -98,6 +98,14 @@ public struct Parameters: Equatable {
     }
 }
 
+public struct GetParametersIns: Equatable {
+    public var config: [String: Scalar]
+    
+    public init(config: [String : Scalar]) {
+        self.config = config
+    }
+}
+
 public struct GetParametersRes: Equatable {
     public var parameters: Parameters
     public var status: Status

--- a/src/swift/flwr/Sources/Flower/CoreML/MLFlwrClient.swift
+++ b/src/swift/flwr/Sources/Flower/CoreML/MLFlwrClient.swift
@@ -84,7 +84,7 @@ public class MLFlwrClient: Client {
     /// Parses the parameters from the local model and returns them as GetParametersRes struct.
     ///
     /// - Returns: Parameters from the local model
-    public func getParameters() -> GetParametersRes {
+    public func getParameters(ins: GetParametersIns) -> GetParametersRes {
         let parameters = parameters.weightsToParameters()
         let status = Status(code: .ok, message: String())
         

--- a/src/swift/flwr/Sources/Flower/CoreML/MLFlwrClient.swift
+++ b/src/swift/flwr/Sources/Flower/CoreML/MLFlwrClient.swift
@@ -24,7 +24,7 @@ public enum MLTask {
 /// ### Usage
 ///
 /// - ``init(layerWrappers:dataLoader:compiledModelUrl:)``
-/// - ``getParameters()``
+/// - ``getParameters(ins:)``
 /// - ``getProperties(ins:)``
 /// - ``fit(ins:)``
 /// - ``evaluate(ins:)``

--- a/src/swift/flwr/Sources/Flower/GRPC/FlwrGRPC.swift
+++ b/src/swift/flwr/Sources/Flower/GRPC/FlwrGRPC.swift
@@ -26,6 +26,7 @@ import os
 /// ### GetParameters
 ///
 /// - ``Parameters``
+/// - ``GetParametersIns``
 /// - ``GetParametersRes``
 ///
 /// ### GetProperties

--- a/src/swift/flwr/Sources/Flower/GRPC/MessageHandler.swift
+++ b/src/swift/flwr/Sources/Flower/GRPC/MessageHandler.swift
@@ -22,7 +22,7 @@ func handle(client: Client, serverMsg: Flwr_Proto_ServerMessage) throws -> (Flwr
         let sleepDuration = tuple.1
         return (disconnectMsg, sleepDuration, false)
     case .getParametersIns:
-        return (getParameters(client: client), 0, true)
+        return (getParameters(client: client, parametersMsg: serverMsg.getParametersIns), 0, true)
     case .fitIns:
         return (fit(client: client, fitMsg: serverMsg.fitIns), 0, true)
     case .evaluateIns:
@@ -50,8 +50,9 @@ func reconnect(reconnectMsg: Flwr_Proto_ServerMessage.ReconnectIns) -> (Flwr_Pro
  }
 
 /// Handle for the server message that requests the local model parameters.
-func getParameters(client: Client) -> Flwr_Proto_ClientMessage {
-    let parametersRes = client.getParameters()
+func getParameters(client: Client, parametersMsg: Flwr_Proto_ServerMessage.GetParametersIns) -> Flwr_Proto_ClientMessage {
+    let getParametersIns = getParametersInsFromProto(msg: parametersMsg)
+    let parametersRes = client.getParameters(ins: getParametersIns)
     let parametersResProto = parametersResToProto(res: parametersRes)
     var ret = Flwr_Proto_ClientMessage()
     ret.getParametersRes = parametersResProto


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->

The `getParameters()` function is not yet adapted to Flower 1.0, it should be able to accept an ins: `GetParametersIns` argument.

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->
Resolves #1943 change request.

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

1. Add new `GetParametersIns` struct with config as its attribute.
2. Add `getParametersInsFromProto()` and `getParametersInsToProto()` functions in `Serde.swift`.
3. Add ins argument to getParameters() in `Client` protocol.
4. Adapt `messageHandler` to handle the new `GetParametersIns`.
5. Add documentation for the new `GetParametersIns` and in all its calling functions.

### Checklist

- [ ] Implement proposed change
- [ ] Write tests
- [ ] Make CI checks pass