### PR TITLE
Add GH previewing for docs after building

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,6 +25,11 @@ jobs:
         run: python -m poetry install --extras "simulation"
       - name: Build docs
         run: ./dev/build-docs.sh
+      - name: HTML Preview
+        id: html_preview
+        uses: pavi2410/html-preview-action@v2
+        with:
+          html_file: 'doc/build/html/index.html'
 
   deploy_docs:
     needs: build_docs


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

Currently the only way to preview docs is to clone the repo and to build them locally.

### Related issues/PRs

N/A

## Proposal

### Explanation

Use a GitHub action to preview the docs.

### Checklist

- [x] Implement proposed change
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

N/A
