### PR TITLE
Fix TensorFlow on windows install

### DIFF
--- a/e2e/tabnet/pyproject.toml
+++ b/e2e/tabnet/pyproject.toml
@@ -11,7 +11,7 @@ authors = ["The Flower Authors <hello@flower.dev>"]
 [tool.poetry.dependencies]
 python = ">=3.8,<3.11"
 flwr = { path = "../../", develop = true, extras = ["simulation"] }
-tensorflow-cpu = {version = ">=2.9.1,<2.11.1 || >2.11.1", markers = "platform_machine == \"x86_64\""}
+tensorflow-cpu = {version = ">=2.9.1,<2.11.1 || >2.11.1", markers = "(sys_platform == \"darwin\" and platform_machine == \"x86_64\") or sys_platform == \"linux\" or sys_platform == \"win32\""}
 tensorflow-macos = {version = ">=2.9.1,<2.11.1 || >2.11.1", markers = "sys_platform == \"darwin\" and platform_machine == \"arm64\""}
 tensorflow_datasets = "4.9.2"
 tabnet = "0.1.6"

--- a/examples/advanced-tensorflow/pyproject.toml
+++ b/examples/advanced-tensorflow/pyproject.toml
@@ -11,5 +11,5 @@ authors = ["The Flower Authors <hello@flower.dev>"]
 [tool.poetry.dependencies]
 python = ">=3.8,<3.11"
 flwr = ">=1.0,<2.0"
-tensorflow-cpu = {version = ">=2.9.1,<2.11.1 || >2.11.1", markers = "platform_machine == \"x86_64\""}
+tensorflow-cpu = {version = ">=2.9.1,<2.11.1 || >2.11.1", markers = "(sys_platform == \"darwin\" and platform_machine == \"x86_64\") or sys_platform == \"linux\" or sys_platform == \"win32\""}
 tensorflow-macos = {version = ">=2.9.1,<2.11.1 || >2.11.1", markers = "sys_platform == \"darwin\" and platform_machine == \"arm64\""}

--- a/examples/android/pyproject.toml
+++ b/examples/android/pyproject.toml
@@ -12,5 +12,5 @@ authors = ["The Flower Authors <hello@flower.dev>"]
 python = ">=3.8,<3.11"
 # flwr = { path = "../../", develop = true }  # Development
 flwr = ">=1.0,<2.0"
-tensorflow-cpu = {version = ">=2.9.1,<2.11.1 || >2.11.1", markers = "platform_machine == \"x86_64\""}
+tensorflow-cpu = {version = ">=2.9.1,<2.11.1 || >2.11.1", markers = "(sys_platform == \"darwin\" and platform_machine == \"x86_64\") or sys_platform == \"linux\" or sys_platform == \"win32\""}
 tensorflow-macos = {version = ">=2.9.1,<2.11.1 || >2.11.1", markers = "sys_platform == \"darwin\" and platform_machine == \"arm64\""}

--- a/examples/dp-sgd-mnist/pyproject.toml
+++ b/examples/dp-sgd-mnist/pyproject.toml
@@ -15,6 +15,6 @@ authors = [
 python = ">=3.8,<3.11"
 # flwr = { path = "../../", develop = true }  # Development
 flwr = ">=1.0,<2.0"
-tensorflow-cpu = {version = ">=2.9.1,<2.11.1 || >2.11.1", markers = "platform_machine == \"x86_64\""}
+tensorflow-cpu = {version = ">=2.9.1,<2.11.1 || >2.11.1", markers = "(sys_platform == \"darwin\" and platform_machine == \"x86_64\") or sys_platform == \"linux\" or sys_platform == \"win32\""}
 tensorflow-macos = {version = ">=2.9.1,<2.11.1 || >2.11.1", markers = "sys_platform == \"darwin\" and platform_machine == \"arm64\""}
 tensorflow-privacy = "0.8.10"

--- a/examples/quickstart-mlcube/pyproject.toml
+++ b/examples/quickstart-mlcube/pyproject.toml
@@ -11,7 +11,7 @@ authors = ["The Flower Authors <hello@flower.dev>"]
 [tool.poetry.dependencies]
 python = ">=3.8,<3.11"
 flwr = ">=1.0,<2.0"  # For development: { path = "../../", develop = true }
-tensorflow-cpu = {version = ">=2.9.1,<2.11.1 || >2.11.1", markers = "platform_machine == \"x86_64\""}
+tensorflow-cpu = {version = ">=2.9.1,<2.11.1 || >2.11.1", markers = "(sys_platform == \"darwin\" and platform_machine == \"x86_64\") or sys_platform == \"linux\" or sys_platform == \"win32\""}
 tensorflow-macos = {version = ">=2.9.1,<2.11.1 || >2.11.1", markers = "sys_platform == \"darwin\" and platform_machine == \"arm64\""}
 mlcube = "0.0.8"
 mlcube-docker = "0.0.8"

--- a/examples/quickstart-tabnet/pyproject.toml
+++ b/examples/quickstart-tabnet/pyproject.toml
@@ -11,7 +11,7 @@ authors = ["The Flower Authors <hello@flower.dev>"]
 [tool.poetry.dependencies]
 python = ">=3.8,<3.11"
 flwr = ">=1.0,<2.0"
-tensorflow-cpu = {version = ">=2.9.1,<2.11.1 || >2.11.1", markers = "platform_machine == \"x86_64\""}
+tensorflow-cpu = {version = ">=2.9.1,<2.11.1 || >2.11.1", markers = "(sys_platform == \"darwin\" and platform_machine == \"x86_64\") or sys_platform == \"linux\" or sys_platform == \"win32\""}
 tensorflow-macos = {version = ">=2.9.1,<2.11.1 || >2.11.1", markers = "sys_platform == \"darwin\" and platform_machine == \"arm64\""}
 tensorflow_datasets = "4.8.3"
 tabnet = "0.1.6"

--- a/examples/quickstart-tensorflow/pyproject.toml
+++ b/examples/quickstart-tensorflow/pyproject.toml
@@ -11,5 +11,5 @@ authors = ["The Flower Authors <hello@flower.dev>"]
 [tool.poetry.dependencies]
 python = ">=3.8,<3.11"
 flwr = ">=1.0,<2.0"
-tensorflow-cpu = {version = ">=2.9.1,<2.11.1 || >2.11.1", markers = "platform_machine == \"x86_64\""}
+tensorflow-cpu = {version = ">=2.9.1,<2.11.1 || >2.11.1", markers = "(sys_platform == \"darwin\" and platform_machine == \"x86_64\") or sys_platform == \"linux\" or sys_platform == \"win32\""}
 tensorflow-macos = {version = ">=2.9.1,<2.11.1 || >2.11.1", markers = "sys_platform == \"darwin\" and platform_machine == \"arm64\""}


### PR DESCRIPTION
## Issue
A user from Slack reported a problem when using an example on Windows.

### Description
The specification for the tensorflow in the example of quickstart-tabnet in pyproject toml didn't include windows.

## Proposal
Change the markers for tensorflow-cpu in the tensorflow examples. 

### Explanation
It was tested on M1 Mac, Intel Mac and Linux. I tried on my old Windows too, but regardless of the version I am not able to install tit here tensorflow via poetry due to 
"Unable to find installation candidates for tensorflow-io-gcs-filesystem (0.32.0)". So, it's not proven to work on Windows but on that Windows, nothing didn't work. It should work theoretically and it doesn't break Mac and Linux that worked previously;.