### PR TITLE
Tiny PR to format `examples/quickstart-pytorch/client.py`

### DIFF
--- a/examples/quickstart-pytorch/client.py
+++ b/examples/quickstart-pytorch/client.py
@@ -100,7 +100,8 @@ parser.add_argument(
     "--node-id",
     choices=[0, 1, 2],
     type=int,
-    help="Partition of the dataset divided into 3 iid partitions created artificially.")
+    help="Partition of the dataset divided into 3 iid partitions created artificially.",
+)
 node_id = parser.parse_args().node_id
 
 # Load model and data (simple CNN, CIFAR-10)


### PR DESCRIPTION
### Problem
`examples/quickstart-pytorch/client.py` is somehow not formatted in the main branch. It is always listed as one of modified files after running `format.sh`. 

### Solution
Format the file.