### PR TITLE
Add Flower Datasets extras

### DIFF
--- a/datasets/pyproject.toml
+++ b/datasets/pyproject.toml
@@ -69,6 +69,10 @@ pytest-watch = "==4.2.0"
 ruff = "==0.0.277"
 types-requests = "==2.28.11.17"
 
+[tool.poetry.extras]
+vision = ["datasets[vision]"]
+audio = ["datasets[audio]"]
+
 [tool.isort]
 line_length = 88
 indent = "    "

--- a/datasets/pyproject.toml
+++ b/datasets/pyproject.toml
@@ -55,6 +55,9 @@ exclude = [
 python = "^3.8"
 numpy = "^1.21.0"
 datasets = "^2.14.3"
+pillow = { version = ">=6.2.1", optional = true }
+soundfile = {version = ">=0.12.1", optional = true}
+librosa = { version = ">=0.10.0.post2", optional = true }
 
 [tool.poetry.dev-dependencies]
 isort = "==5.11.5"
@@ -70,8 +73,8 @@ ruff = "==0.0.277"
 types-requests = "==2.28.11.17"
 
 [tool.poetry.extras]
-vision = ["datasets[vision]"]
-audio = ["datasets[audio]"]
+vision = ["pillow"]
+audio = ["soundfile", "librosa"]
 
 [tool.isort]
 line_length = 88


### PR DESCRIPTION
## Issue
Flower datasets need to have the possibility to work on the image and audio datasets, yet currently, the extras installation is not available (therefore, the image and audio datasets might not work correctly).

## Proposal
Add the Hugging Face datasets' extras to Flower Datasets.

### Explanation

Installation of datasets[vision] is impossible via poetry, therefore the remaining option was to check the dependencies of the Datasets project and map them to this pyproject.toml.