### PR TITLE
Fix baseline creation on linux-base systems

### DIFF
--- a/baselines/dev/create-baseline.sh
+++ b/baselines/dev/create-baseline.sh
@@ -21,5 +21,10 @@ mv $name/$template $name/$name
 
 # adjusting package name in pyproject.toml
 cd $name
-sed -i '' -e "s/<BASELINE_NAME>/$name/" pyproject.toml
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  sed -i '' -e "s/<BASELINE_NAME>/$name/" pyproject.toml
+else
+  sed -i -e "s/<BASELINE_NAME>/$name/" pyproject.toml
+fi
+
 echo "!!! Your directory for your baseline '$name' is ready."


### PR DESCRIPTION
## Issue

### Description
The create-baseline script doesn't fully work on Linux. It leads to `sed: can't read : No such file or directory` on linux - it doesn't change the name in pyproject.toml. 


### Related issues/PRs

NA

## Proposal

### Explanation

The sed works slightly differently on Mac and Linux. The fix causes the script to work differently on Linux and Mac.
