### PR TITLE
Fix build of docker base image

### DIFF
--- a/.github/workflows/_docker-build.yml
+++ b/.github/workflows/_docker-build.yml
@@ -38,6 +38,8 @@ jobs:
     name: Build server image
     runs-on: ubuntu-22.04
     timeout-minutes: 60
+    outputs:
+      build-id: ${{ steps.build-id.outputs.id }}
     strategy:
       fail-fast: true
       matrix:
@@ -48,6 +50,17 @@ jobs:
             { qemu: "arm64", docker: "linux/arm64" },
           ]
     steps:
+      - name: Create build id
+        id: build-id
+        shell: python
+        run: |
+          import hashlib
+          import os
+
+          hash = hashlib.sha256('''${{ inputs.build-args }}'''.encode())
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+              print(f"id={hash.hexdigest()}", file=fh)
+
       - name: Set up QEMU
         if: matrix.platform.qemu != ''
         uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
@@ -87,7 +100,7 @@ jobs:
       - name: Upload digest
         uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
-          name: digests
+          name: digests-${{ steps.build-id.outputs.id }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -103,7 +116,7 @@ jobs:
       - name: Download digests
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
-          name: digests
+          name: digests-${{ needs.build.outputs.build-id }}
           path: /tmp/digests
 
       - name: Docker meta

--- a/.github/workflows/docker-base.yml
+++ b/.github/workflows/docker-base.yml
@@ -43,9 +43,9 @@ jobs:
     uses: ./.github/workflows/_docker-build.yml
     needs: parameters
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, 3.10, 3.11]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     with:
       namespace-repository: flwr/base
       file-dir: src/docker/base


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

The values (python versions) in the matrix were interpreted as floats. When the value `3.10` was passed to the build argument `PYTHON_VERSION` the zero was cut off. This lead the docker build command to fail because it tried to install python `3.1`. 

### Description

- convert python version to strings
- turned the value for `fail-fast` to `false`. if one build fails, we still can push the other.
- make artifact name unique (hash of the build args) to prevent jobs from overwriting each other's artifacts

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

### Checklist

- [ ] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.dev/docs/writing-documentation.html)
- [ ] Update [changelog](https://github.com/adap/flower/blob/main/doc/source/changelog.rst)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.dev/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
