### PR TITLE
Fix canonical URLs for Baselines and Examples

### DIFF
--- a/baselines/doc/source/_templates/base.html
+++ b/baselines/doc/source/_templates/base.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width,initial-scale=1"/>
     <meta name="color-scheme" content="light dark">
-    <link rel="canonical" href="https://flower.dev/docs/framework/{{ pagename }}.html">
+    <link rel="canonical" href="https://flower.dev/docs/baselines/{{ pagename }}.html">
 
     {%- if metatags %}{{ metatags }}{% endif -%}
 

--- a/examples/doc/source/_templates/base.html
+++ b/examples/doc/source/_templates/base.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width,initial-scale=1"/>
     <meta name="color-scheme" content="light dark">
-    <link rel="canonical" href="https://flower.dev/docs/framework/{{ pagename }}.html">
+    <link rel="canonical" href="https://flower.dev/docs/examples/{{ pagename }}.html">
 
     {%- if metatags %}{{ metatags }}{% endif -%}
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

The canonical URLs for Examples and Baselines are incorrect.

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal

### Explanation

Use the correct canonical URLs.

### Checklist

- [x] Implement proposed change
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

N/A
