### PR TITLE
Fix the rendering of math in baselines docs

### DIFF
--- a/baselines/doc/source/conf.py
+++ b/baselines/doc/source/conf.py
@@ -141,3 +141,4 @@ mermaid_version = ""
 # -- Options for MyST config  -------------------------------------
 # Enable this option to link to headers (`#`, `##`, or `###`)
 myst_heading_anchors = 3
+myst_enable_extensions = ["dollarmath"]


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

On the Baselines docs, the math from the markdown text would not be rendered correctly. 

### Related issues/PRs

N/A

## Proposal

### Explanation

Add the `dollarmath` myst extension following this: https://myst-parser.readthedocs.io/en/latest/syntax/math.html#dollar-delimited-math

### Checklist

- [x] Implement proposed change
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

N/A
