### PR TITLE
Add resplitting functionality to Flower Datasets

### DIFF
--- a/datasets/flwr_datasets/federated_dataset_test.py
+++ b/datasets/flwr_datasets/federated_dataset_test.py
@@ -14,13 +14,13 @@
 # ==============================================================================
 """Federated Dataset tests."""
 
-
 import unittest
 
 import pytest
 from parameterized import parameterized, parameterized_class
 
 import datasets
+from datasets import DatasetDict, concatenate_datasets
 from flwr_datasets.federated_dataset import FederatedDataset
 
 
@@ -90,6 +90,55 @@ class RealDatasetsFederatedDatasetsTrainTest(unittest.TestCase):
             len(dataset[self.test_split]) // num_test_partitions,
         )
 
+    def test_resplit_dataset_into_one(self) -> None:
+        """Test resplit into a single dataset."""
+        dataset = datasets.load_dataset(self.dataset_name)
+        dataset_length = sum([len(ds) for ds in dataset.values()])
+        fds = FederatedDataset(
+            dataset=self.dataset_name,
+            partitioners={"train": 100},
+            resplitter={("train", self.test_split): "full"},
+        )
+        full = fds.load_full("full")
+        self.assertEqual(dataset_length, len(full))
+
+    # pylint: disable=protected-access
+    def test_resplit_dataset_to_change_names(self) -> None:
+        """Test resplitter to change the names of the partitions."""
+        fds = FederatedDataset(
+            dataset=self.dataset_name,
+            partitioners={"new_train": 100},
+            resplitter={
+                ("train",): "new_train",
+                (self.test_split,): "new_" + self.test_split,
+            },
+        )
+        _ = fds.load_partition(0, "new_train")
+        assert fds._dataset is not None
+        self.assertEqual(
+            set(fds._dataset.keys()), {"new_train", "new_" + self.test_split}
+        )
+
+    def test_resplit_dataset_by_callable(self) -> None:
+        """Test resplitter to change the names of the partitions."""
+
+        def resplit(dataset: DatasetDict) -> DatasetDict:
+            return DatasetDict(
+                {
+                    "full": concatenate_datasets(
+                        [dataset["train"], dataset[self.test_split]]
+                    )
+                }
+            )
+
+        fds = FederatedDataset(
+            dataset=self.dataset_name, partitioners={"train": 100}, resplitter=resplit
+        )
+        full = fds.load_full("full")
+        dataset = datasets.load_dataset(self.dataset_name)
+        dataset_length = sum([len(ds) for ds in dataset.values()])
+        self.assertEqual(len(full), dataset_length)
+
 
 class IncorrectUsageFederatedDatasets(unittest.TestCase):
     """Test incorrect usages in FederatedDatasets."""
@@ -114,6 +163,18 @@ class IncorrectUsageFederatedDatasets(unittest.TestCase):
         """Test creating FederatedDataset for unsupported dataset."""
         with pytest.raises(ValueError):
             FederatedDataset(dataset="food101", partitioners={"train": 100})
+
+    def test_cannot_use_the_old_split_names(self) -> None:
+        """Test if the initial split names can not be used."""
+        dataset = datasets.load_dataset("mnist")
+        sum([len(ds) for ds in dataset.values()])
+        fds = FederatedDataset(
+            dataset="mnist",
+            partitioners={"train": 100},
+            resplitter={("train", "test"): "full"},
+        )
+        with self.assertRaises(ValueError):
+            fds.load_partition(0, "train")
 
 
 if __name__ == "__main__":

--- a/datasets/flwr_datasets/resplitter.py
+++ b/datasets/flwr_datasets/resplitter.py
@@ -1,0 +1,77 @@
+"""Resplitter class for Flower Datasets."""
+import collections
+from typing import Dict, List, Tuple
+
+import datasets
+from datasets import Dataset, DatasetDict
+
+ResplitStrategy = Dict[Tuple[str, ...], str]
+
+
+class Resplitter:
+    """Create a new dataset splits according to the `resplit_strategy`.
+
+    The dataset comes with some predefined splits e.g. "train", "valid" and "test". This
+    class allows you to create a new dataset with splits created according to your needs
+    specified in `resplit_strategy`.
+
+    Parameters
+    ----------
+    resplit_strategy: ResplitStrategy
+        Dictionary with keys - tuples of the current split names to values - the desired
+        split names
+    """
+
+    def __init__(
+        self,
+        resplit_strategy: ResplitStrategy,
+    ) -> None:
+        self._resplit_strategy: ResplitStrategy = resplit_strategy
+        self._check_duplicate_desired_splits()
+
+    def __call__(self, dataset: DatasetDict) -> DatasetDict:
+        """Resplit the dataset according to the `resplit_strategy`."""
+        self._check_correct_keys_in_resplit_strategy(dataset)
+        return self.resplit(dataset)
+
+    def resplit(self, dataset: DatasetDict) -> DatasetDict:
+        """Resplit the dataset according to the `resplit_strategy`."""
+        resplit_dataset = {}
+        for divided_from__list, divide_to in self._resplit_strategy.items():
+            datasets_from_list: List[Dataset] = []
+            for divide_from in divided_from__list:
+                datasets_from_list.append(dataset[divide_from])
+            if len(datasets_from_list) > 1:
+                resplit_dataset[divide_to] = datasets.concatenate_datasets(
+                    datasets_from_list
+                )
+            else:
+                resplit_dataset[divide_to] = datasets_from_list[0]
+        return datasets.DatasetDict(resplit_dataset)
+
+    def _check_correct_keys_in_resplit_strategy(self, dataset: DatasetDict) -> None:
+        """Check if the keys in resplit_strategy are existing dataset splits."""
+        dataset_keys = dataset.keys()
+        specified_dataset_keys = self._resplit_strategy.keys()
+        for key_list in specified_dataset_keys:
+            for key in key_list:
+                if key not in dataset_keys:
+                    raise ValueError(
+                        f"The given dataset key '{key}' is not present in the given "
+                        f"dataset object. Make sure to use only the keywords that are "
+                        f"available in your dataset."
+                    )
+
+    def _check_duplicate_desired_splits(self) -> None:
+        """Check for duplicate desired split names."""
+        desired_splits = list(self._resplit_strategy.values())
+        duplicates = [
+            item
+            for item, count in collections.Counter(desired_splits).items()
+            if count > 1
+        ]
+        if duplicates:
+            print(f"Duplicate desired split name '{duplicates[0]}' in resplit strategy")
+            raise ValueError(
+                f"Duplicate desired split name '{duplicates[0]}' in resplit strategy"
+            )

--- a/datasets/flwr_datasets/resplitter_test.py
+++ b/datasets/flwr_datasets/resplitter_test.py
@@ -1,0 +1,123 @@
+"""Resplitter tests."""
+import unittest
+
+from datasets import Dataset, DatasetDict
+from flwr_datasets.resplitter import ResplitStrategy, Resplitter
+
+
+class TestResplitter(unittest.TestCase):
+    """Resplitter tests."""
+
+    def setUp(self) -> None:
+        """Set up the dataset with 3 splits for tests."""
+        self.dataset_dict = DatasetDict(
+            {
+                "train": Dataset.from_dict({"data": [1, 2, 3]}),
+                "valid": Dataset.from_dict({"data": [4, 5]}),
+                "test": Dataset.from_dict({"data": [6]}),
+            }
+        )
+
+    def test_resplitting_train_size(self) -> None:
+        """Test if resplitting for just renaming keeps the lengths correct."""
+        strategy: ResplitStrategy = {("train",): "new_train"}
+        resplitter = Resplitter(strategy)
+        new_dataset = resplitter(self.dataset_dict)
+        self.assertEqual(len(new_dataset["new_train"]), 3)
+
+    def test_resplitting_valid_size(self) -> None:
+        """Test if resplitting for just renaming keeps the lengths correct."""
+        strategy: ResplitStrategy = {("valid",): "new_valid"}
+        resplitter = Resplitter(strategy)
+        new_dataset = resplitter(self.dataset_dict)
+        self.assertEqual(len(new_dataset["new_valid"]), 2)
+
+    def test_resplitting_test_size(self) -> None:
+        """Test if resplitting for just renaming keeps the lengths correct."""
+        strategy: ResplitStrategy = {("test",): "new_test"}
+        resplitter = Resplitter(strategy)
+        new_dataset = resplitter(self.dataset_dict)
+        self.assertEqual(len(new_dataset["new_test"]), 1)
+
+    def test_resplitting_train_the_same(self) -> None:
+        """Test if resplitting for just renaming keeps the dataset the same."""
+        strategy: ResplitStrategy = {("train",): "new_train"}
+        resplitter = Resplitter(strategy)
+        new_dataset = resplitter(self.dataset_dict)
+        self.assertTrue(
+            datasets_are_equal(self.dataset_dict["train"], new_dataset["new_train"])
+        )
+
+    def test_combined_train_valid_size(self) -> None:
+        """Test if the resplitting that combines the datasets has correct size."""
+        strategy: ResplitStrategy = {("train", "valid"): "train_valid_combined"}
+        resplitter = Resplitter(strategy)
+        new_dataset = resplitter(self.dataset_dict)
+        self.assertEqual(len(new_dataset["train_valid_combined"]), 5)
+
+    def test_resplitting_test_with_combined_strategy_size(self) -> None:
+        """Test if the resplitting that combines the datasets has correct size."""
+        strategy: ResplitStrategy = {
+            ("train", "valid"): "train_valid_combined",
+            ("test",): "test",
+        }
+        resplitter = Resplitter(strategy)
+        new_dataset = resplitter(self.dataset_dict)
+        self.assertEqual(len(new_dataset["test"]), 1)
+
+    def test_invalid_resplit_strategy_exception_message(self) -> None:
+        """Test if the resplitting raises error when non-existing split is given."""
+        strategy: ResplitStrategy = {
+            ("invalid_split",): "new_train",
+            ("test",): "new_test",
+        }
+        resplitter = Resplitter(strategy)
+        with self.assertRaisesRegex(
+            ValueError, "The given dataset key 'invalid_split' is not present"
+        ):
+            resplitter(self.dataset_dict)
+
+    def test_nonexistent_split_in_strategy(self) -> None:
+        """Test if the exception is raised when the nonexistent split name is given."""
+        strategy: ResplitStrategy = {("nonexistent_split",): "new_split"}
+        resplitter = Resplitter(strategy)
+        with self.assertRaisesRegex(
+            ValueError, "The given dataset key 'nonexistent_split' is not present"
+        ):
+            resplitter(self.dataset_dict)
+
+    def test_duplicate_desired_split_name(self) -> None:
+        """Test that the new split names are not the same."""
+        strategy: ResplitStrategy = {("train",): "new_train", ("valid",): "new_train"}
+        with self.assertRaisesRegex(
+            ValueError, "Duplicate desired split name 'new_train' in resplit strategy"
+        ):
+            _ = Resplitter(strategy)
+
+    def test_empty_dataset_dict(self) -> None:
+        """Test that the error is raised when the empty DatasetDict is given."""
+        empty_dataset = DatasetDict({})
+        strategy: ResplitStrategy = {("train",): "new_train"}
+        resplitter = Resplitter(strategy)
+        with self.assertRaisesRegex(
+            ValueError, "The given dataset key 'train' is not present"
+        ):
+            resplitter(empty_dataset)
+
+
+def datasets_are_equal(ds1: Dataset, ds2: Dataset) -> bool:
+    """Check if two Datasets have the same values."""
+    # Check if both datasets have the same length
+    if len(ds1) != len(ds2):
+        return False
+
+    # Iterate over each row and check for equality
+    for row1, row2 in zip(ds1, ds2):
+        if row1 != row2:
+            return False
+
+    return True
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Issue

The datasets downloaded from Hugging Face come with certain splits. Yet, users might want to use different divisions of the whole dataset, which is currently not possible.

### Description

``` python
fds = FederatedDataset(dataset="mnist", partitioners={"train": 10})
# then I can
fds.load_partition(10, "train")
```
But what if the dataset had three splits "train", "valid", "test" (not 2 like "mnist"). 
In that case, you might want to have a single dataset from which 10 partitions are created.

And the reverse might hold true for just 2-split dataset. What if a user want to have 3 splits. This is also impossible.

## Proposal
Enable the missing functionality described above (and add tests to make sure they are met).
* Introduce the `resplitter` keyword in the `FederatedDataset`
* Enable two major ways of creation of the new dataset (with different splits) 
* The first one `Callable[[DatasetDict], DatasetDict]]` You might perform as sophisticated change as you wish - just provide this as `resplitter` to the `FederatedDataset` (Note: all the checks to use that correctly are on the user side)
* The second option is `Dict[Tuple[str, ...], str]` (called for convenience `ResplitStrategy`). Here is an example `{("train", "valid"): "bigger_train"}`. We create a "bigger_train" split from the "train" and "valid" splits. From this object a `Resplitter` (newly introduced class) is created. That is essentially `Callable[[DatasetDict], DatasetDict]]` with additional check if the splits are used correctly (you can use only the existing splits, and you cannot create a new dataset that has two splits with the same name)
This works as follows:
 Frist option
```python
  def resplit(dataset: DatasetDict) -> DatasetDict:
      return DatasetDict(
          {
              "bigger_train": concatenate_datasets(
                  [dataset["train"], dataset["valid]]
              ),
              "test": dataset["test"]
          }
      )

  fds = FederatedDataset(
      dataset=self.dataset_name, partitioners={"bigger_train": 100}, resplitter=resplit
  )
  bigger_train = fds.load_full("bigger_train")
  # Or just load a partition
  partition_from_bigger = fds.load_partition("bigger_train": 100)
```
The second option (that does the same thing) **ResplitterStrategy** specification => internally **Resplitter** creation
```python
fds = FederatedDataset(
            dataset=self.dataset_name, partitioners={"bigger_train": 100}, resplitter={("train", "valid"): "bigger_train"}
     )
# if I made a mistake using here 
# e.g. resplitter = {("train", "split-that-does- not-exist"): "bigger_train"}
# I'll get a meaningful error
# similarly if I did sth like that 
# resplitter = {("train",): "new", ("valid", ): "new"}
# there can't be two splits named "new" so I'll get an error
bigger_train = fds.load_full("bigger_train")
# Or just load a partition
partition_from_bigger = fds.load_partition("bigger_train": 100)
```