### PR TITLE
Change runner for E2E tests to large GitHub hosted runners

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,7 +17,8 @@ env:
 
 jobs:
   wheel:
-    runs-on: ubuntu-22.04
+    runs-on: 
+      group: ubuntu-runners
     name: Build, test and upload wheel
     steps:
       - uses: actions/checkout@v4
@@ -50,7 +51,8 @@ jobs:
       dir: ${{ steps.upload.outputs.DIR }}
 
   frameworks:
-    runs-on: ubuntu-22.04
+    runs-on: 
+      group: ubuntu-runners
     timeout-minutes: 10
     needs: wheel
     # Using approach described here:


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

### Checklist

- [ ] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.dev/docs/writing-documentation.html)
- [ ] Update [changelog](https://github.com/adap/flower/blob/main/doc/source/changelog.rst)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.dev/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
