### PR TITLE
Make copyright year in Flower docs dynamic

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,19 +24,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Check copyright line
-        shell: bash
-        run: |
-          EXIT_CODE=0
-
-          while IFS= read -r -d '' file; do
-              COPYRIGHT=$(grep -h -r "copyright = " "$file")
-              if [ "$COPYRIGHT" != "copyright = f\"{datetime.date.today().year} Flower Labs GmbH\"" ]; then
-                  echo "::error file=$file::Wrong copyright line. Expected: copyright = f\"{datetime.date.today().year} Flower Labs GmbH\""
-                  EXIT_CODE=1
-              fi
-          done < <(find . -path "*/doc/source/conf.py" -print0)
-
-          exit $EXIT_CODE
+        run: ./dev/test-copyright.sh
       - name: Bootstrap
         uses: ./.github/actions/bootstrap
       - name: Install pandoc

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,6 +23,20 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Check copyright line
+        shell: bash
+        run: |
+          EXIT_CODE=0
+
+          while IFS= read -r -d '' file; do
+              COPYRIGHT=$(grep -h -r "copyright = " "$file")
+              if [ "$COPYRIGHT" != "copyright = f\"{datetime.date.today().year} Flower Labs GmbH\"" ]; then
+                  echo "::error file=$file::Wrong copyright line. Expected: copyright = f\"{datetime.date.today().year} Flower Labs GmbH\""
+                  EXIT_CODE=1
+              fi
+          done < <(find . -path "*/doc/source/conf.py" -print0)
+
+          exit $EXIT_CODE
       - name: Bootstrap
         uses: ./.github/actions/bootstrap
       - name: Install pandoc

--- a/baselines/doc/source/conf.py
+++ b/baselines/doc/source/conf.py
@@ -14,6 +14,7 @@
 # ==============================================================================
 
 
+import datetime
 import os
 import sys
 from sphinx.application import ConfigError
@@ -32,7 +33,7 @@ sys.path.insert(0, os.path.abspath("../../src/py"))
 # -- Project information -----------------------------------------------------
 
 project = "Flower"
-copyright = "2022 Flower Labs GmbH"
+copyright = f"{datetime.date.today().year} Flower Labs GmbH"
 author = "The Flower Authors"
 
 # The full version, including alpha/beta/rc tags

--- a/datasets/doc/source/conf.py
+++ b/datasets/doc/source/conf.py
@@ -14,6 +14,7 @@
 # ==============================================================================
 
 
+import datetime
 import os
 import sys
 from sphinx.application import ConfigError
@@ -33,7 +34,7 @@ sys.path.insert(0, os.path.abspath("../../flwr_datasets"))
 # -- Project information -----------------------------------------------------
 
 project = "Flower Datasets"
-copyright = "2023 Flower Labs GmbH"
+copyright = f"{datetime.date.today().year} Flower Labs GmbH"
 author = "The Flower Authors"
 
 # The full version, including alpha/beta/rc tags
@@ -74,24 +75,26 @@ autosummary_ignore_module_all = False
 # The full name is still at the top of the page
 add_module_names = False
 
+
 def find_test_modules(package_path):
     """Go through the python files and exclude every *_test.py file."""
     full_path_modules = []
     for root, dirs, files in os.walk(package_path):
         for file in files:
-            if file.endswith('_test.py'):
+            if file.endswith("_test.py"):
                 # Construct the module path relative to the package directory
                 full_path = os.path.join(root, file)
                 relative_path = os.path.relpath(full_path, package_path)
                 # Convert file path to dotted module path
-                module_path = os.path.splitext(relative_path)[0].replace(os.sep, '.')
+                module_path = os.path.splitext(relative_path)[0].replace(os.sep, ".")
                 full_path_modules.append(module_path)
     modules = []
     for full_path_module in full_path_modules:
-        parts = full_path_module.split('.')
+        parts = full_path_module.split(".")
         for i in range(len(parts)):
-            modules.append('.'.join(parts[i:]))
+            modules.append(".".join(parts[i:]))
     return modules
+
 
 # Stop from documenting the *_test.py files.
 # That's the only way to do that in autosummary (make the modules as mock_imports).

--- a/dev/test-copyright.sh
+++ b/dev/test-copyright.sh
@@ -1,0 +1,15 @@
+#!/bin/bash -e
+
+cd "$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"/../
+
+EXIT_CODE=0
+
+while IFS= read -r -d '' file; do
+    COPYRIGHT=$(grep -h -r "copyright = " "$file")
+    if [ "$COPYRIGHT" != "copyright = f\"{datetime.date.today().year} Flower Labs GmbH\"" ]; then
+        echo "::error file=$file::Wrong copyright line. Expected: copyright = f\"{datetime.date.today().year} Flower Labs GmbH\""
+        EXIT_CODE=1
+    fi
+done < <(find . -path "*/doc/source/conf.py" -print0)
+
+exit $EXIT_CODE

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -14,6 +14,7 @@
 # ==============================================================================
 
 
+import datetime
 import os
 import sys
 from git import Repo
@@ -81,7 +82,7 @@ gettext_compact = "framework-docs"
 # -- Project information -----------------------------------------------------
 
 project = "Flower"
-copyright = "2022 Flower Labs GmbH"
+copyright = f"{datetime.date.today().year} Flower Labs GmbH"
 author = "The Flower Authors"
 
 # The full version, including alpha/beta/rc tags

--- a/examples/doc/source/conf.py
+++ b/examples/doc/source/conf.py
@@ -22,8 +22,11 @@
 
 # -- Project information -----------------------------------------------------
 
+import datetime
+
+
 project = "Flower"
-copyright = "2022 Flower Labs GmbH"
+copyright = f"{datetime.date.today().year} Flower Labs GmbH"
 author = "The Flower Authors"
 
 # The full version, including alpha/beta/rc tags


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

The copyright year is currently hardcoded. This PR adds a bit of python code to make it dynamic.

### Description


### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

### Checklist

- [ ] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.dev/docs/writing-documentation.html)
- [ ] Update [changelog](https://github.com/adap/flower/blob/main/doc/source/changelog.rst)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.dev/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
