### PR TITLE
Rename Driver to GrpcDriver

### DIFF
--- a/examples/mt-pytorch/driver.py
+++ b/examples/mt-pytorch/driver.py
@@ -2,7 +2,7 @@ from typing import List, Tuple
 import random
 import time
 
-from flwr.driver import Driver
+from flwr.driver import GrpcDriver
 from flwr.common import (
     ServerMessage,
     FitIns,
@@ -43,7 +43,7 @@ def weighted_average(metrics: List[Tuple[int, Metrics]]) -> Metrics:
 
 
 # -------------------------------------------------------------------------- Driver SDK
-driver = Driver(driver_service_address="0.0.0.0:9091", certificates=None)
+driver = GrpcDriver(driver_service_address="0.0.0.0:9091", certificates=None)
 # -------------------------------------------------------------------------- Driver SDK
 
 anonymous_client_nodes = False

--- a/examples/secaggplus-mt/driver.py
+++ b/examples/secaggplus-mt/driver.py
@@ -6,7 +6,7 @@ import numpy as np
 from workflows import get_workflow_factory
 
 from flwr.common import Metrics, ndarrays_to_parameters
-from flwr.driver import Driver
+from flwr.driver import GrpcDriver
 from flwr.proto import driver_pb2, node_pb2, task_pb2
 from flwr.server import History
 
@@ -71,7 +71,7 @@ def weighted_average(metrics: List[Tuple[int, Metrics]]) -> Metrics:
 
 
 # -------------------------------------------------------------------------- Driver SDK
-driver = Driver(driver_service_address="0.0.0.0:9091", certificates=None)
+driver = GrpcDriver(driver_service_address="0.0.0.0:9091", certificates=None)
 # -------------------------------------------------------------------------- Driver SDK
 
 anonymous_client_nodes = False

--- a/src/py/flwr/driver/__init__.py
+++ b/src/py/flwr/driver/__init__.py
@@ -16,9 +16,9 @@
 
 
 from .app import start_driver
-from .driver import Driver
+from .driver import GrpcDriver
 
 __all__ = [
     "start_driver",
-    "Driver",
+    "GrpcDriver",
 ]

--- a/src/py/flwr/driver/app.py
+++ b/src/py/flwr/driver/app.py
@@ -31,7 +31,7 @@ from flwr.server.history import History
 from flwr.server.server import Server
 from flwr.server.strategy import Strategy
 
-from .driver import Driver
+from .driver import GrpcDriver
 from .driver_client_proxy import DriverClientProxy
 
 DEFAULT_SERVER_ADDRESS_DRIVER = "[::]:9091"
@@ -112,7 +112,7 @@ def start_driver(  # pylint: disable=too-many-arguments, too-many-locals
     address = f"[{host}]:{port}" if is_v6 else f"{host}:{port}"
 
     # Create the Driver
-    driver = Driver(driver_service_address=address, certificates=certificates)
+    driver = GrpcDriver(driver_service_address=address, certificates=certificates)
     driver.connect()
     lock = threading.Lock()
 
@@ -157,7 +157,7 @@ def start_driver(  # pylint: disable=too-many-arguments, too-many-locals
 
 
 def update_client_manager(
-    driver: Driver,
+    driver: GrpcDriver,
     client_manager: ClientManager,
     lock: threading.Lock,
 ) -> None:

--- a/src/py/flwr/driver/driver.py
+++ b/src/py/flwr/driver/driver.py
@@ -40,13 +40,13 @@ DEFAULT_SERVER_ADDRESS_DRIVER = "[::]:9091"
 ERROR_MESSAGE_DRIVER_NOT_CONNECTED = """
 [Driver] Error: Not connected.
 
-Call `connect()` on the `Driver` instance before calling any of the other `Driver`
-methods.
+Call `connect()` on the `GrpcDriver` instance before calling any of the other
+`GrpcDriver` methods.
 """
 
 
-class Driver:
-    """`Driver` provides access to the Driver API."""
+class GrpcDriver:
+    """`GrpcDriver` provides access to the gRPC Driver APIs."""
 
     def __init__(
         self,
@@ -59,7 +59,7 @@ class Driver:
         self.stub: Optional[DriverStub] = None
 
     def connect(self) -> None:
-        """Connect to the Driver API."""
+        """Connect to the gRPC Driver API."""
         event(EventType.DRIVER_CONNECT)
         if self.channel is not None or self.stub is not None:
             log(WARNING, "Already connected")
@@ -72,7 +72,7 @@ class Driver:
         log(INFO, "[Driver] Connected to %s", self.driver_service_address)
 
     def disconnect(self) -> None:
-        """Disconnect from the Driver API."""
+        """Disconnect from the gRPC Driver API."""
         event(EventType.DRIVER_DISCONNECT)
         if self.channel is None or self.stub is None:
             log(WARNING, "Already disconnected")
@@ -88,9 +88,9 @@ class Driver:
         # Check if channel is open
         if self.stub is None:
             log(ERROR, ERROR_MESSAGE_DRIVER_NOT_CONNECTED)
-            raise Exception("`Driver` instance not connected")
+            raise Exception("`GrpcDriver` instance not connected")
 
-        # Call Driver API
+        # Call gRPC Driver API
         res: CreateWorkloadResponse = self.stub.CreateWorkload(request=req)
         return res
 
@@ -99,9 +99,9 @@ class Driver:
         # Check if channel is open
         if self.stub is None:
             log(ERROR, ERROR_MESSAGE_DRIVER_NOT_CONNECTED)
-            raise Exception("`Driver` instance not connected")
+            raise Exception("`GrpcDriver` instance not connected")
 
-        # Call Driver API
+        # Call gRPC Driver API
         res: GetNodesResponse = self.stub.GetNodes(request=req)
         return res
 
@@ -110,9 +110,9 @@ class Driver:
         # Check if channel is open
         if self.stub is None:
             log(ERROR, ERROR_MESSAGE_DRIVER_NOT_CONNECTED)
-            raise Exception("`Driver` instance not connected")
+            raise Exception("`GrpcDriver` instance not connected")
 
-        # Call Driver API
+        # Call gRPC Driver API
         res: PushTaskInsResponse = self.stub.PushTaskIns(request=req)
         return res
 
@@ -121,8 +121,8 @@ class Driver:
         # Check if channel is open
         if self.stub is None:
             log(ERROR, ERROR_MESSAGE_DRIVER_NOT_CONNECTED)
-            raise Exception("`Driver` instance not connected")
+            raise Exception("`GrpcDriver` instance not connected")
 
-        # Call Driver API
+        # Call gRPC Driver API
         res: PullTaskResResponse = self.stub.PullTaskRes(request=req)
         return res

--- a/src/py/flwr/driver/driver_client_proxy.py
+++ b/src/py/flwr/driver/driver_client_proxy.py
@@ -23,7 +23,7 @@ from flwr.common import serde
 from flwr.proto import driver_pb2, node_pb2, task_pb2, transport_pb2
 from flwr.server.client_proxy import ClientProxy
 
-from .driver import Driver
+from .driver import GrpcDriver
 
 SLEEP_TIME = 1
 
@@ -31,7 +31,9 @@ SLEEP_TIME = 1
 class DriverClientProxy(ClientProxy):
     """Flower client proxy which delegates work using the Driver API."""
 
-    def __init__(self, node_id: int, driver: Driver, anonymous: bool, workload_id: int):
+    def __init__(
+        self, node_id: int, driver: GrpcDriver, anonymous: bool, workload_id: int
+    ):
         super().__init__(str(node_id))
         self.node_id = node_id
         self.driver = driver


### PR DESCRIPTION
Rename class name `Driver` to `GrpcDriver`.

Update comments accordingly.

I keep the Driver connect and disconnect event unchanged for now (open to discussion).