### PR TITLE
Add fastai E2E test

### DIFF
--- a/e2e/fastai/README.md
+++ b/e2e/fastai/README.md
@@ -1,0 +1,5 @@
+# Flower with FastAI testing
+
+This directory is used for testing Flower with FastAI by using a simple MNIST recognition task.
+
+It uses the `FedAvg` strategy.

--- a/e2e/fastai/client.py
+++ b/e2e/fastai/client.py
@@ -1,0 +1,49 @@
+import warnings
+from collections import OrderedDict
+
+import torch
+from fastai.vision.all import *
+
+import flwr as fl
+
+
+warnings.filterwarnings("ignore", category=UserWarning)
+
+# Download MNIST dataset
+path = untar_data(URLs.MNIST)
+
+# Load dataset
+dls = ImageDataLoaders.from_folder(
+    path, valid_pct=0.5, train="training", valid="testing"
+)
+
+# Define model
+learn = vision_learner(dls, squeezenet1_1, metrics=error_rate)
+
+
+# Define Flower client
+class FlowerClient(fl.client.NumPyClient):
+    def get_parameters(self, config):
+        return [val.numpy() for _, val in learn.model.state_dict().items()]
+
+    def set_parameters(self, parameters):
+        params_dict = zip(learn.model.state_dict().keys(), parameters)
+        state_dict = OrderedDict({k: torch.tensor(v) for k, v in params_dict})
+        learn.model.load_state_dict(state_dict, strict=True)
+
+    def fit(self, parameters, config):
+        self.set_parameters(parameters)
+        learn.fit(1)
+        return self.get_parameters(config={}), len(dls.train), {}
+
+    def evaluate(self, parameters, config):
+        self.set_parameters(parameters)
+        loss, error_rate = learn.validate()
+        return loss, len(dls.valid), {"accuracy": 1 - error_rate}
+
+
+# Start Flower client
+fl.client.start_numpy_client(
+    server_address="127.0.0.1:8080",
+    client=FlowerClient(),
+)

--- a/e2e/fastai/pyproject.toml
+++ b/e2e/fastai/pyproject.toml
@@ -1,0 +1,14 @@
+[build-system]
+requires = ["poetry-core>=1.4.0"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.poetry]
+name = "quickstart_fastai"
+version = "0.1.0"
+description = "Fastai Federated Learning E2E test with Flower"
+authors = ["The Flower Authors <hello@flower.dev>"]
+
+[tool.poetry.dependencies]
+python = ">=3.7,<3.10"
+flwr = "^1.0.0"
+fastai = "^2.7.10"

--- a/e2e/fastai/server.py
+++ b/e2e/fastai/server.py
@@ -1,0 +1,7 @@
+import flwr as fl
+
+hist = fl.server.start_server(
+    server_address="0.0.0.0:8080",
+    config=fl.server.ServerConfig(num_rounds=3),
+)
+assert (hist.losses_distributed[0][1] / hist.losses_distributed[-1][1]) >= 1

--- a/e2e/fastai/simulation.py
+++ b/e2e/fastai/simulation.py
@@ -1,0 +1,14 @@
+import flwr as fl
+
+from client import FlowerClient
+
+def client_fn(cid):
+    _ = cid
+    return FlowerClient()
+
+hist = fl.simulation.start_simulation(
+    client_fn=client_fn,
+    num_clients=2,
+    config=fl.server.ServerConfig(num_rounds=3),
+)
+assert (hist.losses_distributed[0][1] / hist.losses_distributed[-1][1]) > 0.98


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

There is no E2E test for the `fastai` framework.

### Related issues/PRs

N/A

## Proposal

### Explanation

Add E2E test for `fastai`.

### Checklist

- [x] Implement proposed change
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

N/A
