### PR TITLE
Build wheel but skip upload on forks

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,7 +19,6 @@ jobs:
   wheel:
     runs-on: ubuntu-22.04
     name: Build, test and upload wheel
-    if: github.repository == 'adap/flower'
     steps:
       - uses: actions/checkout@v3
       - name: Bootstrap
@@ -31,6 +30,7 @@ jobs:
       - name: Test wheel
         run: ./dev/test-wheel.sh
       - name: Upload wheel
+        if: github.repository == 'adap/flower'
         id: upload
         env:
           AWS_DEFAULT_REGION: ${{ secrets. AWS_DEFAULT_REGION }}


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

Currently the wheel is not build on forks and therefore the tests that depend on it are not ran.

### Related issues/PRs

N/A

## Proposal

### Explanation

Only check if the current CI is running on a fork for the wheel uploading.

### Checklist

- [x] Implement proposed change
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

N/A
