### PR TITLE
Update Flower's RESTful mode to support create and delete nodes.

### DIFF
--- a/examples/mt-pytorch/README.md
+++ b/examples/mt-pytorch/README.md
@@ -49,3 +49,26 @@ Terminal 2+3: start two clients
 ```bash
 python client.py
 ```
+
+## Run Restful API mode
+
+
+Terminal 1: start Flower server restful mode
+
+```bash
+flower-server --rest
+```
+
+Terminal 2: start driver
+
+```bash
+python driver
+```
+
+Open file ```client.py``` set variable ```restful_mode``` is ```True```
+
+Terminal 3+4: start two Flower client nodes
+
+```bash
+python client.py
+```

--- a/examples/mt-pytorch/client.py
+++ b/examples/mt-pytorch/client.py
@@ -13,6 +13,7 @@ from task import (
 )
 
 
+restful_mode = False
 # Load model and data (simple CNN, CIFAR-10)
 net = Net().to(DEVICE)
 trainloader, testloader = load_data()
@@ -35,8 +36,16 @@ class FlowerClient(fl.client.NumPyClient):
 
 
 # Start Flower client
-fl.client.start_numpy_client(
-    server_address="0.0.0.0:9092",
-    client=FlowerClient(),
-    transport="grpc-rere",
-)
+if restful_mode:
+    fl.client.start_numpy_client(
+        server_address="http://0.0.0.0:9093",
+        client=FlowerClient(),
+        rest=True,
+        transport="rest",
+    )
+else:
+    fl.client.start_numpy_client(
+        server_address="0.0.0.0:9092",
+        client=FlowerClient(),
+        transport="grpc-rere",
+    )

--- a/src/py/flwr/client/rest_client/connection.py
+++ b/src/py/flwr/client/rest_client/connection.py
@@ -29,6 +29,10 @@ from flwr.common import GRPC_MAX_MESSAGE_LENGTH
 from flwr.common.constant import MISSING_EXTRA_REST
 from flwr.common.logger import log
 from flwr.proto.fleet_pb2 import (
+    CreateNodeRequest,
+    CreateNodeResponse,
+    DeleteNodeRequest,
+    DeleteNodeResponse,
     PullTaskInsRequest,
     PullTaskInsResponse,
     PushTaskResRequest,
@@ -43,11 +47,14 @@ except ModuleNotFoundError:
     sys.exit(MISSING_EXTRA_REST)
 
 
+KEY_NODE = "node"
 KEY_TASK_INS = "current_task_ins"
 
 
 PATH_PULL_TASK_INS: str = "api/v0/fleet/pull-task-ins"
 PATH_PUSH_TASK_RES: str = "api/v0/fleet/push-task-res"
+PATH_CREATE_NODE: str = "api/v0/fleet/create-node"
+PATH_DELETE_NODE: str = "api/v0/fleet/delete-node"
 
 
 @contextmanager
@@ -114,17 +121,99 @@ def http_request_response(
 
     # Necessary state to link TaskRes to TaskIns
     state: Dict[str, Optional[TaskIns]] = {KEY_TASK_INS: None}
-
+    # Enable create_node and delete_node to store node
+    node_store: Dict[str, Optional[Node]] = {KEY_NODE: None}
+    
     ###########################################################################
     # receive/send functions
     ###########################################################################
 
+    def create_node() -> bool:
+        """Set create_node."""
+        create_node_req_proto = CreateNodeRequest()
+        create_node_req_bytes: bytes = create_node_req_proto.SerializeToString()
+    
+        res = requests.post(
+            url=f"{base_url}/{PATH_CREATE_NODE}",
+            headers={
+                "Accept": "application/protobuf",
+                "Content-Type": "application/protobuf",
+            },
+            data=create_node_req_bytes,
+            verify=verify,
+        )
+
+        # Check status code and headers
+        if res.status_code != 200:
+            return False
+        if "content-type" not in res.headers:
+            log(
+                WARN,
+                "[Node] POST /%s: missing header `Content-Type`",
+                PATH_PULL_TASK_INS,
+            )
+            return False
+        if res.headers["content-type"] != "application/protobuf":
+            log(
+                WARN,
+                "[Node] POST /%s: header `Content-Type` has wrong value",
+                PATH_PULL_TASK_INS,
+            )
+            return False
+        
+        # Deserialize ProtoBuf from bytes
+        create_node_response_proto = CreateNodeResponse()
+        create_node_response_proto.ParseFromString(res.content)
+   
+        node_store[KEY_NODE] = create_node_response_proto.node
+        return True
+    
+    def delete_node() -> bool:
+        if node_store[KEY_NODE] is None:
+            log(ERROR, "Node instance missing")
+            return
+        node: Node = cast(Node, node_store[KEY_NODE])
+        delete_node_req_proto = DeleteNodeRequest(node=node)
+        delete_node_req_req_bytes: bytes = delete_node_req_proto.SerializeToString()
+        res = requests.post(
+            url=f"{base_url}/{PATH_DELETE_NODE}",
+            headers={
+                "Accept": "application/protobuf",
+                "Content-Type": "application/protobuf",
+            },
+            data=delete_node_req_req_bytes,
+            verify=verify,
+        )
+        
+        # Check status code and headers
+        if res.status_code != 200:
+            return False
+        if "content-type" not in res.headers:
+            log(
+                WARN,
+                "[Node] POST /%s: missing header `Content-Type`",
+                PATH_PULL_TASK_INS,
+            )
+            return False
+        if res.headers["content-type"] != "application/protobuf":
+            log(
+                WARN,
+                "[Node] POST /%s: header `Content-Type` has wrong value",
+                PATH_PULL_TASK_INS,
+            )
+            return False
+        # Deserialize ProtoBuf from bytes
+        return True
+
     def receive() -> Optional[TaskIns]:
         """Receive next task from server."""
         # Serialize ProtoBuf to bytes
-        pull_task_ins_req_proto = PullTaskInsRequest(
-            node=Node(node_id=0, anonymous=True),
-        )
+        if node_store[KEY_NODE] is None:
+            log(ERROR, "Node instance missing")
+            return None
+        node: Node = cast(Node, node_store[KEY_NODE])
+        
+        pull_task_ins_req_proto = PullTaskInsRequest( node=node)
         pull_task_ins_req_bytes: bytes = pull_task_ins_req_proto.SerializeToString()
 
         # Request instructions (task) from server
@@ -179,6 +268,12 @@ def http_request_response(
 
     def send(task_res: TaskRes) -> None:
         """Send task result back to server."""
+        # get Node
+        if node_store[KEY_NODE] is None:
+            log(ERROR, "Node instance missing")
+            return None
+        node: Node = cast(Node, node_store[KEY_NODE])
+        
         if state[KEY_TASK_INS] is None:
             log(ERROR, "No current TaskIns")
             return
@@ -206,7 +301,7 @@ def http_request_response(
         # Fill `producer`, `consumer`, and `ancestry` in Task
         task_res.task.MergeFrom(
             Task(
-                producer=Node(node_id=0, anonymous=True),
+                producer=node,
                 consumer=task_ins.task.producer,
                 ancestry=[task_ins.task_id],
             )
@@ -261,6 +356,6 @@ def http_request_response(
 
     try:
         # Yield methods
-        yield (receive, send, None, None)
+        yield (receive, send, create_node, delete_node)
     except Exception as exc:  # pylint: disable=broad-except
         log(ERROR, exc)

--- a/src/py/flwr/server/fleet/rest_rere/rest_api.py
+++ b/src/py/flwr/server/fleet/rest_rere/rest_api.py
@@ -18,7 +18,7 @@
 import sys
 
 from flwr.common.constant import MISSING_EXTRA_REST
-from flwr.proto.fleet_pb2 import PullTaskInsRequest, PushTaskResRequest
+from flwr.proto.fleet_pb2 import PullTaskInsRequest, PushTaskResRequest, CreateNodeRequest, DeleteNodeRequest
 from flwr.server.fleet.message_handler import message_handler
 from flwr.server.state import State
 
@@ -31,6 +31,54 @@ try:
     from starlette.routing import Route
 except ModuleNotFoundError:
     sys.exit(MISSING_EXTRA_REST)
+
+
+async def create_node(request: Request) -> Response:
+    """Create Node"""
+    _check_headers(request.headers)
+
+    # parse base 64 to string
+    create_node_request_bytes: bytes = await request.body()
+    # Deserialize ProtoBuf
+    create_node_request_proto = CreateNodeRequest()
+    create_node_request_proto.ParseFromString(create_node_request_bytes)
+    
+    # Get state from app
+    state: State = app.state.STATE_FACTORY.state()
+    
+    # Handle message
+    new_node_data = message_handler.create_node(create_node_request_proto, state)
+    # Return serialized ProtoBuf
+    new_node_data_bytes = new_node_data.SerializeToString()
+    return Response(
+        status_code=200,
+        content=new_node_data_bytes,
+        headers={"Content-Type": "application/protobuf"},
+    )
+
+
+async def delete_node(request: Request) -> Response:
+    """Delete Node Id"""
+    _check_headers(request.headers)
+
+    # Get the request body as raw bytes
+    delete_node_request_bytes: bytes = await request.body()
+    # Deserialize ProtoBuf
+    delete_node_request_proto = DeleteNodeRequest()
+    delete_node_request_proto.ParseFromString(delete_node_request_bytes)
+    
+    # Get state from app
+    state: State = app.state.STATE_FACTORY.state()
+    
+    # Handle message
+    delete_node_response = message_handler.delete_node(request=request, state=state)
+    # Return Serialize Protobuf
+    delete_node_response_bytes = delete_node_response.SerializeToString()
+    return Response(
+        status_code=200,
+        content=delete_node_response_bytes,
+        headers={"Content-Type": "application/protobuf"},
+    )
 
 
 async def pull_task_ins(request: Request) -> Response:
@@ -92,6 +140,8 @@ async def push_task_res(request: Request) -> Response:  # Check if token is need
 
 
 routes = [
+    Route("/api/v0/fleet/create-node", create_node, methods=["POST"]),
+    Route("/api/v0/fleet/delete-node", delete_node, methods=["POST"]),
     Route("/api/v0/fleet/pull-task-ins", pull_task_ins, methods=["POST"]),
     Route("/api/v0/fleet/push-task-res", push_task_res, methods=["POST"]),
 ]


### PR DESCRIPTION
…nction

<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue
By default, in restful API mode, Flower only supports clients running as anonymous. This makes it difficult to manage tasks and results for each client.
### Description

<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal
-  Update the 2 POST API requests to create and delete a node.
- Update the client code to support calling the API to create a node and delete a node.
- Update the code and README in ```flower/examples/mt-pytorch``` to run and test with restful mode.
### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

### Checklist

- [ ] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.dev/docs/writing-documentation.html)
- [ ] Update [changelog](https://github.com/adap/flower/blob/main/doc/source/changelog.rst)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.dev/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
