### PR TITLE
Update baselines template to flwr to 1.5

### DIFF
--- a/baselines/baseline_template/pyproject.toml
+++ b/baselines/baseline_template/pyproject.toml
@@ -38,8 +38,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = ">=3.8.15, <3.12.0"  # don't change this
-flwr = "1.3.0" # don't change this
-ray = "1.11.1" # don't change this
+flwr = { extras = ["simulation"], version = "1.5.0" }
 hydra-core = "1.3.2" # don't change this
 
 [tool.poetry.dev-dependencies]

--- a/doc/source/ref-changelog.md
+++ b/doc/source/ref-changelog.md
@@ -4,7 +4,7 @@
 
 ### What's new?
 
-- **General Updates to baselines** ([#2301](https://github.com/adap/flower/pull/2301))
+- **General updates to baselines** ([#2301](https://github.com/adap/flower/pull/2301))
 
 ### Incompatible changes
 

--- a/doc/source/ref-changelog.md
+++ b/doc/source/ref-changelog.md
@@ -4,6 +4,8 @@
 
 ### What's new?
 
+- **General Updates to baselines** ([#2301](https://github.com/adap/flower/pull/2301))
+
 ### Incompatible changes
 
 - **Remove support for Python 3.7** ([#2280](https://github.com/adap/flower/pull/2280))


### PR DESCRIPTION
Updates the `pyproject.toml` in the template directory for new baselines to `flwr=1.5.0` with simulation. 