### PR TITLE
Make quote in contributor docs easier to read

### DIFF
--- a/doc/source/contributor-tutorial-contribute-on-github.rst
+++ b/doc/source/contributor-tutorial-contribute-on-github.rst
@@ -357,23 +357,31 @@ Changelog entry
 
 When opening a new PR, inside its description, there should be a ``Changelog entry`` header.
 
-As per the comment above this section::
-
+As per the comment above this section
+  
     Inside the following 'Changelog entry' section, 
     you should put the description of your changes that will be added to the changelog alongside your PR title.
 
     If the section is completely empty (without any token), 
     the changelog will just contain the title of the PR for the changelog entry, without any description. 
+
     If the 'Changelog entry' section is removed entirely, 
     it will categorize the PR as "General improvement" and add it to the changelog accordingly. 
+
     If the section contains some text other than tokens, it will use it to add a description to the change. 
+
     If the section contains one of the following tokens it will ignore any other text and put the PR under the corresponding section of the changelog:
 
     <general> is for classifying a PR as a general improvement.
+
     <skip> is to not add the PR to the changelog
+
     <baselines> is to add a general baselines change to the PR
+
     <examples> is to add a general examples change to the PR
+
     <sdk> is to add a general sdk change to the PR
+
     <simulations> is to add a general simulations change to the PR
 
     Note that only one token should be used.

--- a/doc/source/contributor-tutorial-contribute-on-github.rst
+++ b/doc/source/contributor-tutorial-contribute-on-github.rst
@@ -358,7 +358,7 @@ Changelog entry
 When opening a new PR, inside its description, there should be a ``Changelog entry`` header.
 
 As per the comment above this section
-  
+
     Inside the following 'Changelog entry' section, 
     you should put the description of your changes that will be added to the changelog alongside your PR title.
 

--- a/doc/source/contributor-tutorial-contribute-on-github.rst
+++ b/doc/source/contributor-tutorial-contribute-on-github.rst
@@ -357,7 +357,7 @@ Changelog entry
 
 When opening a new PR, inside its description, there should be a ``Changelog entry`` header.
 
-As per the comment above this section
+Above this header you should see the following comment that explains how to write your changelog entry:
 
     Inside the following 'Changelog entry' section, 
     you should put the description of your changes that will be added to the changelog alongside your PR title.


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

The quote from the PR description comment is hard to read as there is some horizontal scrolling to do.

![image](https://github.com/adap/flower/assets/9378265/4ad77444-f8c9-4fde-8300-173e8c177491)


### Related issues/PRs

N/A

## Proposal

### Explanation

Instead of using a code block, we can just use a quote block to get this result:

![image](https://github.com/adap/flower/assets/9378265/b051f151-7c44-4aa4-bc27-ba98b5a23970)


### Checklist

- [x] Implement proposed change
- [x] Update [documentation](https://flower.dev/docs/writing-documentation.html)
- [x] Update the changelog entry below
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

<!--
Inside the following 'Changelog entry' section, you should put the description of your changes that will be added to the changelog alongside your PR title.

If the section is completely empty (without any token), the changelog will just contain the title of the PR for the changelog entry, without any description. If the 'Changelog entry' section is removed entirely, it will categorize the PR as "General improvement" and add it to the changelog accordingly. If the section contains some text other than tokens, it will use it to add a description to the change. If the section contains one of the following tokens it will ignore any other text and put the PR under the corresponding section of the changelog:

<general> is for classifying a PR as a general improvement.
<skip> is to not add the PR to the changelog
<baselines> is to add a general baselines change to the PR
<examples> is to add a general examples change to the PR
<sdk> is to add a general sdk change to the PR
<simulations> is to add a general simulations change to the PR

Note that only one token should be used.
-->

### Changelog entry

<skip>

### Any other comments?

N/A
