### PR TITLE
Create server-side compatibility package

### DIFF
--- a/e2e/bare-https/driver.py
+++ b/e2e/bare-https/driver.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 
 # Start Flower server
-hist = fl.server.driver.start_driver(
+hist = fl.server.start_driver(
     server_address="127.0.0.1:9091",
     config=fl.server.ServerConfig(num_rounds=3),
     root_certificates=Path("certificates/ca.crt").read_bytes(),

--- a/e2e/bare/driver.py
+++ b/e2e/bare/driver.py
@@ -2,7 +2,7 @@ import flwr as fl
 
 
 # Start Flower server
-hist = fl.server.driver.start_driver(
+hist = fl.server.start_driver(
     server_address="0.0.0.0:9091",
     config=fl.server.ServerConfig(num_rounds=3),
 )

--- a/e2e/fastai/driver.py
+++ b/e2e/fastai/driver.py
@@ -1,6 +1,6 @@
 import flwr as fl
 
-hist = fl.server.driver.start_driver(
+hist = fl.server.start_driver(
     server_address="0.0.0.0:9091",
     config=fl.server.ServerConfig(num_rounds=3),
 )

--- a/e2e/jax/driver.py
+++ b/e2e/jax/driver.py
@@ -1,6 +1,6 @@
 import flwr as fl
 
-hist = fl.server.driver.start_driver(
+hist = fl.server.start_driver(
     server_address="0.0.0.0:9091",
     config=fl.server.ServerConfig(num_rounds=3),
 )

--- a/e2e/opacus/driver.py
+++ b/e2e/opacus/driver.py
@@ -1,6 +1,6 @@
 import flwr as fl
 
-hist = fl.server.driver.start_driver(
+hist = fl.server.start_driver(
     server_address="0.0.0.0:9091",
     config=fl.server.ServerConfig(num_rounds=3),
 )

--- a/e2e/pandas/driver.py
+++ b/e2e/pandas/driver.py
@@ -3,7 +3,7 @@ import flwr as fl
 from strategy import FedAnalytics
 
 # Start Flower server
-hist = fl.server.driver.start_driver(
+hist = fl.server.start_driver(
     server_address="0.0.0.0:9091",
     config=fl.server.ServerConfig(num_rounds=1),
     strategy=FedAnalytics(),

--- a/e2e/pytorch-lightning/driver.py
+++ b/e2e/pytorch-lightning/driver.py
@@ -1,6 +1,6 @@
 import flwr as fl
 
-hist = fl.server.driver.start_driver(
+hist = fl.server.start_driver(
     server_address="0.0.0.0:9091",
     config=fl.server.ServerConfig(num_rounds=3),
 )

--- a/e2e/pytorch/driver.py
+++ b/e2e/pytorch/driver.py
@@ -18,7 +18,7 @@ def weighted_average(metrics: List[Tuple[int, Metrics]]) -> Metrics:
 strategy = fl.server.strategy.FedAvg(evaluate_metrics_aggregation_fn=weighted_average)
 
 # Start Flower server
-hist = fl.server.driver.start_driver(
+hist = fl.server.start_driver(
     server_address="0.0.0.0:9091",
     config=fl.server.ServerConfig(num_rounds=3),
     strategy=strategy,

--- a/e2e/scikit-learn/driver.py
+++ b/e2e/scikit-learn/driver.py
@@ -36,7 +36,7 @@ if __name__ == "__main__":
         evaluate_fn=get_evaluate_fn(model),
         on_fit_config_fn=fit_round,
     )
-    hist = fl.server.driver.start_driver(
+    hist = fl.server.start_driver(
         server_address="0.0.0.0:9091",
         strategy=strategy,
         config=fl.server.ServerConfig(num_rounds=3),

--- a/e2e/tabnet/driver.py
+++ b/e2e/tabnet/driver.py
@@ -1,6 +1,6 @@
 import flwr as fl
 
-hist = fl.server.driver.start_driver(
+hist = fl.server.start_driver(
     server_address="0.0.0.0:9091",
     config=fl.server.ServerConfig(num_rounds=3),
 )

--- a/e2e/tensorflow/driver.py
+++ b/e2e/tensorflow/driver.py
@@ -18,7 +18,7 @@ def weighted_average(metrics: List[Tuple[int, Metrics]]) -> Metrics:
 strategy = fl.server.strategy.FedAvg(evaluate_metrics_aggregation_fn=weighted_average)
 
 # Start Flower server
-hist = fl.server.driver.start_driver(
+hist = fl.server.start_driver(
     server_address="0.0.0.0:9091",
     config=fl.server.ServerConfig(num_rounds=3),
     strategy=strategy,

--- a/examples/quickstart-cpp/driver.py
+++ b/examples/quickstart-cpp/driver.py
@@ -3,7 +3,7 @@ from fedavg_cpp import FedAvgCpp
 
 # Start Flower server for three rounds of federated learning
 if __name__ == "__main__":
-    fl.server.driver.start_driver(
+    fl.server.start_driver(
         server_address="0.0.0.0:9091",
         config=fl.server.ServerConfig(num_rounds=3),
         strategy=FedAvgCpp(),

--- a/src/py/flwr/server/__init__.py
+++ b/src/py/flwr/server/__init__.py
@@ -18,12 +18,13 @@
 from . import driver, strategy
 from .app import run_driver_api as run_driver_api
 from .app import run_fleet_api as run_fleet_api
-from .app import run_server_app as run_server_app
 from .app import run_superlink as run_superlink
 from .app import start_server as start_server
 from .client_manager import ClientManager as ClientManager
 from .client_manager import SimpleClientManager as SimpleClientManager
+from .compat import start_driver as start_driver
 from .history import History as History
+from .run_serverapp import run_server_app as run_server_app
 from .server import Server as Server
 from .server_config import ServerConfig as ServerConfig
 from .serverapp import ServerApp as ServerApp
@@ -40,6 +41,7 @@ __all__ = [
     "ServerApp",
     "ServerConfig",
     "SimpleClientManager",
+    "start_driver",
     "start_server",
     "strategy",
 ]

--- a/src/py/flwr/server/compat/__init__.py
+++ b/src/py/flwr/server/compat/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Flower Labs GmbH. All Rights Reserved.
+# Copyright 2024 Flower Labs GmbH. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,13 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Flower driver SDK."""
+"""Flower ServerApp compatibility package."""
 
 
-from .driver import Driver
-from .grpc_driver import GrpcDriver
+from .app import start_driver as start_driver
 
 __all__ = [
-    "Driver",
-    "GrpcDriver",
+    "start_driver",
 ]

--- a/src/py/flwr/server/compat/app_test.py
+++ b/src/py/flwr/server/compat/app_test.py
@@ -26,7 +26,8 @@ from flwr.proto.driver_pb2 import (  # pylint: disable=E0611
 )
 from flwr.proto.node_pb2 import Node  # pylint: disable=E0611
 from flwr.server.client_manager import SimpleClientManager
-from flwr.server.driver.app import update_client_manager
+
+from .app import update_client_manager
 
 
 class TestClientManagerWithDriver(unittest.TestCase):

--- a/src/py/flwr/server/compat/driver_client_proxy.py
+++ b/src/py/flwr/server/compat/driver_client_proxy.py
@@ -31,7 +31,7 @@ from flwr.common.recordset import RecordSet
 from flwr.proto import driver_pb2, node_pb2, task_pb2  # pylint: disable=E0611
 from flwr.server.client_proxy import ClientProxy
 
-from .grpc_driver import GrpcDriver
+from ..driver.grpc_driver import GrpcDriver
 
 SLEEP_TIME = 1
 

--- a/src/py/flwr/server/compat/driver_client_proxy_test.py
+++ b/src/py/flwr/server/compat/driver_client_proxy_test.py
@@ -44,7 +44,8 @@ from flwr.common.typing import (
     Status,
 )
 from flwr.proto import driver_pb2, node_pb2, task_pb2  # pylint: disable=E0611
-from flwr.server.driver.driver_client_proxy import DriverClientProxy
+
+from .driver_client_proxy import DriverClientProxy
 
 MESSAGE_PARAMETERS = Parameters(tensors=[b"abc"], tensor_type="np")
 

--- a/src/py/flwr/server/run_serverapp.py
+++ b/src/py/flwr/server/run_serverapp.py
@@ -1,0 +1,131 @@
+# Copyright 2024 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Run ServerApp."""
+
+
+import argparse
+import sys
+from logging import DEBUG, WARN
+from pathlib import Path
+
+from flwr.common import EventType, event
+from flwr.common.logger import log
+
+from .serverapp import ServerApp, load_server_app
+
+
+def run_server_app() -> None:
+    """Run Flower server app."""
+    event(EventType.RUN_SERVER_APP_ENTER)
+
+    args = _parse_args_run_server_app().parse_args()
+
+    # Obtain certificates
+    if args.insecure:
+        if args.root_certificates is not None:
+            sys.exit(
+                "Conflicting options: The '--insecure' flag disables HTTPS, "
+                "but '--root-certificates' was also specified. Please remove "
+                "the '--root-certificates' option when running in insecure mode, "
+                "or omit '--insecure' to use HTTPS."
+            )
+        log(
+            WARN,
+            "Option `--insecure` was set. "
+            "Starting insecure HTTP client connected to %s.",
+            args.server,
+        )
+        root_certificates = None
+    else:
+        # Load the certificates if provided, or load the system certificates
+        cert_path = args.root_certificates
+        if cert_path is None:
+            root_certificates = None
+        else:
+            root_certificates = Path(cert_path).read_bytes()
+        log(
+            DEBUG,
+            "Starting secure HTTPS client connected to %s "
+            "with the following certificates: %s.",
+            args.server,
+            cert_path,
+        )
+
+    log(
+        DEBUG,
+        "Flower will load ServerApp `%s`",
+        getattr(args, "server-app"),
+    )
+
+    log(
+        DEBUG,
+        "root_certificates: `%s`",
+        root_certificates,
+    )
+
+    log(WARN, "Not implemented: run_server_app")
+
+    server_app_dir = args.dir
+    if server_app_dir is not None:
+        sys.path.insert(0, server_app_dir)
+
+    def _load() -> ServerApp:
+        server_app: ServerApp = load_server_app(getattr(args, "server-app"))
+        return server_app
+
+    server_app = _load()
+
+    log(DEBUG, "server_app: `%s`", server_app)
+
+    event(EventType.RUN_SERVER_APP_LEAVE)
+
+
+def _parse_args_run_server_app() -> argparse.ArgumentParser:
+    """Parse flower-server-app command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Start a Flower server app",
+    )
+
+    parser.add_argument(
+        "server-app",
+        help="For example: `server:app` or `project.package.module:wrapper.app`",
+    )
+    parser.add_argument(
+        "--insecure",
+        action="store_true",
+        help="Run the server app without HTTPS. By default, the app runs with "
+        "HTTPS enabled. Use this flag only if you understand the risks.",
+    )
+    parser.add_argument(
+        "--root-certificates",
+        metavar="ROOT_CERT",
+        type=str,
+        help="Specifies the path to the PEM-encoded root certificate file for "
+        "establishing secure HTTPS connections.",
+    )
+    parser.add_argument(
+        "--server",
+        default="0.0.0.0:9092",
+        help="Server address",
+    )
+    parser.add_argument(
+        "--dir",
+        default="",
+        help="Add specified directory to the PYTHONPATH and load Flower "
+        "app from there."
+        " Default: current working directory.",
+    )
+
+    return parser


### PR DESCRIPTION
This PR introduces a new sub-package `flwr.server.compat` and moves compatibility-related functions (mostly `start_driver`) into it