### PR TITLE
Add canonical links to Baselines and Examples

### DIFF
--- a/baselines/doc/source/_templates/base.html
+++ b/baselines/doc/source/_templates/base.html
@@ -5,6 +5,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width,initial-scale=1"/>
     <meta name="color-scheme" content="light dark">
+    <link rel="canonical" href="https://flower.dev/docs/framework/{{ pagename }}.html">
 
     {%- if metatags %}{{ metatags }}{% endif -%}
 

--- a/examples/doc/source/_templates/base.html
+++ b/examples/doc/source/_templates/base.html
@@ -5,6 +5,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width,initial-scale=1"/>
     <meta name="color-scheme" content="light dark">
+    <link rel="canonical" href="https://flower.dev/docs/framework/{{ pagename }}.html">
 
     {%- if metatags %}{{ metatags }}{% endif -%}
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

Examples and Baselines lack canonical links.

### Related issues/PRs

N/A

## Proposal

### Explanation

Add canonical links to all pages under Examples and Baselines.

### Checklist

- [x] Implement proposed change
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

N/A
