### PR TITLE
Define client state classes

### DIFF
--- a/doc/source/ref-changelog.md
+++ b/doc/source/ref-changelog.md
@@ -12,6 +12,8 @@
 
   Using the `client_fn`, Flower clients can interchangeably run as standalone processes (i.e. via `start_client`) or in simulation (i.e. via `start_simulation`) without requiring changes to how the client class is defined and instantiated.
 
+- **Make clients stateful** ([#2389](https://github.com/adap/flower/pull/2389))
+
 - **Update Flower Baselines**
 
   - FedProx ([#2286](https://github.com/adap/flower/pull/2286))

--- a/src/py/flwr/client/__init__.py
+++ b/src/py/flwr/client/__init__.py
@@ -18,6 +18,8 @@
 from .app import start_client as start_client
 from .app import start_numpy_client as start_numpy_client
 from .client import Client as Client
+from .client_state import ClientState as ClientState
+from .client_state import WorkloadState as WorkloadState
 from .numpy_client import NumPyClient as NumPyClient
 from .numpy_client_wrapper import to_client as to_client
 from .run import run_client as run_client
@@ -28,7 +30,9 @@ __all__ = [
     "Client",
     "ClientFn",
     "ClientLike",
+    "ClientState",
     "NumPyClient",
+    "WorkloadState",
     "run_client",
     "start_client",
     "start_numpy_client",

--- a/src/py/flwr/client/client.py
+++ b/src/py/flwr/client/client.py
@@ -16,7 +16,9 @@
 
 
 from abc import ABC
+from typing import Optional
 
+from flwr.client.client_state import WorkloadState
 from flwr.common import (
     Code,
     EvaluateIns,
@@ -34,6 +36,8 @@ from flwr.common import (
 
 class Client(ABC):
     """Abstract base class for Flower clients."""
+
+    state: Optional[WorkloadState] = None
 
     def get_properties(self, ins: GetPropertiesIns) -> GetPropertiesRes:
         """Return set of client's properties.

--- a/src/py/flwr/client/client_state.py
+++ b/src/py/flwr/client/client_state.py
@@ -1,0 +1,59 @@
+# Copyright 2023 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Client state."""
+
+from dataclasses import dataclass, field
+from typing import Dict, Optional
+
+
+@dataclass
+class WorkloadState:
+    """Client state when performing a particular workload."""
+
+    cid: Optional[str]
+    workload_id: str
+
+    def __repr__(self) -> str:
+        """Return a string representation of a ClientState."""
+        return (
+            f"{self.__class__.__name__}"
+            f"(cid:{self.cid}, workload: {self.workload_id}): {self.__dict__}"
+        )
+
+
+@dataclass
+class ClientState:
+    """Client state.
+
+    A dataclass that keeps track of a separate state for each workload the client
+    executes.
+    """
+
+    cid: Optional[str] = None
+    workload_states: Dict[str, WorkloadState] = field(default_factory=dict)
+
+    def register_workload(self, workload_id: str) -> None:
+        """Register a new WorkloadState for a client if it does not exist."""
+        if workload_id not in self.workload_states:
+            self.workload_states[workload_id] = WorkloadState(self.cid, workload_id)
+
+    def __getitem__(self, workload_id: str) -> WorkloadState:
+        """Get client's state for a particular workload."""
+        return self.workload_states[workload_id]
+
+    def update_workload_state(self, workload_state: Optional[WorkloadState]) -> None:
+        """Update workload state with the one passed."""
+        if workload_state:
+            self.workload_states[workload_state.workload_id] = workload_state


### PR DESCRIPTION
This PR simply defines the classes to use by clients to record in-memory the state associated to each workload they participate in.