### PR TITLE
Fixes GitHub CI issue because of behaviour change

### DIFF
--- a/.github/workflows/flower-swift_sync.yml
+++ b/.github/workflows/flower-swift_sync.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Pushes src/swift to flower-swift repository
-        uses: cpina/github-action-push-to-another-repository@0a14457
+        uses: cpina/github-action-push-to-another-repository@0a14457bb28b04dfa1652e0ffdfda866d2845c73
         env:
           SSH_DEPLOY_KEY: ${{ secrets.FLOWER_SWIFT_SSH }}
         with:


### PR DESCRIPTION
## Issue

### Description

The CI fails because of this error.

<img width="792" alt="image" src="https://github.com/adap/flower/assets/423981/acf452eb-2b90-4317-b31c-d9dc57bbfb1d">

## Proposal

Do what the error message suggests

### Checklist

- [x] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.dev/docs/writing-documentation.html)
- [ ] Update [changelog](https://github.com/adap/flower/blob/main/doc/source/changelog.rst)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)
