### PR TITLE
Add __version__ to Flower Datasets

### DIFF
--- a/datasets/flwr_datasets/__init__.py
+++ b/datasets/flwr_datasets/__init__.py
@@ -15,6 +15,9 @@
 """Flower Datasets main package."""
 
 
+from flwr.common.version import package_version as _package_version
 from .federated_dataset import FederatedDataset
 
 __all__ = ["FederatedDataset"]
+
+__version__ = _package_version

--- a/datasets/flwr_datasets/__init__.py
+++ b/datasets/flwr_datasets/__init__.py
@@ -16,6 +16,7 @@
 
 
 from flwr.common.version import package_version as _package_version
+
 from .federated_dataset import FederatedDataset
 
 __all__ = ["FederatedDataset"]

--- a/datasets/flwr_datasets/__init__.py
+++ b/datasets/flwr_datasets/__init__.py
@@ -15,7 +15,7 @@
 """Flower Datasets main package."""
 
 
-from flwr.common.version import package_version as _package_version
+from flwr_datasets.common.version import package_version as _package_version
 
 from .federated_dataset import FederatedDataset
 

--- a/datasets/flwr_datasets/common/version.py
+++ b/datasets/flwr_datasets/common/version.py
@@ -1,0 +1,43 @@
+# Copyright 2023 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Flower Datasets package version helper. (Copied from the Flower.)"""
+
+
+import importlib.metadata as importlib_metadata
+from typing import Tuple
+
+
+def _check_package(name: str) -> Tuple[str, str]:
+    version: str = importlib_metadata.version(name)
+    return name, version
+
+
+def _version() -> Tuple[str, str]:
+    """Read and return Flower Dataset package name and version.
+
+    Returns
+    -------
+    package_name, package_version : Tuple[str, str]
+    """
+    for name in ["flwr-datasets", "flwr-datasets-nightly"]:
+        try:
+            return _check_package(name)
+        except importlib_metadata.PackageNotFoundError:
+            pass
+
+    return ("unknown", "unknown")
+
+
+package_name, package_version = _version()

--- a/datasets/flwr_datasets/common/version.py
+++ b/datasets/flwr_datasets/common/version.py
@@ -14,7 +14,7 @@
 # ==============================================================================
 """Flower Datasets package version helper.
 
-The code is copied from flwr.
+The code is an exact copy from flwr.
 """
 
 

--- a/datasets/flwr_datasets/common/version.py
+++ b/datasets/flwr_datasets/common/version.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Flower Datasets package version helper. (Copied from the Flower.)"""
+"""Flower Datasets package version helper.
+
+The code is copied from flwr.
+"""
 
 
 import importlib.metadata as importlib_metadata


### PR DESCRIPTION
## Issue
The version cannot be accessed in the flwr-datasets, yet it's expected behavior.

## Proposal
Add the version functionality exactly as in flwr.

It also includes the flwr-datasets-nightly, which is not currently published, but when it will then can be used. The lack of it won't cause any problems.