### PR TITLE
Fix error when using SQLite with gRPC-rere

### DIFF
--- a/src/py/flwr/server/app.py
+++ b/src/py/flwr/server/app.py
@@ -532,7 +532,7 @@ def _run_fleet_api_grpc_rere(
     """Run Fleet API (gRPC, request-response)."""
     # Create Fleet API gRPC server
     fleet_servicer = FleetServicer(
-        state=state_factory.state(),
+        state_factory=state_factory,
     )
     fleet_add_servicer_to_server_fn = add_FleetServicer_to_server
     fleet_grpc_server = generic_create_grpc_server(

--- a/src/py/flwr/server/fleet/grpc_rere/fleet_servicer.py
+++ b/src/py/flwr/server/fleet/grpc_rere/fleet_servicer.py
@@ -32,14 +32,14 @@ from flwr.proto.fleet_pb2 import (  # pylint: disable=E0611
     PushTaskResResponse,
 )
 from flwr.server.fleet.message_handler import message_handler
-from flwr.server.state import State
+from flwr.server.state import StateFactory
 
 
 class FleetServicer(fleet_pb2_grpc.FleetServicer):
     """Fleet API servicer."""
 
-    def __init__(self, state: State) -> None:
-        self.state = state
+    def __init__(self, state_factory: StateFactory) -> None:
+        self.state_factory = state_factory
 
     def CreateNode(
         self, request: CreateNodeRequest, context: grpc.ServicerContext
@@ -48,7 +48,7 @@ class FleetServicer(fleet_pb2_grpc.FleetServicer):
         log(INFO, "FleetServicer.CreateNode")
         return message_handler.create_node(
             request=request,
-            state=self.state,
+            state=self.state_factory.state(),
         )
 
     def DeleteNode(
@@ -58,7 +58,7 @@ class FleetServicer(fleet_pb2_grpc.FleetServicer):
         log(INFO, "FleetServicer.DeleteNode")
         return message_handler.delete_node(
             request=request,
-            state=self.state,
+            state=self.state_factory.state(),
         )
 
     def PullTaskIns(
@@ -68,7 +68,7 @@ class FleetServicer(fleet_pb2_grpc.FleetServicer):
         log(INFO, "FleetServicer.PullTaskIns")
         return message_handler.pull_task_ins(
             request=request,
-            state=self.state,
+            state=self.state_factory.state(),
         )
 
     def PushTaskRes(
@@ -78,5 +78,5 @@ class FleetServicer(fleet_pb2_grpc.FleetServicer):
         log(INFO, "FleetServicer.PushTaskRes")
         return message_handler.push_task_res(
             request=request,
-            state=self.state,
+            state=self.state_factory.state(),
         )


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

When starting a `flower-server` with SQLite, we get an error saying that SQLite objects created in a specific thread can only be used in that thread.

### Related issues/PRs

N/A

## Proposal

### Explanation

The issue is caused by the fact that we pass the same SQLite `State` object to all the `FleetServicer` functions that are called on different threads. Instead, we should create the `State` object in each of the `FleetServicer` functions.

### Checklist

- [x] Implement proposed change
- [x] Update the changelog entry below
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

<!--
Inside the following 'Changelog entry' section, you should put the description of your changes that will be added to the changelog alongside your PR title.

If the section is completely empty (without any token), the changelog will just contain the title of the PR for the changelog entry, without any description. If the 'Changelog entry' section is removed entirely, it will categorize the PR as "General improvement" and add it to the changelog accordingly. If the section contains some text other than tokens, it will use it to add a description to the change. If the section contains one of the following tokens it will ignore any other text and put the PR under the corresponding section of the changelog:

<general> is for classifying a PR as a general improvement.
<skip> is to not add the PR to the changelog
<baselines> is to add a general baselines change to the PR
<examples> is to add a general examples change to the PR
<sdk> is to add a general sdk change to the PR
<simulations> is to add a general simulations change to the PR

Note that only one token should be used.
-->

### Changelog entry

<general>

### Any other comments?

Should this be an extensive changelog entry?
