### PR TITLE
Add auto-update for PRs set to auto-merge

### DIFF
--- a/.github/workflows/update-pr.yml
+++ b/.github/workflows/update-pr.yml
@@ -1,0 +1,20 @@
+name: PR update
+
+on:
+  push:
+    branches:
+      - 'main'
+jobs:
+  autoupdate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Automatically update PR
+        uses: adRise/update-pr-branch@0.7
+        with:
+          token: ${{ secrets.ACTION_USER_TOKEN }}
+          base: 'main'
+          required_approval_count: 1
+          require_passed_checks: true
+          sort: 'created'
+          direction: 'desc'
+          require_auto_merge_enabled: true


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

Some PRs set to auto-merged can be left unmerged if some changes are merged before the end of the tests.

### Related issues/PRs

N/A

## Proposal

### Explanation

Add a GH workflow to automatically update the PR once it has been set to auto-merge.

### Checklist

- [x] Implement proposed change
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

N/A
