### PR TITLE
Fix spacing around : in parameters in docs

### DIFF
--- a/datasets/flwr_datasets/partitioner/iid_partitioner.py
+++ b/datasets/flwr_datasets/partitioner/iid_partitioner.py
@@ -24,7 +24,7 @@ class IidPartitioner(Partitioner):
 
     Parameters
     ----------
-    num_partitions: int
+    num_partitions : int
         The total number of partitions that the data will be divided into.
     """
 
@@ -44,7 +44,7 @@ class IidPartitioner(Partitioner):
 
         Returns
         -------
-        dataset_partition: Dataset
+        dataset_partition : Dataset
             single dataset partition
         """
         return self.dataset.shard(

--- a/datasets/flwr_datasets/partitioner/natural_id_partitioner.py
+++ b/datasets/flwr_datasets/partitioner/natural_id_partitioner.py
@@ -55,7 +55,7 @@ class NaturalIdPartitioner(Partitioner):
 
         Returns
         -------
-        dataset_partition: Dataset
+        dataset_partition : Dataset
             single dataset partition
         """
         if len(self._node_id_to_natural_id) == 0:

--- a/datasets/flwr_datasets/partitioner/partitioner.py
+++ b/datasets/flwr_datasets/partitioner/partitioner.py
@@ -58,12 +58,12 @@ class Partitioner(ABC):
 
         Parameters
         ----------
-        node_id: int
+        node_id : int
             the index that corresponds to the requested partition
 
         Returns
         -------
-        dataset_partition: Dataset
+        dataset_partition : Dataset
             single dataset partition
         """
 
@@ -75,7 +75,7 @@ class Partitioner(ABC):
 
         Returns
         -------
-        dataset_assigned: bool
+        dataset_assigned : bool
             True if a dataset is assigned, otherwise False.
         """
         return self._dataset is not None

--- a/datasets/flwr_datasets/resplitter/merge_resplitter.py
+++ b/datasets/flwr_datasets/resplitter/merge_resplitter.py
@@ -32,7 +32,7 @@ class MergeResplitter:
 
     Parameters
     ----------
-    merge_config: Dict[str, Tuple[str, ...]]
+    merge_config : Dict[str, Tuple[str, ...]]
         Dictionary with keys - the desired split names to values - tuples of the current
         split names that will be merged together
 

--- a/datasets/flwr_datasets/utils.py
+++ b/datasets/flwr_datasets/utils.py
@@ -38,12 +38,12 @@ def _instantiate_partitioners(
 
     Parameters
     ----------
-    partitioners: Dict[str, Union[Partitioner, int]]
+    partitioners : Dict[str, Union[Partitioner, int]]
         Dataset split to the Partitioner or a number of IID partitions.
 
     Returns
     -------
-    partitioners: Dict[str, Partitioner]
+    partitioners : Dict[str, Partitioner]
         Partitioners specified as split to Partitioner object.
     """
     instantiated_partitioners: Dict[str, Partitioner] = {}


### PR DESCRIPTION
## Issue 
Some of the docs lack the space before the colon describing parameter type

## Proposal
Add missing spaces