### PR TITLE
Introduce experimental feature warning

### DIFF
--- a/src/py/flwr/client/grpc_rere_client/connection.py
+++ b/src/py/flwr/client/grpc_rere_client/connection.py
@@ -16,7 +16,7 @@
 
 
 from contextlib import contextmanager
-from logging import DEBUG, ERROR, WARN
+from logging import DEBUG, ERROR
 from pathlib import Path
 from typing import Callable, Dict, Iterator, Optional, Tuple, Union, cast
 
@@ -28,7 +28,7 @@ from flwr.client.message_handler.task_handler import (
 )
 from flwr.common import GRPC_MAX_MESSAGE_LENGTH
 from flwr.common.grpc import create_channel
-from flwr.common.logger import log
+from flwr.common.logger import log, warn_experimental_feature
 from flwr.proto.fleet_pb2 import (
     CreateNodeRequest,
     DeleteNodeRequest,
@@ -88,6 +88,8 @@ def grpc_request_response(
     create_node : Optional[Callable]
     delete_node : Optional[Callable]
     """
+    warn_experimental_feature("`grpc-rere`")
+
     if isinstance(root_certificates, str):
         root_certificates = Path(root_certificates).read_bytes()
 
@@ -98,14 +100,6 @@ def grpc_request_response(
     )
     channel.subscribe(on_channel_state_change)
     stub = FleetStub(channel)
-
-    log(
-        WARN,
-        """
-        EXPERIMENTAL: `grpc-rere` is an experimental transport layer, it might change
-        considerably in future versions of Flower
-        """,
-    )
 
     # Necessary state to link TaskRes to TaskIns
     state: Dict[str, Optional[TaskIns]] = {KEY_TASK_INS: None}

--- a/src/py/flwr/common/logger.py
+++ b/src/py/flwr/common/logger.py
@@ -16,7 +16,7 @@
 
 
 import logging
-from logging import LogRecord
+from logging import WARN, LogRecord
 from logging.handlers import HTTPHandler
 from typing import Any, Dict, Optional, Tuple
 
@@ -97,3 +97,17 @@ def configure(
 
 logger = logging.getLogger(LOGGER_NAME)  # pylint: disable=invalid-name
 log = logger.log  # pylint: disable=invalid-name
+
+
+def warn_experimental_feature(name: str) -> None:
+    """Warn the user when they use an experimental feature."""
+    log(
+        WARN,
+        """
+        EXPERIMENTAL FEATURE: %s
+
+        This is an experimental feature. It could change significantly or be removed
+        entirely in future versions of Flower.
+        """,
+        name,
+    )


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->

Every now and then, we introduce experimental features in Flower. So far, there is no consistent way to inform the user about the experimental nature of a feature.

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

Once this PR is merged, PR #2393 can be updated to use `warn_experimental_feature`

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

This PR introduces a utility function `warn_experimental_feature` that we can use to log a warning every time a user uses an experimental feature. In addition to that, once we use the utility throughout the codebase, it will also allow us to easily search for experimental features.

### Checklist

- [x] Implement proposed change
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)
