### PR TITLE
Add E2E test for `WorkloadState` and `NodeState`

### DIFF
--- a/e2e/pytorch/client.py
+++ b/e2e/pytorch/client.py
@@ -1,5 +1,6 @@
 import warnings
 from collections import OrderedDict
+from datetime import datetime
 
 import torch
 import torch.nn as nn
@@ -18,6 +19,7 @@ import flwr as fl
 warnings.filterwarnings("ignore", category=UserWarning)
 DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
 SUBSET_SIZE = 1000
+STATE_VAR = 'timestamp'
 
 
 class Net(nn.Module):
@@ -89,16 +91,29 @@ trainloader, testloader = load_data()
 class FlowerClient(fl.client.NumPyClient):
     def get_parameters(self, config):
         return [val.cpu().numpy() for _, val in net.state_dict().items()]
+    
+    def _record_timestamp_to_state(self):
+        """Record timestamp to client's state."""
+        t_stamp = datetime.now().timestamp()
+        if STATE_VAR in self.state.state:
+            self.state.state[STATE_VAR] += f",{t_stamp}"
+        else:
+            self.state.state[STATE_VAR] = str(t_stamp)
+    
+    def _retrieve_timestamp_from_state(self):
+        return self.state.state[STATE_VAR]
 
     def fit(self, parameters, config):
         set_parameters(net, parameters)
         train(net, trainloader, epochs=1)
-        return self.get_parameters(config={}), len(trainloader.dataset), {}
+        self._record_timestamp_to_state()
+        return self.get_parameters(config={}), len(trainloader.dataset), {STATE_VAR: self._retrieve_timestamp_from_state()}
 
     def evaluate(self, parameters, config):
         set_parameters(net, parameters)
         loss, accuracy = test(net, testloader)
-        return loss, len(testloader.dataset), {"accuracy": accuracy}
+        self._record_timestamp_to_state()
+        return loss, len(testloader.dataset), {"accuracy": accuracy, STATE_VAR: self._retrieve_timestamp_from_state()}
 
 def set_parameters(model, parameters):
     params_dict = zip(model.state_dict().keys(), parameters)

--- a/e2e/pytorch/simulation.py
+++ b/e2e/pytorch/simulation.py
@@ -1,11 +1,42 @@
+from typing import List, Tuple
+import numpy as np
+
 import flwr as fl
+from flwr.common import Metrics
+
 
 from client import client_fn
+STATE_VAR = 'timestamp'
+
+
+# Define metric aggregation function
+def record_state_metrics(metrics: List[Tuple[int, Metrics]]) -> Metrics:
+    """Ensure that timestamps are monotonically increasing."""
+    states = []
+    for _, m in metrics:
+        # split string and covert timestamps to float
+        states.append([float(tt) for tt in m[STATE_VAR].split(',')])
+
+    for client_state in states:
+        if len(client_state) == 1:
+            continue
+        deltas = np.diff(client_state)
+        assert np.all(deltas > 0), f"Timestamps are not monotonically increasing: {client_state}"
+
+    return {STATE_VAR: states}
+
+
+strategy = fl.server.strategy.FedAvg(evaluate_metrics_aggregation_fn=record_state_metrics)
 
 hist = fl.simulation.start_simulation(
     client_fn=client_fn,
     num_clients=2,
     config=fl.server.ServerConfig(num_rounds=3),
+    strategy=strategy,
 )
 
 assert hist.losses_distributed[-1][1] == 0 or (hist.losses_distributed[0][1] / hist.losses_distributed[-1][1]) >= 0.98
+
+# The checks in record_state_metrics don't do anythinng if client's state has a single entry
+state_metrics_last_round = hist.metrics_distributed[STATE_VAR][-1]
+assert len(state_metrics_last_round[1][0]) == 2*state_metrics_last_round[0], f"There should be twice as many entries in the client state as rounds"

--- a/e2e/server.py
+++ b/e2e/server.py
@@ -1,8 +1,47 @@
+from typing import List, Tuple
+import numpy as np
+
+
 import flwr as fl
+from flwr.common import Metrics
+STATE_VAR = 'timestamp'
+
+
+# Define metric aggregation function
+def record_state_metrics(metrics: List[Tuple[int, Metrics]]) -> Metrics:
+    """Ensure that timestamps are monotonically increasing."""
+    if not metrics:
+        return {}
+    
+    if STATE_VAR not in metrics[0][1]:
+        # Do nothing if keyword is not present
+        return {}
+
+    states = []
+    for _, m in metrics:
+        # split string and covert timestamps to float
+        states.append([float(tt) for tt in m[STATE_VAR].split(',')])
+
+    for client_state in states:
+        if len(client_state) == 1:
+            continue
+        deltas = np.diff(client_state)
+        assert np.all(deltas > 0), f"Timestamps are not monotonically increasing: {client_state}"
+
+    return {STATE_VAR: states}
+
+
+strategy = fl.server.strategy.FedAvg(evaluate_metrics_aggregation_fn=record_state_metrics)
 
 hist = fl.server.start_server(
     server_address="0.0.0.0:8080",
     config=fl.server.ServerConfig(num_rounds=3),
+    strategy=strategy,
 )
 
 assert hist.losses_distributed[-1][1] == 0 or (hist.losses_distributed[0][1] / hist.losses_distributed[-1][1]) >= 0.98
+
+if STATE_VAR in hist.metrics_distributed:
+    # The checks in record_state_metrics don't do anythinng if client's state has a single entry
+    state_metrics_last_round = hist.metrics_distributed[STATE_VAR][-1]
+    assert len(state_metrics_last_round[1][0]) == 2*state_metrics_last_round[0], f"There should be twice as many entries in the client state as rounds"


### PR DESCRIPTION
The E2E test is designed as follows:
* Clients append to their state the current timestamp the moment they do `fit()` and `evaluate()`. This results in the client's state to have a collection of **monotonically** increasing timestamps.
* The server communicates to the client their timestamps series through the `metrics` return argument
* The strategy checks for timestamp monotonicity after aggregation.

If test pass it means that the mechanism of injecting the `WorkloadState` into the client objects after being retrieved from the `NodeState` is working.

