### PR TITLE
Remove unnecessary imports in C++ Python server

### DIFF
--- a/examples/quickstart-cpp/fedavg_cpp.py
+++ b/examples/quickstart-cpp/fedavg_cpp.py
@@ -1,11 +1,8 @@
-from ast import Bytes
-from collections import OrderedDict
-from io import BytesIO
 import struct
-from typing import Callable, Dict, List, Tuple, Union
+from ast import Bytes
+from typing import Callable, Dict, List, Optional, Tuple, Union
 
 import numpy as np
-
 from flwr.server.strategy import FedAvg
 from flwr.common import (
     EvaluateRes,
@@ -14,11 +11,8 @@ from flwr.common import (
     Scalar,
     NDArrays,
 )
-from typing import Optional
-from flwr.server.client_manager import ClientManager
 from flwr.server.client_proxy import ClientProxy
 from flwr.server.strategy.aggregate import aggregate, weighted_loss_avg
-from numpy import bytes_, numarray
 
 
 class FedAvgCpp(FedAvg):


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

The Python server of the C++ quickstart example had some unnecessary and unordered imports.

### Related issues/PRs

N/A

## Proposal

### Explanation

Remove unnecessary code and reorder imports.

### Checklist

- [x] Implement proposed change
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

N/A
