### PR TITLE
Update torch examples dependency versions

### DIFF
--- a/examples/advanced_pytorch/pyproject.toml
+++ b/examples/advanced_pytorch/pyproject.toml
@@ -12,8 +12,8 @@ authors = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.7"
-flwr = "^1.0.0"
-torch = "^1.12.0"
-torchvision = "^0.13.0"
+python = ">=3.8,<3.11"
+flwr = ">=1.0,<2.0"
+torch = "1.12.0"
+torchvision = "0.13.0"
 validators = "0.18.2"

--- a/examples/advanced_pytorch/requirements.txt
+++ b/examples/advanced_pytorch/requirements.txt
@@ -1,3 +1,4 @@
-flwr~=1.4.0
-torch~=2.0.1
-torchvision~=0.15.2
+flwr>=1.0, <2.0
+torch==1.12.0
+torchvision==0.13.0
+

--- a/examples/mt-pytorch/pyproject.toml
+++ b/examples/mt-pytorch/pyproject.toml
@@ -9,8 +9,8 @@ description = "Multi-Tenant Federated Learning with Flower and PyTorch"
 authors = ["The Flower Authors <hello@flower.dev>"]
 
 [tool.poetry.dependencies]
-python = "^3.7"
-flwr = { path = "../../", develop = true, extras = ["simulation", "rest"] }
-torch = "^1.12.0"
-torchvision = "^0.13.0"
-tqdm = "^4.63.0"
+python = ">=3.8,<3.11"
+flwr-nightly = {extras = ["rest", "simulation"], version = "^1.5.0.dev20230629"}
+torch = "1.12.0"
+torchvision = "0.13.0"
+tqdm = "4.65.0"

--- a/examples/mt-pytorch/requirements.txt
+++ b/examples/mt-pytorch/requirements.txt
@@ -1,4 +1,4 @@
-flwr~=1.4.0
-torch~=2.0.1
-torchvision~=0.15.2
-tqdm~=4.65.0
+flwr-nightly[simulation,rest]
+torch==1.12.0
+torchvision==0.13.0
+tqdm==4.65.0

--- a/examples/pytorch_federated_variational_autoencoder/pyproject.toml
+++ b/examples/pytorch_federated_variational_autoencoder/pyproject.toml
@@ -5,10 +5,10 @@ description = "Federated Variational Autoencoder Example"
 authors = ["The Flower Authors <hello@flower.dev>"]
 
 [tool.poetry.dependencies]
-python = "^3.8"
-flwr = "^1.0.0"
-torch = "^1.9.0"
-torchvision = "^0.10.0"
+python = ">=3.8,<3.11"
+flwr = ">=1.0,<2.0"
+torch = "1.12.0"
+torchvision = "0.13.0"
 
 [build-system]
 requires = ["poetry-core>=1.4.0"]

--- a/examples/pytorch_federated_variational_autoencoder/requirements.txt
+++ b/examples/pytorch_federated_variational_autoencoder/requirements.txt
@@ -1,3 +1,3 @@
-flwr~=1.4.0
-torch~=2.0.1
-torchvision~=0.15.2
+flwr>=1.0, <2.0
+torch==1.12.0
+torchvision==0.13.0

--- a/examples/pytorch_from_centralized_to_federated/pyproject.toml
+++ b/examples/pytorch_from_centralized_to_federated/pyproject.toml
@@ -9,7 +9,7 @@ description = "PyTorch: From Centralized To Federated with Flower"
 authors = ["The Flower Authors <hello@flower.dev>"]
 
 [tool.poetry.dependencies]
-python = "^3.7"
-flwr = "^1.0.0"
-torch = "^1.13.1"
-torchvision = "^0.14.1"
+python = ">=3.8,<3.11"
+flwr = ">=1.0,<2.0"
+torch = "1.12.0"
+torchvision = "0.13.0"

--- a/examples/pytorch_from_centralized_to_federated/requirements.txt
+++ b/examples/pytorch_from_centralized_to_federated/requirements.txt
@@ -1,4 +1,3 @@
-flwr~=1.4.0
-numpy~=1.21.1
-torch~=2.0.1
-torchvision~=0.15.2
+flwr>=1.0, <2.0
+torch==1.12.0
+torchvision==0.13.0

--- a/examples/quickstart_pytorch/pyproject.toml
+++ b/examples/quickstart_pytorch/pyproject.toml
@@ -9,8 +9,8 @@ description = "PyTorch Federated Learning Quickstart with Flower"
 authors = ["The Flower Authors <hello@flower.dev>"]
 
 [tool.poetry.dependencies]
-python = "^3.7"
-flwr = "^1.0.0"
-torch = "^1.12.0"
-torchvision = "^0.13.0"
-tqdm = "^4.63.0"
+python = ">=3.8,<3.11"
+flwr = ">=1.0,<2.0"
+torch = "1.12.0"
+torchvision = "0.13.0"
+tqdm = "4.65.0"

--- a/examples/quickstart_pytorch/requirements.txt
+++ b/examples/quickstart_pytorch/requirements.txt
@@ -1,4 +1,4 @@
-flwr~=1.4.0
-torch~=2.0.1
-torchvision~=0.15.2
-tqdm~=4.65.0
+flwr>=1.0, <2.0
+torch==1.12.0
+torchvision==0.13.0
+tqdm==4.65.0

--- a/examples/quickstart_pytorch_lightning/pyproject.toml
+++ b/examples/quickstart_pytorch_lightning/pyproject.toml
@@ -10,7 +10,7 @@ authors = ["The Flower Authors <hello@flower.dev>"]
 
 [tool.poetry.dependencies]
 python = "^3.7"
-flwr = "^1.0.0"
+flwr = ">=1.0,<2.0"
 # flwr = { path = "../../", develop = true }  # Development
-pytorch-lightning = "^1.4.7"
-torchvision = "^0.10.0"
+pytorch-lightning = "1.4.7"
+torchvision = "0.13.0"

--- a/examples/quickstart_pytorch_lightning/requirements.txt
+++ b/examples/quickstart_pytorch_lightning/requirements.txt
@@ -1,4 +1,3 @@
-flwr~=1.4.0
-pytorch_lightning~=2.0.2
-torch~=2.0.1
-torchvision~=0.15.2
+flwr>=1.0, <2.0
+pytorch_lightning>=1.4.7
+torchvision==0.13.0

--- a/examples/simulation_pytorch/pyproject.toml
+++ b/examples/simulation_pytorch/pyproject.toml
@@ -12,4 +12,4 @@ authors = ["The Flower Authors <hello@flower.dev>"]
 python = ">=3.8,<3.11"
 flwr = {version = ">=1.0,<2.0", extras = ["simulation"]}
 torch = "=1.12.0"
-torchvision = "=0.13.0"
+torchvision = "0.13.0"

--- a/examples/simulation_pytorch/pyproject.toml
+++ b/examples/simulation_pytorch/pyproject.toml
@@ -9,7 +9,7 @@ description = "Federated Learning Simulation with Flower and PyTorch"
 authors = ["The Flower Authors <hello@flower.dev>"]
 
 [tool.poetry.dependencies]
-python = "^3.7"
-flwr = { extras = ["simulation"], version = "^1.0.0" }
-torch = "^1.13.1"
-torchvision = "^0.13.0"
+python = ">=3.8,<3.11"
+flwr = {version = ">=1.0,<2.0", extras = ["simulation"]}
+torch = ">=1.12.0"
+torchvision = ">=0.13.0"

--- a/examples/simulation_pytorch/pyproject.toml
+++ b/examples/simulation_pytorch/pyproject.toml
@@ -11,5 +11,5 @@ authors = ["The Flower Authors <hello@flower.dev>"]
 [tool.poetry.dependencies]
 python = ">=3.8,<3.11"
 flwr = {version = ">=1.0,<2.0", extras = ["simulation"]}
-torch = ">=1.12.0"
-torchvision = ">=0.13.0"
+torch = "=1.12.0"
+torchvision = "=0.13.0"

--- a/examples/simulation_pytorch/requirements.txt
+++ b/examples/simulation_pytorch/requirements.txt
@@ -1,3 +1,3 @@
 flwr[simulation]>=1.0, <2.0
-torch>=1.12.0
-torchvision>=0.13.0
+torch==1.12.0
+torchvision==0.13.0

--- a/examples/simulation_pytorch/requirements.txt
+++ b/examples/simulation_pytorch/requirements.txt
@@ -1,6 +1,3 @@
-flwr~=1.4.0
-numpy~=1.21.1
-Pillow~=9.5.0
-ray~=2.4.0
-torch~=2.0.1
-torchvision~=0.15.2
+flwr[simulation]>=1.0, <2.0
+torch>=1.12.0
+torchvision>=0.13.0


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->

There are some inconsistencies with the examples that uses pytorch as its dependencies, resulting in error when poetry tries to resolve the dependencies. One example is the torchvision dependency requires newer torch version then the specified version in pyproject.toml file.

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->
Helps to fix #1980.

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

Following changes in pyproject.toml and requirements.txt are made to the examples that uses pytorch as its dependencies:
1. Fix torch version to 1.12.0 and torchvision to 0.13.0
2. Opacus' and embedded device's pytorch version are not changed.
3. Fix python version to >=3.8, <3.11.
4. ^ on other dependencies are removed.
5. Flwr local dependency path is changed to the latest flwr-nightly version.
6. Flwr version is fixed to >=1.0, <2.0.

### Checklist

- [x] Implement proposed change
- [x] Make CI checks pass

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.dev/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
