### PR TITLE
Make Flower Datasets docs publishable

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,3 +39,4 @@ jobs:
           aws s3 sync --delete --exclude ".*" --exclude "v/*" --cache-control "no-cache" ./doc/build/html/ s3://flower.dev/docs/framework
           aws s3 sync --delete --exclude ".*" --exclude "v/*" --cache-control "no-cache" ./baselines/doc/build/html/ s3://flower.dev/docs/baselines
           aws s3 sync --delete --exclude ".*" --exclude "v/*" --cache-control "no-cache" ./examples/doc/build/html/ s3://flower.dev/docs/examples
+          aws s3 sync --delete --exclude ".*" --exclude "v/*" --cache-control "no-cache" ./datasets/doc/build/html/ s3://flower.dev/docs/datasets

--- a/dev/build-docs.sh
+++ b/dev/build-docs.sh
@@ -17,3 +17,7 @@ cd examples/doc
 make docs
 
 cd $ROOT
+cd datasets/doc
+make docs
+
+cd $ROOT


### PR DESCRIPTION
* Extend the build-docs.sh script by adding the commands to build the Flower Datasets docs.
* Extend the docs GitHub workflow to make them in sync with AWS S3 bucket