### PR TITLE
Re-add the tutorials to the docs navbar

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -32,11 +32,11 @@ A learning-oriented series of federated learning tutorials, the best place to st
    :maxdepth: 1
    :caption: Tutorial
 
-   tutorial-what-is-federated-learning
-   tutorial-get-started-with-flower-pytorch
-   tutorial-use-a-federated-learning-strategy-pytorch
-   tutorial-build-a-strategy-from-scratch-pytorch
-   tutorial-customize-the-client-pytorch
+   tutorial-series-what-is-federated-learning
+   tutorial-series-get-started-with-flower-pytorch
+   tutorial-series-use-a-federated-learning-strategy-pytorch
+   tutorial-series-build-a-strategy-from-scratch-pytorch
+   tutorial-series-customize-the-client-pytorch
 
 .. toctree::
    :maxdepth: 1

--- a/doc/source/ref-changelog.md
+++ b/doc/source/ref-changelog.md
@@ -6,7 +6,7 @@
 
 - **General updates to baselines** ([#2301](https://github.com/adap/flower/pull/2301).[#2305](https://github.com/adap/flower/pull/2305), [#2307](https://github.com/adap/flower/pull/2307))
 
-- **General improvements** ([#2309](https://github.com/adap/flower/pull/2309))
+- **General improvements** ([#2309](https://github.com/adap/flower/pull/2309), [#2310](https://github.com/adap/flower/pull/2310))
 
   Flower received many improvements under the hood, too many to list here.
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

We accidentally removed the docs from the navbar and this PR is re-adding them.

<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

### Checklist

- [x] Implement proposed change
- [x] Write tests
- [x] Update [documentation](https://flower.dev/docs/writing-documentation.html)
- [x] Update [changelog](https://github.com/adap/flower/blob/main/doc/source/changelog.rst)
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.dev/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
