### PR TITLE
Update pylint checks for baselines

### DIFF
--- a/baselines/baseline_template/pyproject.toml
+++ b/baselines/baseline_template/pyproject.toml
@@ -82,6 +82,9 @@ disable = "bad-continuation,duplicate-code,too-few-public-methods,useless-import
 good-names = "i,j,k,_,x,y,X,Y"
 signature-mutators="hydra.main.main"
 
+[tool.pylint.typecheck]
+generated-members="numpy.*, torch.*, tensorflow.*"
+
 [[tool.mypy.overrides]]
 module = [
     "importlib.metadata.*",


### PR DESCRIPTION
`pylint` test gets many `E1101` errors (e.g. `E1101: Module 'torch' has no 'flatten' member (no-member)`). The change will solve this problem for related `numpy`, `pytorch` and `tensorflow`.