### PR TITLE
Fix Baselines CI PyLint error by using Resampling

### DIFF
--- a/baselines/flwr_baselines/flwr_baselines/publications/leaf/femnist/dataset/nist_preprocessor.py
+++ b/baselines/flwr_baselines/flwr_baselines/publications/leaf/femnist/dataset/nist_preprocessor.py
@@ -188,7 +188,7 @@ class NISTPreprocessor:
             file_path = row["path_by_writer"]
             img = Image.open(file_path)
             gray = img.convert("L")
-            gray.thumbnail(resized_size, Image.LANCZOS)
+            gray.thumbnail(resized_size, Image.Resampling.LANCZOS)
             writer_id = row["writer_id"]
             character = row["character"]
             if writer_id not in writer_to_character_to_count:


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

The CI was failing because of the following PyLint error in Baselines: `E1101: Module 'PIL.Image' has no 'LANCZOS' member (no-member)`.

### Related issues/PRs

N/A

## Proposal

### Explanation

Use `PIL.Image.Resampling.LANCZOS` instead of `PIL.Image.LANCZOS`.

### Checklist

- [x] Implement proposed change
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

N/A
