### PR TITLE
Make `get_task_ins` from state more efficient

### DIFF
--- a/src/py/flwr/server/superlink/state/in_memory_state.py
+++ b/src/py/flwr/server/superlink/state/in_memory_state.py
@@ -87,12 +87,15 @@ class InMemoryState(State):
             # If not annoymous clients, we can get TaskIns efficiently
             # by making use of node_id:task_id mapping
             if node_id:
+                # If node has at least one task assigned to it
                 if (
                     node_id not in self.task_ins_mapping
                     or len(self.task_ins_mapping[node_id]) == 0
                 ):
                     return task_ins_list
+                # Get task ids assigned to this node
                 task_ids = self.task_ins_mapping[node_id]
+                # Resolve how many TaskIns to extract
                 num = min(limit, len(task_ids)) if limit else len(task_ids)
                 while len(task_ins_list) < num:
                     # Remove

--- a/src/py/flwr/server/superlink/state/in_memory_state.py
+++ b/src/py/flwr/server/superlink/state/in_memory_state.py
@@ -93,7 +93,7 @@ class InMemoryState(State):
                 ):
                     return task_ins_list
                 task_ids = self.task_ins_mapping[node_id]
-                num = limit if limit else len(task_ids)
+                num = min(limit, len(task_ids)) if limit else len(task_ids)
                 while len(task_ins_list) < num:
                     # Remove
                     uuid = task_ids.pop(0)


### PR DESCRIPTION
Significantly faster when the number of nodes is large (i.e. when `task_ins_store` contains many thousands of items)