### PR TITLE
Favor Docformatter for multi-line docstrings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,7 +184,7 @@ target-version = "py38"
 line-length = 88
 select = ["D", "E", "F", "W", "B", "ISC", "C4", "UP"]
 fixable = ["D", "E", "F", "W", "B", "ISC", "C4", "UP"]
-ignore = ["B024", "B027"]
+ignore = ["B024", "B027", "D205", "D209"]
 exclude = [
     ".bzr",
     ".direnv",


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

Docformatter and Ruff create conflicts on multi-line single-sentence docstrings. Ruff requires a blank line between summary line and description (D205) and that closing quotes should be on a separate line (D209).

`docformatter` format:

```py
def foo():
    """Here is a multiline docstring, that is a docstring that has to be split on two lines
    but that is still in a single sentence."""
    print("Hello")
```

`ruff` format:

```py
def foo():
    """Here is a multiline docstring, that is a docstring that has to be split on two lines
    but that is still in a single sentence.
    """

    print("Hello")
```

### Related issues/PRs

N/A

## Proposal

### Explanation

Ignore the `ruff` checks.

### Checklist

- [x] Implement proposed change
- [x] Update the changelog entry below
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

<!--
Inside the following 'Changelog entry' section, you should put the description of your changes that will be added to the changelog alongside your PR title.

If the section is completely empty (without any token), the changelog will just contain the title of the PR for the changelog entry, without any description. If the 'Changelog entry' section is removed entirely, it will categorize the PR as "General improvement" and add it to the changelog accordingly. If the section contains some text other than tokens, it will use it to add a description to the change. If the section contains one of the following tokens it will ignore any other text and put the PR under the corresponding section of the changelog:

<general> is for classifying a PR as a general improvement.
<skip> is to not add the PR to the changelog
<baselines> is to add a general baselines change to the PR
<examples> is to add a general examples change to the PR
<sdk> is to add a general sdk change to the PR
<simulations> is to add a general simulations change to the PR

Note that only one token should be used.
-->

### Changelog entry

<general>

### Any other comments?

N/A
