### PR TITLE
Add Javier as codeowner for the changelog file in docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,4 +10,4 @@
 /examples @jafermarq @tanertopal @danieljanes
 
 # Changelog
-doc/source/ref-changelog.md @jafermarq @tanertopal @danieljanes
+/doc/source/ref-changelog.md @jafermarq @tanertopal @danieljanes

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,5 +10,4 @@
 /examples @jafermarq @tanertopal @danieljanes
 
 # Changelog
-CHANGELOG.md @jafermarq @tanertopal @danieljanes
 doc/source/ref-changelog.md @jafermarq @tanertopal @danieljanes

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,3 +8,6 @@
 
 # Flower Examples
 /examples @jafermarq @tanertopal @danieljanes
+
+# Changelog
+CHANGELOG.md @jafermarq @tanertopal @danieljanes

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,3 +11,4 @@
 
 # Changelog
 CHANGELOG.md @jafermarq @tanertopal @danieljanes
+doc/source/ref-changelog.md @jafermarq @tanertopal @danieljanes


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

Adding @jafermarq as codeowner for the doc/source/ref-changelog.md file.

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

### Checklist

- [ ] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.dev/docs/writing-documentation.html)
- [ ] Update [changelog](https://github.com/adap/flower/blob/main/doc/source/changelog.rst)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.dev/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
