### PR TITLE
Strip pycharm metadata in the format.sh script

### DIFF
--- a/dev/format.sh
+++ b/dev/format.sh
@@ -18,7 +18,7 @@ python -m docformatter -i -r examples
 
 # Notebooks
 python -m black --ipynb -q doc/source/*.ipynb
-KEYS="metadata.celltoolbar metadata.language_info metadata.toc metadata.notify_time metadata.varInspector metadata.accelerator metadata.vscode cell.metadata.id cell.metadata.heading_collapsed cell.metadata.hidden cell.metadata.code_folding cell.metadata.tags cell.metadata.init_cell cell.metadata.vscode"
+KEYS="metadata.celltoolbar metadata.language_info metadata.toc metadata.notify_time metadata.varInspector metadata.accelerator metadata.vscode cell.metadata.id cell.metadata.heading_collapsed cell.metadata.hidden cell.metadata.code_folding cell.metadata.tags cell.metadata.init_cell cell.metadata.vscode cell.metadata.pycharm"
 python -m nbstripout doc/source/*.ipynb --extra-keys "$KEYS"
 python -m nbstripout examples/*/*.ipynb --extra-keys "$KEYS"
 


### PR DESCRIPTION
## Issue
The metadata from running the jupyter notebooks is kept in case of running them in PyCharm.

### Description
See this diff for an example of the metadata diff https://github.com/adap/flower/pull/2480/commits/aceeef7bbf903f3ea17b0968b49fc3a5e6030ed5

## Proposal

Extend `--extra-keys` in the `format.sh` script to strip the PyCharm metadata form cells.