### PR TITLE
Enable `_update_client_manager` thread to be terminated from external event.

### DIFF
--- a/src/py/flwr/server/compat/app.py
+++ b/src/py/flwr/server/compat/app.py
@@ -16,6 +16,7 @@
 
 
 import sys
+import threading
 from logging import INFO
 from pathlib import Path
 from typing import Optional, Union
@@ -51,6 +52,7 @@ def start_driver(  # pylint: disable=too-many-arguments, too-many-locals
     client_manager: Optional[ClientManager] = None,
     root_certificates: Optional[Union[bytes, str]] = None,
     driver: Optional[Driver] = None,
+    f_stop: Optional[threading.Event] = None,
 ) -> History:
     """Start a Flower Driver API server.
 
@@ -80,6 +82,10 @@ def start_driver(  # pylint: disable=too-many-arguments, too-many-locals
         established to an SSL-enabled Flower server.
     driver : Optional[Driver] (default: None)
         The Driver object to use.
+    f_stop : Optional[threading.Event] (default: None)
+        A threading event to trigger the stop of the Client Manager thread.
+        If not passed, one will be created and used within the scope of this
+        function.
 
     Returns
     -------
@@ -133,7 +139,7 @@ def start_driver(  # pylint: disable=too-many-arguments, too-many-locals
 
     # Start the thread updating nodes
     thread, f_stop = start_update_client_manager_thread(
-        driver, initialized_server.client_manager()
+        driver, initialized_server.client_manager(), f_stop
     )
 
     # Start training

--- a/src/py/flwr/server/compat/app_utils.py
+++ b/src/py/flwr/server/compat/app_utils.py
@@ -17,7 +17,7 @@
 
 import threading
 import time
-from typing import Dict, Tuple
+from typing import Dict, Optional, Tuple
 
 from ..client_manager import ClientManager
 from ..compat.driver_client_proxy import DriverClientProxy
@@ -27,6 +27,7 @@ from ..driver import Driver
 def start_update_client_manager_thread(
     driver: Driver,
     client_manager: ClientManager,
+    f_stop: Optional[threading.Event] = None,
 ) -> Tuple[threading.Thread, threading.Event]:
     """Periodically update the nodes list in the client manager in a thread.
 
@@ -52,7 +53,8 @@ def start_update_client_manager_thread(
     threading.Event
         An event that, when set, signals the thread to stop.
     """
-    f_stop = threading.Event()
+    if f_stop is None:
+        f_stop = threading.Event()
     thread = threading.Thread(
         target=_update_client_manager,
         args=(

--- a/src/py/flwr/server/run_serverapp.py
+++ b/src/py/flwr/server/run_serverapp.py
@@ -17,6 +17,7 @@
 
 import argparse
 import sys
+import threading
 from logging import DEBUG, WARN
 from pathlib import Path
 from typing import Optional
@@ -33,6 +34,7 @@ def run(
     server_app_dir: str,
     server_app_attr: Optional[str] = None,
     loaded_server_app: Optional[ServerApp] = None,
+    f_stop: Optional[threading.Event] = None,
 ) -> None:
     """Run ServerApp with a given Driver."""
     if not (server_app_attr is None) ^ (loaded_server_app is None):
@@ -58,6 +60,7 @@ def run(
     context = Context(state=RecordSet())
 
     # Call ServerApp
+    server_app._f_stop = f_stop
     server_app(driver=driver, context=context)
 
     log(DEBUG, "ServerApp finished running.")

--- a/src/py/flwr/server/run_serverapp.py
+++ b/src/py/flwr/server/run_serverapp.py
@@ -60,7 +60,7 @@ def run(
     context = Context(state=RecordSet())
 
     # Call ServerApp
-    server_app._f_stop = f_stop
+    server_app._f_stop = f_stop # TODO: not ideal way of handling this?
     server_app(driver=driver, context=context)
 
     log(DEBUG, "ServerApp finished running.")

--- a/src/py/flwr/server/server_app.py
+++ b/src/py/flwr/server/server_app.py
@@ -16,6 +16,7 @@
 
 
 import importlib
+import threading
 from typing import Callable, Optional, cast
 
 from flwr.common import Context, RecordSet
@@ -65,6 +66,7 @@ class ServerApp:
         self._strategy = strategy
         self._client_manager = client_manager
         self._main: Optional[ServerAppCallable] = None
+        self._f_stop = None
 
     def __call__(self, driver: Driver, context: Context) -> None:
         """Execute `ServerApp`."""
@@ -76,6 +78,7 @@ class ServerApp:
                 strategy=self._strategy,
                 client_manager=self._client_manager,
                 driver=driver,
+                f_stop=self._f_stop,
             )
             return
 

--- a/src/py/flwr/simulation/run_simulation.py
+++ b/src/py/flwr/simulation/run_simulation.py
@@ -247,13 +247,12 @@ def _main_loop(
         del driver
         # Trigger async stop event
         af_stop.set()
+        # Triggering stop event server thread
         f_stop.set()
 
         event(EventType.RUN_SUPERLINK_LEAVE)
         if serverapp_th:
-            log(INFO, "Joining server thread.")
             serverapp_th.join()
-            log(INFO, "Joined.")
 
     log(INFO, "Stopping Simulation Engine now.")
 

--- a/src/py/flwr/simulation/run_simulation.py
+++ b/src/py/flwr/simulation/run_simulation.py
@@ -126,7 +126,8 @@ def run_serverapp_th(
     server_app: Optional[ServerApp],
     driver: Driver,
     app_dir: str,
-    f_stop: asyncio.Event,
+    af_stop: asyncio.Event,
+    f_stop: threading.Event,
     enable_tf_gpu_growth: bool,
     delay_launch: int = 3,
 ) -> threading.Thread:
@@ -158,12 +159,13 @@ def run_serverapp_th(
 
     serverapp_th = threading.Thread(
         target=server_th_with_start_checks,
-        args=(enable_tf_gpu_growth, f_stop),
+        args=(enable_tf_gpu_growth, af_stop),
         kwargs={
             "server_app_attr": server_app_attr,
             "loaded_server_app": server_app,
             "driver": driver,
             "server_app_dir": app_dir,
+            "f_stop": f_stop,
         },
     )
     sleep(delay_launch)
@@ -200,7 +202,8 @@ def _main_loop(
         certificates=None,
     )
 
-    f_stop = asyncio.Event()
+    af_stop = asyncio.Event()
+    f_stop = threading.Event()
     serverapp_th = None
     try:
         # Initialize Driver
@@ -215,6 +218,7 @@ def _main_loop(
             server_app=server_app,
             driver=driver,
             app_dir=app_dir,
+            af_stop=af_stop,
             f_stop=f_stop,
             enable_tf_gpu_growth=enable_tf_gpu_growth,
         )
@@ -229,7 +233,7 @@ def _main_loop(
             backend_config_json_stream=backend_config_stream,
             app_dir=app_dir,
             state_factory=state_factory,
-            f_stop=f_stop,
+            f_stop=af_stop,
         )
 
     except Exception as ex:
@@ -241,12 +245,15 @@ def _main_loop(
         # Stop Driver
         driver_server.stop(grace=0)
         del driver
-        # Trigger stop event
+        # Trigger async stop event
+        af_stop.set()
         f_stop.set()
 
         event(EventType.RUN_SUPERLINK_LEAVE)
         if serverapp_th:
+            log(INFO, "Joining server thread.")
             serverapp_th.join()
+            log(INFO, "Joined.")
 
     log(INFO, "Stopping Simulation Engine now.")
 


### PR DESCRIPTION
Enable passing a `threading.Event` to a `ServerApp` so `_update_client_manager` thread can be stopped by an external entity (e.g. when a Simulation is set to be terminated). 