### PR TITLE
Fix flake8 error E266 in baseline template

### DIFF
--- a/baselines/baseline_template/baseline_template/main.py
+++ b/baselines/baseline_template/baseline_template/main.py
@@ -18,10 +18,10 @@ def main(cfg: DictConfig) -> None:
     cfg : DictConfig
         An omegaconf object that stores the hydra config.
     """
-    ## 1. Print parsed config
+    # 1. Print parsed config
     print(OmegaConf.to_yaml(cfg))
 
-    ## 2. Prepare your dataset
+    # 2. Prepare your dataset
     # here you should call a function in datasets.py that returns whatever is needed to:
     # (1) ensure the server can access the dataset used to evaluate your model after
     # aggregation
@@ -29,20 +29,20 @@ def main(cfg: DictConfig) -> None:
     # be a location in the file system, a list of dataloader, a list of ids to extract
     # from a dataset, it's up to you)
 
-    ## 3. Define your clients
+    # 3. Define your clients
     # Define a function that returns another function that will be used during
     # simulation to instantiate each individual client
     # client_fn = client.<my_function_that_returns_a_function>()
 
-    ## 4. Define your strategy
+    # 4. Define your strategy
     # pass all relevant argument (including the global dataset used after aggregation,
     # if needed by your method.)
     # strategy = instantiate(cfg.strategy, <additional arguments if desired>)
 
-    ## 5. Start Simulation
+    # 5. Start Simulation
     # history = fl.simulation.start_simulation(<arguments for simulation>)
 
-    ## 6. Save your results
+    # 6. Save your results
     # Here you can save the `history` returned by the simulation and include
     # also other buffers, statistics, info needed to be saved in order to later
     # on generate the plots you provide in the README.md. You can for instance


### PR DESCRIPTION
## Issue

### Description

Currently, the baseline template fails flake8 check:  `E266 too many leading '#' for block comment`

## Proposal
Remove double ## in main.py.
## Explanation
In order to introduce the flake8 tests the current code should meet its standards.
