### PR TITLE
Use new link for FastAI doc article

### DIFF
--- a/examples/quickstart-fastai/README.md
+++ b/examples/quickstart-fastai/README.md
@@ -71,4 +71,4 @@ Start client 2 in the second terminal:
 python3 client.py
 ```
 
-You will see that fastai is starting a federated training. Have a look to the [Flower Quickstarter documentation](https://flower.dev/docs/quickstart-fastai.html) for a detailed explanation.
+You will see that fastai is starting a federated training. Have a look to the [Flower Quickstarter documentation](https://flower.dev/docs/tutorial-quickstart-fastai.html) for a detailed explanation.

--- a/examples/quickstart-fastai/README.md
+++ b/examples/quickstart-fastai/README.md
@@ -71,4 +71,4 @@ Start client 2 in the second terminal:
 python3 client.py
 ```
 
-You will see that fastai is starting a federated training. Have a look to the [Flower Quickstarter documentation](https://flower.dev/docs/tutorial-quickstart-fastai.html) for a detailed explanation.
+You will see that fastai is starting a federated training. For a more in-depth look, be sure to check out the code on our [repo](https://github.com/adap/flower/tree/main/examples/quickstart-fastai).


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

The FastAI example README redirects to an outdated link.

### Related issues/PRs

N/A

## Proposal

### Explanation

Use up to date link or even remove irrelevant part.

### Checklist

- [x] Implement proposed change
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

N/A
