### PR TITLE
Use `Driver` in `start_driver()`

### DIFF
--- a/src/py/flwr/driver/__init__.py
+++ b/src/py/flwr/driver/__init__.py
@@ -16,9 +16,11 @@
 
 
 from .app import start_driver
-from .driver import GrpcDriver
+from .driver import Driver
+from .grpc_driver import GrpcDriver
 
 __all__ = [
-    "start_driver",
+    "Driver",
     "GrpcDriver",
+    "start_driver",
 ]

--- a/src/py/flwr/driver/app.py
+++ b/src/py/flwr/driver/app.py
@@ -31,8 +31,8 @@ from flwr.server.history import History
 from flwr.server.server import Server
 from flwr.server.strategy import Strategy
 
-from .driver import GrpcDriver
 from .driver_client_proxy import DriverClientProxy
+from .grpc_driver import GrpcDriver
 
 DEFAULT_SERVER_ADDRESS_DRIVER = "[::]:9091"
 

--- a/src/py/flwr/driver/driver.py
+++ b/src/py/flwr/driver/driver.py
@@ -15,119 +15,17 @@
 """Flower driver service client."""
 
 
-from logging import ERROR, INFO, WARNING
 from typing import Iterable, List, Optional, Tuple
 
-import grpc
-
-from flwr.common import EventType, event
-from flwr.common.grpc import create_channel
-from flwr.common.logger import log
+from flwr.driver.grpc_driver import GrpcDriver
 from flwr.proto.driver_pb2 import (
     CreateWorkloadRequest,
-    CreateWorkloadResponse,
     GetNodesRequest,
-    GetNodesResponse,
     PullTaskResRequest,
-    PullTaskResResponse,
     PushTaskInsRequest,
-    PushTaskInsResponse,
 )
-from flwr.proto.driver_pb2_grpc import DriverStub
 from flwr.proto.node_pb2 import Node
 from flwr.proto.task_pb2 import TaskIns, TaskRes
-
-DEFAULT_SERVER_ADDRESS_DRIVER = "[::]:9091"
-
-ERROR_MESSAGE_DRIVER_NOT_CONNECTED = """
-[Driver] Error: Not connected.
-
-Call `connect()` on the `GrpcDriver` instance before calling any of the other
-`GrpcDriver` methods.
-"""
-
-
-class GrpcDriver:
-    """`GrpcDriver` provides access to the gRPC Driver API/service."""
-
-    def __init__(
-        self,
-        driver_service_address: str = DEFAULT_SERVER_ADDRESS_DRIVER,
-        certificates: Optional[bytes] = None,
-    ) -> None:
-        self.driver_service_address = driver_service_address
-        self.certificates = certificates
-        self.channel: Optional[grpc.Channel] = None
-        self.stub: Optional[DriverStub] = None
-
-    def connect(self) -> None:
-        """Connect to the Driver API."""
-        event(EventType.DRIVER_CONNECT)
-        if self.channel is not None or self.stub is not None:
-            log(WARNING, "Already connected")
-            return
-        self.channel = create_channel(
-            server_address=self.driver_service_address,
-            root_certificates=self.certificates,
-        )
-        self.stub = DriverStub(self.channel)
-        log(INFO, "[Driver] Connected to %s", self.driver_service_address)
-
-    def disconnect(self) -> None:
-        """Disconnect from the Driver API."""
-        event(EventType.DRIVER_DISCONNECT)
-        if self.channel is None or self.stub is None:
-            log(WARNING, "Already disconnected")
-            return
-        channel = self.channel
-        self.channel = None
-        self.stub = None
-        channel.close()
-        log(INFO, "[Driver] Disconnected")
-
-    def create_workload(self, req: CreateWorkloadRequest) -> CreateWorkloadResponse:
-        """Request for workload ID."""
-        # Check if channel is open
-        if self.stub is None:
-            log(ERROR, ERROR_MESSAGE_DRIVER_NOT_CONNECTED)
-            raise Exception("`GrpcDriver` instance not connected")
-
-        # Call Driver API
-        res: CreateWorkloadResponse = self.stub.CreateWorkload(request=req)
-        return res
-
-    def get_nodes(self, req: GetNodesRequest) -> GetNodesResponse:
-        """Get client IDs."""
-        # Check if channel is open
-        if self.stub is None:
-            log(ERROR, ERROR_MESSAGE_DRIVER_NOT_CONNECTED)
-            raise Exception("`GrpcDriver` instance not connected")
-
-        # Call gRPC Driver API
-        res: GetNodesResponse = self.stub.GetNodes(request=req)
-        return res
-
-    def push_task_ins(self, req: PushTaskInsRequest) -> PushTaskInsResponse:
-        """Schedule tasks."""
-        # Check if channel is open
-        if self.stub is None:
-            log(ERROR, ERROR_MESSAGE_DRIVER_NOT_CONNECTED)
-            raise Exception("`GrpcDriver` instance not connected")
-
-        # Call gRPC Driver API
-        res: PushTaskInsResponse = self.stub.PushTaskIns(request=req)
-        return res
-
-    def pull_task_res(self, req: PullTaskResRequest) -> PullTaskResResponse:
-        """Get task results."""
-        # Check if channel is open
-        if self.stub is None:
-            log(ERROR, ERROR_MESSAGE_DRIVER_NOT_CONNECTED)
-            raise Exception("`GrpcDriver` instance not connected")
-
-        # Call Driver API
-        res: PullTaskResResponse = self.stub.PullTaskRes(request=req)
-        return res
 
 
 class Driver:

--- a/src/py/flwr/driver/driver.py
+++ b/src/py/flwr/driver/driver.py
@@ -17,7 +17,7 @@
 
 from typing import Iterable, List, Optional, Tuple
 
-from flwr.driver.grpc_driver import GrpcDriver
+from flwr.driver.grpc_driver import DEFAULT_SERVER_ADDRESS_DRIVER, GrpcDriver
 from flwr.proto.driver_pb2 import (
     CreateWorkloadRequest,
     GetNodesRequest,
@@ -31,7 +31,13 @@ from flwr.proto.task_pb2 import TaskIns, TaskRes
 class Driver:
     """`Driver` class provides an interface to the Driver API."""
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        driver_service_address: str = DEFAULT_SERVER_ADDRESS_DRIVER,
+        certificates: Optional[bytes] = None,
+    ) -> None:
+        self.addr = driver_service_address
+        self.certificates = certificates
         self.grpc_driver: Optional[GrpcDriver] = None
         self.workload_id: Optional[int] = None
         self.node = Node(node_id=0, anonymous=True)
@@ -40,7 +46,9 @@ class Driver:
         # Check if the GrpcDriver is initialized
         if self.grpc_driver is None or self.workload_id is None:
             # Connect and create workload
-            self.grpc_driver = GrpcDriver()
+            self.grpc_driver = GrpcDriver(
+                driver_service_address=self.addr, certificates=self.certificates
+            )
             self.grpc_driver.connect()
             res = self.grpc_driver.create_workload(CreateWorkloadRequest())
             self.workload_id = res.workload_id

--- a/src/py/flwr/driver/driver_client_proxy.py
+++ b/src/py/flwr/driver/driver_client_proxy.py
@@ -23,7 +23,7 @@ from flwr.common import serde
 from flwr.proto import driver_pb2, node_pb2, task_pb2, transport_pb2
 from flwr.server.client_proxy import ClientProxy
 
-from .driver import GrpcDriver
+from .grpc_driver import GrpcDriver
 
 SLEEP_TIME = 1
 

--- a/src/py/flwr/driver/grpc_driver.py
+++ b/src/py/flwr/driver/grpc_driver.py
@@ -1,0 +1,128 @@
+# Copyright 2023 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Flower driver service client."""
+
+
+from logging import ERROR, INFO, WARNING
+from typing import Optional
+
+import grpc
+
+from flwr.common import EventType, event
+from flwr.common.grpc import create_channel
+from flwr.common.logger import log
+from flwr.proto.driver_pb2 import (
+    CreateWorkloadRequest,
+    CreateWorkloadResponse,
+    GetNodesRequest,
+    GetNodesResponse,
+    PullTaskResRequest,
+    PullTaskResResponse,
+    PushTaskInsRequest,
+    PushTaskInsResponse,
+)
+from flwr.proto.driver_pb2_grpc import DriverStub
+
+DEFAULT_SERVER_ADDRESS_DRIVER = "[::]:9091"
+
+ERROR_MESSAGE_DRIVER_NOT_CONNECTED = """
+[Driver] Error: Not connected.
+
+Call `connect()` on the `GrpcDriver` instance before calling any of the other
+`GrpcDriver` methods.
+"""
+
+
+class GrpcDriver:
+    """`GrpcDriver` provides access to the gRPC Driver API/service."""
+
+    def __init__(
+        self,
+        driver_service_address: str = DEFAULT_SERVER_ADDRESS_DRIVER,
+        certificates: Optional[bytes] = None,
+    ) -> None:
+        self.driver_service_address = driver_service_address
+        self.certificates = certificates
+        self.channel: Optional[grpc.Channel] = None
+        self.stub: Optional[DriverStub] = None
+
+    def connect(self) -> None:
+        """Connect to the Driver API."""
+        event(EventType.DRIVER_CONNECT)
+        if self.channel is not None or self.stub is not None:
+            log(WARNING, "Already connected")
+            return
+        self.channel = create_channel(
+            server_address=self.driver_service_address,
+            root_certificates=self.certificates,
+        )
+        self.stub = DriverStub(self.channel)
+        log(INFO, "[Driver] Connected to %s", self.driver_service_address)
+
+    def disconnect(self) -> None:
+        """Disconnect from the Driver API."""
+        event(EventType.DRIVER_DISCONNECT)
+        if self.channel is None or self.stub is None:
+            log(WARNING, "Already disconnected")
+            return
+        channel = self.channel
+        self.channel = None
+        self.stub = None
+        channel.close()
+        log(INFO, "[Driver] Disconnected")
+
+    def create_workload(self, req: CreateWorkloadRequest) -> CreateWorkloadResponse:
+        """Request for workload ID."""
+        # Check if channel is open
+        if self.stub is None:
+            log(ERROR, ERROR_MESSAGE_DRIVER_NOT_CONNECTED)
+            raise Exception("`GrpcDriver` instance not connected")
+
+        # Call Driver API
+        res: CreateWorkloadResponse = self.stub.CreateWorkload(request=req)
+        return res
+
+    def get_nodes(self, req: GetNodesRequest) -> GetNodesResponse:
+        """Get client IDs."""
+        # Check if channel is open
+        if self.stub is None:
+            log(ERROR, ERROR_MESSAGE_DRIVER_NOT_CONNECTED)
+            raise Exception("`GrpcDriver` instance not connected")
+
+        # Call gRPC Driver API
+        res: GetNodesResponse = self.stub.GetNodes(request=req)
+        return res
+
+    def push_task_ins(self, req: PushTaskInsRequest) -> PushTaskInsResponse:
+        """Schedule tasks."""
+        # Check if channel is open
+        if self.stub is None:
+            log(ERROR, ERROR_MESSAGE_DRIVER_NOT_CONNECTED)
+            raise Exception("`GrpcDriver` instance not connected")
+
+        # Call gRPC Driver API
+        res: PushTaskInsResponse = self.stub.PushTaskIns(request=req)
+        return res
+
+    def pull_task_res(self, req: PullTaskResRequest) -> PullTaskResResponse:
+        """Get task results."""
+        # Check if channel is open
+        if self.stub is None:
+            log(ERROR, ERROR_MESSAGE_DRIVER_NOT_CONNECTED)
+            raise Exception("`GrpcDriver` instance not connected")
+
+        # Call Driver API
+        res: PullTaskResResponse = self.stub.PullTaskRes(request=req)
+        return res


### PR DESCRIPTION
`start_driver()` currently accesses Driver API via `GrpcDriver`. A more ideal way is to use the `Driver` instead, given that `Driver` will be able to handle errors coming from network connections in the near future.

Based on #2535, this PR replaces `GrpcDriver` in `start_driver()` with `Driver` and updates the code and unit tests accordingly.  