### PR TITLE
Wrap VCE's `run_fl` in try/except

### DIFF
--- a/src/py/flwr/simulation/app.py
+++ b/src/py/flwr/simulation/app.py
@@ -195,7 +195,6 @@ def start_simulation(  # pylint: disable=too-many-arguments
     # pylint: disable=broad-except
     try:
         # Start training
-        print(dfsfsfs)
         hist = run_fl(
             server=initialized_server,
             config=initialized_config,
@@ -210,7 +209,8 @@ def start_simulation(  # pylint: disable=too-many-arguments
             "`client_resources`. You used: %s"
             "\n\t > Too many VirtualClients were spawned causing an issue: try raising "
             "`client_resources`. You used: %s",
-            client_resources, client_resources
+            client_resources,
+            client_resources,
         )
         hist = History()
 

--- a/src/py/flwr/simulation/app.py
+++ b/src/py/flwr/simulation/app.py
@@ -193,10 +193,21 @@ def start_simulation(  # pylint: disable=too-many-arguments
         initialized_server.client_manager().register(client=client_proxy)
 
     # Start training
-    hist = run_fl(
-        server=initialized_server,
-        config=initialized_config,
-    )
+    try:
+        hist = run_fl(
+            server=initialized_server,
+            config=initialized_config,
+        )
+    except Exception as ex:
+        log(ERROR, ex)
+        log(
+            ERROR,
+            "Your simulation crashed :(. This could be because of several reasons."
+            "The most common are: "
+            "\n\t > Your system couldn't fit a single VirtualClient: try lowering "
+            f"`client_resources`. You used: {client_resources}",
+        )
+        hist = None
 
     event(EventType.START_SIMULATION_LEAVE)
 

--- a/src/py/flwr/simulation/app.py
+++ b/src/py/flwr/simulation/app.py
@@ -205,9 +205,11 @@ def start_simulation(  # pylint: disable=too-many-arguments
             "Your simulation crashed :(. This could be because of several reasons."
             "The most common are: "
             "\n\t > Your system couldn't fit a single VirtualClient: try lowering "
+            f"`client_resources`. You used: {client_resources}"
+            "\n\t > Too many VirtualClients were spawned causing an issue: try raising "
             f"`client_resources`. You used: {client_resources}",
         )
-        hist = None
+        hist = History()
 
     event(EventType.START_SIMULATION_LEAVE)
 

--- a/src/py/flwr/simulation/app.py
+++ b/src/py/flwr/simulation/app.py
@@ -192,8 +192,10 @@ def start_simulation(  # pylint: disable=too-many-arguments
         )
         initialized_server.client_manager().register(client=client_proxy)
 
-    # Start training
+    # pylint: disable=broad-except
     try:
+        # Start training
+        print(dfsfsfs)
         hist = run_fl(
             server=initialized_server,
             config=initialized_config,
@@ -205,9 +207,10 @@ def start_simulation(  # pylint: disable=too-many-arguments
             "Your simulation crashed :(. This could be because of several reasons."
             "The most common are: "
             "\n\t > Your system couldn't fit a single VirtualClient: try lowering "
-            f"`client_resources`. You used: {client_resources}"
+            "`client_resources`. You used: %s"
             "\n\t > Too many VirtualClients were spawned causing an issue: try raising "
-            f"`client_resources`. You used: {client_resources}",
+            "`client_resources`. You used: %s",
+            client_resources, client_resources
         )
         hist = History()
 


### PR DESCRIPTION
Wraps `run_fl` in `start_simulation` inside a try/except statement. If an exception is encountered, an error message is shown suggesting users to adjust the `client_resources`.