### PR TITLE
Add `terminate` method to backends and introduce `asyncio` stopping event.

### DIFF
--- a/src/py/flwr/server/superlink/fleet/vce/backend/backend.py
+++ b/src/py/flwr/server/superlink/fleet/vce/backend/backend.py
@@ -54,6 +54,10 @@ class Backend(ABC):
         """Report whether a backend worker is idle and can therefore run a ClientApp."""
 
     @abstractmethod
+    async def terminate(self) -> None:
+        """Terminate backend."""
+
+    @abstractmethod
     async def process_message(
         self,
         app: Callable[[], ClientApp],

--- a/src/py/flwr/server/superlink/fleet/vce/vce_api.py
+++ b/src/py/flwr/server/superlink/fleet/vce/vce_api.py
@@ -14,9 +14,10 @@
 # ==============================================================================
 """Fleet VirtualClientEngine API."""
 
+import asyncio
 import json
 from logging import ERROR, INFO
-from typing import Dict
+from typing import Dict, Optional
 
 from flwr.client.clientapp import ClientApp, load_client_app
 from flwr.client.node_state import NodeState
@@ -49,6 +50,7 @@ def start_vce(
     backend_config_json_stream: str,
     state_factory: StateFactory,
     working_dir: str,
+    f_stop: Optional[asyncio.Event] = None,
 ) -> None:
     """Start Fleet API with the VirtualClientEngine (VCE)."""
     # Register SuperNodes


### PR DESCRIPTION
Introducing some components to gracefully terminate a simulation:
* `terminate()` method for Backends. In the case of the `RayBackend` it will manually terminate each actor
* Pass a `asyncio.Event` to the entry function that starts the simulation. This will be used to terminate tasks when the event is (externally) set.