### PR TITLE
Add description tags for quickstart tutorials

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -2,8 +2,8 @@ Flower Framework Documentation
 ==============================
 
 .. meta::
-   :description lang=en: Documentation of the main Flower Framework enabling easy Python development for Federated Learning.
-   :description lang=fr: Documentation du framework principal de Flower permettant de developper des apps de Federated Learning en utilisant Python.
+   :description lang=en: Check out the documentation of the main Flower Framework enabling easy Python development for Federated Learning.
+   :description lang=fr: Découvrez la documentation du framework principal de Flower permettant de developper des apps de Federated Learning en utilisant Python.
 
 Welcome to Flower's documentation. `Flower <https://flower.dev>`_ is a friendly federated learning framework.
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,6 +1,10 @@
 Flower Framework Documentation
 ==============================
 
+.. meta::
+   :description lang=en: Documentation of the main Flower Framework enabling easy Python development for Federated Learning.
+   :description lang=fr: Documentation du framework principal de Flower permettant de developper des apps de Federated Learning en utilisant Python.
+
 Welcome to Flower's documentation. `Flower <https://flower.dev>`_ is a friendly federated learning framework.
 
 

--- a/doc/source/tutorial-quickstart-android.rst
+++ b/doc/source/tutorial-quickstart-android.rst
@@ -5,8 +5,8 @@ Quickstart Android
 ==================
 
 .. meta::
-   :description lang=en: Federated Learning quickstart tutorial for creating an Android app using Flower.
-   :description lang=fr: Tutoriel de Federated Learning pour créer une app Android en utilisant Flower.
+   :description lang=en: Read this Federated Learning quickstart tutorial for creating an Android app using Flower.
+   :description lang=fr: Lisez ce tutoriel de Federated Learning pour créer une app Android en utilisant Flower.
 
 Let's build a federated learning system using TFLite and Flower on Android!
 

--- a/doc/source/tutorial-quickstart-android.rst
+++ b/doc/source/tutorial-quickstart-android.rst
@@ -4,6 +4,10 @@
 Quickstart Android
 ==================
 
+.. meta::
+   :description lang=en: Federated Learning quickstart tutorial for creating an Android app using Flower.
+   :description lang=fr: Tutoriel de Federated Learning pour créer une app Android en utilisant Flower.
+
 Let's build a federated learning system using TFLite and Flower on Android!
 
 Please refer to the `full code example <https://github.com/adap/flower/tree/main/examples/android>`_ to learn more.

--- a/doc/source/tutorial-quickstart-fastai.rst
+++ b/doc/source/tutorial-quickstart-fastai.rst
@@ -4,6 +4,10 @@
 Quickstart fastai
 =================
 
+.. meta::
+   :description lang=en: Federated Learning quickstart tutorial for using Flower with FastAI to train a vision model on CIFAR-10.
+   :description lang=fr: Tutoriel de Federated Learning pour utiliser Flower avec FastAI pour entrainer un modèle de vision sur CIFAR-10.
+
 Let's build a federated learning system using fastai and Flower!
 
 Please refer to the `full code example <https://github.com/adap/flower/tree/main/examples/quickstart-fastai>`_ to learn more.

--- a/doc/source/tutorial-quickstart-fastai.rst
+++ b/doc/source/tutorial-quickstart-fastai.rst
@@ -5,8 +5,8 @@ Quickstart fastai
 =================
 
 .. meta::
-   :description lang=en: Federated Learning quickstart tutorial for using Flower with FastAI to train a vision model on CIFAR-10.
-   :description lang=fr: Tutoriel de Federated Learning pour utiliser Flower avec FastAI pour entrainer un modèle de vision sur CIFAR-10.
+   :description lang=en: Check out this Federated Learning quickstart tutorial for using Flower with FastAI to train a vision model on CIFAR-10.
+   :description lang=fr: Découvrez ce tutoriel de Federated Learning pour utiliser Flower avec FastAI pour entrainer un modèle de vision sur CIFAR-10.
 
 Let's build a federated learning system using fastai and Flower!
 

--- a/doc/source/tutorial-quickstart-huggingface.rst
+++ b/doc/source/tutorial-quickstart-huggingface.rst
@@ -5,8 +5,8 @@ Quickstart 🤗 Transformers
 ==========================
 
 .. meta::
-   :description lang=en: Federating Learning quickstart tutorial for using Flower with HuggingFace Transformers in order to fine-tune an LLM.
-   :description lang=fr: Tutoriel de Federated Learning pour utiliser Flower avec les Transformers de HuggingFace pour fine-tuner un LLM.
+   :description lang=en: Check out this Federating Learning quickstart tutorial for using Flower with HuggingFace Transformers in order to fine-tune an LLM.
+   :description lang=fr: Découvrez ce tutoriel de Federated Learning pour utiliser Flower avec les Transformers de HuggingFace pour fine-tuner un LLM.
 
 Let's build a federated learning system using Hugging Face Transformers and Flower!
 

--- a/doc/source/tutorial-quickstart-huggingface.rst
+++ b/doc/source/tutorial-quickstart-huggingface.rst
@@ -4,6 +4,10 @@
 Quickstart 🤗 Transformers
 ==========================
 
+.. meta::
+   :description lang=en: Federating Learning quickstart tutorial for using Flower with HuggingFace Transformers in order to fine-tune an LLM.
+   :description lang=fr: Tutoriel de Federated Learning pour utiliser Flower avec les Transformers de HuggingFace pour fine-tuner un LLM.
+
 Let's build a federated learning system using Hugging Face Transformers and Flower!
 
 We will leverage Hugging Face to federate the training of language models over multiple clients using Flower. 

--- a/doc/source/tutorial-quickstart-ios.rst
+++ b/doc/source/tutorial-quickstart-ios.rst
@@ -4,6 +4,10 @@
 Quickstart iOS
 ==============
 
+.. meta::
+   :description lang=en: Federated Learning quickstart tutorial for creating an iOS app using Flower to train a neural network on MNIST.
+   :description lang=fr: Tutoriel de Federated Learning pour créer une app iOS en utilisant Flower pour entrainer un réseau neurones sur MNIST.
+
 In this tutorial we will learn how to train a Neural Network on MNIST using Flower and CoreML on iOS devices. 
 
 First of all, for running the Flower Python server, it is recommended to create a virtual environment and run everything within a `virtualenv <https://flower.dev/docs/recommended-env-setup.html>`_.

--- a/doc/source/tutorial-quickstart-ios.rst
+++ b/doc/source/tutorial-quickstart-ios.rst
@@ -5,8 +5,8 @@ Quickstart iOS
 ==============
 
 .. meta::
-   :description lang=en: Federated Learning quickstart tutorial for creating an iOS app using Flower to train a neural network on MNIST.
-   :description lang=fr: Tutoriel de Federated Learning pour créer une app iOS en utilisant Flower pour entrainer un réseau neurones sur MNIST.
+   :description lang=en: Read this Federated Learning quickstart tutorial for creating an iOS app using Flower to train a neural network on MNIST.
+   :description lang=fr: Lisez ce tutoriel de Federated Learning pour créer une app iOS en utilisant Flower pour entrainer un réseau neurones sur MNIST.
 
 In this tutorial we will learn how to train a Neural Network on MNIST using Flower and CoreML on iOS devices. 
 

--- a/doc/source/tutorial-quickstart-jax.rst
+++ b/doc/source/tutorial-quickstart-jax.rst
@@ -5,8 +5,8 @@ Quickstart JAX
 ==============
 
 .. meta::
-   :description lang=en: Federated Learning quickstart tutorial for using Flower with Jax to train a linear regression model on a scikit-learn dataset.
-   :description lang=fr: Tutoriel de Federated Learning pour utiliser Flower avec Jax pour entrainer un modèle de régression linéaire sur un dataset de scikit-learn.
+   :description lang=en: Check out this Federated Learning quickstart tutorial for using Flower with Jax to train a linear regression model on a scikit-learn dataset.
+   :description lang=fr: Découvrez ce tutoriel de Federated Learning pour utiliser Flower avec Jax pour entrainer un modèle de régression linéaire sur un dataset de scikit-learn.
 
 This tutorial will show you how to use Flower to build a federated version of an existing JAX workload.
 We are using JAX to train a linear regression model on a scikit-learn dataset.

--- a/doc/source/tutorial-quickstart-jax.rst
+++ b/doc/source/tutorial-quickstart-jax.rst
@@ -4,6 +4,10 @@
 Quickstart JAX
 ==============
 
+.. meta::
+   :description lang=en: Federated Learning quickstart tutorial for using Flower with Jax to train a linear regression model on a scikit-learn dataset.
+   :description lang=fr: Tutoriel de Federated Learning pour utiliser Flower avec Jax pour entrainer un modèle de régression linéaire sur un dataset de scikit-learn.
+
 This tutorial will show you how to use Flower to build a federated version of an existing JAX workload.
 We are using JAX to train a linear regression model on a scikit-learn dataset.
 We will structure the example similar to our `PyTorch - From Centralized To Federated <https://github.com/adap/flower/blob/main/examples/pytorch-from-centralized-to-federated>`_ walkthrough.

--- a/doc/source/tutorial-quickstart-mxnet.rst
+++ b/doc/source/tutorial-quickstart-mxnet.rst
@@ -5,8 +5,8 @@ Quickstart MXNet
 ================
 
 .. meta::
-   :description lang=en: Federated Learning quickstart tutorial for using Flower with MXNet to train a Sequential model on MNIST.
-   :description lang=fr: Tutoriel de Federated Learning pour utiliser Flower avec MXNet pour entrainer un modèle séquentiel sur MNIST.
+   :description lang=en: Check out this Federated Learning quickstart tutorial for using Flower with MXNet to train a Sequential model on MNIST.
+   :description lang=fr: Découvrez ce tutoriel de Federated Learning pour utiliser Flower avec MXNet pour entrainer un modèle séquentiel sur MNIST.
 
 In this tutorial, we will learn how to train a :code:`Sequential` model on MNIST using Flower and MXNet. 
 

--- a/doc/source/tutorial-quickstart-mxnet.rst
+++ b/doc/source/tutorial-quickstart-mxnet.rst
@@ -4,6 +4,10 @@
 Quickstart MXNet
 ================
 
+.. meta::
+   :description lang=en: Federated Learning quickstart tutorial for using Flower with MXNet to train a Sequential model on MNIST.
+   :description lang=fr: Tutoriel de Federated Learning pour utiliser Flower avec MXNet pour entrainer un modèle séquentiel sur MNIST.
+
 In this tutorial, we will learn how to train a :code:`Sequential` model on MNIST using Flower and MXNet. 
 
 It is recommended to create a virtual environment and run everything within this `virtualenv <https://flower.dev/docs/recommended-env-setup.html>`_. 

--- a/doc/source/tutorial-quickstart-pandas.rst
+++ b/doc/source/tutorial-quickstart-pandas.rst
@@ -5,8 +5,8 @@ Quickstart Pandas
 =================
 
 .. meta::
-   :description lang=en: Federated Learning quickstart tutorial for using Flower with Pandas to perform Federated Analytics.
-   :description lang=fr: Tutoriel de Federated Learning pour utiliser Flower avec Pandas pour faire effectuer de l'analyse fédérée.
+   :description lang=en: Check out this Federated Learning quickstart tutorial for using Flower with Pandas to perform Federated Analytics.
+   :description lang=fr: Découvrez ce tutoriel de Federated Learning pour utiliser Flower avec Pandas pour faire effectuer de l'analyse fédérée.
 
 Let's build a federated analytics system using Pandas and Flower!
 

--- a/doc/source/tutorial-quickstart-pandas.rst
+++ b/doc/source/tutorial-quickstart-pandas.rst
@@ -4,6 +4,10 @@
 Quickstart Pandas
 =================
 
+.. meta::
+   :description lang=en: Federated Learning quickstart tutorial for using Flower with Pandas to perform Federated Analytics.
+   :description lang=fr: Tutoriel de Federated Learning pour utiliser Flower avec Pandas pour faire effectuer de l'analyse fédérée.
+
 Let's build a federated analytics system using Pandas and Flower!
 
 Please refer to the `full code example <https://github.com/adap/flower/tree/main/examples/quickstart-pandas>`_ to learn more.

--- a/doc/source/tutorial-quickstart-pytorch-lightning.rst
+++ b/doc/source/tutorial-quickstart-pytorch-lightning.rst
@@ -5,8 +5,8 @@ Quickstart PyTorch Lightning
 ============================
 
 .. meta::
-   :description lang=en: Federated Learning quickstart tutorial for using Flower with PyTorch Lightning to train an Auto Encoder model on MNIST.
-   :description lang=fr: Tutoriel de Federated Learning pour utiliser Flower avec PyTorch Lightning pour entrainer un Auto-encodeur sur MNIST.
+   :description lang=en: Check out this Federated Learning quickstart tutorial for using Flower with PyTorch Lightning to train an Auto Encoder model on MNIST.
+   :description lang=fr: Découvrez ce tutoriel de Federated Learning pour utiliser Flower avec PyTorch Lightning pour entrainer un Auto-encodeur sur MNIST.
 
 Let's build a federated learning system using PyTorch Lightning and Flower!
 

--- a/doc/source/tutorial-quickstart-pytorch-lightning.rst
+++ b/doc/source/tutorial-quickstart-pytorch-lightning.rst
@@ -4,6 +4,10 @@
 Quickstart PyTorch Lightning
 ============================
 
+.. meta::
+   :description lang=en: Federated Learning quickstart tutorial for using Flower with PyTorch Lightning to train an Auto Encoder model on MNIST.
+   :description lang=fr: Tutoriel de Federated Learning pour utiliser Flower avec PyTorch pour entrainer un Auto-encodeur sur MNIST.
+
 Let's build a federated learning system using PyTorch Lightning and Flower!
 
 Please refer to the `full code example <https://github.com/adap/flower/tree/main/examples/quickstart-pytorch-lightning>`_ to learn more.

--- a/doc/source/tutorial-quickstart-pytorch-lightning.rst
+++ b/doc/source/tutorial-quickstart-pytorch-lightning.rst
@@ -6,7 +6,7 @@ Quickstart PyTorch Lightning
 
 .. meta::
    :description lang=en: Federated Learning quickstart tutorial for using Flower with PyTorch Lightning to train an Auto Encoder model on MNIST.
-   :description lang=fr: Tutoriel de Federated Learning pour utiliser Flower avec PyTorch pour entrainer un Auto-encodeur sur MNIST.
+   :description lang=fr: Tutoriel de Federated Learning pour utiliser Flower avec PyTorch Lightning pour entrainer un Auto-encodeur sur MNIST.
 
 Let's build a federated learning system using PyTorch Lightning and Flower!
 

--- a/doc/source/tutorial-quickstart-pytorch.rst
+++ b/doc/source/tutorial-quickstart-pytorch.rst
@@ -5,8 +5,8 @@ Quickstart PyTorch
 ==================
 
 .. meta::
-   :description lang=en: Federated Learning quickstart tutorial for using Flower with PyTorch to train a CNN model on MNIST.
-   :description lang=fr: Tutoriel de Federated Learning pour utiliser Flower avec PyTorch pour entrainer un CNN sur MNIST.
+   :description lang=en: Check out this Federated Learning quickstart tutorial for using Flower with PyTorch to train a CNN model on MNIST.
+   :description lang=fr: Découvrez ce tutoriel de Federated Learning pour utiliser Flower avec PyTorch pour entrainer un CNN sur MNIST.
 
 ..  youtube:: jOmmuzMIQ4c
    :width: 100%

--- a/doc/source/tutorial-quickstart-pytorch.rst
+++ b/doc/source/tutorial-quickstart-pytorch.rst
@@ -4,6 +4,10 @@
 Quickstart PyTorch
 ==================
 
+.. meta::
+   :description lang=en: Federated Learning quickstart tutorial for using Flower with PyTorch to train a CNN model on MNIST.
+   :description lang=fr: Tutoriel de Federated Learning pour utiliser Flower avec PyTorch pour entrainer un CNN sur MNIST.
+
 ..  youtube:: jOmmuzMIQ4c
    :width: 100%
 

--- a/doc/source/tutorial-quickstart-scikitlearn.rst
+++ b/doc/source/tutorial-quickstart-scikitlearn.rst
@@ -5,8 +5,8 @@ Quickstart scikit-learn
 =======================
 
 .. meta::
-   :description lang=en: Federated Learning quickstart tutorial for using Flower with scikit-learn to train a linear regression model.
-   :description lang=fr: Tutoriel de Federated Learning pour utiliser Flower avec scikit-learn pour entrainer un modèle de régression linéaire.
+   :description lang=en: Check out this Federated Learning quickstart tutorial for using Flower with scikit-learn to train a linear regression model.
+   :description lang=fr: Découvrez ce tutoriel de Federated Learning pour utiliser Flower avec scikit-learn pour entrainer un modèle de régression linéaire.
 
 In this tutorial, we will learn how to train a :code:`Logistic Regression` model on MNIST using Flower and scikit-learn. 
 

--- a/doc/source/tutorial-quickstart-scikitlearn.rst
+++ b/doc/source/tutorial-quickstart-scikitlearn.rst
@@ -4,6 +4,10 @@
 Quickstart scikit-learn
 =======================
 
+.. meta::
+   :description lang=en: Federated Learning quickstart tutorial for using Flower with scikit-learn to train a linear regression model.
+   :description lang=fr: Tutoriel de Federated Learning pour utiliser Flower avec scikit-learn pour entrainer un modèle de régression linéaire.
+
 In this tutorial, we will learn how to train a :code:`Logistic Regression` model on MNIST using Flower and scikit-learn. 
 
 It is recommended to create a virtual environment and run everything within this `virtualenv <https://flower.dev/docs/recommended-env-setup.html>`_. 

--- a/doc/source/tutorial-quickstart-tensorflow.rst
+++ b/doc/source/tutorial-quickstart-tensorflow.rst
@@ -5,8 +5,8 @@ Quickstart TensorFlow
 =====================
 
 .. meta::
-   :description lang=en: Federated Learning quickstart tutorial for using Flower with TensorFlow to train a MobilNetV2 model on CIFAR-10.
-   :description lang=fr: Tutoriel de Federated Learning pour utiliser Flower avec TensorFlow pour entrainer un MobilNet sur CIFAR-10.
+   :description lang=en: Check out this Federated Learning quickstart tutorial for using Flower with TensorFlow to train a MobilNetV2 model on CIFAR-10.
+   :description lang=fr: Découvrez ce tutoriel de Federated Learning pour utiliser Flower avec TensorFlow pour entrainer un MobilNet sur CIFAR-10.
 
 ..  youtube:: FGTc2TQq7VM
    :width: 100%

--- a/doc/source/tutorial-quickstart-tensorflow.rst
+++ b/doc/source/tutorial-quickstart-tensorflow.rst
@@ -4,6 +4,10 @@
 Quickstart TensorFlow
 =====================
 
+.. meta::
+   :description lang=en: Federated Learning quickstart tutorial for using Flower with TensorFlow to train a MobilNetV2 model on CIFAR-10.
+   :description lang=fr: Tutoriel de Federated Learning pour utiliser Flower avec TensorFlow pour entrainer un MobilNet sur CIFAR-10.
+
 ..  youtube:: FGTc2TQq7VM
    :width: 100%
 

--- a/doc/source/tutorial-quickstart-xgboost.rst
+++ b/doc/source/tutorial-quickstart-xgboost.rst
@@ -4,6 +4,10 @@
 Quickstart XGBoost
 ==================
 
+.. meta::
+   :description lang=en: Federated Learning quickstart tutorial for using Flower with XGBoost to train classification models on trees.
+   :description lang=fr: Tutoriel de Federated Learning pour utiliser Flower avec XGBoost pour entrainer des modèles de classification sur des arbres.
+
 Let's build a horizontal federated learning system using XGBoost and Flower!
 
 Please refer to the `full code example <https://github.com/adap/flower/tree/main/examples/quickstart-xgboost-horizontal>`_ to learn more.

--- a/doc/source/tutorial-quickstart-xgboost.rst
+++ b/doc/source/tutorial-quickstart-xgboost.rst
@@ -5,8 +5,8 @@ Quickstart XGBoost
 ==================
 
 .. meta::
-   :description lang=en: Federated Learning quickstart tutorial for using Flower with XGBoost to train classification models on trees.
-   :description lang=fr: Tutoriel de Federated Learning pour utiliser Flower avec XGBoost pour entrainer des modèles de classification sur des arbres.
+   :description lang=en: Check out this Federated Learning quickstart tutorial for using Flower with XGBoost to train classification models on trees.
+   :description lang=fr: Découvrez ce tutoriel de Federated Learning pour utiliser Flower avec XGBoost pour entrainer des modèles de classification sur des arbres.
 
 Let's build a horizontal federated learning system using XGBoost and Flower!
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

Our quickstart tutorials doc pages lack description metadata tags.

### Related issues/PRs

N/A

## Proposal

### Explanation

Add tags to quickstart tutorial docs.

### Checklist

- [x] Implement proposed change
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

N/A
