### PR TITLE
Clarify partitioners parameter description in docs

### DIFF
--- a/datasets/flwr_datasets/federated_dataset.py
+++ b/datasets/flwr_datasets/federated_dataset.py
@@ -49,7 +49,8 @@ class FederatedDataset:
     partitioners : Dict[str, Union[Partitioner, int]]
         A dictionary mapping the Dataset split (a `str`) to a `Partitioner` or an `int`
         (representing the number of IID partitions that this split should be partitioned
-        into).
+        into). One or multiple `Partitioner`s can be specified in that manner, but at
+        most, one per split.
     shuffle : bool
         Whether to randomize the order of samples. Applied prior to resplitting,
         speratelly to each of the present splits in the dataset. It uses the `seed`


### PR DESCRIPTION
## Issue
The `partitioners` parameter description in docs is not comprehensive.

## Proposal
Clarify that there might be one or multiple partitioners specified and that at most, one per split.

"At most one Partitioner per split" makes also sense from the dictionary point of view - the keys need to be unique.

