### PR TITLE
Skip publishing jobs on fork PRs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Build docs
         run: ./dev/build-docs.sh
       - name: Deploy docs
-        if: github.ref == 'refs/heads/main' && github.repository == 'adap/flower'
+        if: github.ref == 'refs/heads/main' && github.repository == 'adap/flower' && ${{ !github.event.pull_request.head.repo.fork }}
         env:
           AWS_DEFAULT_REGION: ${{ secrets. AWS_DEFAULT_REGION }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Test wheel
         run: ./dev/test-wheel.sh
       - name: Upload wheel
-        if: github.repository == 'adap/flower'
+        if: github.repository == 'adap/flower' && ${{ !github.event.pull_request.head.repo.fork }}
         id: upload
         env:
           AWS_DEFAULT_REGION: ${{ secrets. AWS_DEFAULT_REGION }}
@@ -121,7 +121,7 @@ jobs:
       - name: Install dependencies
         run: python -m poetry install
       - name: Install Flower wheel from artifact store
-        if: github.repository == 'adap/flower'
+        if: github.repository == 'adap/flower' && ${{ !github.event.pull_request.head.repo.fork }}
         run: |
           python -m pip install https://artifact.flower.dev/py/${{ github.head_ref }}/${{ needs.wheel.outputs.short_sha }}/${{ needs.wheel.outputs.whl_path }}
       - name: Download dataset
@@ -156,7 +156,7 @@ jobs:
         run: |
           python -m poetry install
       - name: Install Flower wheel from artifact store
-        if: github.repository == 'adap/flower'
+        if: github.repository == 'adap/flower' && ${{ !github.event.pull_request.head.repo.fork }}
         run: |
           python -m pip install https://artifact.flower.dev/py/${{ github.head_ref }}/${{ needs.wheel.outputs.short_sha }}/${{ needs.wheel.outputs.whl_path }}
       - name: Cache Datasets

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -40,7 +40,7 @@ jobs:
 
   deploy_docs:
     needs: "build_docs"
-    if: github.ref == 'refs/heads/main' && github.repository == 'adap/flower'
+    if: github.ref == 'refs/heads/main' && github.repository == 'adap/flower' && ${{ !github.event.pull_request.head.repo.fork }}
     runs-on: macos-latest
     name: Deploy docs 
     steps:


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

Even though the publishing jobs are correctly skipped on forks, when a pull request is opened from a fork, it will still try to run them.

### Related issues/PRs

#2468 

## Proposal

### Explanation

Skip the publishing workflows based on the PR's origin.

### Checklist

- [x] Implement proposed change
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

N/A
