### PR TITLE
Use minimal ray package

### DIFF
--- a/doc/source/ref-changelog.md
+++ b/doc/source/ref-changelog.md
@@ -20,7 +20,7 @@
 
 - **General updates to the simulation engine** ([#2331](https://github.com/adap/flower/pull/2331))
 
-- **General improvements** ([#2309](https://github.com/adap/flower/pull/2309), [#2310](https://github.com/adap/flower/pull/2310), [2313](https://github.com/adap/flower/pull/2313), [#2316](https://github.com/adap/flower/pull/2316), [2317](https://github.com/adap/flower/pull/2317),[#2349](https://github.com/adap/flower/pull/2349), [#2360](https://github.com/adap/flower/pull/2360))
+- **General improvements** ([#2309](https://github.com/adap/flower/pull/2309), [#2310](https://github.com/adap/flower/pull/2310), [2313](https://github.com/adap/flower/pull/2313), [#2316](https://github.com/adap/flower/pull/2316), [2317](https://github.com/adap/flower/pull/2317),[#2349](https://github.com/adap/flower/pull/2349), [#2360](https://github.com/adap/flower/pull/2360), [#2402](https://github.com/adap/flower/pull/2402))
 
   Flower received many improvements under the hood, too many to list here.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ cryptography = "^41.0.2"
 pycryptodome = "^3.18.0"
 iterators = "^0.0.2"
 # Optional dependencies (VCE)
-ray = { version = "==2.6.3", extras = ["default"], optional = true }
+ray = { version = "==2.6.3", optional = true }
 pydantic = { version = "<2.0.0", optional = true }
 # Optional dependencies (REST transport layer)
 requests = { version = "^2.31.0", optional = true }


### PR DESCRIPTION
Instead of using `ray[default]`, let's just use `ray`. This helps with an issue related to `gpustat` package (>1.0.0). 