### PR TITLE
Remove ACL argument when deploying

### DIFF
--- a/dev/deploy-docs.sh
+++ b/dev/deploy-docs.sh
@@ -24,14 +24,14 @@ ROOT=`pwd`
 cd doc
 ./build-versioned-docs.sh
 cd build/html
-aws s3 sync --delete --exclude ".*" --exclude "v/*" --acl public-read --cache-control "no-cache" ./ s3://flower.dev/docs/framework
+aws s3 sync --delete --exclude ".*" --exclude "v/*" --cache-control "no-cache" ./ s3://flower.dev/docs/framework
 
 # Build and deploy Flower Baselines docs
 cd $ROOT
 cd baselines/doc
 make docs
 cd build/html
-aws s3 sync --delete --exclude ".*" --exclude "v/*" --acl public-read --cache-control "no-cache" ./ s3://flower.dev/docs/baselines
+aws s3 sync --delete --exclude ".*" --exclude "v/*" --cache-control "no-cache" ./ s3://flower.dev/docs/baselines
 
 # Build and deploy Flower Examples docs
 cd $ROOT
@@ -39,4 +39,4 @@ cd $ROOT
 cd examples/doc
 make docs
 cd build/html
-aws s3 sync --delete --exclude ".*" --exclude "v/*" --acl public-read --cache-control "no-cache" ./ s3://flower.dev/docs/examples
+aws s3 sync --delete --exclude ".*" --exclude "v/*" --cache-control "no-cache" ./ s3://flower.dev/docs/examples

--- a/dev/deploy-swift-docs.sh
+++ b/dev/deploy-swift-docs.sh
@@ -24,4 +24,4 @@ ROOT=`pwd`
 cd $ROOT
 ./dev/build-swift-api-ref.sh
 cd SwiftDoc/html
-aws s3 sync --delete --exclude ".*" --acl public-read --cache-control "no-cache" ./ s3://flower.dev/docs/ios
+aws s3 sync --delete --exclude ".*" --cache-control "no-cache" ./ s3://flower.dev/docs/ios


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

After changes made to AWS, the ACL argument is useless for deployement.

### Related issues/PRs

N/A

## Proposal

### Explanation

Remove the `--acl public-read` argument from `deploy-docs.sh` and `deploy-swift-docs.sh`.

### Checklist

- [x] Implement proposed change
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

N/A
