### PR TITLE
Fix get-latest-changelog script

### DIFF
--- a/dev/get-latest-changelog.sh
+++ b/dev/get-latest-changelog.sh
@@ -9,9 +9,9 @@ tags=$(git tag --sort=-v:refname)
 new_version=$(echo "$tags" | sed -n '1p')
 old_version=$(echo "$tags" | sed -n '2p')
 
-awk -v start="$new_version" -v end="$old_version" '
+awk '{sub(/<!--.*-->/, ""); print}' doc/source/ref-changelog.md | awk -v start="$new_version" -v end="$old_version" '
     $0 ~ start {flag=1; next}
     $0 ~ end {flag=0}
     flag && !printed && /^$/ {next}  # skip the first blank line
     flag && !printed {printed=1}
-    flag' doc/source/ref-changelog.md
+    flag'


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

The script didn't output the list of contributors' names.

### Related issues/PRs

N/A

## Proposal

### Explanation

Remove the token before passing the text to `awk`.

### Checklist

- [x] Implement proposed change
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

N/A
