### PR TITLE
Use specific Ubuntu version for workflows

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -16,7 +16,7 @@ jobs:
             working-directory: src/kotlin
     name: Release build and publish
     if: github.repository == 'adap/flower'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build_and_test:
     name: Build and test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/framework-release.yml
+++ b/.github/workflows/framework-release.yml
@@ -9,7 +9,7 @@ jobs:
   publish:
     if: ${{ github.repository == 'adap/flower' }}
     name: Publish draft
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/update-pr.yml
+++ b/.github/workflows/update-pr.yml
@@ -6,7 +6,7 @@ on:
       - 'main'
 jobs:
   autoupdate:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Automatically update mergeable PRs
         uses: adRise/update-pr-branch@v0.7.0


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

We sometimes used `ubuntu-latest` in our worflows.

### Related issues/PRs

N/A

## Proposal

### Explanation

Use `ubuntu-22.04` everywhere.

### Checklist

- [x] Implement proposed change
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

N/A
