### PR TITLE
Add PR titles by default in the changelog

### DIFF
--- a/src/py/flwr_tool/update_changelog.py
+++ b/src/py/flwr_tool/update_changelog.py
@@ -62,7 +62,7 @@ def _extract_changelog_entry(pr_info):
         f"{CHANGELOG_SECTION_HEADER}(.+?)(?=##|$)", pr_info.body, re.DOTALL
     )
     if not entry_match:
-        return None, "general"
+        return None, None
 
     entry_text = entry_match.group(1).strip()
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

Currently, when no changelog entry is found, we automatically add the PR to the list of general improvements. This makes it hard to check which PRs have been added.

### Related issues/PRs

N/A

## Proposal

### Explanation

Instead add the title of the PR if no changelog entry is found.

### Checklist

- [x] Implement proposed change
- [x] Update the changelog entry below
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

<!--
Inside the following 'Changelog entry' section, you should put the description of your changes that will be added to the changelog alongside your PR title.

If the section is completely empty (without any token), the changelog will just contain the title of the PR for the changelog entry, without any description. If the 'Changelog entry' section is removed entirely, it will categorize the PR as "General improvement" and add it to the changelog accordingly. If the section contains some text other than tokens, it will use it to add a description to the change. If the section contains one of the following tokens it will ignore any other text and put the PR under the corresponding section of the changelog:

<general> is for classifying a PR as a general improvement.
<skip> is to not add the PR to the changelog
<baselines> is to add a general baselines change to the PR
<examples> is to add a general examples change to the PR
<sdk> is to add a general sdk change to the PR
<simulations> is to add a general simulations change to the PR

Note that only one token should be used.
-->

### Changelog entry

<skip>

### Any other comments?

N/A
