### PR TITLE
Remove && from the end of lines

### DIFF
--- a/dev/test.sh
+++ b/dev/test.sh
@@ -6,52 +6,52 @@ echo "=== test.sh ==="
 
 echo "- Start Python checks"
 
-echo "- clang-format:  start" &&
-clang-format --Werror --dry-run src/proto/flwr/proto/* &&
-echo "- clang-format:  done" &&
+echo "- clang-format:  start"
+clang-format --Werror --dry-run src/proto/flwr/proto/*
+echo "- clang-format:  done"
 
-echo "- isort: start" &&
-python -m isort --check-only --skip src/py/flwr/proto src/py/flwr &&
-echo "- isort: done" &&
+echo "- isort: start"
+python -m isort --check-only --skip src/py/flwr/proto src/py/flwr
+echo "- isort: done"
 
-echo "- black: start" &&
-python -m black --exclude "src\/py\/flwr\/proto" --check src/py/flwr &&
-echo "- black: done" &&
+echo "- black: start"
+python -m black --exclude "src\/py\/flwr\/proto" --check src/py/flwr
+echo "- black: done"
 
-echo "- init_py_check: start" &&
-python -m flwr_tool.init_py_check src/py/flwr src/py/flwr_tool &&
-echo "- init_py_check: done" &&
+echo "- init_py_check: start"
+python -m flwr_tool.init_py_check src/py/flwr src/py/flwr_tool
+echo "- init_py_check: done"
 
-echo "- docformatter: start" &&
-python -m docformatter -c -r src/py/flwr -e src/py/flwr/proto &&
-echo "- docformatter:  done" &&
+echo "- docformatter: start"
+python -m docformatter -c -r src/py/flwr -e src/py/flwr/proto
+echo "- docformatter:  done"
 
-echo "- ruff: start" &&
-python -m ruff check src/py/flwr &&
-echo "- ruff: done" &&
+echo "- ruff: start"
+python -m ruff check src/py/flwr
+echo "- ruff: done"
 
-echo "- mypy: start" &&
-python -m mypy src/py &&
-echo "- mypy: done" &&
+echo "- mypy: start"
+python -m mypy src/py
+echo "- mypy: done"
 
-echo "- pylint: start" &&
-python -m pylint --ignore=src/py/flwr/proto src/py/flwr &&
-echo "- pylint: done" &&
+echo "- pylint: start"
+python -m pylint --ignore=src/py/flwr/proto src/py/flwr
+echo "- pylint: done"
 
-echo "- flake8: start" &&
-python -m flake8 src/py/flwr &&
-echo "- flake8: done" &&
+echo "- flake8: start"
+python -m flake8 src/py/flwr
+echo "- flake8: done"
 
-echo "- pytest: start" &&
-python -m pytest --cov=src/py/flwr &&
-echo "- pytest: done" &&
+echo "- pytest: start"
+python -m pytest --cov=src/py/flwr
+echo "- pytest: done"
 
 echo "- All Python checks passed"
 
 echo "- Start Markdown checks"
 
-echo "- mdformat: start" &&
-python -m mdformat --check --number doc/source/tutorial examples &&
-echo "- mdformat: done" &&
+echo "- mdformat: start"
+python -m mdformat --check --number doc/source/tutorial examples
+echo "- mdformat: done"
 
 echo "- All Markdown checks passed"


### PR DESCRIPTION
## Issue
At the end of lines in test.sh there is always a `&&` symbol. It is redundant.

### Description
NA


### Related issues/PRs

NA

## Proposal
Remove `&&` from the end of the lines.

### Explanation

In Bash scripts, && is a logical AND operator.
It's used in the following way:
```
command1 && command2
```
It doesn't change the execution if applied as follows (no next command to be chained)
```
command1 &&
```

### Comments
I thought about it while creating the code equality tests for baselines by adapting this script.
