### PR TITLE
Enable KEEPALIVE_PERMIT_WITHOUT_CALLS for testing

### DIFF
--- a/src/py/flwr/server/fleet/grpc_bidi/grpc_server.py
+++ b/src/py/flwr/server/fleet/grpc_bidi/grpc_server.py
@@ -236,7 +236,7 @@ def generic_create_grpc_server(  # pylint: disable=too-many-arguments
         # Is it permissible to send keepalive pings from the client without
         # any outstanding streams. More explanation here:
         # https://github.com/adap/flower/pull/2197
-        ("grpc.keepalive_permit_without_calls", 0),
+        ("grpc.keepalive_permit_without_calls", 1),
     ]
 
     server = grpc.server(


### PR DESCRIPTION

<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

Just a draft PR to autogenerate a wheel.

Enable KEEPALIVE_PERMIT_WITHOUT_CALLS to autogenerate a wheel which a user wants to test.

<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

### Checklist

- [ ] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.dev/docs/writing-documentation.html)
- [ ] Update [changelog](https://github.com/adap/flower/blob/main/doc/source/changelog.rst)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.dev/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
