### PR TITLE
Restructure Flower Datasets docs

### DIFF
--- a/datasets/doc/source/ref-api-FederatedDataset.rst
+++ b/datasets/doc/source/ref-api-FederatedDataset.rst
@@ -1,0 +1,13 @@
+FederatedDataset
+================
+
+.. automodule:: flwr_datasets.federated_dataset
+
+.. autoclass:: FederatedDataset
+   :members:
+
+   .. rubric:: Methods
+
+   .. autosummary::
+      ~FederatedDataset.load_partition
+      ~FederatedDataset.load_full

--- a/datasets/doc/source/ref-api-flwr-datasets.rst
+++ b/datasets/doc/source/ref-api-flwr-datasets.rst
@@ -1,27 +1,25 @@
 flwr\_datasets (Python API reference)
-======================
+=====================================
 
-Federated Dataset
------------------
-.. autoclass:: flwr_datasets.federated_dataset.FederatedDataset
-   :members:
+Welcome to the Flower Dataset API Reference Manual! The Flower Dataset library is a pivotal tool designed to address
+the unique challenges of managing datasets in the realm of federated learning.
 
+Here, you will find:
 
-partitioner
------------
+* **Detailed Descriptions**: Understand the core components and functionalities of the Flower Dataset library.
+* **Function, Class and Method Definitions**: Get specifications on inputs, outputs, and behaviors for each function class and method available.
+* **Sample Code and Usage**: See the Flower Dataset library in action with short code snippets included in the docstrings.
 
-.. automodule:: flwr_datasets.partitioner
+For full examples please visit the tutorial section or Flower examples that work end to end using this library.
 
+.. rubric:: Federated Dataset
+.. toctree::
+   :maxdepth: 3
 
-Partitioner
------------
+   ref-api-FederatedDataset
 
-.. autoclass:: flwr_datasets.partitioner.Partitioner
-   :members:
+.. rubric:: Partitioners
+.. toctree::
+   :maxdepth: 4
 
-
-IID Partitioner
----------------
-
-.. autoclass:: flwr_datasets.partitioner.IidPartitioner
-   :members:
+   ref-api-partitioner

--- a/datasets/doc/source/ref-api-partitioner.IidPartitioner.rst
+++ b/datasets/doc/source/ref-api-partitioner.IidPartitioner.rst
@@ -1,0 +1,13 @@
+partitioner.IidPartitioner
+===========================================
+
+.. autoclass:: flwr_datasets.partitioner.IidPartitioner
+   :members:
+   :inherited-members:
+
+   .. rubric:: Methods
+
+   .. autosummary::
+      ~IidPartitioner.dataset
+      ~IidPartitioner.load_partition
+      ~IidPartitioner.is_dataset_assigned

--- a/datasets/doc/source/ref-api-partitioner.Partitioner.rst
+++ b/datasets/doc/source/ref-api-partitioner.Partitioner.rst
@@ -1,0 +1,12 @@
+partitioner.Partitioner
+===================================
+
+.. autoclass:: flwr_datasets.partitioner.Partitioner
+   :members:
+
+   .. rubric:: Methods
+
+   .. autosummary::
+      ~Partitioner.dataset
+      ~Partitioner.load_partition
+      ~Partitioner.is_dataset_assigned

--- a/datasets/doc/source/ref-api-partitioner.rst
+++ b/datasets/doc/source/ref-api-partitioner.rst
@@ -1,0 +1,18 @@
+partitioner
+============================
+
+.. automodule:: flwr_datasets.partitioner
+
+   .. rubric:: Classes
+
+   .. autosummary::
+
+      Partitioner
+      IidPartitioner
+
+.. rubric:: Structure
+
+.. toctree::
+
+   ref-api-partitioner.Partitioner
+   ref-api-partitioner.IidPartitioner


### PR DESCRIPTION
## Issue

The current API Reference is displayed on a single page. This makes it hard to navigate, reference, or send links.

## Proposal
This PR introduces manually created .rst files that divide the current version into separate files (per module and/or package). Note that this process might need further automation.