### PR TITLE
Rename `node_id` to `partition_id` in examples

### DIFF
--- a/examples/advanced-pytorch/utils.py
+++ b/examples/advanced-pytorch/utils.py
@@ -9,10 +9,10 @@ from flwr_datasets import FederatedDataset
 warnings.filterwarnings("ignore")
 
 
-def load_partition(node_id, toy: bool = False):
+def load_partition(partition_id, toy: bool = False):
     """Load partition CIFAR10 data."""
     fds = FederatedDataset(dataset="cifar10", partitioners={"train": 10})
-    partition = fds.load_partition(node_id)
+    partition = fds.load_partition(partition_id)
     # Divide data on each node: 80% train, 20% test
     partition_train_test = partition.train_test_split(test_size=0.2)
     partition_train_test = partition_train_test.with_transform(apply_transforms)

--- a/examples/embedded-devices/client_pytorch.py
+++ b/examples/embedded-devices/client_pytorch.py
@@ -105,8 +105,8 @@ def prepare_dataset(use_mnist: bool):
 
     trainsets = []
     validsets = []
-    for node_id in range(NUM_CLIENTS):
-        partition = fds.load_partition(node_id, "train")
+    for partition_id in range(NUM_CLIENTS):
+        partition = fds.load_partition(partition_id, "train")
         # Divide data on each node: 90% train, 10% test
         partition = partition.train_test_split(test_size=0.1)
         partition = partition.with_transform(apply_transforms)

--- a/examples/embedded-devices/client_tf.py
+++ b/examples/embedded-devices/client_tf.py
@@ -40,8 +40,8 @@ def prepare_dataset(use_mnist: bool):
         fds = FederatedDataset(dataset="cifar10", partitioners={"train": NUM_CLIENTS})
         img_key = "img"
     partitions = []
-    for node_id in range(NUM_CLIENTS):
-        partition = fds.load_partition(node_id, "train")
+    for partition_id in range(NUM_CLIENTS):
+        partition = fds.load_partition(partition_id, "train")
         partition.set_format("numpy")
         # Divide data on each node: 90% train, 10% test
         partition = partition.train_test_split(test_size=0.1)

--- a/examples/pytorch-from-centralized-to-federated/cifar.py
+++ b/examples/pytorch-from-centralized-to-federated/cifar.py
@@ -51,10 +51,10 @@ class Net(nn.Module):
         return x
 
 
-def load_data(node_id: int):
+def load_data(partition_id: int):
     """Load partition CIFAR10 data."""
     fds = FederatedDataset(dataset="cifar10", partitioners={"train": 10})
-    partition = fds.load_partition(node_id)
+    partition = fds.load_partition(partition_id)
     # Divide data on each node: 80% train, 20% test
     partition_train_test = partition.train_test_split(test_size=0.2)
     pytorch_transforms = Compose(

--- a/examples/pytorch-from-centralized-to-federated/client.py
+++ b/examples/pytorch-from-centralized-to-federated/client.py
@@ -81,11 +81,11 @@ class CifarClient(fl.client.NumPyClient):
 def main() -> None:
     """Load data, start CifarClient."""
     parser = argparse.ArgumentParser(description="Flower")
-    parser.add_argument("--node-id", type=int, required=True, choices=range(0, 10))
+    parser.add_argument("--partition-id", type=int, required=True, choices=range(0, 10))
     args = parser.parse_args()
 
     # Load data
-    trainloader, testloader = cifar.load_data(args.node_id)
+    trainloader, testloader = cifar.load_data(args.partition_id)
 
     # Load model
     model = cifar.Net().to(DEVICE).train()

--- a/examples/pytorch-from-centralized-to-federated/run.sh
+++ b/examples/pytorch-from-centralized-to-federated/run.sh
@@ -6,7 +6,7 @@ sleep 3  # Sleep for 3s to give the server enough time to start
 
 for i in $(seq 0 1); do
     echo "Starting client $i"
-    python client.py --node-id $i &
+    python client.py --partition-id $i &
 done
 
 # This will allow you to use CTRL+C to stop all background processes

--- a/examples/quickstart-huggingface/README.md
+++ b/examples/quickstart-huggingface/README.md
@@ -62,13 +62,13 @@ Now you are ready to start the Flower clients which will participate in the lear
 Start client 1 in the first terminal:
 
 ```shell
-python3 client.py --node-id 0
+python3 client.py --partition-id 0
 ```
 
 Start client 2 in the second terminal:
 
 ```shell
-python3 client.py --node-id 1
+python3 client.py --partition-id 1
 ```
 
 You will see that PyTorch is starting a federated training.

--- a/examples/quickstart-huggingface/client.py
+++ b/examples/quickstart-huggingface/client.py
@@ -17,10 +17,10 @@ DEVICE = torch.device("cpu")
 CHECKPOINT = "distilbert-base-uncased"  # transformer model checkpoint
 
 
-def load_data(node_id):
+def load_data(partition_id):
     """Load IMDB data (training and eval)"""
     fds = FederatedDataset(dataset="imdb", partitioners={"train": 1_000})
-    partition = fds.load_partition(node_id)
+    partition = fds.load_partition(partition_id)
     # Divide data: 80% train, 20% test
     partition_train_test = partition.train_test_split(test_size=0.2)
 
@@ -78,12 +78,12 @@ def test(net, testloader):
     return loss, accuracy
 
 
-def main(node_id):
+def main(partition_id):
     net = AutoModelForSequenceClassification.from_pretrained(
         CHECKPOINT, num_labels=2
     ).to(DEVICE)
 
-    trainloader, testloader = load_data(node_id)
+    trainloader, testloader = load_data(partition_id)
 
     # Flower client
     class IMDBClient(fl.client.NumPyClient):
@@ -116,12 +116,12 @@ def main(node_id):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Flower")
     parser.add_argument(
-        "--node-id",
+        "--partition-id",
         choices=list(range(1_000)),
         required=True,
         type=int,
         help="Partition of the dataset divided into 1,000 iid partitions created "
         "artificially.",
     )
-    node_id = parser.parse_args().node_id
-    main(node_id)
+    partition_id = parser.parse_args().partition_id
+    main(partition_id)

--- a/examples/quickstart-huggingface/run.sh
+++ b/examples/quickstart-huggingface/run.sh
@@ -6,7 +6,7 @@ sleep 3  # Sleep for 3s to give the server enough time to start
 
 for i in `seq 0 1`; do
     echo "Starting client $i"
-    python client.py --node-id ${i}&
+    python client.py --partition-id ${i}&
 done
 
 # This will allow you to use CTRL+C to stop all background processes

--- a/examples/quickstart-mlx/README.md
+++ b/examples/quickstart-mlx/README.md
@@ -66,19 +66,19 @@ following commands.
 Start a first client in the first terminal:
 
 ```shell
-python3 client.py --node-id 0
+python3 client.py --partition-id 0
 ```
 
 And another one in the second terminal:
 
 ```shell
-python3 client.py --node-id 1
+python3 client.py --partition-id 1
 ```
 
 If you want to utilize your GPU, you can use the `--gpu` argument:
 
 ```shell
-python3 client.py --gpu --node-id 2
+python3 client.py --gpu --partition-id 2
 ```
 
 Note that you can start many more clients if you want, but each will have to be in its own terminal.
@@ -96,7 +96,7 @@ We will use `flwr_datasets` to easily download and partition the `MNIST` dataset
 
 ```python
 fds = FederatedDataset(dataset="mnist", partitioners={"train": 3})
-partition = fds.load_partition(node_id = args.node_id)
+partition = fds.load_partition(partition_id = args.partition_id)
 partition_splits = partition.train_test_split(test_size=0.2)
 
 partition_splits['train'].set_format("numpy")

--- a/examples/quickstart-mlx/client.py
+++ b/examples/quickstart-mlx/client.py
@@ -89,7 +89,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser("Train a simple MLP on MNIST with MLX.")
     parser.add_argument("--gpu", action="store_true", help="Use the Metal back-end.")
     parser.add_argument(
-        "--node-id",
+        "--partition-id",
         choices=[0, 1, 2],
         type=int,
         help="Partition of the dataset divided into 3 iid partitions created artificially.",
@@ -106,7 +106,7 @@ if __name__ == "__main__":
     learning_rate = 1e-1
 
     fds = FederatedDataset(dataset="mnist", partitioners={"train": 3})
-    partition = fds.load_partition(node_id=args.node_id)
+    partition = fds.load_partition(partition_id=args.partition_id)
     partition_splits = partition.train_test_split(test_size=0.2)
 
     partition_splits["train"].set_format("numpy")

--- a/examples/quickstart-mlx/run.sh
+++ b/examples/quickstart-mlx/run.sh
@@ -8,7 +8,7 @@ sleep 3  # Sleep for 3s to give the server enough time to start
 
 for i in $(seq 0 1); do
     echo "Starting client $i"
-    python client.py --node-id $i &
+    python client.py --partition-id $i &
 done
 
 # Enable CTRL+C to stop all background processes

--- a/examples/quickstart-pandas/README.md
+++ b/examples/quickstart-pandas/README.md
@@ -70,13 +70,13 @@ Now you are ready to start the Flower clients which will participate in the lear
 Start client 1 in the first terminal:
 
 ```shell
-$ python3 client.py --node-id 0
+$ python3 client.py --partition-id 0
 ```
 
 Start client 2 in the second terminal:
 
 ```shell
-$ python3 client.py --node-id 1
+$ python3 client.py --partition-id 1
 ```
 
 You will see that the server is printing aggregated statistics about the dataset distributed amongst clients. Have a look to the [Flower Quickstarter documentation](https://flower.ai/docs/quickstart-pandas.html) for a detailed explanation.

--- a/examples/quickstart-pandas/client.py
+++ b/examples/quickstart-pandas/client.py
@@ -42,14 +42,14 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description="Flower")
     parser.add_argument(
-        "--node-id",
+        "--partition-id",
         type=int,
         choices=range(0, N_CLIENTS),
         required=True,
-        help="Specifies the node id of artificially partitioned datasets.",
+        help="Specifies the partition id of artificially partitioned datasets.",
     )
     args = parser.parse_args()
-    partition_id = args.node_id
+    partition_id = args.partition_id
 
     # Load the partition data
     fds = FederatedDataset(dataset="hitorilabs/iris", partitioners={"train": N_CLIENTS})

--- a/examples/quickstart-pandas/run.sh
+++ b/examples/quickstart-pandas/run.sh
@@ -4,7 +4,7 @@ sleep 3  # Sleep for 3s to give the server enough time to start
 
 for i in `seq 0 1`; do
     echo "Starting client $i"
-    python client.py --node-id ${i} &
+    python client.py --partition-id ${i} &
 done
 
 # This will allow you to use CTRL+C to stop all background processes

--- a/examples/quickstart-pytorch-lightning/README.md
+++ b/examples/quickstart-pytorch-lightning/README.md
@@ -57,20 +57,20 @@ Afterwards you are ready to start the Flower server as well as the clients. You 
 python server.py
 ```
 
-Now you are ready to start the Flower clients which will participate in the learning. We need to specify the node id to
+Now you are ready to start the Flower clients which will participate in the learning. We need to specify the partition id to
 use different partitions of the data on different nodes.  To do so simply open two more terminal windows and run the
 following commands.
 
 Start client 1 in the first terminal:
 
 ```shell
-python client.py --node-id 0
+python client.py --partition-id 0
 ```
 
 Start client 2 in the second terminal:
 
 ```shell
-python client.py --node-id 1
+python client.py --partition-id 1
 ```
 
 You will see that PyTorch is starting a federated training. Look at the [code](https://github.com/adap/flower/tree/main/examples/quickstart-pytorch) for a detailed explanation.

--- a/examples/quickstart-pytorch-lightning/client.py
+++ b/examples/quickstart-pytorch-lightning/client.py
@@ -58,18 +58,18 @@ def _set_parameters(model, parameters):
 def main() -> None:
     parser = argparse.ArgumentParser(description="Flower")
     parser.add_argument(
-        "--node-id",
+        "--partition-id",
         type=int,
         choices=range(0, 10),
         required=True,
         help="Specifies the artificial data partition",
     )
     args = parser.parse_args()
-    node_id = args.node_id
+    partition_id = args.partition_id
 
     # Model and data
     model = mnist.LitAutoEncoder()
-    train_loader, val_loader, test_loader = mnist.load_data(node_id)
+    train_loader, val_loader, test_loader = mnist.load_data(partition_id)
 
     # Flower client
     client = FlowerClient(model, train_loader, val_loader, test_loader).to_client()

--- a/examples/quickstart-pytorch-lightning/run.sh
+++ b/examples/quickstart-pytorch-lightning/run.sh
@@ -6,7 +6,7 @@ sleep 3 # Sleep for 3s to give the server enough time to start
 
 for i in $(seq 0 1); do
     echo "Starting client $i"
-    python client.py --node-id "${i}" &
+    python client.py --partition-id "${i}" &
 done
 
 # This will allow you to use CTRL+C to stop all background processes

--- a/examples/quickstart-pytorch/README.md
+++ b/examples/quickstart-pytorch/README.md
@@ -55,20 +55,20 @@ Afterwards you are ready to start the Flower server as well as the clients. You 
 python3 server.py
 ```
 
-Now you are ready to start the Flower clients which will participate in the learning. We need to specify the node id to
+Now you are ready to start the Flower clients which will participate in the learning. We need to specify the partition id to
 use different partitions of the data on different nodes.  To do so simply open two more terminal windows and run the
 following commands.
 
 Start client 1 in the first terminal:
 
 ```shell
-python3 client.py --node-id 0
+python3 client.py --partition-id 0
 ```
 
 Start client 2 in the second terminal:
 
 ```shell
-python3 client.py --node-id 1
+python3 client.py --partition-id 1
 ```
 
 You will see that PyTorch is starting a federated training. Look at the [code](https://github.com/adap/flower/tree/main/examples/quickstart-pytorch) for a detailed explanation.

--- a/examples/quickstart-pytorch/client.py
+++ b/examples/quickstart-pytorch/client.py
@@ -69,10 +69,10 @@ def test(net, testloader):
     return loss, accuracy
 
 
-def load_data(node_id):
+def load_data(partition_id):
     """Load partition CIFAR10 data."""
     fds = FederatedDataset(dataset="cifar10", partitioners={"train": 3})
-    partition = fds.load_partition(node_id)
+    partition = fds.load_partition(partition_id)
     # Divide data on each node: 80% train, 20% test
     partition_train_test = partition.train_test_split(test_size=0.2)
     pytorch_transforms = Compose(
@@ -94,20 +94,20 @@ def load_data(node_id):
 # 2. Federation of the pipeline with Flower
 # #############################################################################
 
-# Get node id
+# Get partition id
 parser = argparse.ArgumentParser(description="Flower")
 parser.add_argument(
-    "--node-id",
+    "--partition-id",
     choices=[0, 1, 2],
     required=True,
     type=int,
     help="Partition of the dataset divided into 3 iid partitions created artificially.",
 )
-node_id = parser.parse_args().node_id
+partition_id = parser.parse_args().partition_id
 
 # Load model and data (simple CNN, CIFAR-10)
 net = Net().to(DEVICE)
-trainloader, testloader = load_data(node_id=node_id)
+trainloader, testloader = load_data(partition_id=partition_id)
 
 
 # Define Flower client

--- a/examples/quickstart-pytorch/run.sh
+++ b/examples/quickstart-pytorch/run.sh
@@ -8,7 +8,7 @@ sleep 3  # Sleep for 3s to give the server enough time to start
 
 for i in $(seq 0 1); do
     echo "Starting client $i"
-    python client.py --node-id "$i" &
+    python client.py --partition-id "$i" &
 done
 
 # Enable CTRL+C to stop all background processes

--- a/examples/quickstart-sklearn-tabular/README.md
+++ b/examples/quickstart-sklearn-tabular/README.md
@@ -63,15 +63,15 @@ poetry run python3 server.py
 Now you are ready to start the Flower clients which will participate in the learning. To do so simply open two more terminals and run the following command in each:
 
 ```shell
-poetry run python3 client.py --node-id 0 # node-id should be any of {0,1,2}
+poetry run python3 client.py --partition-id 0 # partition-id should be any of {0,1,2}
 ```
 
 Alternatively you can run all of it in one shell as follows:
 
 ```shell
 poetry run python3 server.py &
-poetry run python3 client.py --node-id 0 &
-poetry run python3 client.py --node-id 1
+poetry run python3 client.py --partition-id 0 &
+poetry run python3 client.py --partition-id 1
 ```
 
 You will see that Flower is starting a federated training.

--- a/examples/quickstart-sklearn-tabular/client.py
+++ b/examples/quickstart-sklearn-tabular/client.py
@@ -13,14 +13,14 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description="Flower")
     parser.add_argument(
-        "--node-id",
+        "--partition-id",
         type=int,
         choices=range(0, N_CLIENTS),
         required=True,
         help="Specifies the artificial data partition",
     )
     args = parser.parse_args()
-    partition_id = args.node_id
+    partition_id = args.partition_id
 
     # Load the partition data
     fds = FederatedDataset(dataset="hitorilabs/iris", partitioners={"train": N_CLIENTS})

--- a/examples/quickstart-sklearn-tabular/run.sh
+++ b/examples/quickstart-sklearn-tabular/run.sh
@@ -8,7 +8,7 @@ sleep 3  # Sleep for 3s to give the server enough time to start
 
 for i in $(seq 0 1); do
     echo "Starting client $i"
-    python client.py --node-id "${i}" &
+    python client.py --partition-id "${i}" &
 done
 
 # This will allow you to use CTRL+C to stop all background processes

--- a/examples/quickstart-tensorflow/client.py
+++ b/examples/quickstart-tensorflow/client.py
@@ -11,7 +11,7 @@ os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"
 # Parse arguments
 parser = argparse.ArgumentParser(description="Flower")
 parser.add_argument(
-    "--node-id",
+    "--partition-id",
     type=int,
     choices=[0, 1, 2],
     required=True,
@@ -26,7 +26,7 @@ model.compile("adam", "sparse_categorical_crossentropy", metrics=["accuracy"])
 
 # Download and partition dataset
 fds = FederatedDataset(dataset="cifar10", partitioners={"train": 3})
-partition = fds.load_partition(args.node_id, "train")
+partition = fds.load_partition(args.partition_id, "train")
 partition.set_format("numpy")
 
 # Divide data on each node: 80% train, 20% test

--- a/examples/quickstart-tensorflow/run.sh
+++ b/examples/quickstart-tensorflow/run.sh
@@ -6,7 +6,7 @@ sleep 3  # Sleep for 3s to give the server enough time to start
 
 for i in `seq 0 1`; do
     echo "Starting client $i"
-    python client.py --node-id $i &
+    python client.py --partition-id $i &
 done
 
 # This will allow you to use CTRL+C to stop all background processes

--- a/examples/sklearn-logreg-mnist/README.md
+++ b/examples/sklearn-logreg-mnist/README.md
@@ -62,13 +62,13 @@ Now you are ready to start the Flower clients which will participate in the lear
 Start client 1 in the first terminal:
 
 ```shell
-python3 client.py --node-id 0 # or any integer in {0-9}
+python3 client.py --partition-id 0 # or any integer in {0-9}
 ```
 
 Start client 2 in the second terminal:
 
 ```shell
-python3 client.py --node-id 1 # or any integer in {0-9}
+python3 client.py --partition-id 1 # or any integer in {0-9}
 ```
 
 Alternatively, you can run all of it in one shell as follows:

--- a/examples/sklearn-logreg-mnist/client.py
+++ b/examples/sklearn-logreg-mnist/client.py
@@ -13,14 +13,14 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description="Flower")
     parser.add_argument(
-        "--node-id",
+        "--partition-id",
         type=int,
         choices=range(0, N_CLIENTS),
         required=True,
         help="Specifies the artificial data partition",
     )
     args = parser.parse_args()
-    partition_id = args.node_id
+    partition_id = args.partition_id
 
     # Load the partition data
     fds = FederatedDataset(dataset="mnist", partitioners={"train": N_CLIENTS})

--- a/examples/sklearn-logreg-mnist/run.sh
+++ b/examples/sklearn-logreg-mnist/run.sh
@@ -8,7 +8,7 @@ sleep 3  # Sleep for 3s to give the server enough time to start
 
 for i in $(seq 0 1); do
     echo "Starting client $i"
-    python client.py --node-id "${i}" &
+    python client.py --partition-id "${i}" &
 done
 
 # This will allow you to use CTRL+C to stop all background processes

--- a/examples/xgboost-comprehensive/README.md
+++ b/examples/xgboost-comprehensive/README.md
@@ -120,10 +120,10 @@ You can also run the example without the scripts. First, launch the server:
 python server.py --train-method=bagging/cyclic --pool-size=N --num-clients-per-round=N
 ```
 
-Then run at least two clients (each on a new terminal or computer in your network) passing different `NODE_ID` and all using the same `N` (denoting the total number of clients or data partitions):
+Then run at least two clients (each on a new terminal or computer in your network) passing different `PARTITION_ID` and all using the same `N` (denoting the total number of clients or data partitions):
 
 ```bash
-python client.py --train-method=bagging/cyclic --node-id=NODE_ID --num-partitions=N
+python client.py --train-method=bagging/cyclic --partition-id=PARTITION_ID --num-partitions=N
 ```
 
 ### Flower Simulation Setup

--- a/examples/xgboost-comprehensive/client.py
+++ b/examples/xgboost-comprehensive/client.py
@@ -35,9 +35,9 @@ fds = FederatedDataset(
     resplitter=resplit,
 )
 
-# Load the partition for this `node_id`
+# Load the partition for this `partition_id`
 log(INFO, "Loading partition...")
-partition = fds.load_partition(node_id=args.node_id, split="train")
+partition = fds.load_partition(partition_id=args.partition_id, split="train")
 partition.set_format("numpy")
 
 if args.centralised_eval:

--- a/examples/xgboost-comprehensive/run_bagging.sh
+++ b/examples/xgboost-comprehensive/run_bagging.sh
@@ -8,7 +8,7 @@ sleep 30  # Sleep for 30s to give the server enough time to start
 
 for i in `seq 0 4`; do
     echo "Starting client $i"
-    python3 client.py --node-id=$i --num-partitions=5 --partitioner-type=exponential &
+    python3 client.py --partition-id=$i --num-partitions=5 --partitioner-type=exponential &
 done
 
 # Enable CTRL+C to stop all background processes

--- a/examples/xgboost-comprehensive/run_cyclic.sh
+++ b/examples/xgboost-comprehensive/run_cyclic.sh
@@ -8,7 +8,7 @@ sleep 15  # Sleep for 15s to give the server enough time to start
 
 for i in `seq 0 4`; do
     echo "Starting client $i"
-    python3 client.py --node-id=$i --train-method=cyclic --num-partitions=5 --partitioner-type=exponential --centralised-eval &
+    python3 client.py --partition-id=$i --train-method=cyclic --num-partitions=5 --partitioner-type=exponential --centralised-eval &
 done
 
 # Enable CTRL+C to stop all background processes

--- a/examples/xgboost-comprehensive/sim.py
+++ b/examples/xgboost-comprehensive/sim.py
@@ -98,9 +98,9 @@ def main():
 
     # Load and process all client partitions. This upfront cost is amortized soon
     # after the simulation begins since clients wont need to preprocess their partition.
-    for node_id in tqdm(range(args.pool_size), desc="Extracting client partition"):
-        # Extract partition for client with node_id
-        partition = fds.load_partition(node_id=node_id, split="train")
+    for partition_id in tqdm(range(args.pool_size), desc="Extracting client partition"):
+        # Extract partition for client with partition_id
+        partition = fds.load_partition(partition_id=partition_id, split="train")
         partition.set_format("numpy")
 
         if args.centralised_eval_client:

--- a/examples/xgboost-comprehensive/utils.py
+++ b/examples/xgboost-comprehensive/utils.py
@@ -37,10 +37,10 @@ def client_args_parser():
         help="Partitioner types.",
     )
     parser.add_argument(
-        "--node-id",
+        "--partition-id",
         default=0,
         type=int,
-        help="Node ID used for the current client.",
+        help="Partition ID used for the current client.",
     )
     parser.add_argument(
         "--seed", default=42, type=int, help="Seed used for train/test splitting."

--- a/examples/xgboost-quickstart/README.md
+++ b/examples/xgboost-quickstart/README.md
@@ -67,13 +67,13 @@ To do so simply open two more terminal windows and run the following commands.
 Start client 1 in the first terminal:
 
 ```shell
-python3 client.py --node-id=0
+python3 client.py --partition-id=0
 ```
 
 Start client 2 in the second terminal:
 
 ```shell
-python3 client.py --node-id=1
+python3 client.py --partition-id=1
 ```
 
 You will see that XGBoost is starting a federated training.

--- a/examples/xgboost-quickstart/client.py
+++ b/examples/xgboost-quickstart/client.py
@@ -24,13 +24,13 @@ from flwr_datasets.partitioner import IidPartitioner
 
 warnings.filterwarnings("ignore", category=UserWarning)
 
-# Define arguments parser for the client/node ID.
+# Define arguments parser for the client/partition ID.
 parser = argparse.ArgumentParser()
 parser.add_argument(
-    "--node-id",
+    "--partition-id",
     default=0,
     type=int,
-    help="Node ID used for the current client.",
+    help="Partition ID used for the current client.",
 )
 args = parser.parse_args()
 
@@ -61,9 +61,9 @@ def transform_dataset_to_dmatrix(data: Union[Dataset, DatasetDict]) -> xgb.core.
 partitioner = IidPartitioner(num_partitions=30)
 fds = FederatedDataset(dataset="jxie/higgs", partitioners={"train": partitioner})
 
-# Load the partition for this `node_id`
+# Load the partition for this `partition_id`
 log(INFO, "Loading partition...")
-partition = fds.load_partition(node_id=args.node_id, split="train")
+partition = fds.load_partition(partition_id=args.partition_id, split="train")
 partition.set_format("numpy")
 
 # Train/test splitting

--- a/examples/xgboost-quickstart/run.sh
+++ b/examples/xgboost-quickstart/run.sh
@@ -8,7 +8,7 @@ sleep 5  # Sleep for 5s to give the server enough time to start
 
 for i in `seq 0 1`; do
     echo "Starting client $i"
-    python3 client.py --node-id=$i &
+    python3 client.py --partition-id=$i &
 done
 
 # Enable CTRL+C to stop all background processes


### PR DESCRIPTION
We might abuse the name "node id" (or "Node ID", "node_id", etc.) in our examples. Given that the `node_id` should be allocated by the superlink, we should avoid making users think they should set `node_id`.

A better name is `partition_id`, which is intuitive and aligns with the names in `flwr-datasets` and in simulation.