### PR TITLE
Fixing deprecated-baselines CI

### DIFF
--- a/baselines/flwr_baselines/pyproject.toml
+++ b/baselines/flwr_baselines/pyproject.toml
@@ -62,6 +62,7 @@ flake8 = "==3.9.2"
 pytest = "==6.2.4"
 pytest-watch = "==4.2.0"
 types-requests = "==2.27.7"
+pydantic = "==2.4.2"
 
 [tool.isort]
 line_length = 88

--- a/baselines/flwr_baselines/pyproject.toml
+++ b/baselines/flwr_baselines/pyproject.toml
@@ -48,6 +48,7 @@ matplotlib = "^3.5.1"
 scikit-image = "^0.18.1"
 scikit-learn = "^1.2.1"
 wget = "^3.2"
+virtualenv = "==20.24.6"
 pandas = "^1.5.3"
 pyhamcrest = "^2.0.4"
 

--- a/baselines/flwr_baselines/pyproject.toml
+++ b/baselines/flwr_baselines/pyproject.toml
@@ -48,7 +48,7 @@ matplotlib = "^3.5.1"
 scikit-image = "^0.18.1"
 scikit-learn = "^1.2.1"
 wget = "^3.2"
-virtualenv = "==20.24.6"
+virtualenv = "^20.24.6"
 pandas = "^1.5.3"
 pyhamcrest = "^2.0.4"
 

--- a/baselines/flwr_baselines/requirements.txt
+++ b/baselines/flwr_baselines/requirements.txt
@@ -27,3 +27,4 @@ flake8 == 3.9.2
 pytest == 6.2.4
 pytest-watch == 4.2.0
 types-requests == 2.27.7
+pydantic ==2.4.2

--- a/baselines/flwr_baselines/requirements.txt
+++ b/baselines/flwr_baselines/requirements.txt
@@ -15,6 +15,7 @@ matplotlib >= 3.5.0
 scikit-image >= 0.18.1
 scikit-learn >= 0.24.2
 wget >= 3.2
+virtualenv >= 20.24.6
 
 ##### dev-dependencies
 isort == 5.11.5


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

The CI was failing due to some `virtualenv` error. It seems that `virtualenv` was being downgraded to a previous version by another dependency (not sure which one).

### Related issues/PRs

N/A

## Proposal

### Explanation

Explicitly set `virtualenv`'s version in `pyproject.toml`.

### Checklist

- [x] Implement proposed change
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

N/A
