### PR TITLE
Remove deprecate warning for `numpyclient`

### DIFF
--- a/doc/source/ref-changelog.md
+++ b/doc/source/ref-changelog.md
@@ -48,7 +48,7 @@
 
 - **General updates to the simulation engine** ([#2331](https://github.com/adap/flower/pull/2331), [#2447](https://github.com/adap/flower/pull/2447), [#2448](https://github.com/adap/flower/pull/2448))
 
-- **General improvements** ([#2309](https://github.com/adap/flower/pull/2309), [#2310](https://github.com/adap/flower/pull/2310), [2313](https://github.com/adap/flower/pull/2313), [#2316](https://github.com/adap/flower/pull/2316), [2317](https://github.com/adap/flower/pull/2317),[#2349](https://github.com/adap/flower/pull/2349), [#2360](https://github.com/adap/flower/pull/2360), [#2402](https://github.com/adap/flower/pull/2402), [#2446](https://github.com/adap/flower/pull/2446))
+- **General improvements** ([#2309](https://github.com/adap/flower/pull/2309), [#2310](https://github.com/adap/flower/pull/2310), [2313](https://github.com/adap/flower/pull/2313), [#2316](https://github.com/adap/flower/pull/2316), [2317](https://github.com/adap/flower/pull/2317),[#2349](https://github.com/adap/flower/pull/2349), [#2360](https://github.com/adap/flower/pull/2360), [#2402](https://github.com/adap/flower/pull/2402), [#2446](https://github.com/adap/flower/pull/2446) [#2561](https://github.com/adap/flower/pull/2561))
 
   Flower received many improvements under the hood, too many to list here.
 

--- a/src/py/flwr/client/app.py
+++ b/src/py/flwr/client/app.py
@@ -17,7 +17,6 @@
 
 import sys
 import time
-import warnings
 from logging import INFO
 from typing import Callable, ContextManager, Optional, Tuple, Union
 
@@ -239,18 +238,18 @@ def start_numpy_client(
     >>>     root_certificates=Path("/crts/root.pem").read_bytes(),
     >>> )
     """
-    warnings.warn(
-        "flwr.client.start_numpy_client() is deprecated and will "
-        "be removed in a future version of Flower. Instead, pass "
-        "your client to `flwr.client.start_client()` by calling "
-        "first the `.to_client()` method as shown below: \n"
-        "\tflwr.client.start_client(\n"
-        "\t\tserver_address='<IP>:<PORT>',\n"
-        "\t\tclient=FlowerClient().to_client()\n"
-        "\t)",
-        DeprecationWarning,
-        stacklevel=2,
-    )
+    # warnings.warn(
+    #     "flwr.client.start_numpy_client() is deprecated and will "
+    #     "be removed in a future version of Flower. Instead, pass "
+    #     "your client to `flwr.client.start_client()` by calling "
+    #     "first the `.to_client()` method as shown below: \n"
+    #     "\tflwr.client.start_client(\n"
+    #     "\t\tserver_address='<IP>:<PORT>',\n"
+    #     "\t\tclient=FlowerClient().to_client()\n"
+    #     "\t)",
+    #     DeprecationWarning,
+    #     stacklevel=2,
+    # )
 
     # Calling this function is deprecated. A warning is thrown.
     # We first need to convert either the supplied client to `Client.`

--- a/src/py/flwr/simulation/ray_transport/utils.py
+++ b/src/py/flwr/simulation/ray_transport/utils.py
@@ -15,7 +15,6 @@
 """Utilities for Actors in the Virtual Client Engine."""
 
 import traceback
-import warnings
 from logging import ERROR
 
 from flwr.client import Client
@@ -27,7 +26,7 @@ except ModuleNotFoundError:
     TF = None
 
 # Display Deprecation warning once
-warnings.filterwarnings("once", category=DeprecationWarning)
+# warnings.filterwarnings("once", category=DeprecationWarning)
 
 
 def enable_tf_gpu_growth() -> None:
@@ -70,15 +69,15 @@ def check_clientfn_returns_client(client: Client) -> Client:
     the client internally to `Client` by calling `.to_client()`.
     """
     if not isinstance(client, Client):
-        mssg = (
-            " Ensure your client is of type `Client`. Please convert it"
-            " using the `.to_client()` method before returning it"
-            " in the `client_fn` you pass to `start_simulation`."
-            " We have applied this conversion on your behalf."
-            " Not returning a `Client` might trigger an error in future"
-            " versions of Flower."
-        )
+        # mssg = (
+        #     " Ensure your client is of type `Client`. Please convert it"
+        #     " using the `.to_client()` method before returning it"
+        #     " in the `client_fn` you pass to `start_simulation`."
+        #     " We have applied this conversion on your behalf."
+        #     " Not returning a `Client` might trigger an error in future"
+        #     " versions of Flower."
+        # )
 
-        warnings.warn(mssg, DeprecationWarning, stacklevel=2)
+        # warnings.warn(mssg, DeprecationWarning, stacklevel=2)
         client = client.to_client()
     return client


### PR DESCRIPTION
Comments the deprecation warning if users make us of `NumPyClient` either via `start_numpy_client` or in simulation. It is commented instead of removed because the plan is to bring it back soon.