### PR TITLE
Show complete error trace

### DIFF
--- a/src/py/flwr/simulation/app.py
+++ b/src/py/flwr/simulation/app.py
@@ -17,6 +17,7 @@
 
 import sys
 import threading
+import traceback
 from logging import ERROR, INFO
 from typing import Any, Callable, Dict, List, Optional, Type, Union
 
@@ -292,6 +293,7 @@ def start_simulation(  # pylint: disable=too-many-arguments
         )
     except Exception as ex:
         log(ERROR, ex)
+        log(ERROR, traceback.format_exc())
         log(
             ERROR,
             "Your simulation crashed :(. This could be because of several reasons."


### PR DESCRIPTION
The VCE only shows the full error trace if something fails on the client side, others (e.g. in strategies) are very quietly shown which might make them difficult to pinpoint where there originate. Now the full error trace is shown.