### PR TITLE
Make videos bigger to allow for index

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -63,10 +63,10 @@ QUICKSTART TUTORIALS: :doc:`PyTorch <tutorial-quickstart-pytorch>` | :doc:`Tenso
 
 
 ..  youtube:: jOmmuzMIQ4c
-   :width: 100%
+   :width: 40%
 
 ..  youtube:: FGTc2TQq7VM
-   :width: 100%
+   :width: 40%
 
 How-to guides
 ~~~~~~~~~~~~~

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -61,17 +61,12 @@ A learning-oriented series of federated learning tutorials, the best place to st
 
 QUICKSTART TUTORIALS: :doc:`PyTorch <tutorial-quickstart-pytorch>` | :doc:`TensorFlow <tutorial-quickstart-tensorflow>` | :doc:`🤗 Transformers <tutorial-quickstart-huggingface>` | :doc:`JAX <tutorial-quickstart-jax>` | :doc:`Pandas <tutorial-quickstart-pandas>` | :doc:`fastai <tutorial-quickstart-fastai>` | :doc:`PyTorch Lightning <tutorial-quickstart-pytorch-lightning>` | :doc:`MXNet <tutorial-quickstart-mxnet>` | :doc:`scikit-learn <tutorial-quickstart-scikitlearn>` | :doc:`XGBoost <tutorial-quickstart-xgboost>` | :doc:`Android <tutorial-quickstart-android>` | :doc:`iOS <tutorial-quickstart-ios>`
 
-.. grid:: 2
 
-  .. grid-item-card::  PyTorch
+..  youtube:: jOmmuzMIQ4c
+   :width: 100%
 
-    ..  youtube:: jOmmuzMIQ4c
-       :width: 100%
-
-  .. grid-item-card::  TensorFlow
-
-    ..  youtube:: FGTc2TQq7VM
-       :width: 100%
+..  youtube:: FGTc2TQq7VM
+   :width: 100%
 
 How-to guides
 ~~~~~~~~~~~~~

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -61,12 +61,15 @@ A learning-oriented series of federated learning tutorials, the best place to st
 
 QUICKSTART TUTORIALS: :doc:`PyTorch <tutorial-quickstart-pytorch>` | :doc:`TensorFlow <tutorial-quickstart-tensorflow>` | :doc:`🤗 Transformers <tutorial-quickstart-huggingface>` | :doc:`JAX <tutorial-quickstart-jax>` | :doc:`Pandas <tutorial-quickstart-pandas>` | :doc:`fastai <tutorial-quickstart-fastai>` | :doc:`PyTorch Lightning <tutorial-quickstart-pytorch-lightning>` | :doc:`MXNet <tutorial-quickstart-mxnet>` | :doc:`scikit-learn <tutorial-quickstart-scikitlearn>` | :doc:`XGBoost <tutorial-quickstart-xgboost>` | :doc:`Android <tutorial-quickstart-android>` | :doc:`iOS <tutorial-quickstart-ios>`
 
+We also made video tutorials for PyTorch:
 
 ..  youtube:: jOmmuzMIQ4c
-   :width: 40%
+   :width: 80%
+
+And TensorFlow:
 
 ..  youtube:: FGTc2TQq7VM
-   :width: 40%
+   :width: 80%
 
 How-to guides
 ~~~~~~~~~~~~~


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

The videos on the Framework docs landing page were too small to be indexed by Google.

### Related issues/PRs

N/A

## Proposal

### Explanation

Make the videos larger to fix the issue.

### Checklist

- [x] Implement proposed change
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

N/A
