### PR TITLE
Rename docs building job and remove unused envs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,11 +23,7 @@ jobs:
         run: sudo apt install pandoc
       - name: Install dependencies (mandatory only)
         run: python -m poetry install --extras "simulation"
-      - name: Build and deploy docs
-        env:
-          AWS_DEFAULT_REGION: ${{ secrets. AWS_DEFAULT_REGION }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets. AWS_SECRET_ACCESS_KEY }}
+      - name: Build docs
         run: ./dev/build-docs.sh
 
   deploy_docs:


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

Some environment variables are declared for the docs building job but never used inside. Also the job is misleadingly named "Build and Deploy docs", whereas it only builds.

### Related issues/PRs

N/A

## Proposal

### Explanation

- Remove the unused env variables
- Rename job to "Build docs"

### Checklist

- [x] Implement proposed change
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

N/A
