### PR TITLE
Lazy Async Aggregation

### DIFF
--- a/src/py/flwr/server/strategy/aggregate.py
+++ b/src/py/flwr/server/strategy/aggregate.py
@@ -16,12 +16,54 @@
 # mypy: disallow_untyped_calls=False
 
 from functools import reduce
-from typing import Any, Callable, List, Tuple
+from typing import Any, Callable, Iterable, List, Tuple
 
 import numpy as np
 
 from flwr.common import FitRes, NDArray, NDArrays, parameters_to_ndarrays
 from flwr.server.client_proxy import ClientProxy
+
+def aggregate_cumulative_average(
+    results: Iterable[Tuple[ClientProxy, FitRes]]
+) -> NDArrays | None:
+    """Compute in-place weighted average, lazily and async."""
+    # Initialize params,
+    # the iterator may not contain anything
+    # and we do not want a next+try-except
+    params: NDArrays | None = None
+
+    num_total_examples: int = 0  # total number of examples, aggregated over time
+
+    for client_proxy, fit_res in results:
+        # Compute the new total number of samples
+        new_total_samples = num_total_examples + fit_res.num_examples
+
+        # Compute scaling factor for the update
+        scaling_factor: float = float(fit_res.num_examples) / new_total_samples
+
+        # Generator to multiply the layers by the scaling factor
+        # Lazy operation, will be expanded in the zip
+        res = (scaling_factor * x for x in parameters_to_ndarrays(fit_res.parameters))
+
+        if params is None:
+            # Initialize with the first set of parameters
+            params = list(res)
+        else:
+            # Invert the previous division now
+            # that we have updated information on the number of samples
+            # Then divide by the new total number
+            general_scaling = float(num_total_examples) / new_total_samples
+
+            # Lazy generator for scaled layers
+            scaled_params = (general_scaling * x for x in params)
+
+            # Create new parameters
+            params = [np.add(x, y) for x, y in zip(scaled_params, res)]
+
+        # Update total number of examples
+        num_total_examples = new_total_samples
+
+    return params
 
 
 def aggregate(results: List[Tuple[NDArrays, int]]) -> NDArrays:


### PR DESCRIPTION
## Issue

Aggregation of potentially async results.

### Description

Flower server implementations may choose to aggregate results as soon as they are received.

The current aggregations block computation until the total number of clients necessary to compute the new parameters or the total number of samples has been reached. 

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal

A form of in-place aggregation that is mathematically equivalent but does not require pre-computing the total number of client samples within the round.

### Explanation

The new aggregation method allows for no memory overhead over the memory requirements of a single client when using an amenable iterable implementation. 

Similarly, it permits overlapping client training with aggregation time, thus potentially reducing the overhead of server aggregation to zero if the server is capable of aggregating clients as soon as they arrive.

### Checklist

- [ ] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.dev/docs/writing-documentation.html)
- [ ] Update the changelog entry below
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)


### Changelog entry

<general>

### Any other comments?

