### PR TITLE
Make Flake8 compatible with Black

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,6 @@
 [flake8]
 max-line-length = 88
 exclude = src/py/flwr/proto
-ignore = E302,W503
+ignore = E302,W503,E203
 per-file-ignores =
     src/py/flwr/server/strategy/*.py:E501


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

Black and Flake8 were incompatible due to E203. 

### Related issues/PRs

N/A

## Proposal

### Explanation

Ignore E203 in the Flake8 config.

### Checklist

- [x] Implement proposed change
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

N/A
