### PR TITLE
Add flwr-datasets samplers

### DIFF
--- a/datasets/flwr_datasets/sampler.py
+++ b/datasets/flwr_datasets/sampler.py
@@ -1,0 +1,213 @@
+from typing import Optional, Union, List, Dict
+import datasets
+from abc import ABC, abstractmethod
+import numpy as np
+from datasets import Dataset, DatasetDict
+
+
+class Sampler(ABC):
+    # does it make a difference if it should work on only the references
+    # or also on the data
+    def __init__(
+            self,
+            n_partitions: Optional[int] = None,
+            partition_size: Optional[int] = None,
+            partition_by: Optional[str] = None,
+    ):
+        # self.dataset = dataset
+        self._n_partitions = n_partitions
+        self._partition_size = partition_size
+        self._partition_by = partition_by
+
+    def _determine_n_partitions(self, dataset):
+        dataset_length = dataset.num_rows
+        # The remainder is taken care of, document it
+        self._n_partitions = dataset_length // self._partition_size
+
+    @abstractmethod
+    def get_partition(self, dataset,
+                      partition_index: Union[int, str]) -> datasets.Dataset:
+        pass
+
+    @abstractmethod
+    def get_partitions(self, dataset) -> List[datasets.Dataset]:
+        raise NotImplementedError
+
+    # This methods might be needed for all in samplers in order to provide
+    # reproducibility
+    # def create_partition_references(
+    #         self, indices, labels, sampler
+    # ) -> List[List[int]]:  # or map of lists ?
+    #
+    # def save_partition_references(self):
+    #     pass
+
+
+class CIDSampler(Sampler):  # or Natural Division Sampler
+    def __init__(
+            self,
+            # dataset: datasets.Dataset,
+            n_partitions: Optional[int] = None,
+            partition_size: Optional[int] = None,
+            partition_by: Optional[str] = None
+    ):
+        super().__init__(n_partitions, partition_size, partition_by)
+        self._index_to_cid: Dict[int, str] = {}
+
+    def _create_int_idx_to_cid(self, dataset):
+        unique_cid = dataset.unique(self._partition_by)
+        index_to_cid = {index: cid for index, cid in
+                        zip(range(len(unique_cid)), unique_cid)}
+        self._index_to_cid = index_to_cid
+
+    def get_partition(self, dataset, partition_index) -> datasets.Dataset:
+        if self._n_partitions is None:
+            self._determine_n_partitions(dataset)
+        if len(self._index_to_cid) == 0:
+            self._create_int_idx_to_cid(dataset)
+        if self._n_partitions is None:
+            self._n_partitions = len(self._index_to_cid)
+        return dataset.filter(
+            lambda row: row[self._partition_by] == self._index_to_cid[partition_index])
+
+    def get_partitions(self, dataset) -> List[datasets.Dataset]:
+        if self._n_partitions is None:
+            self._determine_n_partitions(dataset)
+        if len(self._index_to_cid) == 0:
+            self._create_int_idx_to_cid(dataset)
+        if self._n_partitions is None:
+            self._n_partitions = len(self._index_to_cid)
+        partitions = []
+        for partition_index in range(self._n_partitions):
+            partitions.append(self.get_partition(dataset, partition_index))
+        return partitions
+
+
+class IIDSampler(Sampler):
+    def __init__(
+            self,
+            # dataset: datasets.Dataset,
+            n_partitions: Optional[int] = None,
+            partition_size: Optional[int] = None):
+        super().__init__(n_partitions, partition_size, partition_by=None)
+
+    def get_partition(self, dataset, partition_index) -> datasets.Dataset:
+        return dataset.shard(num_shards=self._n_partitions, index=partition_index,
+                             contiguous=True)
+
+    def get_partitions(self, dataset) -> List[datasets.Dataset]:
+        partitions = []
+        for partition_index in range(self._n_partitions):
+            partitions.append(self.get_partition(dataset, partition_index))
+        return partitions
+
+
+class PowerLawSampler(Sampler):
+    # That implementation => probably all implementations need to change
+    # The dataset/reference to indices should be kept after the initial get_partition
+    # There should be no need to give the datasets each time the get_partition is called
+    # At the same time there should not be the need to give the dataset while
+    # initialization because it doesn't allow to do the dependency inject with this
+    # class. Setter after the initialization in a strange option too. That leaves me
+    # with more convoluted creation e.g. using the factory_method with a string name to
+    # sampler dictionary and specification of additional keyword. Alternatively (not
+    # (I don't like it) there might be a dict-like object - SamplerConfig but it's very
+    # similar to the factory method BUT additinally adds the complexity by creating a
+    # custom new "class" - the dict
+
+    # Maybe further abstraction is needed to capture the sampling methods for
+    # artificially divided. Yet there are some sampler that might be used in case of
+    # both, so it might be implicitly assumed that fi the partition_by is None then
+    # the dataset should be treated as artificially divided
+    def __init__(
+            self,
+            dataset: datasets.Dataset,
+            n_partitions: Optional[int] = None,
+            partition_size: Optional[int] = None,
+            partition_by: Optional[str] = None,
+            min_partition_size: Optional[int] = None,
+            n_labels_per_partition=None,
+            mean: Optional[float] = 0.0,
+            sigma: Optional[float] = 2.0,
+    ):
+        super().__init__(n_partitions, partition_size, partition_by)
+        self._min_partition_size = min_partition_size
+        self._n_labels_per_partition = n_labels_per_partition
+        self._mean: float = mean
+        self._sigma: float = sigma
+        self._sorted_dataset: Optional[Dataset] = None
+        self._partition_reference: List[List[int]] = self._create_partition_references(
+            dataset)
+
+    def get_partition(self, dataset: Dataset, partition_index) -> datasets.Dataset:
+        return self._sorted_dataset.select(self._partition_reference[partition_index])
+
+    def get_partitions(self, dataset) -> List[datasets.Dataset]:
+        partitions = []
+        for partition_index in range(self._n_partitions):
+            partitions.append(self.get_partition(dataset, partition_index))
+        return partitions
+
+    def _create_partition_references(self, dataset: Dataset):
+        self._sorted_dataset = dataset.sort("label")
+        labels = self._sorted_dataset["label"]
+        full_idx = range(len(labels))
+
+        class_counts = np.bincount(labels)
+        labels_cs = np.cumsum(class_counts)
+        labels_cs = [0] + labels_cs[:-1].tolist()
+
+        partitions_idx = []
+        num_classes = len(np.bincount(labels))
+        hist = np.zeros(num_classes, dtype=np.int32)
+
+        # assign min_samples_per_partition
+        min_samples_per_label_per_partition = int(
+            self._min_partition_size / self._n_labels_per_partition)
+        for u_id in range(self._n_partitions):
+            partitions_idx.append([])
+            for cls_idx in range(self._n_labels_per_partition):
+                # label for the u_id-th client
+                cls = (u_id + cls_idx) % num_classes
+                # record minimum data
+                indices = list(
+                    full_idx[
+                    labels_cs[cls]
+                    + hist[cls]: labels_cs[cls]
+                                 + hist[cls]
+                                 + min_samples_per_label_per_partition
+                    ]
+                )
+                partitions_idx[-1].extend(indices)
+                hist[cls] += min_samples_per_label_per_partition
+
+        # add remaining images following power-law
+        probs = np.random.lognormal(
+            self._mean,
+            self._sigma,
+            (
+                num_classes, int(self._n_partitions / num_classes),
+                self._n_labels_per_partition),
+        )
+        remaining_per_class = class_counts - hist
+        # obtain how many samples each partition should be assigned for each of the
+        # labels it contains
+        probs = (
+                remaining_per_class.reshape(-1, 1, 1)
+                * probs
+                / np.sum(probs, (1, 2), keepdims=True)
+        )
+
+        for u_id in range(self._n_partitions):
+            for cls_idx in range(self._n_labels_per_partition):
+                cls = (u_id + cls_idx) % num_classes
+                count = int(probs[cls, u_id // num_classes, cls_idx])
+
+                # add count of specific class to partition
+                indices = full_idx[
+                          labels_cs[cls] + hist[cls]: labels_cs[cls] + hist[cls] + count
+                          ]
+                partitions_idx[u_id].extend(indices)
+                hist[cls] += count
+
+        return partitions_idx

--- a/datasets/flwr_datasets/sampler_test.py
+++ b/datasets/flwr_datasets/sampler_test.py
@@ -1,0 +1,78 @@
+from datasets import Dataset
+import unittest
+
+from sampler import IIDSampler, CIDSampler
+
+
+class TestIIDSampler(unittest.TestCase):
+    """Test IIDSampler."""
+
+    def setUp(self):
+        """Create a dummy dataset with 100 rows, numerical features, and labels."""
+        data = {
+            "features": [i for i in range(100)],
+            "labels": [i % 2 for i in range(100)]
+        }
+        self.dataset = Dataset.from_dict(data)
+        self.n_partitions = 10
+        self.partition_size = self.dataset.num_rows // self.n_partitions
+        self.sampler = IIDSampler(n_partitions=self.n_partitions)
+
+    def test_get_partition(self):
+        partition_index = 2
+        partition = self.sampler.get_partition(self.dataset, partition_index)
+        self.assertEqual(partition.num_rows, self.partition_size)
+        self.assertEqual(partition["features"][0],
+                         partition_index * self.partition_size)
+
+    def test_get_partitions(self):
+        partitions = self.sampler.get_partitions(self.dataset)
+        for i, partition in enumerate(partitions):
+            self.assertEqual(partition.num_rows, self.partition_size)
+            self.assertEqual(partition["features"][0], i * self.partition_size)
+
+    def test_get_partitions_size(self):
+        partitions = self.sampler.get_partitions(self.dataset)
+        self.assertEqual(len(partitions), self.n_partitions)
+
+
+class TestCIDSampler(unittest.TestCase):
+    """Test CIDSampler."""
+
+    def setUp(self):
+        """Create a 100-row dummy dataset with numerical features, labels, and cids."""
+        data = {
+            "features": [i for i in range(100)],
+            "labels": [i % 2 for i in range(100)],
+            "cid": [str(i // 10) for i in range(100)]  # 10 different cids
+        }
+        self.dataset = Dataset.from_dict(data)
+        self.n_partitions = 10
+        self.partition_size = self.dataset.num_rows // self.n_partitions
+        self.partition_by = "cid"
+        self.sampler = CIDSampler(n_partitions=self.n_partitions,
+                                  partition_by=self.partition_by)
+
+    def test_create_int_idx_to_cid_size(self):
+        self.sampler._create_int_idx_to_cid(self.dataset)
+        self.assertEqual(len(self.sampler._index_to_cid), self.n_partitions)
+
+    def test_create_int_idx_to_cid_mapping(self):
+        self.sampler._create_int_idx_to_cid(self.dataset)
+        self.assertEqual(int(self.sampler._index_to_cid[0]), 0)
+
+    def test_get_partition(self):
+        partition_index = 2
+        partition = self.sampler.get_partition(self.dataset, partition_index)
+        self.assertEqual(partition["cid"][0],
+                         self.sampler._index_to_cid[partition_index])
+
+    def test_partitions_have_single_unique_cid(self):
+        partitions = self.sampler.get_partitions(self.dataset)
+        for partition in partitions:
+            unique_cids = set(partition['cid'])
+            self.assertEqual(len(unique_cids), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Issue

Each dataset for FL needs division among the edge devices. This functionality so far is mostly created by users themselves by manually writing up the code.


### Related issues/PRs

Flwr datasets saga:
* https://github.com/adap/flower/pull/2168

## Proposal

This PR introduces a `Sampler` abstraction. That is responsible solely for the division of a dataset among edge devices (clients).

There are 3 concrete classes - sampling strategies.
* CIDSampling - some datasets come with a field (feature) that enables natural division among the clients (e.g. client id, or organization id). The user provides the feature and based on that the division happens.
*  IIDSampling - each client's data distribution follows the whole dataset distribution.
* PowerLaw - adapted from the fedprox baseline code.

### Explanation
The various `Sampler`s are supposed to be used according to the strategy design pattern - all of them provide the same `get_partition(dataset, partition_id)` and `get_partitions(dataset)` methods. Therefore can be used internally in the same way. 

## Remaining questions/ Potential changes
It's unsure to me at this point how the `Sampler` should access the dataset.
If a dataset is passed as an argument during the initialization, there's one major problem against it - it won't enable easy creation of the sampler prior to the downloaded dataset. 
Probably a non-pythonic way of a setter is more appropriate. 
The current implementation takes the dataset as an argument to the `get_partition(dataset, partition_id)` which is also non-ideal.