### PR TITLE
Add support for Python 3.12

### DIFF
--- a/doc/source/ref-changelog.md
+++ b/doc/source/ref-changelog.md
@@ -4,7 +4,7 @@
 
 ### What's new?
 
-- **Add support for Python 3.12** ([#2564](https://github.com/adap/flower/pull/2564))
+- **Add experimental support for Python 3.12** ([#2564](https://github.com/adap/flower/pull/2564))
 
 - **Support custom** `ClientManager` **in** `start_driver()` ([#2292](https://github.com/adap/flower/pull/2292))
 

--- a/doc/source/ref-changelog.md
+++ b/doc/source/ref-changelog.md
@@ -4,6 +4,8 @@
 
 ### What's new?
 
+- **Add support for Python 3.12** ([#2564](https://github.com/adap/flower/pull/2564))
+
 - **Support custom** `ClientManager` **in** `start_driver()` ([#2292](https://github.com/adap/flower/pull/2292))
 
 - **Update REST API to support create and delete nodes** ([#2283](https://github.com/adap/flower/pull/2283))

--- a/doc/source/ref-changelog.md
+++ b/doc/source/ref-changelog.md
@@ -4,7 +4,7 @@
 
 ### What's new?
 
-- **Add experimental support for Python 3.12** ([#2564](https://github.com/adap/flower/pull/2564))
+- **Add experimental support for Python 3.12** ([#2565](https://github.com/adap/flower/pull/2565))
 
 - **Support custom** `ClientManager` **in** `start_driver()` ([#2292](https://github.com/adap/flower/pull/2292))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Scientific/Engineering",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

Python 3.12 is out but we don't officially support it.

### Related issues/PRs

N/A

## Proposal

### Explanation

Add the mention that we support Python 3.12

### Checklist

- [x] Implement proposed change
- [x] Update [changelog](https://github.com/adap/flower/blob/main/doc/source/changelog.rst)
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

N/A
