### PR TITLE
Deprecate old central DP wrapper classes

### DIFF
--- a/src/py/flwr/server/strategy/dpfedavg_adaptive.py
+++ b/src/py/flwr/server/strategy/dpfedavg_adaptive.py
@@ -20,6 +20,7 @@ Paper: arxiv.org/pdf/1905.03871.pdf
 
 import math
 from typing import Dict, List, Optional, Tuple, Union
+import warnings
 
 import numpy as np
 
@@ -31,6 +32,9 @@ from flwr.server.strategy.strategy import Strategy
 
 
 class DPFedAvgAdaptive(DPFedAvgFixed):
+
+    warnings.warn("DPFedAvgAdaptive is deprecated and will be removed in future versions.", DeprecationWarning)
+
     """Wrapper for configuring a Strategy for DP with Adaptive Clipping."""
 
     # pylint: disable=too-many-arguments,too-many-instance-attributes
@@ -45,6 +49,8 @@ class DPFedAvgAdaptive(DPFedAvgFixed):
         clip_norm_target_quantile: float = 0.5,
         clip_count_stddev: Optional[float] = None,
     ) -> None:
+        warnings.warn("DPFedAvgAdaptive is deprecated and will be removed in future versions.", DeprecationWarning)
+        
         super().__init__(
             strategy=strategy,
             num_sampled_clients=num_sampled_clients,

--- a/src/py/flwr/server/strategy/dpfedavg_adaptive.py
+++ b/src/py/flwr/server/strategy/dpfedavg_adaptive.py
@@ -19,8 +19,8 @@ Paper: arxiv.org/pdf/1905.03871.pdf
 
 
 import math
-from typing import Dict, List, Optional, Tuple, Union
 import warnings
+from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
 
@@ -32,8 +32,10 @@ from flwr.server.strategy.strategy import Strategy
 
 
 class DPFedAvgAdaptive(DPFedAvgFixed):
-
-    warnings.warn("DPFedAvgAdaptive is deprecated and will be removed in future versions.", DeprecationWarning)
+    warnings.warn(
+        "DPFedAvgAdaptive is deprecated and will be removed in future versions.",
+        DeprecationWarning,
+    )
 
     """Wrapper for configuring a Strategy for DP with Adaptive Clipping."""
 
@@ -49,8 +51,11 @@ class DPFedAvgAdaptive(DPFedAvgFixed):
         clip_norm_target_quantile: float = 0.5,
         clip_count_stddev: Optional[float] = None,
     ) -> None:
-        warnings.warn("DPFedAvgAdaptive is deprecated and will be removed in future versions.", DeprecationWarning)
-        
+        warnings.warn(
+            "DPFedAvgAdaptive is deprecated and will be removed in future versions.",
+            DeprecationWarning,
+        )
+
         super().__init__(
             strategy=strategy,
             num_sampled_clients=num_sampled_clients,

--- a/src/py/flwr/server/strategy/dpfedavg_adaptive.py
+++ b/src/py/flwr/server/strategy/dpfedavg_adaptive.py
@@ -35,10 +35,11 @@ class DPFedAvgAdaptive(DPFedAvgFixed):
     warnings.warn(
         "DPFedAvgAdaptive is deprecated and will be removed in future versions.",
         DeprecationWarning,
+        stacklevel=2,
     )
     """Wrapper for configuring a Strategy for DP with Adaptive Clipping."""
 
-    # pylint: disable=too-many-arguments,too-many-instance-attributes
+    # pylint: disable=too-many-arguments,too-many-instance-attributes,line-too-long,missing-docstring
     def __init__(
         self,
         strategy: Strategy,
@@ -53,6 +54,7 @@ class DPFedAvgAdaptive(DPFedAvgFixed):
         warnings.warn(
             "DPFedAvgAdaptive is deprecated and will be removed in future versions.",
             DeprecationWarning,
+            stacklevel=2,
         )
 
         super().__init__(

--- a/src/py/flwr/server/strategy/dpfedavg_adaptive.py
+++ b/src/py/flwr/server/strategy/dpfedavg_adaptive.py
@@ -36,7 +36,6 @@ class DPFedAvgAdaptive(DPFedAvgFixed):
         "DPFedAvgAdaptive is deprecated and will be removed in future versions.",
         DeprecationWarning,
     )
-
     """Wrapper for configuring a Strategy for DP with Adaptive Clipping."""
 
     # pylint: disable=too-many-arguments,too-many-instance-attributes

--- a/src/py/flwr/server/strategy/dpfedavg_fixed.py
+++ b/src/py/flwr/server/strategy/dpfedavg_fixed.py
@@ -34,7 +34,6 @@ class DPFedAvgFixed(Strategy):
         "DPFedAvgFixed is deprecated and will be removed in future versions.",
         DeprecationWarning,
     )
-
     """Wrapper for configuring a Strategy for DP with Fixed Clipping."""
 
     # pylint: disable=too-many-arguments,too-many-instance-attributes

--- a/src/py/flwr/server/strategy/dpfedavg_fixed.py
+++ b/src/py/flwr/server/strategy/dpfedavg_fixed.py
@@ -19,6 +19,7 @@ Paper: arxiv.org/pdf/1710.06963.pdf
 
 
 from typing import Dict, List, Optional, Tuple, Union
+import warnings
 
 from flwr.common import EvaluateIns, EvaluateRes, FitIns, FitRes, Parameters, Scalar
 from flwr.common.dp import add_gaussian_noise
@@ -29,6 +30,9 @@ from flwr.server.strategy.strategy import Strategy
 
 
 class DPFedAvgFixed(Strategy):
+
+    warnings.warn("DPFedAvgFixed is deprecated and will be removed in future versions.", DeprecationWarning)
+
     """Wrapper for configuring a Strategy for DP with Fixed Clipping."""
 
     # pylint: disable=too-many-arguments,too-many-instance-attributes
@@ -40,6 +44,8 @@ class DPFedAvgFixed(Strategy):
         noise_multiplier: float = 1,
         server_side_noising: bool = True,
     ) -> None:
+        warnings.warn("DPFedAvgFixed is deprecated and will be removed in future versions.", DeprecationWarning)
+        
         super().__init__()
         self.strategy = strategy
         # Doing fixed-size subsampling as in https://arxiv.org/abs/1905.03871.

--- a/src/py/flwr/server/strategy/dpfedavg_fixed.py
+++ b/src/py/flwr/server/strategy/dpfedavg_fixed.py
@@ -33,10 +33,11 @@ class DPFedAvgFixed(Strategy):
     warnings.warn(
         "DPFedAvgFixed is deprecated and will be removed in future versions.",
         DeprecationWarning,
+        stacklevel=2,
     )
     """Wrapper for configuring a Strategy for DP with Fixed Clipping."""
 
-    # pylint: disable=too-many-arguments,too-many-instance-attributes
+    # pylint: disable=too-many-arguments,too-many-instance-attributes, line-too-long
     def __init__(
         self,
         strategy: Strategy,
@@ -48,6 +49,7 @@ class DPFedAvgFixed(Strategy):
         warnings.warn(
             "DPFedAvgFixed is deprecated and will be removed in future versions.",
             DeprecationWarning,
+            stacklevel=2,
         )
 
         super().__init__()

--- a/src/py/flwr/server/strategy/dpfedavg_fixed.py
+++ b/src/py/flwr/server/strategy/dpfedavg_fixed.py
@@ -18,8 +18,8 @@ Paper: arxiv.org/pdf/1710.06963.pdf
 """
 
 
-from typing import Dict, List, Optional, Tuple, Union
 import warnings
+from typing import Dict, List, Optional, Tuple, Union
 
 from flwr.common import EvaluateIns, EvaluateRes, FitIns, FitRes, Parameters, Scalar
 from flwr.common.dp import add_gaussian_noise
@@ -30,8 +30,10 @@ from flwr.server.strategy.strategy import Strategy
 
 
 class DPFedAvgFixed(Strategy):
-
-    warnings.warn("DPFedAvgFixed is deprecated and will be removed in future versions.", DeprecationWarning)
+    warnings.warn(
+        "DPFedAvgFixed is deprecated and will be removed in future versions.",
+        DeprecationWarning,
+    )
 
     """Wrapper for configuring a Strategy for DP with Fixed Clipping."""
 
@@ -44,8 +46,11 @@ class DPFedAvgFixed(Strategy):
         noise_multiplier: float = 1,
         server_side_noising: bool = True,
     ) -> None:
-        warnings.warn("DPFedAvgFixed is deprecated and will be removed in future versions.", DeprecationWarning)
-        
+        warnings.warn(
+            "DPFedAvgFixed is deprecated and will be removed in future versions.",
+            DeprecationWarning,
+        )
+
         super().__init__()
         self.strategy = strategy
         # Doing fixed-size subsampling as in https://arxiv.org/abs/1905.03871.


### PR DESCRIPTION
We are creating a new central DP feature at the server side. This PR deprecates the old existing ones. 