### PR TITLE
Add the simulation video tutorial to the docs

### DIFF
--- a/doc/source/how-to-run-simulations.rst
+++ b/doc/source/how-to-run-simulations.rst
@@ -1,6 +1,10 @@
 Run simulations
 ===============
 
+..  youtube:: cRebUIGB5RU
+   :url_parameters: ?list=PLNG4feLHqCWlnj8a_E1A_n5zr2-8pafTB
+   :width: 100%
+
 Simulating Federated Learning workloads is useful for a multitude of use-cases: you might want to run your workload on a large cohort of clients but without having to source, configure and mange a large number of physical devices; you might want to run your FL workloads as fast as possible on the compute systems you have access to without having to go through a complex setup process; you might want to validate your algorithm on different scenarios at varying levels of data and system heterogeneity, client availability, privacy budgets, etc. These are among some of the use-cases where simulating FL workloads makes sense. Flower can accommodate these scenarios by means of its `VirtualClientEngine <contributor-explanation-architecture.html#virtual-client-engine>`_ or VCE.
 
 The :code:`VirtualClientEngine` schedules, launches and manages `virtual` clients. These clients are identical to `non-virtual` clients (i.e. the ones you launch via the command `flwr.client.start_numpy_client <ref-api-flwr.html#start-numpy-client>`_) in the sense that they can be configure by creating a class inheriting, for example, from `flwr.client.NumPyClient <ref-api-flwr.html#flwr.client.NumPyClient>`_ and therefore behave in an identical way. In addition to that, clients managed by the :code:`VirtualClientEngine` are:


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

The simulation video playlist can be very helpful for those researching the topic, but it cannot be found on the docs.

### Related issues/PRs

N/A

## Proposal

### Explanation

Add an embedding of the introduction video with the playlist link.

### Checklist

- [x] Implement proposed change
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

N/A
