### PR TITLE
Add base image for other python versions

### DIFF
--- a/.github/workflows/docker-base.yml
+++ b/.github/workflows/docker-base.yml
@@ -3,7 +3,12 @@ name: Build docker base image
 on:
   push:
     branches: ["main"]
-    paths: ["src/docker/base/**"]
+    paths:
+      - "src/docker/base/**"
+      - ".github/workflows/docker-base.yml"
+      # re-run if something chnages in the bootstrap action (e.g. version of the dependencies)
+      - ".github/actions/bootstrap/action.yml"
+      - ".github/workflows/_docker-build.yml"
 
 permissions:
   contents: read
@@ -40,7 +45,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: [3.11]
+        python-version: [3.8, 3.9, 3.10, 3.11]
     with:
       namespace-repository: flwr/base
       file-dir: src/docker/base

--- a/.github/workflows/docker-server.yml
+++ b/.github/workflows/docker-server.yml
@@ -35,7 +35,7 @@ jobs:
       dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
 
   summary:
-    name: Summary
+    name: Build images
     runs-on: ubuntu-22.04
     needs: build-server-images
     timeout-minutes: 10


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

We want to provide base images for 3.8, 3.9 and 3.10.

### Description

- adjusts the ci job so that we build base images not just for python 3.11 but also for 3.8, 3.9 and 3.10
- renames the job name `Summary` to `Build images` so that the title of the github workflow summary is `Build images summary` instead of `Summary summary`
![Screenshot 2023-12-08 at 11 22 55](https://github.com/adap/flower/assets/10488408/86c93c7c-8093-4277-84a3-56b850dbdc59)

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

### Checklist

- [ ] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.dev/docs/writing-documentation.html)
- [ ] Update [changelog](https://github.com/adap/flower/blob/main/doc/source/changelog.rst)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.dev/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
