### PR TITLE
Remove description meta tags in french

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -2,8 +2,7 @@ Flower Framework Documentation
 ==============================
 
 .. meta::
-   :description lang=en: Check out the documentation of the main Flower Framework enabling easy Python development for Federated Learning.
-   :description lang=fr: Découvrez la documentation du framework principal de Flower permettant de developper des apps de Federated Learning en utilisant Python.
+   :description: Check out the documentation of the main Flower Framework enabling easy Python development for Federated Learning.
 
 Welcome to Flower's documentation. `Flower <https://flower.dev>`_ is a friendly federated learning framework.
 

--- a/doc/source/tutorial-quickstart-android.rst
+++ b/doc/source/tutorial-quickstart-android.rst
@@ -5,8 +5,7 @@ Quickstart Android
 ==================
 
 .. meta::
-   :description lang=en: Read this Federated Learning quickstart tutorial for creating an Android app using Flower.
-   :description lang=fr: Lisez ce tutoriel de Federated Learning pour créer une app Android en utilisant Flower.
+   :description: Read this Federated Learning quickstart tutorial for creating an Android app using Flower.
 
 Let's build a federated learning system using TFLite and Flower on Android!
 

--- a/doc/source/tutorial-quickstart-fastai.rst
+++ b/doc/source/tutorial-quickstart-fastai.rst
@@ -5,8 +5,7 @@ Quickstart fastai
 =================
 
 .. meta::
-   :description lang=en: Check out this Federated Learning quickstart tutorial for using Flower with FastAI to train a vision model on CIFAR-10.
-   :description lang=fr: Découvrez ce tutoriel de Federated Learning pour utiliser Flower avec FastAI pour entrainer un modèle de vision sur CIFAR-10.
+   :description: Check out this Federated Learning quickstart tutorial for using Flower with FastAI to train a vision model on CIFAR-10.
 
 Let's build a federated learning system using fastai and Flower!
 

--- a/doc/source/tutorial-quickstart-huggingface.rst
+++ b/doc/source/tutorial-quickstart-huggingface.rst
@@ -5,8 +5,7 @@ Quickstart 🤗 Transformers
 ==========================
 
 .. meta::
-   :description lang=en: Check out this Federating Learning quickstart tutorial for using Flower with HuggingFace Transformers in order to fine-tune an LLM.
-   :description lang=fr: Découvrez ce tutoriel de Federated Learning pour utiliser Flower avec les Transformers de HuggingFace pour fine-tuner un LLM.
+   :description: Check out this Federating Learning quickstart tutorial for using Flower with HuggingFace Transformers in order to fine-tune an LLM.
 
 Let's build a federated learning system using Hugging Face Transformers and Flower!
 

--- a/doc/source/tutorial-quickstart-ios.rst
+++ b/doc/source/tutorial-quickstart-ios.rst
@@ -5,8 +5,7 @@ Quickstart iOS
 ==============
 
 .. meta::
-   :description lang=en: Read this Federated Learning quickstart tutorial for creating an iOS app using Flower to train a neural network on MNIST.
-   :description lang=fr: Lisez ce tutoriel de Federated Learning pour créer une app iOS en utilisant Flower pour entrainer un réseau neurones sur MNIST.
+   :description: Read this Federated Learning quickstart tutorial for creating an iOS app using Flower to train a neural network on MNIST.
 
 In this tutorial we will learn how to train a Neural Network on MNIST using Flower and CoreML on iOS devices. 
 

--- a/doc/source/tutorial-quickstart-jax.rst
+++ b/doc/source/tutorial-quickstart-jax.rst
@@ -5,8 +5,7 @@ Quickstart JAX
 ==============
 
 .. meta::
-   :description lang=en: Check out this Federated Learning quickstart tutorial for using Flower with Jax to train a linear regression model on a scikit-learn dataset.
-   :description lang=fr: Découvrez ce tutoriel de Federated Learning pour utiliser Flower avec Jax pour entrainer un modèle de régression linéaire sur un dataset de scikit-learn.
+   :description: Check out this Federated Learning quickstart tutorial for using Flower with Jax to train a linear regression model on a scikit-learn dataset.
 
 This tutorial will show you how to use Flower to build a federated version of an existing JAX workload.
 We are using JAX to train a linear regression model on a scikit-learn dataset.

--- a/doc/source/tutorial-quickstart-mxnet.rst
+++ b/doc/source/tutorial-quickstart-mxnet.rst
@@ -5,8 +5,7 @@ Quickstart MXNet
 ================
 
 .. meta::
-   :description lang=en: Check out this Federated Learning quickstart tutorial for using Flower with MXNet to train a Sequential model on MNIST.
-   :description lang=fr: Découvrez ce tutoriel de Federated Learning pour utiliser Flower avec MXNet pour entrainer un modèle séquentiel sur MNIST.
+   :description: Check out this Federated Learning quickstart tutorial for using Flower with MXNet to train a Sequential model on MNIST.
 
 In this tutorial, we will learn how to train a :code:`Sequential` model on MNIST using Flower and MXNet. 
 

--- a/doc/source/tutorial-quickstart-pandas.rst
+++ b/doc/source/tutorial-quickstart-pandas.rst
@@ -5,8 +5,7 @@ Quickstart Pandas
 =================
 
 .. meta::
-   :description lang=en: Check out this Federated Learning quickstart tutorial for using Flower with Pandas to perform Federated Analytics.
-   :description lang=fr: Découvrez ce tutoriel de Federated Learning pour utiliser Flower avec Pandas pour faire effectuer de l'analyse fédérée.
+   :description: Check out this Federated Learning quickstart tutorial for using Flower with Pandas to perform Federated Analytics.
 
 Let's build a federated analytics system using Pandas and Flower!
 

--- a/doc/source/tutorial-quickstart-pytorch-lightning.rst
+++ b/doc/source/tutorial-quickstart-pytorch-lightning.rst
@@ -5,8 +5,7 @@ Quickstart PyTorch Lightning
 ============================
 
 .. meta::
-   :description lang=en: Check out this Federated Learning quickstart tutorial for using Flower with PyTorch Lightning to train an Auto Encoder model on MNIST.
-   :description lang=fr: Découvrez ce tutoriel de Federated Learning pour utiliser Flower avec PyTorch Lightning pour entrainer un Auto-encodeur sur MNIST.
+   :description: Check out this Federated Learning quickstart tutorial for using Flower with PyTorch Lightning to train an Auto Encoder model on MNIST.
 
 Let's build a federated learning system using PyTorch Lightning and Flower!
 

--- a/doc/source/tutorial-quickstart-pytorch.rst
+++ b/doc/source/tutorial-quickstart-pytorch.rst
@@ -5,8 +5,7 @@ Quickstart PyTorch
 ==================
 
 .. meta::
-   :description lang=en: Check out this Federated Learning quickstart tutorial for using Flower with PyTorch to train a CNN model on MNIST.
-   :description lang=fr: Découvrez ce tutoriel de Federated Learning pour utiliser Flower avec PyTorch pour entrainer un CNN sur MNIST.
+   :description: Check out this Federated Learning quickstart tutorial for using Flower with PyTorch to train a CNN model on MNIST.
 
 ..  youtube:: jOmmuzMIQ4c
    :width: 100%

--- a/doc/source/tutorial-quickstart-scikitlearn.rst
+++ b/doc/source/tutorial-quickstart-scikitlearn.rst
@@ -5,8 +5,7 @@ Quickstart scikit-learn
 =======================
 
 .. meta::
-   :description lang=en: Check out this Federated Learning quickstart tutorial for using Flower with scikit-learn to train a linear regression model.
-   :description lang=fr: Découvrez ce tutoriel de Federated Learning pour utiliser Flower avec scikit-learn pour entrainer un modèle de régression linéaire.
+   :description: Check out this Federated Learning quickstart tutorial for using Flower with scikit-learn to train a linear regression model.
 
 In this tutorial, we will learn how to train a :code:`Logistic Regression` model on MNIST using Flower and scikit-learn. 
 

--- a/doc/source/tutorial-quickstart-tensorflow.rst
+++ b/doc/source/tutorial-quickstart-tensorflow.rst
@@ -5,8 +5,7 @@ Quickstart TensorFlow
 =====================
 
 .. meta::
-   :description lang=en: Check out this Federated Learning quickstart tutorial for using Flower with TensorFlow to train a MobilNetV2 model on CIFAR-10.
-   :description lang=fr: Découvrez ce tutoriel de Federated Learning pour utiliser Flower avec TensorFlow pour entrainer un MobilNet sur CIFAR-10.
+   :description: Check out this Federated Learning quickstart tutorial for using Flower with TensorFlow to train a MobilNetV2 model on CIFAR-10.
 
 ..  youtube:: FGTc2TQq7VM
    :width: 100%

--- a/doc/source/tutorial-quickstart-xgboost.rst
+++ b/doc/source/tutorial-quickstart-xgboost.rst
@@ -5,8 +5,7 @@ Quickstart XGBoost
 ==================
 
 .. meta::
-   :description lang=en: Check out this Federated Learning quickstart tutorial for using Flower with XGBoost to train classification models on trees.
-   :description lang=fr: Découvrez ce tutoriel de Federated Learning pour utiliser Flower avec XGBoost pour entrainer des modèles de classification sur des arbres.
+   :description: Check out this Federated Learning quickstart tutorial for using Flower with XGBoost to train classification models on trees.
 
 Let's build a horizontal federated learning system using XGBoost and Flower!
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

The meta tags in french cause some duplication, which is bad for SEO.

### Related issues/PRs

N/A

## Proposal

### Explanation

Remove the descriptions in french.

### Checklist

- [x] Implement proposed change
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

N/A
