### PR TITLE
Narrow down Python version in FDS TF e2e test

### DIFF
--- a/datasets/e2e/tensorflow/pyproject.toml
+++ b/datasets/e2e/tensorflow/pyproject.toml
@@ -9,7 +9,7 @@ description = "Flower Datasets with TensorFlow"
 authors = ["The Flower Authors <hello@flower.dev>"]
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = ">=3.8,<3.11"
 flwr-datasets = { path = "./../../", extras = ["vision"] }
 tensorflow-cpu = "^2.9.1, !=2.11.1"
 parameterized = "==0.9.0"


### PR DESCRIPTION
## Issue
The python version in pyproject.toml was specified as `python = "^3.8"` which disables the successful versions resolution.

### Description
A few new PRs fail due to that reason.

## Proposal
Change to `python = ">=3.8,<3.11"` which is used in many examples to successfully find the proper dependency versions.
