### PR TITLE
Use latest versions of frameworks for E2E testing

### DIFF
--- a/e2e/jax/pyproject.toml
+++ b/e2e/jax/pyproject.toml
@@ -7,10 +7,10 @@ authors = ["The Flower Authors <hello@flower.dev>"]
 [tool.poetry.dependencies]
 python = "^3.8"
 flwr = { path = "../../", develop = true, extras = ["simulation"] }
-jax = "^0.4.0"
-jaxlib = "^0.4.0"
-scikit-learn = "^1.1.1"
-numpy = "^1.21.4"
+jax = "*"
+jaxlib = "*"
+scikit-learn = "*"
+numpy = "*"
 
 [build-system]
 requires = ["poetry-core>=1.4.0"]

--- a/e2e/mxnet/pyproject.toml
+++ b/e2e/mxnet/pyproject.toml
@@ -12,4 +12,4 @@ authors = ["The Flower Authors <hello@flower.dev>"]
 python = "^3.8"
 flwr = { path = "../../", develop = true, extras = ["simulation"] }
 mxnet = "*"
-numpy = "*"
+numpy = "1.23.1"

--- a/e2e/mxnet/pyproject.toml
+++ b/e2e/mxnet/pyproject.toml
@@ -11,5 +11,5 @@ authors = ["The Flower Authors <hello@flower.dev>"]
 [tool.poetry.dependencies]
 python = "^3.8"
 flwr = { path = "../../", develop = true, extras = ["simulation"] }
-mxnet = "^1.7.0"
-numpy = "1.23.1"
+mxnet = "*"
+numpy = "*"

--- a/e2e/pandas/pyproject.toml
+++ b/e2e/pandas/pyproject.toml
@@ -12,6 +12,6 @@ maintainers = ["The Flower Authors <hello@flower.dev>"]
 [tool.poetry.dependencies]
 python = "^3.8"
 flwr = { path = "../../", develop = true, extras = ["simulation"] }
-numpy = "^1.21.0"
-pandas = "^2.0.0"
-scikit-learn = "^1.1.1"
+numpy = "*"
+pandas = "*"
+scikit-learn = "*"

--- a/e2e/pytorch/pyproject.toml
+++ b/e2e/pytorch/pyproject.toml
@@ -11,6 +11,6 @@ authors = ["The Flower Authors <hello@flower.dev>"]
 [tool.poetry.dependencies]
 python = "^3.7"
 flwr = { path = "../../", develop = true, extras = ["simulation"] }
-torch = "^1.12.0"
-torchvision = "^0.13.0"
-tqdm = "^4.63.0"
+torch = "*"
+torchvision = "*"
+tqdm = "*"

--- a/e2e/scikit-learn/pyproject.toml
+++ b/e2e/scikit-learn/pyproject.toml
@@ -14,5 +14,5 @@ authors = [
 [tool.poetry.dependencies]
 python = "^3.8"
 flwr = { path = "../../", develop = true, extras = ["simulation"] }
-scikit-learn = "^1.1.1"
-openml = "^0.12.2"
+scikit-learn = "*"
+openml = "*"

--- a/e2e/tensorflow/pyproject.toml
+++ b/e2e/tensorflow/pyproject.toml
@@ -11,4 +11,4 @@ authors = ["The Flower Authors <hello@flower.dev>"]
 [tool.poetry.dependencies]
 python = ">=3.7,<3.11"
 flwr = { path = "../../", develop = true, extras = ["simulation"] }
-tensorflow-cpu = "^2.9.1, !=2.11.1"
+tensorflow-cpu = "*"


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

It might be useful to see if some versions of the framework we work with fail our tests.

### Related issues/PRs

N/A

## Proposal

### Explanation

Use the latest version of the framework we test from end to end.

### Checklist

- [x] Implement proposed change
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

N/A
