### PR TITLE
Add names to unnamed workflow jobs

### DIFF
--- a/.github/workflows/baselines.yml
+++ b/.github/workflows/baselines.yml
@@ -26,6 +26,7 @@ defaults:
 
 jobs:
   test_baselines:
+    name: Test
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/deprecated_baselines.yml
+++ b/.github/workflows/deprecated_baselines.yml
@@ -17,6 +17,7 @@ defaults:
 
 jobs:
   test_deprecated_baselines:
+    name: Test
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

Jobs under `Baselines` and `Deprecated-Baselines` don't have names.

### Related issues/PRs

N/A

## Proposal

### Explanation

Add name to these jobs so all workflows and jobs are consistent in their naming.

### Checklist

- [x] Implement proposed change
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

N/A
