### PR TITLE
Change the settings for IidPartitioner

### DIFF
--- a/datasets/flwr_datasets/partitioner/iid_partitioner.py
+++ b/datasets/flwr_datasets/partitioner/iid_partitioner.py
@@ -48,5 +48,5 @@ class IidPartitioner(Partitioner):
             single dataset partition
         """
         return self.dataset.shard(
-            num_shards=self._num_partitions, index=idx, contiguous=False
+            num_shards=self._num_partitions, index=idx, contiguous=True
         )

--- a/datasets/flwr_datasets/partitioner/iid_partitioner_test.py
+++ b/datasets/flwr_datasets/partitioner/iid_partitioner_test.py
@@ -18,7 +18,6 @@
 import unittest
 from typing import Tuple
 
-import numpy as np
 from parameterized import parameterized
 
 from datasets import Dataset
@@ -107,10 +106,10 @@ class TestIidPartitioner(unittest.TestCase):
         partition = partitioner.load_partition(partition_index)
         row_id = 0
         self.assertEqual(
-            partition["features"][row_id],
+            partition[row_id]["features"],
             # Note it's contiguous so partition_size * partition_index gets the first
             # element of the partition of partition_index
-            dataset["features"][partition_size * partition_index + row_id],
+            dataset[partition_size * partition_index + row_id]["features"],
         )
 
     @parameterized.expand(  # type: ignore

--- a/datasets/flwr_datasets/partitioner/iid_partitioner_test.py
+++ b/datasets/flwr_datasets/partitioner/iid_partitioner_test.py
@@ -102,14 +102,15 @@ class TestIidPartitioner(unittest.TestCase):
     ) -> None:
         """Test if the data in partition is equal to the expected."""
         dataset, partitioner = _dummy_setup(num_partitions, num_rows)
+        partition_size = num_rows // num_partitions
         partition_index = 2
         partition = partitioner.load_partition(partition_index)
         row_id = 0
         self.assertEqual(
             partition["features"][row_id],
-            dataset[np.arange(partition_index, len(dataset), num_partitions)][
-                "features"
-            ][row_id],
+            # Note it's contiguous so partition_size * partition_index gets the first
+            # element of the partition of partition_index
+            dataset["features"][partition_size * partition_index + row_id],
         )
 
     @parameterized.expand(  # type: ignore


### PR DESCRIPTION
## Issue
The https://github.com/adap/flower/pull/2588 introduces shuffling. Therefore, now the `contiguous=False` does not make sense.

### Description

`contiguous` tells whether the shards=partitions are from the contiguous block. 

## Proposal
Change back to `contiguous=True`.

### Explanation
This is necessary for the future introduction of more performance boosts. The `flatten_idices` that might be introduced in the future will happen prior to partitioning; therefore, we later want a contiguous block of memory.

This will also be consistent with v0.0.1 where `shuffle=False` (the contiguous=True was changed after the release).
