### PR TITLE
Fix release doc format

### DIFF
--- a/doc/source/contributor-how-to-release-flower.rst
+++ b/doc/source/contributor-how-to-release-flower.rst
@@ -18,8 +18,7 @@ During the release
 The version number of a release is stated in ``pyproject.toml``. To release a new version of Flower, the following things need to happen (in that order):
 
 1. Update the ``changelog.md`` section header ``Unreleased`` to contain the version number and date for the release you are building. Create a pull request with the change.
-2. Tag the release commit with the version number as soon as the PR is merged: ``git tag v0.12.3``, then ``git push --tags``. This will create a draft release on GitHub 
-containing the correct artifacts and the relevant part of the changelog.
+2. Tag the release commit with the version number as soon as the PR is merged: ``git tag v0.12.3``, then ``git push --tags``. This will create a draft release on GitHub containing the correct artifacts and the relevant part of the changelog.
 3. Check the draft release on GitHub, and if everything is good, publish it.
 
 After the release


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

The formatting of a list in the release doc was wrong.

### Related issues/PRs

N/A

## Proposal

### Explanation

Fix the formatting.

### Checklist

- [x] Implement proposed change
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

N/A
