### PR TITLE
Fix LogisticRegression model

### DIFF
--- a/baselines/fedprox/fedprox/models.py
+++ b/baselines/fedprox/fedprox/models.py
@@ -77,7 +77,7 @@ class LogisticRegression(nn.Module):
         torch.Tensor
             The resulting Tensor after it has passed through the network
         """
-        output_tensor = self.linear(torch.flatten(input_tensor, 1))
+        output_tensor = torch.sigmoid(self.linear(torch.flatten(input_tensor, 1)))
         return output_tensor
 
 


### PR DESCRIPTION
## Issue
The currently implemented model is in practice LinearRegression not LogisticRegression as described.

### Description
In the implementation of `LogisticRegression` the sigmoid operation is missing.

## Proposal
Add the missing sigmoid to the model.