### PR TITLE
Make tags visible for GitHub action to fix docs versions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,6 +33,8 @@ jobs:
     name: Deploy 
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Bootstrap
         uses: ./.github/actions/bootstrap
       - name: Install pandoc

--- a/dev/build-docs.sh
+++ b/dev/build-docs.sh
@@ -5,7 +5,7 @@ cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"/../
 ROOT=`pwd`
 
 cd doc
-make html
+./build-versioned-docs.sh
 
 cd $ROOT
 cd baselines/doc

--- a/dev/deploy-docs.sh
+++ b/dev/deploy-docs.sh
@@ -22,7 +22,7 @@ ROOT=`pwd`
 
 # Build and deploy Flower Framework docs
 cd doc
-sh build-versioned-docs.sh
+./build-versioned-docs.sh
 cd build/html
 aws s3 sync --delete --exclude ".*" --exclude "v/*" --acl public-read --cache-control "no-cache" ./ s3://flower.dev/docs/framework
 

--- a/doc/build-versioned-docs.sh
+++ b/doc/build-versioned-docs.sh
@@ -94,10 +94,6 @@ for current_version in ${versions}; do
           cp -r ${tmp_dir}/locales/$current_language locales/
           # Add necessary config to conf.py
           echo "$language_config" >> source/conf.py
-
-          # Update the text and the translation to match the source files
-          make gettext
-          sphinx-intl update -p build/gettext -l ${current_language}
         fi
 
         # Copy updated version of html files
@@ -114,8 +110,8 @@ for current_version in ${versions}; do
       # Restore branch as it was to avoid conflicts
       if [ changed ]; then
         git restore source/conf.py
-        rm -rf locales/${current_language}
-        rm -rf source/_templates/sidebar
+        git restore locales/${current_language} || rm -rf locales/${current_language}
+        git restore source/_templates/sidebar || rm -rf source/_templates/sidebar
         git restore source/_templates/base.html
       fi
    done


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

The currently deployed docs only show the main branch of the repo because during the CI, only this branch is visible to the machine.

### Related issues/PRs

N/A

## Proposal

### Explanation

Add the `fetch-depth: 0` argument to the checkout action.

### Checklist

- [x] Implement proposed change
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

I also added another change that was necessary to have the versions functioning properly, i.e, restoring the git state correctly in between checkouts.
I also realised that lines that were very long to execute were actually useless, so I removed them.
And finally I modify the `build-docs.sh` script so it calls the `build-versioned-docs.sh` script. This is because otherwise, this new script (that is deployed) was not tested.
