### PR TITLE
Fix typo in URL for docs (leading to 404)

### DIFF
--- a/doc/source/how-to-configure-clients.rst
+++ b/doc/source/how-to-configure-clients.rst
@@ -86,7 +86,7 @@ Configuring individual clients
 
 In some cases, it is necessary to send different configuration values to different clients.
 
-This can be achieved by customizing an existing strategy or by `implementing a custom strategy from scratch <https://flower.dev/docs/how-to-implement-strategies.html>`_. Here's a nonsensical example that customizes :code:`FedAvg` by adding a custom ``"hello": "world"`` configuration key/value pair to the config dict of a *single client* (only the first client in the list, the other clients in this round to not receive this "special" config value):
+This can be achieved by customizing an existing strategy or by `implementing a custom strategy from scratch <https://flower.dev/docs/framework/how-to-implement-strategies.html>`_. Here's a nonsensical example that customizes :code:`FedAvg` by adding a custom ``"hello": "world"`` configuration key/value pair to the config dict of a *single client* (only the first client in the list, the other clients in this round to not receive this "special" config value):
 
 .. code-block:: python
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

A 404 is generated by a link in the docs.

### Related issues/PRs

N/A

## Proposal

### Explanation

Use the correct link.

### Checklist

- [x] Implement proposed change
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

N/A
