### PR TITLE
Add client_fn argument to start_server

### DIFF
--- a/src/py/flwr/client/message_handler/message_handler.py
+++ b/src/py/flwr/client/message_handler/message_handler.py
@@ -15,7 +15,7 @@
 """Client-side message handler."""
 
 
-from typing import Tuple
+from typing import Callable, Tuple
 
 from flwr.client.client import (
     Client,
@@ -38,13 +38,13 @@ class UnknownServerMessage(Exception):
     """Exception indicating that the received message is unknown."""
 
 
-def handle(client: Client, task_ins: TaskIns) -> Tuple[TaskRes, int, bool]:
+def handle(client_fn: Callable, task_ins: TaskIns) -> Tuple[TaskRes, int, bool]:
     """Handle incoming TaskIns from the server.
 
     Parameters
     ----------
-    client : Client
-        The Client instance provided by the user.
+    client_fn : Callable
+        ...
     task_ins: TaskIns
         The task instruction coming from the server, to be processed by the client.
 
@@ -60,6 +60,7 @@ def handle(client: Client, task_ins: TaskIns) -> Tuple[TaskRes, int, bool]:
         reconnect later (False).
     """
     server_msg = get_server_message_from_task_ins(task_ins, exclude_reconnect_ins=False)
+    client = client_fn(cid="0")  # TODO which cid should we use?
     if server_msg is None:
         # Secure Aggregation
         if task_ins.task.HasField("sa") and isinstance(


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

### Checklist

- [ ] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.dev/docs/writing-documentation.html)
- [ ] Update [changelog](https://github.com/adap/flower/blob/main/doc/source/changelog.rst)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.dev/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
