### PR TITLE
Update bare E2E test client

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -78,6 +78,7 @@ jobs:
 
   bare:
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python
@@ -94,7 +95,7 @@ jobs:
         run: |
           cd e2e/bare
           python -m poetry install
-      - name: Run tests
+      - name: Run edge client test
         run: |
           cd e2e/bare
           ./test.sh

--- a/e2e/bare/client.py
+++ b/e2e/bare/client.py
@@ -23,6 +23,6 @@ class FlowerClient(fl.client.NumPyClient):
         accuracy = 1 - loss
         return loss, 1, {"accuracy": accuracy}
 
-
-# Start Flower client
-fl.client.start_numpy_client(server_address="127.0.0.1:8080", client=FlowerClient())
+if __name__ == "__main__":
+    # Start Flower client
+    fl.client.start_numpy_client(server_address="127.0.0.1:8080", client=FlowerClient())


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

The bare E2E test needs to be updated to work with simulation.

### Related issues/PRs

#1974 

## Proposal

### Explanation

Only trigger training when the `client.py` file is called directly.

### Checklist

- [x] Implement proposed change
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

N/A