### PR TITLE
fixing create_federated_dataloaders to work with iid option

### DIFF
--- a/baselines/flwr_baselines/flwr_baselines/publications/leaf/femnist/dataset/dataset.py
+++ b/baselines/flwr_baselines/flwr_baselines/publications/leaf/femnist/dataset/dataset.py
@@ -3,7 +3,7 @@
 
 import pathlib
 from logging import INFO
-from typing import List, Tuple
+from typing import List, Tuple, Optional
 
 import numpy as np
 import pandas as pd
@@ -202,7 +202,8 @@ def create_federated_dataloaders(
     train_fraction: float,
     validation_fraction: float,
     test_fraction: float,
-    random_seed: int,
+    random_seed: int = None,
+    n_clients: Optional[int] = None,
 ) -> Tuple[List[DataLoader], List[DataLoader], List[DataLoader]]:
     """Create the federated dataloaders by following all the preprocessing
     steps and division.
@@ -251,9 +252,16 @@ def create_federated_dataloaders(
     df_info_path = pathlib.Path("data/processed_FeMNIST/processed_images_to_labels.csv")
     df_info = pd.read_csv(df_info_path, index_col=0)
     sampler = NistSampler(df_info)
-    sampled_data_info = sampler.sample(
-        sampling_type, dataset_fraction, random_seed=random_seed
-    )
+    if sampling_type == 'niid':
+        sampled_data_info = sampler.sample(
+            sampling_type, dataset_fraction, random_seed=random_seed
+        )
+    elif sampling_type == 'iid':
+        sampled_data_info = sampler.sample(
+            sampling_type, dataset_fraction,
+            n_clients=n_clients,
+            random_seed=random_seed
+        )
     sampled_data_info_path = pathlib.Path(
         f"data/processed_FeMNIST/{sampling_type}_sampled_images_to_labels.csv"
     )


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

None
### Description

In dataset.py of the leaf baseline, the idd sampling type throws an error. This is because it doesn't take the n_clients parameter which is required for `iid`. I added that parameter.

```
trainloaders, valloaders, testloaders = create_federated_dataloaders(
    sampling_type = 'iid',
    dataset_fraction = 1,
    batch_size = 32,
    train_fraction = 0.8,
    validation_fraction = 0.1,
    test_fraction = 0.1,
    random_seed = 42,
    n_clients=10
)
```
Error: "n_clients can not be None for idd training"


### Related issues/PRs

None
## Proposal
Add the n_clients parameter to the function and add an if else statement for iid and non-idd. 

### Explanation

I added the `n_clients` parameter and made the necessary changes in the function.

```
trainloaders, valloaders, testloaders = create_federated_dataloaders(
    sampling_type = 'iid',
    dataset_fraction = 1,
    batch_size = 32,
    train_fraction = 0.8,
    validation_fraction = 0.1,
    test_fraction = 0.1,
    random_seed = 42,
)
```

### Checklist

- [X] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.dev/docs/writing-documentation.html)
- [ ] Update [changelog](https://github.com/adap/flower/blob/main/doc/source/changelog.rst)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?
Not sure how to write the tests for this. `idd` test case is missing from dataset_test.py
