### PR TITLE
Fix simulation error caused by Pydantic version in Ray

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ importlib-metadata = { version = "^4.0.0", markers = "python_version < '3.8'" }
 iterators = "^0.0.2"
 # Optional dependencies (VCE)
 ray = { version = "==2.5.1", extras = ["default"], optional = true }
+pydantic = { version = "<2.0.0", optional = true }
 # Optional dependencies (REST transport layer)
 requests = { version = "^2.28.2", optional = true }
 fastapi = { version = "^0.95.0", optional = true }
@@ -66,7 +67,7 @@ starlette = { version = "^0.27.0", optional = true }
 uvicorn = { version = "^0.21.1", extras = ["standard"], optional = true }
 
 [tool.poetry.extras]
-simulation = ["ray"]
+simulation = ["ray", "pydantic"]
 rest = ["fastapi", "requests", "starlette", "uvicorn"]
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

Simulations currently crash with the latest version of the packages. This is caused by a `pydantic` error from `ray`.

### Related issues/PRs

#1974 

## Proposal

### Explanation

Fix the `pydantic` version to `<2.0.0` as described [here](https://github.com/ray-project/ray/pull/37000).

### Checklist

- [x] Implement proposed change
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

N/A
