### PR TITLE
Improve script to prepare changelog for release

### DIFF
--- a/dev/prepare-release-changelog.sh
+++ b/dev/prepare-release-changelog.sh
@@ -2,6 +2,9 @@
 set -e
 cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"/../
 
+# Get the current date in the format YYYY-MM-DD
+current_date=$(date +"%Y-%m-%d")
+
 tags=$(git tag --sort=-v:refname)
 new_version=$1
 old_version=$(echo "$tags" | sed -n '1p')
@@ -14,8 +17,8 @@ thanks="\n### Thanks to our contributors\n\nWe would like to give our special th
 # Check if the token exists in the markdown file
 if ! grep -q "$token" doc/source/ref-changelog.md; then
     # If the token does not exist in the markdown file, append the new content after the version
-    awk -v version="$new_version" -v text="$thanks" \
-        '{print} $0 ~ "## " version {print text}' doc/source/ref-changelog.md > temp.md && mv temp.md doc/source/ref-changelog.md
+    awk -v version="$new_version" -v date="$current_date" -v text="$thanks" \
+        '{ if ($0 ~ "## Unreleased") print "## " version " (" date ")\n" text; else print $0 }' doc/source/ref-changelog.md > temp.md && mv temp.md doc/source/ref-changelog.md
 else
     # If the token exists, replace the line containing the token with the new shortlog
     awk -v token="$token" -v newlog="$shortlog $token" '{ if ($0 ~ token) print newlog; else print $0 }' doc/source/ref-changelog.md > temp.md && mv temp.md doc/source/ref-changelog.md


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

The current `add-shortlog` script still requires someone to remove the 'Unreleased' header and to add the new version and date. 

### Related issues/PRs

N/A

## Proposal

### Explanation

This new version makes the changelog directly ready for publication.

### Checklist

- [x] Implement proposed change
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

N/A
