### PR TITLE
Fix bugs in serde function for Value

### DIFF
--- a/src/py/flwr/common/serde.py
+++ b/src/py/flwr/common/serde.py
@@ -510,17 +510,18 @@ _python_list_type_to_message_and_field_name = {
 def _check_value(value: typing.Value) -> None:
     if isinstance(value, tuple(_python_type_to_field_name.keys())):
         return
-    if isinstance(value, list) and isinstance(
-        value[0], tuple(_python_type_to_field_name.keys())
-    ):
-        data_type = type(value[0])
-        for element in value:
-            if isinstance(element, data_type):
-                continue
-            raise Exception(
-                f"Inconsistent type: the types of elements in the list must be the same"
-                f"(expected {data_type}, but got {type(element)})"
-            )
+    if isinstance(value, list):
+        if len(value) > 0 and isinstance(
+            value[0], tuple(_python_type_to_field_name.keys())
+        ):
+            data_type = type(value[0])
+            for element in value:
+                if isinstance(element, data_type):
+                    continue
+                raise Exception(
+                    f"Inconsistent type: the types of elements in the list must "
+                    f"be the same (expected {data_type}, but got {type(element)})."
+                )
     else:
         raise TypeError(
             f"Accepted types: {bool, bytes, float, int, str} or "
@@ -535,7 +536,7 @@ def value_to_proto(value: typing.Value) -> Value:
     arg = {}
     if isinstance(value, list):
         msg_class, field_name = _python_list_type_to_message_and_field_name[
-            type(value[0])
+            type(value[0]) if len(value) > 0 else int
         ]
         arg[field_name] = msg_class(vals=value)
     else:

--- a/src/py/flwr/common/serde_test.py
+++ b/src/py/flwr/common/serde_test.py
@@ -98,6 +98,8 @@ def test_value_serialization_deserialization() -> None:
         # string scalar and list
         "abcdefghijklmnopqrstuvwxy",
         ["456hgdhfd", "1234567890123456789012345678901", "I'm a string."],
+        # empty list
+        [],
     ]
 
     for value in values:
@@ -134,6 +136,8 @@ def test_named_values_serialization_deserialization() -> None:
         # string scalar and list
         "abcdefghijklmnopqrstuvwxy",
         ["456hgdhfd", "1234567890123456789012345678901", "I'm a string."],
+        # empty list
+        [],
     ]
     named_values = {f"value {i}": value for i, value in enumerate(values)}
 


### PR DESCRIPTION
## Issue

Value can be scalar or a list of scalar. But currently, the serde functions for Value do not work when Value is an empty list.