### PR TITLE
Make versioned script POSIX compliant to fix error

### DIFF
--- a/doc/build-versioned-docs.sh
+++ b/doc/build-versioned-docs.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Defining some language parameters to add to the outdated config files
 language_config=$(cat <<-END
@@ -66,7 +66,7 @@ for current_version in ${versions}; do
    echo "INFO: Building sites for ${current_version}"
   
    # Skip this branch if it doesn't have our docs dir & sphinx config
-   if [ ! -e 'source/conf.py' ]; then
+   if [[ ! -e 'source/conf.py' ]]; then
       echo "INFO: Couldn't find 'doc/source/conf.py' (skipped)"
       continue
    fi

--- a/doc/build-versioned-docs.sh
+++ b/doc/build-versioned-docs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Defining some language parameters to add to the outdated config files
 language_config=$(cat <<-END
@@ -66,7 +66,7 @@ for current_version in ${versions}; do
    echo "INFO: Building sites for ${current_version}"
   
    # Skip this branch if it doesn't have our docs dir & sphinx config
-   if [[ ! -e 'source/conf.py' ]]; then
+   if [ ! -e 'source/conf.py' ]; then
       echo "INFO: Couldn't find 'doc/source/conf.py' (skipped)"
       continue
    fi
@@ -80,10 +80,10 @@ for current_version in ${versions}; do
   
       echo "INFO: Building for ${current_language}"
 
-      if [[ ! -f "locales/$current_language/LC_MESSAGES/framework-docs.po" ]]; then
+      if [ ! -f "locales/$current_language/LC_MESSAGES/framework-docs.po" ]; then
 
         # Adding translation to versions that didn't contain one
-        if [[ $current_language != "en" ]]; then
+        if [ $current_language != "en" ]; then
           echo "No translation, using default one"
 
           # Remove any previous file in locales
@@ -112,7 +112,7 @@ for current_version in ${versions}; do
       sphinx-build -b html source/ build/html/${current_version}/${current_language} -A lang=True -D language=${current_language}
 
       # Restore branch as it was to avoid conflicts
-      if [[ changed ]]; then
+      if [ changed ]; then
         git restore source/conf.py
         rm -rf locales/${current_language}
         rm -rf source/_templates/sidebar
@@ -122,7 +122,7 @@ for current_version in ${versions}; do
 done
   
 # Build the main version (main for GH CI, local branch for local) 
-if [[ $GITHUB_ACTIONS ]]
+if [ $GITHUB_ACTIONS ]
 then
   git switch main
 else


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

From https://github.com/adap/flower/actions/runs/6029993574/job/16360943081, we have `build-versioned-docs.sh: 125: [[: not found`.

### Related issues/PRs

N/A

## Proposal

### Explanation

The issue is that we use `bash` syntax with `sh`, if we switch to POSIX compliant syntax (i.e `[` instead of `[[`) we will resolve the issue.

### Checklist

- [x] Implement proposed change
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

N/A
