### PR TITLE
Add metatags to documentation

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,6 +1,10 @@
 Flower Framework Documentation
 ==============================
 
+.. meta::
+   :description: Documentation of the Flower Federated Learning Framework.
+   :keywords: machine learning, federated learning, federated pytorch
+
 Welcome to Flower's documentation. `Flower <https://flower.dev>`_ is a friendly federated learning framework.
 
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -3,7 +3,6 @@ Flower Framework Documentation
 
 .. meta::
    :description: Documentation of the Flower Federated Learning Framework.
-   :keywords: machine learning, federated learning, federated pytorch
 
 Welcome to Flower's documentation. `Flower <https://flower.dev>`_ is a friendly federated learning framework.
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

This PR adds the meta tags `description` to docs pages so we can control what is shown in the search engine results preview, as can be seen here:

<img width="738" alt="image" src="https://github.com/adap/flower/assets/423981/137ccfe9-b12f-4364-8821-da128fb64508">

Currently, we are not controlling what is shown there for docs pages.

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

### Checklist

- [ ] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.dev/docs/writing-documentation.html)
- [ ] Update [changelog](https://github.com/adap/flower/blob/main/doc/source/changelog.rst)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

We are not setting the meta keyword tag as its useless for SEO => https://ahrefs.com/blog/meta-keywords/
