### PR TITLE
Add an error msg check in central DP mods

### DIFF
--- a/src/py/flwr/client/mod/centraldp_mods.py
+++ b/src/py/flwr/client/mod/centraldp_mods.py
@@ -63,6 +63,11 @@ def fixedclipping_mod(
 
     # Call inner app
     out_msg = call_next(msg, ctxt)
+
+    # Check if the msg has error
+    if out_msg.has_error():
+        return out_msg
+
     fit_res = compat.recordset_to_fitres(out_msg.content, keep_input=True)
 
     client_to_server_params = parameters_to_ndarrays(fit_res.parameters)
@@ -119,6 +124,11 @@ def adaptiveclipping_mod(
 
     # Call inner app
     out_msg = call_next(msg, ctxt)
+
+    # Check if the msg has error
+    if out_msg.has_error():
+        return out_msg
+
     fit_res = compat.recordset_to_fitres(out_msg.content, keep_input=True)
 
     client_to_server_params = parameters_to_ndarrays(fit_res.parameters)


### PR DESCRIPTION
In central DP mods, there needs to be a check if the msg has error before performing the clipping on the content. 
### Changelog entry



### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.ai/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
