### PR TITLE
Rename `certificates` to `root_certificates` in `Driver` class and `GrpcDriver` class

### DIFF
--- a/examples/mt-pytorch/driver.py
+++ b/examples/mt-pytorch/driver.py
@@ -43,7 +43,7 @@ def weighted_average(metrics: List[Tuple[int, Metrics]]) -> Metrics:
 
 
 # -------------------------------------------------------------------------- Driver SDK
-driver = GrpcDriver(driver_service_address="0.0.0.0:9091", certificates=None)
+driver = GrpcDriver(driver_service_address="0.0.0.0:9091", root_certificates=None)
 # -------------------------------------------------------------------------- Driver SDK
 
 anonymous_client_nodes = False

--- a/examples/secaggplus-mt/driver.py
+++ b/examples/secaggplus-mt/driver.py
@@ -71,7 +71,7 @@ def weighted_average(metrics: List[Tuple[int, Metrics]]) -> Metrics:
 
 
 # -------------------------------------------------------------------------- Driver SDK
-driver = GrpcDriver(driver_service_address="0.0.0.0:9091", certificates=None)
+driver = GrpcDriver(driver_service_address="0.0.0.0:9091", root_certificates=None)
 # -------------------------------------------------------------------------- Driver SDK
 
 anonymous_client_nodes = False

--- a/src/py/flwr/driver/app.py
+++ b/src/py/flwr/driver/app.py
@@ -110,7 +110,9 @@ def start_driver(  # pylint: disable=too-many-arguments, too-many-locals
     # Create the Driver
     if isinstance(root_certificates, str):
         root_certificates = Path(root_certificates).read_bytes()
-    driver = GrpcDriver(driver_service_address=address, certificates=root_certificates)
+    driver = GrpcDriver(
+        driver_service_address=address, root_certificates=root_certificates
+    )
     driver.connect()
     lock = threading.Lock()
 

--- a/src/py/flwr/driver/driver.py
+++ b/src/py/flwr/driver/driver.py
@@ -49,10 +49,10 @@ class Driver:
     def __init__(
         self,
         driver_service_address: str = DEFAULT_SERVER_ADDRESS_DRIVER,
-        certificates: Optional[bytes] = None,
+        root_certificates: Optional[bytes] = None,
     ) -> None:
         self.addr = driver_service_address
-        self.certificates = certificates
+        self.root_certificates = root_certificates
         self.grpc_driver: Optional[GrpcDriver] = None
         self.run_id: Optional[int] = None
         self.node = Node(node_id=0, anonymous=True)
@@ -62,7 +62,8 @@ class Driver:
         if self.grpc_driver is None or self.run_id is None:
             # Connect and create run
             self.grpc_driver = GrpcDriver(
-                driver_service_address=self.addr, certificates=self.certificates
+                driver_service_address=self.addr,
+                root_certificates=self.root_certificates,
             )
             self.grpc_driver.connect()
             res = self.grpc_driver.create_run(CreateRunRequest())

--- a/src/py/flwr/driver/grpc_driver.py
+++ b/src/py/flwr/driver/grpc_driver.py
@@ -51,10 +51,10 @@ class GrpcDriver:
     def __init__(
         self,
         driver_service_address: str = DEFAULT_SERVER_ADDRESS_DRIVER,
-        certificates: Optional[bytes] = None,
+        root_certificates: Optional[bytes] = None,
     ) -> None:
         self.driver_service_address = driver_service_address
-        self.certificates = certificates
+        self.root_certificates = root_certificates
         self.channel: Optional[grpc.Channel] = None
         self.stub: Optional[DriverStub] = None
 
@@ -66,8 +66,8 @@ class GrpcDriver:
             return
         self.channel = create_channel(
             server_address=self.driver_service_address,
-            insecure=(self.certificates is None),
-            root_certificates=self.certificates,
+            insecure=(self.root_certificates is None),
+            root_certificates=self.root_certificates,
         )
         self.stub = DriverStub(self.channel)
         log(INFO, "[Driver] Connected to %s", self.driver_service_address)


### PR DESCRIPTION
This PR is to make the naming in Driver consistent with other places in `flwr`.
- Renamed the args and variables to `root_certificates` from `certificates` in `Driver` class and `GrpcDriver` class.
- Updated two files in `examples/`