### PR TITLE
Do not use gRPC context peers to identify clients

### DIFF
--- a/src/py/flwr/server/fleet/grpc_bidi/flower_service_servicer.py
+++ b/src/py/flwr/server/fleet/grpc_bidi/flower_service_servicer.py
@@ -18,7 +18,7 @@ Relevant knowledge for reading this modules code:
 - https://github.com/grpc/grpc/blob/master/doc/statuscodes.md
 """
 
-
+import uuid
 from typing import Callable, Iterator
 
 import grpc
@@ -88,7 +88,11 @@ class FlowerServiceServicer(transport_pb2_grpc.FlowerServiceServicer):
           wrapping the actual message
         - The `Join` method is (pretty much) unaware of the protocol
         """
-        peer: str = context.peer()
+        # NOTE(aloga): this is a hack. when running flower behind a proxy, the peer can
+        # be the same for different clients (i.e. ip:port) so we use a uuid that is
+        # unique.
+        # peer: str = context.peer()
+        peer = uuid.uuid4().hex
         bridge = self.grpc_bridge_factory()
         client_proxy = self.client_proxy_factory(peer, bridge)
         is_success = register_client_proxy(self.client_manager, client_proxy, context)


### PR DESCRIPTION
## Issue

### Description

When running flower behind a proxy, the peer can be the same for different clients (i.e. ip:port) so we use a uuid that is unique. This makes impossible to use flower behind some reverse proxies, like Traefik

### Related issues/PRs

Fixes #1972

## Proposal

### Explanation

The peer ID is not used outside the join method, so we can rely on an uuid for each of the clients, so they do not overlap.

### Checklist

- [x] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.dev/docs/writing-documentation.html)
- [ ] Update the changelog entry below
- [ ] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)