### PR TITLE
Exclude baselines/doc from tests in CI

### DIFF
--- a/.github/workflows/baselines.yml
+++ b/.github/workflows/baselines.yml
@@ -54,7 +54,13 @@ jobs:
             # Pull request event triggered for any commit to a pull request
             change_references="main..HEAD"
           fi
-          dirs=$(git diff --dirstat=files,0 ${change_references} . | awk '{print $2}' | grep -E '^baselines/[^/]*/$' | grep -v -e '^baselines/dev' -e '^baselines/baseline_template' -e '^baselines/flwr_baselines' -e '^baselines/doc' | sed 's/^baselines\///')
+          dirs=$(git diff --dirstat=files,0 ${change_references} . | awk '{print $2}' | grep -E '^baselines/[^/]*/$' | \
+          grep -v \
+            -e '^baselines/dev' \
+            -e '^baselines/baseline_template' \
+            -e '^baselines/flwr_baselines' \
+            -e '^baselines/doc' \
+          | sed 's/^baselines\///')
           # git diff --dirstat=files,0 ${change_references} . - checks the differences
           #   and a file is counted as changed if more than 0 lines were changed
           #   it returns the results in the format x.y% path/to/dir/

--- a/.github/workflows/baselines.yml
+++ b/.github/workflows/baselines.yml
@@ -54,7 +54,7 @@ jobs:
             # Pull request event triggered for any commit to a pull request
             change_references="main..HEAD"
           fi
-          dirs=$(git diff --dirstat=files,0 ${change_references} . | awk '{print $2}' | grep -E '^baselines/[^/]*/$' | grep -v -e '^baselines/dev' -e '^baselines/baseline_template' -e '^baselines/flwr_baselines' | sed 's/^baselines\///')
+          dirs=$(git diff --dirstat=files,0 ${change_references} . | awk '{print $2}' | grep -E '^baselines/[^/]*/$' | grep -v -e '^baselines/dev' -e '^baselines/baseline_template' -e '^baselines/flwr_baselines' -e '^baselines/doc' | sed 's/^baselines\///')
           # git diff --dirstat=files,0 ${change_references} . - checks the differences
           #   and a file is counted as changed if more than 0 lines were changed
           #   it returns the results in the format x.y% path/to/dir/


### PR DESCRIPTION
## Issue

### Description

The new directory `doc` in `baselines` makes the pipeline fail.
### Related PRs
https://github.com/adap/flower/pull/2060 (it makes this change fail the tests)

## Proposal
Exclude the `baseline/doc` from checks.

### Explanation
The check didn't take into account the possibility of new directories, therefore it's detected as a change and then the tests fail. This solves it by excluding this directory therefore no changes should be detected.