### PR TITLE
Make examples' titles more consistent

### DIFF
--- a/examples/quickstart-pytorch-lightning/README.md
+++ b/examples/quickstart-pytorch-lightning/README.md
@@ -1,1 +1,1 @@
-# Quickstart PyTorch Lightning example
+# Flower Examples using PyTorch Lightning

--- a/examples/simulation-pytorch/README.md
+++ b/examples/simulation-pytorch/README.md
@@ -1,4 +1,4 @@
-# example_simulation_ray
+# Flower Simulation example using PyTorch
 
 This code splits CIFAR-10 dataset into `pool_size` partitions (user defined) and does a few rounds of CIFAR-10 training. In this example, we leverage [`Ray`](https://docs.ray.io/en/latest/index.html) to simulate Flower Clients participating in FL rounds in an resource-aware fashion. This is possible via the [`RayClientProxy`](https://github.com/adap/flower/blob/main/src/py/flwr/simulation/ray_transport/ray_client_proxy.py) which bridges a standard Flower server with standard Flower clients while excluding the gRPC communication protocol and the Client Manager in favour of Ray's scheduling and communication layers.
 

--- a/examples/simulation-tensorflow/README.md
+++ b/examples/simulation-tensorflow/README.md
@@ -1,4 +1,4 @@
-# EXPERIMENTAL Flower Simulation Example using TensorFlow/Keras
+# Flower Simulation example using TensorFlow/Keras
 
 This introductory example uses the simulation capabilities of Flower to simulate a large number of clients on either a single machine of a cluster of machines.
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

Some examples' titles were inconsistent with the rest.

### Related issues/PRs

#2133 

## Proposal

### Explanation

Use better titles for some examples.

### Checklist

- [x] Implement proposed change
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

N/A
