### PR TITLE
Migrate from FastAPI to Starlette

### DIFF
--- a/doc/source/changelog.md
+++ b/doc/source/changelog.md
@@ -26,6 +26,10 @@
 
   The (experimental) `start_client` argument `rest` was deprecated in favor of a new argument `transport`. `start_client(transport="rest")` will yield the same behaviour as `start_client(rest=True)` did before. All code should migrate to the new argument `transport`. The deprecated argument `rest` will be removed in a future release.
 
+- **Migrate experimental REST API to Starlette** ([2171](https://github.com/adap/flower/pull/2171))
+
+  The (experimental) REST API used to be implemented in [FastAPI](https://fastapi.tiangolo.com/), but it has now been migrated to use [Starlette](https://www.starlette.io/) directly.
+
 - **General improvements** ([#1872](https://github.com/adap/flower/pull/1872), [#1866](https://github.com/adap/flower/pull/1866), [#1884](https://github.com/adap/flower/pull/1884))
 
 ### Incompatible changes

--- a/examples/mt-pytorch/README.md
+++ b/examples/mt-pytorch/README.md
@@ -1,6 +1,6 @@
 # Multi-Tenant Federated Learning with Flower and PyTorch
 
-This example contains highly experimental code. Please consult the regular PyTorch code examples ([quickstart](https://github.com/adap/flower/tree/main/examples/quickstart-pytorch), [advanced](https://github.com/adap/flower/tree/main/examples/advanced-pytorch)) to learn how to use Flower with PyTorch.
+This example contains experimental code. Please consult the regular PyTorch code examples ([quickstart](https://github.com/adap/flower/tree/main/examples/quickstart-pytorch), [advanced](https://github.com/adap/flower/tree/main/examples/advanced-pytorch)) to learn how to use Flower with PyTorch.
 
 ## Setup
 
@@ -16,7 +16,7 @@ Terminal 1: start Flower server
 flower-server
 ```
 
-Terminal 2+3: start two clients
+Terminal 2+3: start two Flower client nodes
 
 ```bash
 python client.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,14 +71,13 @@ iterators = "^0.0.2"
 ray = { version = "==2.5.1", extras = ["default"], optional = true }
 pydantic = { version = "<2.0.0", optional = true }
 # Optional dependencies (REST transport layer)
-requests = { version = "^2.28.2", optional = true }
-fastapi = { version = "^0.95.0", optional = true }
-starlette = { version = "^0.27.0", optional = true }
-uvicorn = { version = "^0.21.1", extras = ["standard"], optional = true }
+requests = { version = "^2.31.0", optional = true }
+starlette = { version = "^0.29.0", optional = true }
+uvicorn = { version = "^0.22.0", extras = ["standard"], optional = true }
 
 [tool.poetry.extras]
 simulation = ["ray", "pydantic"]
-rest = ["fastapi", "requests", "starlette", "uvicorn"]
+rest = ["requests", "starlette", "uvicorn"]
 
 [tool.poetry.group.dev.dependencies]
 types-dataclasses = "==0.6.6"

--- a/src/py/flwr/server/app.py
+++ b/src/py/flwr/server/app.py
@@ -282,8 +282,7 @@ def run_fleet_api() -> None:
     # Start Fleet API
     if args.fleet_api_type == TRANSPORT_TYPE_REST:
         if (
-            importlib.util.find_spec("fastapi")
-            and importlib.util.find_spec("requests")
+            importlib.util.find_spec("requests")
             and importlib.util.find_spec("starlette")
             and importlib.util.find_spec("uvicorn")
         ) is None:
@@ -376,8 +375,7 @@ def run_server() -> None:
     # Start Fleet API
     if args.fleet_api_type == TRANSPORT_TYPE_REST:
         if (
-            importlib.util.find_spec("fastapi")
-            and importlib.util.find_spec("requests")
+            importlib.util.find_spec("requests")
             and importlib.util.find_spec("starlette")
             and importlib.util.find_spec("uvicorn")
         ) is None:

--- a/src/py/flwr/server/fleet/rest_rere/rest_api.py
+++ b/src/py/flwr/server/fleet/rest_rere/rest_api.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""REST API server."""
+"""Experimental REST API server."""
 
 
 import sys
@@ -23,16 +23,16 @@ from flwr.server.fleet.message_handler import message_handler
 from flwr.server.state import State
 
 try:
-    from fastapi import FastAPI, HTTPException, Request, Response
+    from starlette.applications import Starlette
     from starlette.datastructures import Headers
+    from starlette.exceptions import HTTPException
+    from starlette.requests import Request
+    from starlette.responses import Response
+    from starlette.routing import Route
 except ModuleNotFoundError:
     sys.exit(MISSING_EXTRA_REST)
 
 
-app: FastAPI = FastAPI()
-
-
-@app.post("/api/v0/fleet/pull-task-ins", response_class=Response)
 async def pull_task_ins(request: Request) -> Response:
     """Pull TaskIns."""
     _check_headers(request.headers)
@@ -62,7 +62,6 @@ async def pull_task_ins(request: Request) -> Response:
     )
 
 
-@app.post("/api/v0/fleet/push-task-res", response_class=Response)
 async def push_task_res(request: Request) -> Response:  # Check if token is needed here
     """Push TaskRes."""
     _check_headers(request.headers)
@@ -90,6 +89,17 @@ async def push_task_res(request: Request) -> Response:  # Check if token is need
         content=push_task_res_response_bytes,
         headers={"Content-Type": "application/protobuf"},
     )
+
+
+routes = [
+    Route("/api/v0/fleet/pull-task-ins", pull_task_ins, methods=["POST"]),
+    Route("/api/v0/fleet/push-task-res", push_task_res, methods=["POST"]),
+]
+
+app: Starlette = Starlette(
+    debug=False,
+    routes=routes,
+)
 
 
 def _check_headers(headers: Headers) -> None:


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->

This PR changes the implementation of the experimental REST API to use Starlette instead of FastAPI. FastAPI is a wrapper around Starlette, and using Starlette directly avoids the overheads introduced by FastAPI.

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

None

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

### Checklist

- [x] Implement proposed change
- [x] Update [documentation](https://flower.dev/docs/writing-documentation.html)
- [x] Update [changelog](https://github.com/adap/flower/blob/main/doc/source/changelog.rst)
- [x] Make CI checks pass

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.dev/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
