### PR TITLE
Sort tags by versions to get changelog

### DIFF
--- a/dev/get-latest-changelog.sh
+++ b/dev/get-latest-changelog.sh
@@ -5,7 +5,7 @@ cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"/../
 
 # Extract the latest release notes from the changelog, which starts at the line containing 
 # the latest version tag and ends one line before the previous version tag.
-tags=$(git tag --sort=-creatordate)
+tags=$(git tag --sort=-v:refname)
 new_version=$(echo "$tags" | sed -n '1p')
 old_version=$(echo "$tags" | sed -n '2p')
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

Currently the `get-latest-changelog` script, will get the latest changelog based on the creation date. But that means that if we release bug fixes as patch versions to already released minor versions after the next minor version has been released, the script wouldn't work.

### Related issues/PRs

N/A

## Proposal

### Explanation

Use the actual version in order to sort the list of tags.

### Checklist

- [x] Implement proposed change
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

N/A
