### PR TITLE
Add `__repr__ for fedxgb_bagging and fedxgb_cyclic strategies

### DIFF
--- a/src/py/flwr/server/strategy/fedxgb_bagging.py
+++ b/src/py/flwr/server/strategy/fedxgb_bagging.py
@@ -44,6 +44,11 @@ class FedXgbBagging(FedAvg):
         self.global_model: Optional[bytes] = None
         super().__init__(**kwargs)
 
+    def __repr__(self) -> str:
+        """Compute a string representation of the strategy."""
+        rep = f"FedXgbBagging(accept_failures={self.accept_failures})"
+        return rep
+
     def aggregate_fit(
         self,
         server_round: int,

--- a/src/py/flwr/server/strategy/fedxgb_cyclic.py
+++ b/src/py/flwr/server/strategy/fedxgb_cyclic.py
@@ -37,6 +37,11 @@ class FedXgbCyclic(FedAvg):
         self.global_model: Optional[bytes] = None
         super().__init__(**kwargs)
 
+    def __repr__(self) -> str:
+        """Compute a string representation of the strategy."""
+        rep = f"FedXgbCyclic(accept_failures={self.accept_failures})"
+        return rep
+
     def aggregate_fit(
         self,
         server_round: int,


### PR DESCRIPTION
## Issue
`fedxgb_bagging` and `fedxgb_cyclic` strategies requires `__repr__`.

## Proposal
Add `__repr__` for `fedxgb_bagging` and `fedxgb_cyclic` strategies


### Changelog entry

<general>

