### PR TITLE
Use `dist` directory when publishing via CI

### DIFF
--- a/.github/workflows/framework-release.yml
+++ b/.github/workflows/framework-release.yml
@@ -34,7 +34,9 @@ jobs:
         wheel_url="https://artifact.flower.dev/py/release/v${TAG_NAME}/${wheel_name}"
         tar_url="https://artifact.flower.dev/py/release/v${TAG_NAME}/${tar_name}"
 
-        curl $wheel_url --output $wheel_name
-        curl $tar_url --output $tar_name
+        mkdir -p dist
+
+        curl $wheel_url --output dist/$wheel_name
+        curl $tar_url --output dist/$tar_name
 
         python -m poetry publish -u __token__ -p ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

Currently, the release process fails as the build artifacts are not found by `poetry`.

### Related issues/PRs

N/A

## Proposal

### Explanation

Place the build artifacts in a newly created `dist` folder to fix the issue.

### Checklist

- [x] Implement proposed change
- [x] Update the changelog entry below
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

<!--
Inside the following 'Changelog entry' section, you should put the description of your changes that will be added to the changelog alongside your PR title.

If the section is completely empty (without any token) or non-existant, the changelog will just contain the title of the PR for the changelog entry, without any description. If the section contains some text other than tokens, it will use it to add a description to the change. If the section contains one of the following tokens it will ignore any other text and put the PR under the corresponding section of the changelog:

<general> is for classifying a PR as a general improvement.
<skip> is to not add the PR to the changelog
<baselines> is to add a general baselines change to the PR
<examples> is to add a general examples change to the PR
<sdk> is to add a general sdk change to the PR
<simulations> is to add a general simulations change to the PR

Note that only one token should be used.
-->

### Changelog entry

<skip>

### Any other comments?

This PR won't appear on the changelog as I used the `skip` token.
