### PR TITLE
FDS small docs fix

### DIFF
--- a/datasets/doc/source/conf.py
+++ b/datasets/doc/source/conf.py
@@ -37,7 +37,7 @@ copyright = "2023 Flower Labs GmbH"
 author = "The Flower Authors"
 
 # The full version, including alpha/beta/rc tags
-release = "0.0.1"
+release = "0.0.2"
 
 
 # -- General configuration ---------------------------------------------------

--- a/datasets/flwr_datasets/federated_dataset.py
+++ b/datasets/flwr_datasets/federated_dataset.py
@@ -49,8 +49,8 @@ class FederatedDataset:
     partitioners : Dict[str, Union[Partitioner, int]]
         A dictionary mapping the Dataset split (a `str`) to a `Partitioner` or an `int`
         (representing the number of IID partitions that this split should be partitioned
-        into). One or multiple `Partitioner`s can be specified in that manner, but at
-        most, one per split.
+        into). One or multiple `Partitioner` objects can be specified in that manner,
+        but at most, one per split.
     shuffle : bool
         Whether to randomize the order of samples. Applied prior to resplitting,
         speratelly to each of the present splits in the dataset. It uses the `seed`


### PR DESCRIPTION
## Issue
* The version in the `conf.py` was not updated.
* The sequence "`Partitioner`s" (the s right after the backtick with no spaces) is misinterpreted and leads to a warning in docs.

### Description
Warning: `flower/datasets/flwr_datasets/federated_dataset.py:docstring of flwr_datasets.federated_dataset.FederatedDataset:16: WARNING: Inline interpreted text or phrase reference start-string without end-string.`


## Proposal
* update the version
* Rephrase the docs to convey plural. 

Before:
(the backticks are present)
![image](https://github.com/adap/flower/assets/51029327/924e5df7-42d8-460e-a44e-efb242958515)

After:
![image](https://github.com/adap/flower/assets/51029327/a95f372e-ef79-4e70-9461-1f082eecaaa0)
