### PR TITLE
Revert "Update numpy requirement from 1.23.1 to 1.24.4 in /e2e/mxnet"

### DIFF
--- a/e2e/mxnet/pyproject.toml
+++ b/e2e/mxnet/pyproject.toml
@@ -12,4 +12,4 @@ authors = ["The Flower Authors <hello@flower.dev>"]
 python = "^3.8"
 flwr = { path = "../../", develop = true, extras = ["simulation"] }
 mxnet = "^1.7.0"
-numpy = "1.24.4"
+numpy = "1.23.1"


### PR DESCRIPTION
Reverts adap/flower#2085

This actually breaks `mxnet` I think this was able to be merged because the E2E tests are not set as required.