### PR TITLE
Allow to run multiple baseline tests for collaborators

### DIFF
--- a/.github/workflows/_baselines-fork.yml
+++ b/.github/workflows/_baselines-fork.yml
@@ -1,0 +1,125 @@
+name: Baselines Fork
+# The aim of this workflow is to test only the changed (or added) baseline.
+# Here is the rough idea of how it works (more details are presented later in the comments):
+# 1. Checks for the changes between the current branch and the main - in case of PR -
+#  or between the HEAD and HEAD~1 (main last commit and the previous one) - in case of
+#  a push to main.
+# 2. Fails the test if there are changes to more than one baseline. Passes the test
+#  (skips the rests) if there are no changes to any baselines. Follows the test if only
+#  one baseline is added or modified.
+# 3. Sets up the env specified for the baseline.
+# 4. Runs the tests.
+on:
+  workflow_call:
+
+env:
+  FLWR_TELEMETRY_ENABLED: 0
+
+defaults:
+  run:
+    working-directory: baselines
+
+jobs:
+  test_baselines:
+    name: Test
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        # The depth two of the checkout is needed in case of merging to the main
+        # because we compare the HEAD (current version) with HEAD~1 (version before
+        # the PR was merged)
+        with:
+          fetch-depth: 2
+      - name: Fetch main branch
+        run: |
+          # The main branch is needed in case of the PR to make a comparison (by
+          # default the workflow takes as little information as possible - it does not
+          # have the history
+          if [ ${{ github.event_name }} == "pull_request" ]
+          then
+            git fetch origin main:main
+          fi
+      - name: Find changed/new baselines
+        id: find_changed_baselines_dirs
+        run: |
+          if [ ${{ github.event_name }} == "push" ]
+          then
+            # Push event triggered when merging to main
+            change_references="HEAD..HEAD~1"
+          else
+            # Pull request event triggered for any commit to a pull request
+            change_references="main..HEAD"
+          fi
+          dirs=$(git diff --dirstat=files,0 ${change_references} . | awk '{print $2}' | grep -E '^baselines/[^/]*/$' | \
+          grep -v \
+            -e '^baselines/dev' \
+            -e '^baselines/baseline_template' \
+            -e '^baselines/flwr_baselines' \
+            -e '^baselines/doc' \
+          | sed 's/^baselines\///')
+          # git diff --dirstat=files,0 ${change_references} . - checks the differences
+          #   and a file is counted as changed if more than 0 lines were changed
+          #   it returns the results in the format x.y% path/to/dir/
+          # awk '{print $2}' - takes only the directories (skips the percentages)
+          # grep -E '^baselines/[^/]*/$' - takes only the paths that start with
+          #   baseline (and have at least one subdirectory)
+          # grep -v -e ... - excludes the `baseline_template`, `dev`, `flwr_baselines`
+          # sed 's/^baselines\///' - narrows down the path to baseline/<subdirectory>
+          echo "Detected changed directories: ${dirs}"
+          # Save changed dirs to output of this step
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          echo "dirs<<EOF" >> "$GITHUB_OUTPUT"
+          for dir in $dirs
+          do
+            echo "$dir" >> "$GITHUB_OUTPUT"
+          done
+          echo "EOF" >> "$GITHUB_OUTPUT"
+      - name: Validate changed/new baselines
+        id: validate_changed_baselines_dirs
+        run: |
+          dirs="${{ steps.find_changed_baselines_dirs.outputs.dirs }}"
+          dirs_array=()
+          if [[ -n $dirs ]]; then
+            while IFS= read -r line; do
+              dirs_array+=("$line")
+            done <<< "$dirs"
+          fi
+          length=${#dirs_array[@]}
+          echo "The number of changed baselines is $length"
+
+          if [ $length -gt 1 ]; then
+          echo "The changes should only apply to a single baseline"
+          exit 1
+          fi
+
+          if [ $length -eq 0 ]; then
+          echo "The baselines were not changed - skipping the remaining steps."
+          echo "baseline_changed=false" >> "$GITHUB_OUTPUT"
+          exit 0
+          fi
+
+          echo "changed_dir=${dirs[0]}" >> "$GITHUB_OUTPUT"
+          echo "baseline_changed=true" >> "$GITHUB_OUTPUT"
+      - name: Bootstrap
+        if: steps.validate_changed_baselines_dirs.outputs.baseline_changed == 'true'
+        uses: ./.github/actions/bootstrap
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        if: steps.validate_changed_baselines_dirs.outputs.baseline_changed == 'true'
+        run: |
+          changed_dir="${{ steps.validate_changed_baselines_dirs.outputs.changed_dir }}"
+          cd "${changed_dir}"
+          python -m poetry install
+      - name: Test
+        if: steps.validate_changed_baselines_dirs.outputs.baseline_changed == 'true'
+        run: |
+          dir="${{ steps.validate_changed_baselines_dirs.outputs.changed_dir }}"
+          echo "Testing ${dir}"
+          ./dev/test-baseline.sh $dir
+      - name: Test Structure
+        if: steps.validate_changed_baselines_dirs.outputs.baseline_changed == 'true'
+        run: |
+          dir="${{ steps.validate_changed_baselines_dirs.outputs.changed_dir }}"
+          echo "Testing ${dir}"
+          ./dev/test-baseline-structure.sh $dir

--- a/.github/workflows/_baselines.yml
+++ b/.github/workflows/_baselines.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       pull-requests: read
     outputs:
-      packages: ${{ steps.filter.outputs.changes }}
+      baselines: ${{ steps.filter.outputs.changes }}
     steps:
       - uses: actions/checkout@v4
 
@@ -46,9 +46,10 @@ jobs:
   test:
     runs-on: ubuntu-22.04
     needs: changes
+    if: ${{ needs.changes.outputs.baselines != '' && toJson(fromJson(needs.changes.outputs.baselines)) != '[]' }}
     strategy:
       matrix:
-        baseline: ${{ fromJSON(needs.changes.outputs.packages) }}
+        baseline: ${{ fromJSON(needs.changes.outputs.baselines) }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/_baselines.yml
+++ b/.github/workflows/_baselines.yml
@@ -24,7 +24,13 @@ jobs:
             while read -d $'\0' BASELINES_PATH; do
                 DIR=$(basename $BASELINES_PATH)
                 FILTER+=$(echo "$DIR: ${BASELINES_PATH}/**\n")
-            done < <(find baselines -maxdepth 1 -name ".*" -prune -o -type d -print0)
+            done < <(find baselines -maxdepth 1 \
+                -name ".*" -prune -o \
+                -path "baselines/doc" -prune -o \
+                -path "baselines/dev" -prune -o \
+                -path "baselines/baseline_template" -prune -o \
+                -path "baselines/flwr_baselines" -prune -o \
+                -type d -print0)
             FILTER=$(echo -e "$FILTER")
             # remove first line
             FILTER=${FILTER#*$'\n'}

--- a/.github/workflows/_baselines.yml
+++ b/.github/workflows/_baselines.yml
@@ -1,0 +1,68 @@
+name: Baselines
+on:
+  workflow_call:
+
+env:
+  FLWR_TELEMETRY_ENABLED: 0
+
+jobs:
+  changes:
+    runs-on: ubuntu-22.04
+    permissions:
+      pull-requests: read
+    outputs:
+      packages: ${{ steps.filter.outputs.changes }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - shell: bash
+        run: |
+          # create a list of all directories in baselines
+          {
+            echo 'FILTER_PATHS<<EOF'
+            FILTER=""
+            while read -d $'\0' BASELINES_PATH; do
+                DIR=$(basename $BASELINES_PATH)
+                FILTER+=$(echo "$DIR: ${BASELINES_PATH}/**\n")
+            done < <(find baselines -maxdepth 1 -name ".*" -prune -o -type d -print0)
+            FILTER=$(echo -e "$FILTER")
+            # remove first line
+            FILTER=${FILTER#*$'\n'}
+            echo "$FILTER"
+            echo EOF
+          } >> "$GITHUB_ENV"
+
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: ${{ env.FILTER_PATHS }}
+
+  test:
+    runs-on: ubuntu-22.04
+    needs: changes
+    strategy:
+      matrix:
+        baseline: ${{ fromJSON(needs.changes.outputs.packages) }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Bootstrap
+        uses: ./.github/actions/bootstrap
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        working-directory: baselines/${{ matrix.baseline }}
+        run: python -m poetry install
+
+      - name: Test
+        working-directory: baselines
+        run: |
+          echo "Testing ${{ matrix.baseline }}"
+          ./dev/test-baseline.sh ${{ matrix.baseline }}
+
+      - name: Test Structure
+        working-directory: baselines
+        run: |
+          echo "Testing ${{ matrix.baseline }}"
+          ./dev/test-baseline-structure.sh ${{ matrix.baseline }}

--- a/.github/workflows/baselines.yml
+++ b/.github/workflows/baselines.yml
@@ -1,14 +1,5 @@
 name: Baselines
-# The aim of this workflow is to test only the changed (or added) baseline.
-# Here is the rough idea of how it works (more details are presented later in the comments):
-# 1. Checks for the changes between the current branch and the main - in case of PR -
-#  or between the HEAD and HEAD~1 (main last commit and the previous one) - in case of
-#  a push to main.
-# 2. Fails the test if there are changes to more than one baseline. Passes the test
-#  (skips the rests) if there are no changes to any baselines. Follows the test if only
-#  one baseline is added or modified.
-# 3. Sets up the env specified for the baseline.
-# 4. Runs the tests.
+
 on:
   push:
     branches:
@@ -21,115 +12,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-env:
-  FLWR_TELEMETRY_ENABLED: 0
-
-defaults:
-  run:
-    working-directory: baselines
-
 jobs:
-  test_baselines:
-    name: Test
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v4
-        # The depth two of the checkout is needed in case of merging to the main
-        # because we compare the HEAD (current version) with HEAD~1 (version before
-        # the PR was merged)
-        with:
-          fetch-depth: 2
-      - name: Fetch main branch
-        run: |
-          # The main branch is needed in case of the PR to make a comparison (by 
-          # default the workflow takes as little information as possible - it does not
-          # have the history
-          if [ ${{ github.event_name }} == "pull_request" ]
-          then
-            git fetch origin main:main
-          fi
-      - name: Find changed/new baselines
-        id: find_changed_baselines_dirs
-        run: |
-          if [ ${{ github.event_name }} == "push" ]
-          then
-            # Push event triggered when merging to main
-            change_references="HEAD..HEAD~1"
-          else
-            # Pull request event triggered for any commit to a pull request
-            change_references="main..HEAD"
-          fi
-          dirs=$(git diff --dirstat=files,0 ${change_references} . | awk '{print $2}' | grep -E '^baselines/[^/]*/$' | \
-          grep -v \
-            -e '^baselines/dev' \
-            -e '^baselines/baseline_template' \
-            -e '^baselines/flwr_baselines' \
-            -e '^baselines/doc' \
-          | sed 's/^baselines\///')
-          # git diff --dirstat=files,0 ${change_references} . - checks the differences
-          #   and a file is counted as changed if more than 0 lines were changed
-          #   it returns the results in the format x.y% path/to/dir/
-          # awk '{print $2}' - takes only the directories (skips the percentages)
-          # grep -E '^baselines/[^/]*/$' - takes only the paths that start with 
-          #   baseline (and have at least one subdirectory)
-          # grep -v -e ... - excludes the `baseline_template`, `dev`, `flwr_baselines`
-          # sed 's/^baselines\///' - narrows down the path to baseline/<subdirectory>
-          echo "Detected changed directories: ${dirs}"
-          # Save changed dirs to output of this step
-          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
-          echo "dirs<<EOF" >> "$GITHUB_OUTPUT"
-          for dir in $dirs
-          do
-            echo "$dir" >> "$GITHUB_OUTPUT"
-          done
-          echo "EOF" >> "$GITHUB_OUTPUT"
-      - name: Validate changed/new baselines
-        id: validate_changed_baselines_dirs
-        run: |
-          dirs="${{ steps.find_changed_baselines_dirs.outputs.dirs }}"
-          dirs_array=()
-          if [[ -n $dirs ]]; then
-            while IFS= read -r line; do
-              dirs_array+=("$line")
-            done <<< "$dirs"
-          fi
-          length=${#dirs_array[@]}
-          echo "The number of changed baselines is $length"
-          
-          if [ $length -gt 1 ]; then
-          echo "The changes should only apply to a single baseline"
-          exit 1
-          fi
-          
-          if [ $length -eq 0 ]; then
-          echo "The baselines were not changed - skipping the remaining steps."
-          echo "baseline_changed=false" >> "$GITHUB_OUTPUT"
-          exit 0
-          fi
-          
-          echo "changed_dir=${dirs[0]}" >> "$GITHUB_OUTPUT"
-          echo "baseline_changed=true" >> "$GITHUB_OUTPUT"
-      - name: Bootstrap
-        if: steps.validate_changed_baselines_dirs.outputs.baseline_changed == 'true'
-        uses: ./.github/actions/bootstrap
-        with:
-          python-version: '3.10'
-      - name: Install dependencies
-        if: steps.validate_changed_baselines_dirs.outputs.baseline_changed == 'true'
-        run: |
-          changed_dir="${{ steps.validate_changed_baselines_dirs.outputs.changed_dir }}"
-          cd "${changed_dir}"
-          python -m poetry install
-      - name: Test
-        if: steps.validate_changed_baselines_dirs.outputs.baseline_changed == 'true'
-        run: |
-          dir="${{ steps.validate_changed_baselines_dirs.outputs.changed_dir }}"
-          echo "Testing ${dir}"
-          ./dev/test-baseline.sh $dir
-      - name: Test Structure
-        if: steps.validate_changed_baselines_dirs.outputs.baseline_changed == 'true'
-        run: |
-          dir="${{ steps.validate_changed_baselines_dirs.outputs.changed_dir }}"
-          echo "Testing ${dir}"
-          ./dev/test-baseline-structure.sh $dir
+  test-baselines:
+    if: ${{ !github.event.pull_request.head.repo.fork }}
+    name: Test Baselines
+    uses: ./.github/workflows/_baselines.yml
 
+  test-baselines-fork:
+    if: ${{ github.event.pull_request.head.repo.fork }}
+    name: Test Baselines Fork
+    uses: ./.github/workflows/_baselines-fork.yml


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->

- Converted the current baseline workflow into a reusable workflow (that one is used for forks).
- Created a reusable workflow that can run multiple baseline tests if the PR is created by a repository collaborator.
- Test run https://github.com/adap/flower/actions/runs/7916090205/job/21609244580
   - one test failed because of `ERROR: baselines/hfedxgboost/hfedxgboost/strategy.py Imports are incorrectly sorted and/or formatted.`. we should fix it in a followup PR.
   - PR: #2960 

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

### Checklist

- [ ] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.dev/docs/writing-documentation.html)
- [ ] Update the changelog entry below
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

<!--
Inside the following 'Changelog entry' section, you should put the description of your changes that will be added to the changelog alongside your PR title.

If the section is completely empty (without any token) or non-existant, the changelog will just contain the title of the PR for the changelog entry, without any description. If the section contains some text other than tokens, it will use it to add a description to the change. If the section contains one of the following tokens it will ignore any other text and put the PR under the corresponding section of the changelog:

<general> is for classifying a PR as a general improvement.
<skip> is to not add the PR to the changelog
<baselines> is to add a general baselines change to the PR
<examples> is to add a general examples change to the PR
<sdk> is to add a general sdk change to the PR
<simulations> is to add a general simulations change to the PR

Note that only one token should be used.
-->

### Changelog entry

<skip>

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.dev/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
