### PR TITLE
Remove `numpy` from dependabot's `mxnet` check

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,9 @@ updates:
     directory: "/e2e/mxnet"
     schedule:
       interval: "daily"
+    ignore:
+      # Ignore updates from certain packages
+      - dependency-name: "numpy"
     open-pull-requests-limit: 2
 
   - package-ecosystem: "pip"


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

Dependabot was opening PRs for updating the NumPy version of the MXNet E2E example eventhough this breaks MXNet.

### Related issues/PRs

N/A

## Proposal

### Explanation

Exclude `numpy` from those checks.

### Checklist

- [x] Implement proposed change
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

N/A
