### PR TITLE
Fix simulation requirements.txt

### DIFF
--- a/examples/simulation-pytorch/requirements.txt
+++ b/examples/simulation-pytorch/requirements.txt
@@ -1,3 +1,3 @@
-flwr[simulation]>=1.0, <2.0
+flwr[simulation] @ git+https://github.com/adap/flower.git@main
 torch==1.13.1
 torchvision==0.14.1

--- a/examples/simulation-tensorflow/requirements.txt
+++ b/examples/simulation-tensorflow/requirements.txt
@@ -1,3 +1,3 @@
-flwr[simulation]>=1.0, <2.0
+flwr[simulation] @ git+https://github.com/adap/flower.git@main
 tensorflow-macos>=2.9.1, != 2.11.1 ; sys_platform == "darwin" and platform_machine == "arm64"
 tensorflow-cpu>=2.9.1, != 2.11.1 ; platform_machine == "x86_64"


### PR DESCRIPTION
fixes `requirements.txt` for the updated simulation examples. Now `requirements.txt` point to flower in `main` branch (just like `pyproject.toml` does)