### PR TITLE
Move the Resplitter type definition to resplitter package

### DIFF
--- a/datasets/flwr_datasets/common/__init__.py
+++ b/datasets/flwr_datasets/common/__init__.py
@@ -13,8 +13,3 @@
 # limitations under the License.
 # ==============================================================================
 """Common components in Flower Datasets."""
-
-
-from .typing import Resplitter
-
-__all__ = ["Resplitter"]

--- a/datasets/flwr_datasets/federated_dataset.py
+++ b/datasets/flwr_datasets/federated_dataset.py
@@ -19,8 +19,8 @@ from typing import Dict, Optional, Tuple, Union
 
 import datasets
 from datasets import Dataset, DatasetDict
-from flwr_datasets.common import Resplitter
 from flwr_datasets.partitioner import Partitioner
+from flwr_datasets.resplitter import Resplitter
 from flwr_datasets.utils import (
     _check_if_dataset_tested,
     _instantiate_partitioners,

--- a/datasets/flwr_datasets/resplitter/__init__.py
+++ b/datasets/flwr_datasets/resplitter/__init__.py
@@ -16,7 +16,9 @@
 
 
 from .merge_resplitter import MergeResplitter
+from .resplitter import Resplitter
 
 __all__ = [
     "MergeResplitter",
+    "Resplitter",
 ]

--- a/datasets/flwr_datasets/resplitter/resplitter.py
+++ b/datasets/flwr_datasets/resplitter/resplitter.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Flower Datasets type definitions."""
+"""Resplitter."""
 
 
 from typing import Callable

--- a/datasets/flwr_datasets/utils.py
+++ b/datasets/flwr_datasets/utils.py
@@ -18,8 +18,8 @@
 import warnings
 from typing import Dict, Optional, Tuple, Union, cast
 
-from flwr_datasets.common import Resplitter
 from flwr_datasets.partitioner import IidPartitioner, Partitioner
+from flwr_datasets.resplitter import Resplitter
 from flwr_datasets.resplitter.merge_resplitter import MergeResplitter
 
 tested_datasets = [


### PR DESCRIPTION
## Issue
The new resplitter package was created for the resplitters. Though the def was not moved.

## Proposal

Move the definition and update the imports.