### PR TITLE
Remove SciKit-Learn E2E test from CI

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -54,10 +54,10 @@ jobs:
               import mxnet as mx
               mx.test_utils.get_mnist()
 
-          - directory: scikit-learn
-            dataset: |
-              import openml
-              openml.datasets.get_dataset(554)
+          # - directory: scikit-learn
+          #   dataset: |
+          #     import openml
+          #     openml.datasets.get_dataset(554)
 
           - directory: fastai
             dataset: |


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

The Scikit-Learn E2E test breaks the CI due to this issue: https://github.com/openml/OpenML/issues/1196.

### Related issues/PRs

#2142 Reverts this change

## Proposal

### Explanation

Remove it temporarily.

### Checklist

- [x] Implement proposed change
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

N/A
