### PR TITLE
Add option to the grpc_server

### DIFF
--- a/doc/source/changelog.md
+++ b/doc/source/changelog.md
@@ -30,6 +30,10 @@
 
   The (experimental) REST API used to be implemented in [FastAPI](https://fastapi.tiangolo.com/), but it has now been migrated to use [Starlette](https://www.starlette.io/) directly.
 
+- **Add a new gRPC option** ([#2197](https://github.com/adap/flower/pull/2197))
+
+  We now start a gRPC server with the `grpc.keepalive_permit_without_calls` option set to 0 by default. This prevents the clients from sending keepalive pings when there is no outstanding stream.
+
 - **General improvements** ([#1872](https://github.com/adap/flower/pull/1872), [#1866](https://github.com/adap/flower/pull/1866), [#1884](https://github.com/adap/flower/pull/1884))
 
 ### Incompatible changes

--- a/src/py/flwr/server/fleet/grpc_bidi/grpc_server.py
+++ b/src/py/flwr/server/fleet/grpc_bidi/grpc_server.py
@@ -233,6 +233,9 @@ def generic_create_grpc_server(  # pylint: disable=too-many-arguments
         # Setting this to zero will allow sending unlimited keepalive pings in between
         # sending actual data frames.
         ("grpc.http2.max_pings_without_data", 0),
+        # Is it permissible to send keepalive pings from the client without 
+        # any outstanding streams.
+        ("grpc.keepalive_permit_without_calls", 0),
     ]
 
     server = grpc.server(

--- a/src/py/flwr/server/fleet/grpc_bidi/grpc_server.py
+++ b/src/py/flwr/server/fleet/grpc_bidi/grpc_server.py
@@ -234,7 +234,8 @@ def generic_create_grpc_server(  # pylint: disable=too-many-arguments
         # sending actual data frames.
         ("grpc.http2.max_pings_without_data", 0),
         # Is it permissible to send keepalive pings from the client without
-        # any outstanding streams.
+        # any outstanding streams. More explanation here:
+        # https://github.com/adap/flower/pull/2197
         ("grpc.keepalive_permit_without_calls", 0),
     ]
 

--- a/src/py/flwr/server/fleet/grpc_bidi/grpc_server.py
+++ b/src/py/flwr/server/fleet/grpc_bidi/grpc_server.py
@@ -233,7 +233,7 @@ def generic_create_grpc_server(  # pylint: disable=too-many-arguments
         # Setting this to zero will allow sending unlimited keepalive pings in between
         # sending actual data frames.
         ("grpc.http2.max_pings_without_data", 0),
-        # Is it permissible to send keepalive pings from the client without 
+        # Is it permissible to send keepalive pings from the client without
         # any outstanding streams.
         ("grpc.keepalive_permit_without_calls", 0),
     ]


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

A user reported the following error while running a federation locally in separated terminals:
```
Received a GOAWAY with error code ENHANCE_YOUR_CALM and debug data equal to "too_many_pings".
```

It is a gRPC error, but it is hard to pin point exactly where the error came from (probably not a framework bug, as this is the first instance of such an issue, but it could be from the execution environment or some parts of the user's code).

### Related issues/PRs

N/A

## Proposal

### Explanation

Setting the gRPC option `grpc.keepalive_permit_without_calls` to 0 in `src/py/flwr/server/fleet/grpc_bidi/grpc_server.py` fixed the issue for the user. This channel argument if set to 1 (0 : false; 1 : true), allows keepalive pings to be sent even if there are no calls in flight (from https://grpc.github.io/grpc/core/md_doc_keepalive.html) or in an other phrasing, tells the server "Is it permissible to send keepalive pings from the client without any outstanding streams" (from https://grpc.github.io/grpc/core/group__grpc__arg__keys.html#gaf900669f52f137677c4dbb9a7a902c92). In this PR we add this option by default for any gRPC server.

### Checklist

- [x] Implement proposed change
- [x] Update [changelog](https://github.com/adap/flower/blob/main/doc/source/changelog.rst)
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

A bit of background on the error and the proposed solution: https://stackoverflow.com/a/65994473

To quote from the link:

_This is to safeguard from grpc clients streams who stay connected even when there is no data movements in the stream. When the stream is active and no data movement, the client keeps on pinging server to know whether its alive!! Thes continuous ping requests are basically abusive from servers point-of-view. When such a stale connection is detected, server sends this error and discontinues with client and the client is not able to further communicate or send any request._

_But certainly some use cases arise when client want to stay connected for hours even if there is no incoming requests. Basically a stale stream._

_In those cases both client and server has to configure themselves to allow such HTTP/2 Pings!_


An other interesting explanation: https://stackoverflow.com/a/76327925
