### PR TITLE
Reorganize artifact folders

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -42,7 +42,7 @@ jobs:
           sha_short=$(git rev-parse --short HEAD)
           echo "SHORT_SHA=$sha_short" >> "$GITHUB_OUTPUT"
           [ -z "${{ github.head_ref }}" ] && dir="${{ github.ref_name }}" || dir="pr/${{ github.head_ref }}"
-          echo "DIR=$dir" >> "GITHUB_OUTPUT"
+          echo "DIR=$dir" >> "$GITHUB_OUTPUT"
           aws s3 cp --content-disposition "attachment" --cache-control "no-cache" ./ s3://artifact.flower.dev/py/$dir/$sha_short --recursive
     outputs:
       whl_path: ${{ steps.upload.outputs.WHL_PATH }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -41,10 +41,13 @@ jobs:
           echo "WHL_PATH=$(ls *.whl)" >> "$GITHUB_OUTPUT"
           sha_short=$(git rev-parse --short HEAD)
           echo "SHORT_SHA=$sha_short" >> "$GITHUB_OUTPUT"
-          aws s3 cp --content-disposition "attachment" --cache-control "no-cache" ./ s3://artifact.flower.dev/py/${{ github.head_ref || github.ref_name }}/$sha_short --recursive
+          [ -z "${{ github.head_ref }}" ] && dir="${{ github.ref_name }}" || dir="pr/${{ github.head_ref }}"
+          echo "DIR=$dir" >> "GITHUB_OUTPUT"
+          aws s3 cp --content-disposition "attachment" --cache-control "no-cache" ./ s3://artifact.flower.dev/py/$dir/$sha_short --recursive
     outputs:
       whl_path: ${{ steps.upload.outputs.WHL_PATH }}
       short_sha: ${{ steps.upload.outputs.SHORT_SHA }}
+      dir: ${{ steps.upload.outputs.DIR }}
 
   frameworks:
     runs-on: ubuntu-22.04
@@ -123,7 +126,7 @@ jobs:
       - name: Install Flower wheel from artifact store
         if: ${{ github.repository == 'adap/flower' && !github.event.pull_request.head.repo.fork }}
         run: |
-          python -m pip install https://artifact.flower.dev/py/${{ github.head_ref || github.ref_name }}/${{ needs.wheel.outputs.short_sha }}/${{ needs.wheel.outputs.whl_path }}
+          python -m pip install https://artifact.flower.dev/py/${{ needs.wheel.outputs.dir }}/${{ needs.wheel.outputs.short_sha }}/${{ needs.wheel.outputs.whl_path }}
       - name: Download dataset
         if: ${{ matrix.dataset }}
         run: python -c "${{ matrix.dataset }}"
@@ -158,7 +161,7 @@ jobs:
       - name: Install Flower wheel from artifact store
         if: ${{ github.repository == 'adap/flower' && !github.event.pull_request.head.repo.fork }}
         run: |
-          python -m pip install https://artifact.flower.dev/py/${{ github.head_ref || github.ref_name }}/${{ needs.wheel.outputs.short_sha }}/${{ needs.wheel.outputs.whl_path }}
+          python -m pip install https://artifact.flower.dev/py/${{ needs.wheel.outputs.dir }}/${{ needs.wheel.outputs.short_sha }}/${{ needs.wheel.outputs.whl_path }}
       - name: Cache Datasets
         uses: actions/cache@v3
         with:

--- a/.github/workflows/framework-release.yml
+++ b/.github/workflows/framework-release.yml
@@ -38,7 +38,15 @@ jobs:
           
           curl $wheel_url --output $wheel_name
           curl $tar_url --output $tar_name
-
+      - name: Upload wheel
+        env:
+          AWS_DEFAULT_REGION: ${{ secrets. AWS_DEFAULT_REGION }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets. AWS_SECRET_ACCESS_KEY }}
+        run: |
+          aws s3 cp --content-disposition "attachment" --cache-control "no-cache" ./${{ env.WHEEL_NAME }} s3://artifact.flower.dev/py/release/v${{ env.TAG_NAME }}/${{ env.WHEEL_NAME }}
+          aws s3 cp --content-disposition "attachment" --cache-control "no-cache" ./${{ env.TAR_NAME }} s3://artifact.flower.dev/py/release/v${{ env.TAG_NAME }}/${{ env.TAR_NAME }}
+          
       - name: Generate body
         run: |
           ./dev/get-latest-changelog.sh > body.md


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

The current artifact store is a bit messy.

### Related issues/PRs

N/A

## Proposal

### Explanation

We want to have all commits to main under a `main/` folder, all commits to branches under `pr/<branch-name>/`, and all releases under `release/<version>/`.

### Checklist

- [x] Implement proposed change
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

N/A
