### PR TITLE
Fix wrong status Code int value in Android SDK

### DIFF
--- a/src/kotlin/flwr/src/main/java/dev/flower/android/Typing.kt
+++ b/src/kotlin/flwr/src/main/java/dev/flower/android/Typing.kt
@@ -23,11 +23,11 @@ typealias Properties = Map<String, Scalar>
  * The `Code` class defines client status codes used in the application.
  */
 enum class Code(val value: Int) {
-    OK(1),
-    GET_PROPERTIES_NOT_IMPLEMENTED(2),
-    GET_PARAMETERS_NOT_IMPLEMENTED(3),
-    FIT_NOT_IMPLEMENTED(4),
-    EVALUATE_NOT_IMPLEMENTED(5);
+    OK(0),
+    GET_PROPERTIES_NOT_IMPLEMENTED(1),
+    GET_PARAMETERS_NOT_IMPLEMENTED(2),
+    FIT_NOT_IMPLEMENTED(3),
+    EVALUATE_NOT_IMPLEMENTED(4);
 
     companion object {
         fun fromInt(value: Int): Code = values().first { it.value == value }


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->
Android SDK status Code int value starts at 1, but it should starts at 0.

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->
Fix the status Code int value to starts with 0 instead of 1.

### Checklist

- [x] Implement proposed change
- [x] Write tests
- [x] Update [documentation](https://flower.dev/docs/writing-documentation.html)
- [x] Update [changelog](https://github.com/adap/flower/blob/main/doc/source/changelog.rst)
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.dev/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
