### PR TITLE
Allow for docs versioning

### DIFF
--- a/doc/source/_templates/sidebar/versioning.html
+++ b/doc/source/_templates/sidebar/versioning.html
@@ -1,0 +1,68 @@
+{% if versions %}
+
+<style>
+input[type='checkbox'] {
+  display: none;
+}
+
+.lbl-toggle {
+  display: block;
+
+  padding: 1rem;
+
+  cursor: pointer;
+
+  border-radius: 7px;
+  transition: all 0.25s ease-out;
+}
+
+.lbl-toggle::before {
+  content: ' ';
+  display: inline-block;
+
+  border-top: 5px solid transparent;
+  border-bottom: 5px solid transparent;
+  border-left: 5px solid currentColor;
+
+  vertical-align: middle;
+  margin-right: .7rem;
+  transform: translateY(-2px);
+
+  transition: transform .2s ease-out;
+}
+
+.collapsible-content {
+  max-height: 0px;
+  overflow: hidden;
+
+  transition: max-height .25s ease-in-out;
+}
+
+.toggle:checked + .lbl-toggle + .collapsible-content {
+  max-height: 100vh;
+}
+
+.toggle:checked + .lbl-toggle::before {
+  transform: rotate(90deg) translateX(-3px);
+}
+
+.toggle:checked + .lbl-toggle {
+  border-bottom-right-radius: 0;
+  border-bottom-left-radius: 0;
+}
+</style>
+
+<div class="wrap-collabsible"> 
+  <input id="collapsible" class="toggle" type="checkbox"> 
+  <label for="collapsible" class="lbl-toggle">Versions</label>
+  <div class="collapsible-content">
+    <div class="content-inner">
+      <ul>
+        {%- for item in versions %}
+        <li><a href="{{ item.url }}">{{ item.name }}</a></li>
+        {%- endfor %}
+      </ul>
+    </div>
+  </div>
+</div>
+{% endif %}

--- a/doc/source/_templates/sidebar/versioning.html
+++ b/doc/source/_templates/sidebar/versioning.html
@@ -50,6 +50,14 @@ input[type='checkbox'] {
   border-bottom-right-radius: 0;
   border-bottom-left-radius: 0;
 }
+
+.content-inner {
+  padding-bottom: 1rem;
+}
+
+.wrap-collabsible {
+  background-color: var(--color-background-item);
+}
 </style>
 
 <div class="wrap-collabsible"> 
@@ -58,8 +66,8 @@ input[type='checkbox'] {
   <div class="collapsible-content">
     <div class="content-inner">
       <ul>
-        {%- for item in versions %}
-        <li><a href="{{ item.url }}">{{ item.name }}</a></li>
+        {%- for item in versions|sort(reverse = True) %}
+        <li><a href="{{ item.url }}" style="text-decoration:none">{{ item.name }}{{ ' (unstable)' if item.name == 'main' else '' }}</a></li>
         {%- endfor %}
       </ul>
     </div>

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -58,6 +58,7 @@ extensions = [
     "sphinxcontrib.youtube",
     "sphinx_reredirects",
     "nbsphinx",
+    "sphinx_multiversion",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -92,6 +93,8 @@ redirects = {
     "publications": "index.html",
 }
 
+# Versioning options
+smv_branch_whitelist = r'^main$'
 
 # -- Options for HTML output -------------------------------------------------
 
@@ -133,6 +136,16 @@ html_theme_options = {
 html_static_path = ["_static"]
 html_css_files = ["custom.css"]
 
+html_sidebars = {
+    "**": [
+        "sidebar/brand.html",
+        "sidebar/search.html",
+        "sidebar/scroll-start.html",
+        "sidebar/navigation.html",
+        "sidebar/scroll-end.html",
+        "sidebar/versioning.html",
+    ]
+}
 # -- Options for nbsphinx -------------------------------------------------
 
 nbsphinx_execute = "never"

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -94,6 +94,7 @@ redirects = {
 }
 
 # Versioning options
+smv_tag_whitelist = r'^v(([1-9]|[0-9]{2,}).*)$'
 smv_branch_whitelist = r'^main$'
 
 # -- Options for HTML output -------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,7 @@ mdformat-beautysh = "==0.1.1"
 mdformat-myst = "==0.1.5"
 twine = "==4.0.2"
 pyroma = "==4.2"
+sphinx-multiversion = "==0.2.4"
 
 [tool.isort]
 line_length = 88


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

Our docs only show the current state of the main branch of the repo.

### Related issues/PRs

N/A

## Proposal

### Explanation

Add a way to switch between different versions of the framework (after 1.0.0).

### Checklist

- [x] Implement proposed change
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

Nothing will be deployed on the docs yet, the visual changes will be part of a subsequent PR.
