### PR TITLE
Add sphinx-intl to pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,6 @@ pydantic = { version = "<2.0.0", optional = true }
 requests = { version = "^2.31.0", optional = true }
 starlette = { version = "^0.29.0", optional = true }
 uvicorn = { version = "^0.22.0", extras = ["standard"], optional = true }
-sphinx-intl = "2.1.0"
 
 [tool.poetry.extras]
 simulation = ["ray", "pydantic"]
@@ -101,6 +100,7 @@ jupyterlab = "==3.6.5"
 rope = "==1.9.0"
 semver = "==2.13.0"
 sphinx = "==5.3.0"
+sphinx-intl = "==2.1.0"
 myst-parser = "==1.0.0"
 sphinx-design = "==0.4.1"
 sphinx-copybutton = "==0.5.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ pydantic = { version = "<2.0.0", optional = true }
 requests = { version = "^2.31.0", optional = true }
 starlette = { version = "^0.29.0", optional = true }
 uvicorn = { version = "^0.22.0", extras = ["standard"], optional = true }
+sphinx-intl = "2.1.0"
 
 [tool.poetry.extras]
 simulation = ["ray", "pydantic"]


### PR DESCRIPTION
We need `sphinx-intl` to prepare docs translations, right? Maybe it got discarded unintentionally from https://github.com/adap/flower/pull/2201