### PR TITLE
Skip upload wheel step for dependabot

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,12 +30,12 @@ jobs:
       - name: Test wheel
         run: ./dev/test-wheel.sh
       - name: Upload wheel
-        if: ${{ github.repository == 'adap/flower' && !github.event.pull_request.head.repo.fork }}
+        if: ${{ github.repository == 'adap/flower' && !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
         id: upload
         env:
-          AWS_DEFAULT_REGION: ${{ secrets. AWS_DEFAULT_REGION }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets. AWS_SECRET_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
           cd ./dist
           echo "WHL_PATH=$(ls *.whl)" >> "$GITHUB_OUTPUT"
@@ -73,7 +73,7 @@ jobs:
             dataset: |
               import tensorflow as tf
               tf.keras.datasets.cifar10.load_data()
-              
+
           - directory: tabnet
             dataset: |
               import tensorflow_datasets as tfds
@@ -83,7 +83,7 @@ jobs:
             dataset: |
               from torchvision.datasets import CIFAR10
               CIFAR10('./data', download=True)
-              
+
           - directory: pytorch-lightning
             dataset: |
               from torchvision.datasets import MNIST
@@ -102,7 +102,7 @@ jobs:
           - directory: fastai
             dataset: |
               from fastai.vision.all import untar_data, URLs
-              untar_data(URLs.MNIST) 
+              untar_data(URLs.MNIST)
 
           - directory: pandas
             dataset: |


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

Dependabot does not have access to secrets. Therefore the `Upload wheel` step in the `E2E` workflow is failing.

### Description

The issue is fixed by skipping the `upload wheel` step if the actor is dependabot.

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

### Checklist

- [ ] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.dev/docs/writing-documentation.html)
- [ ] Update [changelog](https://github.com/adap/flower/blob/main/doc/source/changelog.rst)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.dev/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
