### PR TITLE
Move server functions to `server.py`

### DIFF
--- a/src/py/flwr/server/compat/app.py
+++ b/src/py/flwr/server/compat/app.py
@@ -26,10 +26,9 @@ from flwr.common import EventType, event
 from flwr.common.address import parse_address
 from flwr.common.logger import log, warn_deprecated_feature
 from flwr.proto import driver_pb2  # pylint: disable=E0611
-from flwr.server.app import init_defaults, run_fl
 from flwr.server.client_manager import ClientManager
 from flwr.server.history import History
-from flwr.server.server import Server
+from flwr.server.server import Server, init_defaults, run_fl
 from flwr.server.server_config import ServerConfig
 from flwr.server.strategy import Strategy
 

--- a/src/py/flwr/simulation/app.py
+++ b/src/py/flwr/simulation/app.py
@@ -28,10 +28,9 @@ from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 from flwr.client import ClientFn
 from flwr.common import EventType, event
 from flwr.common.logger import log
-from flwr.server import Server
-from flwr.server.app import init_defaults, run_fl
 from flwr.server.client_manager import ClientManager
 from flwr.server.history import History
+from flwr.server.server import Server, init_defaults, run_fl
 from flwr.server.server_config import ServerConfig
 from flwr.server.strategy import Strategy
 from flwr.simulation.ray_transport.ray_actor import (


### PR DESCRIPTION
Moves `init_defaults` and `run_fl` out of `sever/app.py` and into `server/server.py`. Helps with imports for upcoming features.