### PR TITLE
Add backoff dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ protobuf = "^3.19.0"
 cryptography = "^41.0.2"
 pycryptodome = "^3.18.0"
 iterators = "^0.0.2"
+backoff = "^2.2.1"
 # Optional dependencies (VCE)
 ray = { version = "==2.6.3", optional = true }
 pydantic = { version = "<2.0.0", optional = true }


### PR DESCRIPTION
[Backoff library](https://pypi.org/project/backoff/) provides an easy-to-use decorator that facilitates retry and exception handling. We may use Backoff to stabilize `start_driver()`.