### PR TITLE
Refactor Flower client

### DIFF
--- a/doc/source/ref-changelog.md
+++ b/doc/source/ref-changelog.md
@@ -8,7 +8,7 @@
 
 - **General updates to baselines** ([#2301](https://github.com/adap/flower/pull/2301).[#2305](https://github.com/adap/flower/pull/2305), [#2307](https://github.com/adap/flower/pull/2307), [#2327](https://github.com/adap/flower/pull/2327))
 
-- **General improvements** ([#2309](https://github.com/adap/flower/pull/2309), [#2310](https://github.com/adap/flower/pull/2310), [2313](https://github.com/adap/flower/pull/2313), [#2316](https://github.com/adap/flower/pull/2316), [2317](https://github.com/adap/flower/pull/2317))
+- **General improvements** ([#2309](https://github.com/adap/flower/pull/2309), [#2310](https://github.com/adap/flower/pull/2310), [2313](https://github.com/adap/flower/pull/2313), [#2316](https://github.com/adap/flower/pull/2316), [2317](https://github.com/adap/flower/pull/2317),[#2349](https://github.com/adap/flower/pull/2349))
 
   Flower received many improvements under the hood, too many to list here.
 

--- a/src/py/flwr/client/__init__.py
+++ b/src/py/flwr/client/__init__.py
@@ -20,11 +20,17 @@ from .app import start_client as start_client
 from .app import start_numpy_client as start_numpy_client
 from .client import Client as Client
 from .numpy_client import NumPyClient as NumPyClient
+from .numpy_client_wrapper import to_client as to_client
+from .typing import ClientFn as ClientFn
+from .typing import ClientLike as ClientLike
 
 __all__ = [
     "Client",
     "NumPyClient",
+    "ClientLike",
+    "ClientFn",
     "run_client",
     "start_client",
     "start_numpy_client",
+    "to_client",
 ]

--- a/src/py/flwr/client/__init__.py
+++ b/src/py/flwr/client/__init__.py
@@ -26,9 +26,9 @@ from .typing import ClientLike as ClientLike
 
 __all__ = [
     "Client",
-    "NumPyClient",
-    "ClientLike",
     "ClientFn",
+    "ClientLike",
+    "NumPyClient",
     "run_client",
     "start_client",
     "start_numpy_client",

--- a/src/py/flwr/client/app.py
+++ b/src/py/flwr/client/app.py
@@ -18,15 +18,9 @@
 import sys
 import time
 from logging import INFO
-from typing import Callable, Dict, Optional, Union
+from typing import Optional, Union
 
-from flwr.common import (
-    GRPC_MAX_MESSAGE_LENGTH,
-    EventType,
-    event,
-    ndarrays_to_parameters,
-    parameters_to_ndarrays,
-)
+from flwr.common import GRPC_MAX_MESSAGE_LENGTH, EventType, event
 from flwr.common.address import parse_address
 from flwr.common.constant import (
     MISSING_EXTRA_REST,
@@ -36,57 +30,13 @@ from flwr.common.constant import (
     TRANSPORT_TYPES,
 )
 from flwr.common.logger import log
-from flwr.common.typing import (
-    Code,
-    EvaluateIns,
-    EvaluateRes,
-    FitIns,
-    FitRes,
-    GetParametersIns,
-    GetParametersRes,
-    GetPropertiesIns,
-    GetPropertiesRes,
-    NDArrays,
-    Status,
-)
 
 from .client import Client
 from .grpc_client.connection import grpc_connection
 from .grpc_rere_client.connection import grpc_request_response
 from .message_handler.message_handler import handle
 from .numpy_client import NumPyClient
-from .numpy_client import has_evaluate as numpyclient_has_evaluate
-from .numpy_client import has_fit as numpyclient_has_fit
-from .numpy_client import has_get_parameters as numpyclient_has_get_parameters
-from .numpy_client import has_get_properties as numpyclient_has_get_properties
-
-EXCEPTION_MESSAGE_WRONG_RETURN_TYPE_FIT = """
-NumPyClient.fit did not return a tuple with 3 elements.
-The returned values should have the following type signature:
-
-    Tuple[NDArrays, int, Dict[str, Scalar]]
-
-Example
--------
-
-    model.get_weights(), 10, {"accuracy": 0.95}
-
-"""
-
-EXCEPTION_MESSAGE_WRONG_RETURN_TYPE_EVALUATE = """
-NumPyClient.evaluate did not return a tuple with 3 elements.
-The returned values should have the following type signature:
-
-    Tuple[float, int, Dict[str, Scalar]]
-
-Example
--------
-
-    0.5, 10, {"accuracy": 0.95}
-
-"""
-
-ClientLike = Union[Client, NumPyClient]
+from .numpy_client_wrapper import _wrap_numpy_client
 
 
 # pylint: disable=import-outside-toplevel,too-many-locals,too-many-branches
@@ -280,110 +230,6 @@ def start_numpy_client(
         root_certificates=root_certificates,
         transport=transport,
     )
-
-
-def to_client(client_like: ClientLike) -> Client:
-    """Take any Client-like object and return it as a Client."""
-    if isinstance(client_like, NumPyClient):
-        return _wrap_numpy_client(client=client_like)
-    return client_like
-
-
-def _constructor(self: Client, numpy_client: NumPyClient) -> None:
-    self.numpy_client = numpy_client  # type: ignore
-
-
-def _get_properties(self: Client, ins: GetPropertiesIns) -> GetPropertiesRes:
-    """Return the current client properties."""
-    properties = self.numpy_client.get_properties(config=ins.config)  # type: ignore
-    return GetPropertiesRes(
-        status=Status(code=Code.OK, message="Success"),
-        properties=properties,
-    )
-
-
-def _get_parameters(self: Client, ins: GetParametersIns) -> GetParametersRes:
-    """Return the current local model parameters."""
-    parameters = self.numpy_client.get_parameters(config=ins.config)  # type: ignore
-    parameters_proto = ndarrays_to_parameters(parameters)
-    return GetParametersRes(
-        status=Status(code=Code.OK, message="Success"), parameters=parameters_proto
-    )
-
-
-def _fit(self: Client, ins: FitIns) -> FitRes:
-    """Refine the provided parameters using the locally held dataset."""
-    # Deconstruct FitIns
-    parameters: NDArrays = parameters_to_ndarrays(ins.parameters)
-
-    # Train
-    results = self.numpy_client.fit(parameters, ins.config)  # type: ignore
-    if not (
-        len(results) == 3
-        and isinstance(results[0], list)
-        and isinstance(results[1], int)
-        and isinstance(results[2], dict)
-    ):
-        raise Exception(EXCEPTION_MESSAGE_WRONG_RETURN_TYPE_FIT)
-
-    # Return FitRes
-    parameters_prime, num_examples, metrics = results
-    parameters_prime_proto = ndarrays_to_parameters(parameters_prime)
-    return FitRes(
-        status=Status(code=Code.OK, message="Success"),
-        parameters=parameters_prime_proto,
-        num_examples=num_examples,
-        metrics=metrics,
-    )
-
-
-def _evaluate(self: Client, ins: EvaluateIns) -> EvaluateRes:
-    """Evaluate the provided parameters using the locally held dataset."""
-    parameters: NDArrays = parameters_to_ndarrays(ins.parameters)
-
-    results = self.numpy_client.evaluate(parameters, ins.config)  # type: ignore
-    if not (
-        len(results) == 3
-        and isinstance(results[0], float)
-        and isinstance(results[1], int)
-        and isinstance(results[2], dict)
-    ):
-        raise Exception(EXCEPTION_MESSAGE_WRONG_RETURN_TYPE_EVALUATE)
-
-    # Return EvaluateRes
-    loss, num_examples, metrics = results
-    return EvaluateRes(
-        status=Status(code=Code.OK, message="Success"),
-        loss=loss,
-        num_examples=num_examples,
-        metrics=metrics,
-    )
-
-
-def _wrap_numpy_client(client: NumPyClient) -> Client:
-    member_dict: Dict[str, Callable] = {  # type: ignore
-        "__init__": _constructor,
-    }
-
-    # Add wrapper type methods (if overridden)
-
-    if numpyclient_has_get_properties(client=client):
-        member_dict["get_properties"] = _get_properties
-
-    if numpyclient_has_get_parameters(client=client):
-        member_dict["get_parameters"] = _get_parameters
-
-    if numpyclient_has_fit(client=client):
-        member_dict["fit"] = _fit
-
-    if numpyclient_has_evaluate(client=client):
-        member_dict["evaluate"] = _evaluate
-
-    # Create wrapper class
-    wrapper_class = type("NumPyClientWrapper", (Client,), member_dict)
-
-    # Create and return an instance of the newly created class
-    return wrapper_class(numpy_client=client)  # type: ignore
 
 
 def run_client() -> None:

--- a/src/py/flwr/client/app_test.py
+++ b/src/py/flwr/client/app_test.py
@@ -17,8 +17,7 @@
 
 from typing import Dict, Tuple
 
-from flwr.client.numpy_client_wrapper import to_client
-from flwr.client.typing import ClientLike
+from flwr.client import ClientLike, to_client
 from flwr.common import (
     Config,
     EvaluateIns,

--- a/src/py/flwr/client/app_test.py
+++ b/src/py/flwr/client/app_test.py
@@ -17,6 +17,8 @@
 
 from typing import Dict, Tuple
 
+from flwr.client.numpy_client_wrapper import to_client
+from flwr.client.typing import ClientLike
 from flwr.common import (
     Config,
     EvaluateIns,
@@ -31,7 +33,7 @@ from flwr.common import (
     Scalar,
 )
 
-from .app import ClientLike, start_client, start_numpy_client, to_client
+from .app import start_client, start_numpy_client
 from .client import Client
 from .numpy_client import NumPyClient
 

--- a/src/py/flwr/client/numpy_client_wrapper.py
+++ b/src/py/flwr/client/numpy_client_wrapper.py
@@ -1,0 +1,170 @@
+# Copyright 2023 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Wrapper for NumPyClient objects."""
+
+from typing import Callable, Dict
+
+from flwr.client.typing import ClientLike
+from flwr.common import ndarrays_to_parameters, parameters_to_ndarrays
+from flwr.common.typing import (
+    Code,
+    EvaluateIns,
+    EvaluateRes,
+    FitIns,
+    FitRes,
+    GetParametersIns,
+    GetParametersRes,
+    GetPropertiesIns,
+    GetPropertiesRes,
+    NDArrays,
+    Status,
+)
+
+from .client import Client
+from .numpy_client import NumPyClient
+from .numpy_client import has_evaluate as numpyclient_has_evaluate
+from .numpy_client import has_fit as numpyclient_has_fit
+from .numpy_client import has_get_parameters as numpyclient_has_get_parameters
+from .numpy_client import has_get_properties as numpyclient_has_get_properties
+
+EXCEPTION_MESSAGE_WRONG_RETURN_TYPE_FIT = """
+NumPyClient.fit did not return a tuple with 3 elements.
+The returned values should have the following type signature:
+
+    Tuple[NDArrays, int, Dict[str, Scalar]]
+
+Example
+-------
+
+    model.get_weights(), 10, {"accuracy": 0.95}
+
+"""
+
+EXCEPTION_MESSAGE_WRONG_RETURN_TYPE_EVALUATE = """
+NumPyClient.evaluate did not return a tuple with 3 elements.
+The returned values should have the following type signature:
+
+    Tuple[float, int, Dict[str, Scalar]]
+
+Example
+-------
+
+    0.5, 10, {"accuracy": 0.95}
+
+"""
+
+
+def to_client(client_like: ClientLike) -> Client:
+    """Take any Client-like object and return it as a Client."""
+    if isinstance(client_like, NumPyClient):
+        return _wrap_numpy_client(client=client_like)
+    return client_like
+
+
+def _constructor(self: Client, numpy_client: NumPyClient) -> None:
+    self.numpy_client = numpy_client  # type: ignore
+
+
+def _get_properties(self: Client, ins: GetPropertiesIns) -> GetPropertiesRes:
+    """Return the current client properties."""
+    properties = self.numpy_client.get_properties(config=ins.config)  # type: ignore
+    return GetPropertiesRes(
+        status=Status(code=Code.OK, message="Success"),
+        properties=properties,
+    )
+
+
+def _get_parameters(self: Client, ins: GetParametersIns) -> GetParametersRes:
+    """Return the current local model parameters."""
+    parameters = self.numpy_client.get_parameters(config=ins.config)  # type: ignore
+    parameters_proto = ndarrays_to_parameters(parameters)
+    return GetParametersRes(
+        status=Status(code=Code.OK, message="Success"), parameters=parameters_proto
+    )
+
+
+def _fit(self: Client, ins: FitIns) -> FitRes:
+    """Refine the provided parameters using the locally held dataset."""
+    # Deconstruct FitIns
+    parameters: NDArrays = parameters_to_ndarrays(ins.parameters)
+
+    # Train
+    results = self.numpy_client.fit(parameters, ins.config)  # type: ignore
+    if not (
+        len(results) == 3
+        and isinstance(results[0], list)
+        and isinstance(results[1], int)
+        and isinstance(results[2], dict)
+    ):
+        raise Exception(EXCEPTION_MESSAGE_WRONG_RETURN_TYPE_FIT)
+
+    # Return FitRes
+    parameters_prime, num_examples, metrics = results
+    parameters_prime_proto = ndarrays_to_parameters(parameters_prime)
+    return FitRes(
+        status=Status(code=Code.OK, message="Success"),
+        parameters=parameters_prime_proto,
+        num_examples=num_examples,
+        metrics=metrics,
+    )
+
+
+def _evaluate(self: Client, ins: EvaluateIns) -> EvaluateRes:
+    """Evaluate the provided parameters using the locally held dataset."""
+    parameters: NDArrays = parameters_to_ndarrays(ins.parameters)
+
+    results = self.numpy_client.evaluate(parameters, ins.config)  # type: ignore
+    if not (
+        len(results) == 3
+        and isinstance(results[0], float)
+        and isinstance(results[1], int)
+        and isinstance(results[2], dict)
+    ):
+        raise Exception(EXCEPTION_MESSAGE_WRONG_RETURN_TYPE_EVALUATE)
+
+    # Return EvaluateRes
+    loss, num_examples, metrics = results
+    return EvaluateRes(
+        status=Status(code=Code.OK, message="Success"),
+        loss=loss,
+        num_examples=num_examples,
+        metrics=metrics,
+    )
+
+
+def _wrap_numpy_client(client: NumPyClient) -> Client:
+    member_dict: Dict[str, Callable] = {  # type: ignore
+        "__init__": _constructor,
+    }
+
+    # Add wrapper type methods (if overridden)
+
+    if numpyclient_has_get_properties(client=client):
+        member_dict["get_properties"] = _get_properties
+
+    if numpyclient_has_get_parameters(client=client):
+        member_dict["get_parameters"] = _get_parameters
+
+    if numpyclient_has_fit(client=client):
+        member_dict["fit"] = _fit
+
+    if numpyclient_has_evaluate(client=client):
+        member_dict["evaluate"] = _evaluate
+
+    # Create wrapper class
+    wrapper_class = type("NumPyClientWrapper", (Client,), member_dict)
+
+    # Create and return an instance of the newly created class
+    return wrapper_class(numpy_client=client)  # type: ignore

--- a/src/py/flwr/client/typing.py
+++ b/src/py/flwr/client/typing.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Adap GmbH. All Rights Reserved.
+# Copyright 2023 Flower Labs GmbH. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,19 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Flower client."""
+"""Custom types for Flower clients."""
 
+from typing import Callable, Union
 
-from .app import run_client as run_client
-from .app import start_client as start_client
-from .app import start_numpy_client as start_numpy_client
 from .client import Client as Client
 from .numpy_client import NumPyClient as NumPyClient
 
-__all__ = [
-    "Client",
-    "NumPyClient",
-    "run_client",
-    "start_client",
-    "start_numpy_client",
-]
+ClientLike = Union[Client, NumPyClient]
+ClientFn = Callable[[str], ClientLike]

--- a/src/py/flwr/simulation/app.py
+++ b/src/py/flwr/simulation/app.py
@@ -24,7 +24,7 @@ from typing import Any, Callable, Dict, List, Optional, Type, Union
 import ray
 from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 
-from flwr.client import ClientLike
+from flwr.client.typing import ClientLike
 from flwr.common import EventType, event
 from flwr.common.logger import log
 from flwr.server import Server

--- a/src/py/flwr/simulation/app.py
+++ b/src/py/flwr/simulation/app.py
@@ -19,12 +19,12 @@ import sys
 import threading
 import traceback
 from logging import ERROR, INFO
-from typing import Any, Callable, Dict, List, Optional, Type, Union
+from typing import Any, Dict, List, Optional, Type, Union
 
 import ray
 from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 
-from flwr.client.typing import ClientLike
+from flwr.client import ClientFn
 from flwr.common import EventType, event
 from flwr.common.logger import log
 from flwr.server import Server
@@ -47,7 +47,7 @@ Invalid Arguments in method:
 
 `start_simulation(
     *,
-    client_fn: Callable[[str], ClientLike],
+    client_fn: ClientFn,
     num_clients: Optional[int] = None,
     clients_ids: Optional[List[str]] = None,
     client_resources: Optional[Dict[str, float]] = None,
@@ -70,7 +70,7 @@ REASON:
 
 def start_simulation(  # pylint: disable=too-many-arguments
     *,
-    client_fn: Callable[[str], ClientLike],
+    client_fn: ClientFn,
     num_clients: Optional[int] = None,
     clients_ids: Optional[List[str]] = None,
     client_resources: Optional[Dict[str, float]] = None,
@@ -88,7 +88,7 @@ def start_simulation(  # pylint: disable=too-many-arguments
 
     Parameters
     ----------
-    client_fn : Callable[[str], ClientLike]
+    client_fn : ClientFn
         A function creating client instances. The function must take a single
         `str` argument called `cid`. It should return a single client instance
         of type ClientLike. Note that the created client instances are ephemeral

--- a/src/py/flwr/simulation/ray_transport/ray_client_proxy.py
+++ b/src/py/flwr/simulation/ray_transport/ray_client_proxy.py
@@ -30,15 +30,13 @@ from flwr.client.client import (
     maybe_call_get_properties,
 )
 from flwr.client.numpy_client_wrapper import to_client
-from flwr.client.typing import ClientLike
+from flwr.client.typing import ClientFn, ClientLike
 from flwr.common.logger import log
 from flwr.server.client_proxy import ClientProxy
 from flwr.simulation.ray_transport.ray_actor import (
     ClientRes,
     VirtualClientEngineActorPool,
 )
-
-ClientFn = Callable[[str], ClientLike]
 
 
 class RayClientProxy(ClientProxy):

--- a/src/py/flwr/simulation/ray_transport/ray_client_proxy.py
+++ b/src/py/flwr/simulation/ray_transport/ray_client_proxy.py
@@ -22,13 +22,15 @@ from typing import Callable, Dict, Optional, cast
 import ray
 
 from flwr import common
-from flwr.client import Client, ClientLike, to_client
+from flwr.client import Client
 from flwr.client.client import (
     maybe_call_evaluate,
     maybe_call_fit,
     maybe_call_get_parameters,
     maybe_call_get_properties,
 )
+from flwr.client.numpy_client_wrapper import to_client
+from flwr.client.typing import ClientLike
 from flwr.common.logger import log
 from flwr.server.client_proxy import ClientProxy
 from flwr.simulation.ray_transport.ray_actor import (

--- a/src/py/flwr/simulation/ray_transport/ray_client_proxy.py
+++ b/src/py/flwr/simulation/ray_transport/ray_client_proxy.py
@@ -22,15 +22,13 @@ from typing import Callable, Dict, Optional, cast
 import ray
 
 from flwr import common
-from flwr.client import Client
+from flwr.client import Client, ClientFn, ClientLike, to_client
 from flwr.client.client import (
     maybe_call_evaluate,
     maybe_call_fit,
     maybe_call_get_parameters,
     maybe_call_get_properties,
 )
-from flwr.client.numpy_client_wrapper import to_client
-from flwr.client.typing import ClientFn, ClientLike
 from flwr.common.logger import log
 from flwr.server.client_proxy import ClientProxy
 from flwr.simulation.ray_transport.ray_actor import (


### PR DESCRIPTION
Refactored Flower client:
* created a `typing.py` in client where types used throughout flower (ClientLike and ClientFn) are defined. It makes easier to access them like this instead that from client app where many things are imported.
* Moved all the numpy wrapping logic to `numpy_client_wrapper.py`, again so we can access important functions such as `to_client()` w/o having to worry about circular imports due to it being previously defined in client app