### PR TITLE
Fix quickstart-fastai example

### DIFF
--- a/examples/quickstart_fastai/client.py
+++ b/examples/quickstart_fastai/client.py
@@ -14,7 +14,7 @@ path = untar_data(URLs.MNIST)
 
 # Load dataset
 dls = ImageDataLoaders.from_folder(
-    path, valid_pct=0.5, train="training", valid="testing"
+    path, valid_pct=0.5, train="training", valid="testing", num_workers=0
 )
 
 # Define model
@@ -24,7 +24,7 @@ learn = vision_learner(dls, squeezenet1_1, metrics=error_rate)
 # Define Flower client
 class FlowerClient(fl.client.NumPyClient):
     def get_parameters(self, config):
-        return [val.numpy() for _, val in learn.model.state_dict().items()]
+        return [val.cpu().numpy() for _, val in learn.model.state_dict().items()]
 
     def set_parameters(self, parameters):
         params_dict = zip(learn.model.state_dict().keys(), parameters)


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

The `quickstart_fastai` example could have some issues depending on the hardware used to run it.

### Related issues/PRs

N/A

## Proposal

### Explanation

Disable parallelism for the data loading and use `cpu()` before converting tensor to numpy. 

### Checklist

- [x] Implement proposed change
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

N/A
