### PR TITLE
Delete node locally in gRPC-rere

### DIFF
--- a/src/py/flwr/client/grpc_rere_client/connection.py
+++ b/src/py/flwr/client/grpc_rere_client/connection.py
@@ -135,7 +135,7 @@ def grpc_request_response(
 
         delete_node_request = DeleteNodeRequest(node=node)
         stub.DeleteNode(request=delete_node_request)
-        
+
         del node_store[KEY_NODE]
 
     def receive() -> Optional[TaskIns]:

--- a/src/py/flwr/client/grpc_rere_client/connection.py
+++ b/src/py/flwr/client/grpc_rere_client/connection.py
@@ -135,6 +135,8 @@ def grpc_request_response(
 
         delete_node_request = DeleteNodeRequest(node=node)
         stub.DeleteNode(request=delete_node_request)
+        
+        del node_store[KEY_NODE]
 
     def receive() -> Optional[TaskIns]:
         """Receive next task from server."""


### PR DESCRIPTION
When we delete a node on the server-side it is not deleted in the context manager

<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

When we delete a node on the server-side it is not deleted in the context manager.

### Related issues/PRs

N/A

## Proposal

### Explanation

Delete the node from the locally stored dict.

### Checklist

- [x] Implement proposed change
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

N/A
