### PR TITLE
Fix CI by downgrading torch on fastai E2E

### DIFF
--- a/e2e/fastai/pyproject.toml
+++ b/e2e/fastai/pyproject.toml
@@ -12,4 +12,4 @@ authors = ["The Flower Authors <hello@flower.dev>"]
 python = ">=3.8,<3.10"
 flwr = { path = "../../", develop = true, extras = ["simulation"] }
 fastai = "^2.7.12"
-torch = ">=2.0.0, !=2.0.1"
+torch = ">=2.0.0, !=2.0.1, < 2.1.0"


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

The CI is failing due to a new torch version that doesn't install the CUDA libraries automatically.

### Related issues/PRs

N/A

## Proposal

### Explanation

Fix the torch version to under 2.1.0.

### Checklist

- [x] Implement proposed change
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

N/A
