### PR TITLE
XGBoost -- Fix node_id issue to fit FDSv0.0.2

### DIFF
--- a/doc/source/tutorial-quickstart-xgboost.rst
+++ b/doc/source/tutorial-quickstart-xgboost.rst
@@ -93,7 +93,7 @@ Prior to local training, we require loading the HIGGS dataset from Flower Datase
     fds = FederatedDataset(dataset="jxie/higgs", partitioners={"train": partitioner})
 
     # Load the partition for this `node_id`
-    partition = fds.load_partition(idx=args.node_id, split="train")
+    partition = fds.load_partition(node_id=args.node_id, split="train")
     partition.set_format("numpy")
 
 In this example, we split the dataset into two partitions with uniform distribution (:code:`IidPartitioner(num_partitions=2)`).

--- a/examples/xgboost-comprehensive/client.py
+++ b/examples/xgboost-comprehensive/client.py
@@ -43,13 +43,13 @@ partitioner = instantiate_partitioner(
     partitioner_type=partitioner_type, num_partitions=num_partitions
 )
 fds = FederatedDataset(
-    dataset="jxie/higgs", partitioners={"train": partitioner}, resplitter=resplit
+    dataset="jxie/higgs", partitioners={"train": partitioner}, resplitter=resplit,
 )
 
 # Load the partition for this `node_id`
 log(INFO, "Loading partition...")
 node_id = args.node_id
-partition = fds.load_partition(idx=node_id, split="train")
+partition = fds.load_partition(node_id=node_id, split="train")
 partition.set_format("numpy")
 
 if args.centralised_eval:

--- a/examples/xgboost-comprehensive/client.py
+++ b/examples/xgboost-comprehensive/client.py
@@ -43,7 +43,9 @@ partitioner = instantiate_partitioner(
     partitioner_type=partitioner_type, num_partitions=num_partitions
 )
 fds = FederatedDataset(
-    dataset="jxie/higgs", partitioners={"train": partitioner}, resplitter=resplit,
+    dataset="jxie/higgs",
+    partitioners={"train": partitioner},
+    resplitter=resplit,
 )
 
 # Load the partition for this `node_id`

--- a/examples/xgboost-comprehensive/pyproject.toml
+++ b/examples/xgboost-comprehensive/pyproject.toml
@@ -10,6 +10,6 @@ authors = ["The Flower Authors <hello@flower.dev>"]
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.11"
-flwr = ">=1.0,<2.0"
+flwr-nightly = ">=1.0,<2.0"
 flwr-datasets = ">=0.0.2,<1.0.0"
 xgboost = ">=2.0.0,<3.0.0"

--- a/examples/xgboost-comprehensive/requirements.txt
+++ b/examples/xgboost-comprehensive/requirements.txt
@@ -1,3 +1,3 @@
-flwr>=1.0, <2.0
+flwr-nightly>=1.0, <2.0
 flwr-datasets>=0.0.2, <1.0.0
 xgboost>=2.0.0, <3.0.0

--- a/examples/xgboost-quickstart/client.py
+++ b/examples/xgboost-quickstart/client.py
@@ -63,7 +63,7 @@ fds = FederatedDataset(dataset="jxie/higgs", partitioners={"train": partitioner}
 
 # Load the partition for this `node_id`
 log(INFO, "Loading partition...")
-partition = fds.load_partition(idx=args.node_id, split="train")
+partition = fds.load_partition(node_id=args.node_id, split="train")
 partition.set_format("numpy")
 
 # Train/test splitting

--- a/examples/xgboost-quickstart/pyproject.toml
+++ b/examples/xgboost-quickstart/pyproject.toml
@@ -10,6 +10,6 @@ authors = ["The Flower Authors <hello@flower.dev>"]
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.11"
-flwr = ">=1.0,<2.0"
+flwr-nightly = ">=1.0,<2.0"
 flwr-datasets = ">=0.0.1,<1.0.0"
 xgboost = ">=2.0.0,<3.0.0"

--- a/examples/xgboost-quickstart/requirements.txt
+++ b/examples/xgboost-quickstart/requirements.txt
@@ -1,3 +1,3 @@
-flwr>=1.0, <2.0
+flwr-nightly>=1.0, <2.0
 flwr-datasets>=0.0.1, <1.0.0
 xgboost>=2.0.0, <3.0.0


### PR DESCRIPTION
## Proposal

Fix `node_id` issue to fit FDSv0.0.2. The changes includes:

- quick start client.py, change `idx` to `node_id`
- comprehensive start client.py, change `idx` to `node_id`
- Tutorial document
- Temporarily change required package to `flwr-nightly` before flwr 1.6.0