### PR TITLE
Fix pytorch-lightning e2e test

### DIFF
--- a/e2e/pytorch-lightning/mnist.py
+++ b/e2e/pytorch-lightning/mnist.py
@@ -65,13 +65,13 @@ def load_data():
     trainset = MNIST("./data", train=True, download=True, transform=transforms.ToTensor())
     trainset = Subset(trainset, range(1000))
     mnist_train, mnist_val = random_split(trainset, [800, 200])
-    train_loader = DataLoader(mnist_train, batch_size=32, shuffle=True, num_workers=2)
-    val_loader = DataLoader(mnist_val, batch_size=32, shuffle=False, num_workers=2)
+    train_loader = DataLoader(mnist_train, batch_size=32, shuffle=True, num_workers=0)
+    val_loader = DataLoader(mnist_val, batch_size=32, shuffle=False, num_workers=0)
 
     # Test set
     testset = MNIST("./data", train=False, download=True, transform=transforms.ToTensor())
     testset = Subset(testset, range(10))
-    test_loader = DataLoader(testset, batch_size=32, shuffle=False, num_workers=2)
+    test_loader = DataLoader(testset, batch_size=32, shuffle=False, num_workers=0)
 
     return train_loader, val_loader, test_loader
 

--- a/e2e/pytorch-lightning/mnist.py
+++ b/e2e/pytorch-lightning/mnist.py
@@ -65,13 +65,13 @@ def load_data():
     trainset = MNIST("./data", train=True, download=True, transform=transforms.ToTensor())
     trainset = Subset(trainset, range(1000))
     mnist_train, mnist_val = random_split(trainset, [800, 200])
-    train_loader = DataLoader(mnist_train, batch_size=32, shuffle=True, num_workers=16)
-    val_loader = DataLoader(mnist_val, batch_size=32, shuffle=False, num_workers=16)
+    train_loader = DataLoader(mnist_train, batch_size=32, shuffle=True, num_workers=2)
+    val_loader = DataLoader(mnist_val, batch_size=32, shuffle=False, num_workers=2)
 
     # Test set
     testset = MNIST("./data", train=False, download=True, transform=transforms.ToTensor())
     testset = Subset(testset, range(10))
-    test_loader = DataLoader(testset, batch_size=32, shuffle=False, num_workers=16)
+    test_loader = DataLoader(testset, batch_size=32, shuffle=False, num_workers=2)
 
     return train_loader, val_loader, test_loader
 


### PR DESCRIPTION
The Pytorch-Lightning e2e test used `num_workers=16` when creating dataloaders. That seems to be the cause of recent segmentation faults when running the tests. Here I reduce the value down to ~`num_workers=2`~ `num_workers=0` (i.e. disable multi-process data loading) which seem to make it run.