### PR TITLE
Add REST transport to client callable

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -133,6 +133,9 @@ jobs:
         run: python simulation.py
       - name: Run driver test
         run: ./../test_driver.sh "${{ matrix.directory }}"
+      - name: Run driver test with REST
+        if: ${{ matrix.directory == 'bare' }}
+        run: ./../test_driver.sh "${{ matrix.directory }}" rest
 
   strategies:
     runs-on: ubuntu-22.04

--- a/e2e/bare/pyproject.toml
+++ b/e2e/bare/pyproject.toml
@@ -10,4 +10,4 @@ authors = ["The Flower Authors <hello@flower.dev>"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-flwr = { path = "../../", develop = true, extras = ["simulation"] }
+flwr = { path = "../../", develop = true, extras = ["simulation", "rest"] }

--- a/e2e/test_driver.sh
+++ b/e2e/test_driver.sh
@@ -13,13 +13,24 @@ case "$1" in
     ;;
 esac
 
-timeout 2m flower-server $server_arg &
+case "$2" in
+  rest)
+    rest_arg="--rest"
+    server_address="http://127.0.0.1:9092"
+    ;;
+  *)
+    rest_arg=""
+    server_address="127.0.0.1:9092"
+    ;;
+esac
+
+timeout 2m flower-server $server_arg $rest_arg &
 sleep 3
 
-timeout 2m flower-client client:flower $client_arg --server 127.0.0.1:9092 &
+timeout 2m flower-client client:flower $client_arg --server $server_address &
 sleep 3
 
-timeout 2m flower-client client:flower $client_arg --server 127.0.0.1:9092 &
+timeout 2m flower-client client:flower $client_arg $rest_arg --server $server_address &
 sleep 3
 
 timeout 2m python driver.py &

--- a/e2e/test_driver.sh
+++ b/e2e/test_driver.sh
@@ -16,7 +16,7 @@ esac
 case "$2" in
   rest)
     rest_arg="--rest"
-    server_address="http://127.0.0.1:9093"
+    server_address="http://localhost:9093"
     db_arg="--database :flwr-in-memory-state:"
     ;;
   sqlite)

--- a/e2e/test_driver.sh
+++ b/e2e/test_driver.sh
@@ -16,7 +16,7 @@ esac
 case "$2" in
   rest)
     rest_arg="--rest"
-    server_address="http://127.0.0.1:9092"
+    server_address="http://127.0.0.1:9093"
     db_arg="--database :flwr-in-memory-state:"
     ;;
   sqlite)

--- a/e2e/test_driver.sh
+++ b/e2e/test_driver.sh
@@ -34,7 +34,7 @@ esac
 timeout 2m flower-server $server_arg $db_arg $rest_arg &
 sleep 3
 
-timeout 2m flower-client client:flower $client_arg --server $server_address &
+timeout 2m flower-client client:flower $client_arg $rest_arg --server $server_address &
 sleep 3
 
 timeout 2m flower-client client:flower $client_arg $rest_arg --server $server_address &

--- a/src/py/flwr/client/app.py
+++ b/src/py/flwr/client/app.py
@@ -88,7 +88,7 @@ def run_client() -> None:
     _start_client_internal(
         server_address=args.server,
         load_flower_callable_fn=_load,
-        transport="grpc-rere",  # Only
+        transport="rest" if args.rest else "grpc-rere",
         root_certificates=root_certificates,
         insecure=args.insecure,
     )
@@ -110,6 +110,11 @@ def _parse_args_client() -> argparse.ArgumentParser:
         action="store_true",
         help="Run the client without HTTPS. By default, the client runs with "
         "HTTPS enabled. Use this flag only if you understand the risks.",
+    )
+    parser.add_argument(
+        "--rest",
+        action="store_true",
+        help="Use REST as a transport layer for the client.",
     )
     parser.add_argument(
         "--root-certificates",


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

The current client callable cannot instantiate REST clients.

### Related issues/PRs

N/A

## Proposal

### Explanation

Add a new argument to the callable that instantiates a REST client. Also adds new E2E tests for REST clients.

### Checklist

- [x] Implement proposed change
- [x] Write tests
- [x] Update the changelog entry below
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

<!--
Inside the following 'Changelog entry' section, you should put the description of your changes that will be added to the changelog alongside your PR title.

If the section is completely empty (without any token), the changelog will just contain the title of the PR for the changelog entry, without any description. If the 'Changelog entry' section is removed entirely, it will categorize the PR as "General improvement" and add it to the changelog accordingly. If the section contains some text other than tokens, it will use it to add a description to the change. If the section contains one of the following tokens it will ignore any other text and put the PR under the corresponding section of the changelog:

<general> is for classifying a PR as a general improvement.
<skip> is to not add the PR to the changelog
<baselines> is to add a general baselines change to the PR
<examples> is to add a general examples change to the PR
<sdk> is to add a general sdk change to the PR
<simulations> is to add a general simulations change to the PR

Note that only one token should be used.
-->

### Changelog entry

<general>

### Any other comments?

N/A
