### PR TITLE
Update `mt-pytorch` example

### DIFF
--- a/examples/mt-pytorch/start_driver.py
+++ b/examples/mt-pytorch/start_driver.py
@@ -35,7 +35,7 @@ strategy = fl.server.strategy.FedAvg(
 
 if __name__ == "__main__":
     # Start Flower server
-    fl.server.driver.start_driver(
+    fl.server.compat.start_driver(
         server_address="0.0.0.0:9091",
         config=fl.server.ServerConfig(num_rounds=3),
         strategy=strategy,


### PR DESCRIPTION
`start_driver` is now behind `server.compat`.(see https://github.com/adap/flower/pull/2957)

### Changelog entry

<examples>