### PR TITLE
Add base template for consistent naming convention for functions

### DIFF
--- a/datasets/doc/source/_templates/autosummary/base.rst
+++ b/datasets/doc/source/_templates/autosummary/base.rst
@@ -1,0 +1,5 @@
+{{ name | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+.. auto{{ objtype }}:: {{ objname }}


### PR DESCRIPTION
## Issue
In `flwr-datasets`, the base template was not added (when introducing new docs type) because I didn't see the need for that. I didn't see the need because it affects the public functions, and there are not yet any public functions that could have been documented.

The lack of a base template means inconsistent naming. 

### Description
The base template dictates the basic behavior regarding the generation of the docs for functions.

### Related issues/PRs
The same base template is used here https://github.com/adap/flower/pull/2644 

## Proposal
Add the same template to `flwr-dataset` (here) and to `flwr` (https://github.com/adap/flower/pull/2644 ) for docs consistency.