### PR TITLE
Add test for versioned docs building script

### DIFF
--- a/dev/build-docs.sh
+++ b/dev/build-docs.sh
@@ -5,7 +5,7 @@ cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"/../
 ROOT=`pwd`
 
 cd doc
-make html
+sh build-versioned-docs.sh no_translate
 
 cd $ROOT
 cd baselines/doc

--- a/doc/build-versioned-docs.sh
+++ b/doc/build-versioned-docs.sh
@@ -96,7 +96,7 @@ for current_version in ${versions}; do
           echo "$language_config" >> source/conf.py
 
           # Update the text and the translation to match the source files if no_translate is not provided
-          if [ ! $1 == "no_translate" || ! $1 ]; then
+          if [ ! $1 ] || [ ! $1 == "no_translate" ]; then
             make gettext
             sphinx-intl update -p build/gettext -l ${current_language}
           fi

--- a/doc/build-versioned-docs.sh
+++ b/doc/build-versioned-docs.sh
@@ -95,9 +95,11 @@ for current_version in ${versions}; do
           # Add necessary config to conf.py
           echo "$language_config" >> source/conf.py
 
-          # Update the text and the translation to match the source files
-          make gettext
-          sphinx-intl update -p build/gettext -l ${current_language}
+          # Update the text and the translation to match the source files if no_translate is not provided
+          if [ ! $1 == "no_translate" ]; then
+            make gettext
+            sphinx-intl update -p build/gettext -l ${current_language}
+          fi
         fi
 
         # Copy updated version of html files

--- a/doc/build-versioned-docs.sh
+++ b/doc/build-versioned-docs.sh
@@ -96,7 +96,7 @@ for current_version in ${versions}; do
           echo "$language_config" >> source/conf.py
 
           # Update the text and the translation to match the source files if no_translate is not provided
-          if [ ! $1 == "no_translate" ]; then
+          if [ ! $1 == "no_translate" || ! $1 ]; then
             make gettext
             sphinx-intl update -p build/gettext -l ${current_language}
           fi


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

We don't test the new `build-versioned-docs.sh` script, mainly because the full version is quite slow to run.

### Related issues/PRs

N/A

## Proposal

### Explanation

In this PR we add a new parameter that allows the script to run way faster (without recomputing the translations) and call the script with the parameter in the `dev/build-docs.sh` script.

### Checklist

- [x] Implement proposed change
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

N/A
