### PR TITLE
Fix type check error in `flwr/common/secure_aggregation/quantization.py`

### DIFF
--- a/src/py/flwr/common/secure_aggregation/quantization.py
+++ b/src/py/flwr/common/secure_aggregation/quantization.py
@@ -33,14 +33,16 @@ def quantize(
     parameters: List[NDArrayFloat], clipping_range: float, target_range: int
 ) -> List[NDArrayInt]:
     """Quantize float Numpy arrays to integer Numpy arrays."""
-    quantized_list = []
+    quantized_list: List[NDArrayInt] = []
     quantizer = target_range / (2 * clipping_range)
     for arr in parameters:
         # Stochastic quantization
-        quantized = (
-            np.clip(arr, -clipping_range, clipping_range) + clipping_range
-        ) * quantizer
-        quantized = _stochastic_round(quantized)
+        pre_quantized = cast(
+            NDArrayFloat,
+            (np.clip(arr, -clipping_range, clipping_range) + clipping_range)
+            * quantizer,
+        )
+        quantized = _stochastic_round(pre_quantized)
         quantized_list.append(quantized)
     return quantized_list
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

### Checklist

- [ ] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.dev/docs/writing-documentation.html)
- [ ] Update [changelog](https://github.com/adap/flower/blob/main/doc/source/changelog.rst)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.dev/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
