### PR TITLE
Revert to AWS_DEFAULT_REGION

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Upload wheel
         id: upload
         env:
-          AWS_REGION: ${{ secrets. AWS_DEFAULT_REGION }}
+          AWS_DEFAULT_REGION: ${{ secrets. AWS_DEFAULT_REGION }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets. AWS_SECRET_ACCESS_KEY }}
         run: |


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

It turns out changing to `AWS_REGION` isn't necessary and doesn't fix the core issue.

### Related issues/PRs

Reverts #2454 

## Proposal

### Explanation

Use `AWS_DEFAULT_REGION` instead of `AWS_REGION`.

### Checklist

- [x] Implement proposed change
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

N/A
