### PR TITLE
Add dependabot to E2E tests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,39 @@ updates:
       - dependency-name: "mypy-protobuf"
       - dependency-name: "types-protobuf"
     open-pull-requests-limit: 3
+
+  - package-ecosystem: "pip"
+    directory: "/e2e/pytorch"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 2
+
+  - package-ecosystem: "pip"
+    directory: "/e2e/tensorflow"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 2
+
+  - package-ecosystem: "pip"
+    directory: "/e2e/mxnet"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 2
+
+  - package-ecosystem: "pip"
+    directory: "/e2e/jax"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 2
+
+  - package-ecosystem: "pip"
+    directory: "/e2e/pandas"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 2
+
+  - package-ecosystem: "pip"
+    directory: "/e2e/scikit-learn"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 2


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

We would like to have the latest versions of frameworks tested with E2E tests.

### Related issues/PRs

#2078 

## Proposal

### Explanation

Add dependabot to E2E tests.

### Checklist

- [x] Implement proposed change
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

N/A
