### PR TITLE
Use correct indent for logging feature warnings

### DIFF
--- a/src/py/flwr/common/logger.py
+++ b/src/py/flwr/common/logger.py
@@ -168,11 +168,10 @@ def warn_experimental_feature(name: str) -> None:
     """Warn the user when they use an experimental feature."""
     log(
         WARN,
-        """
-        EXPERIMENTAL FEATURE: %s
+        """EXPERIMENTAL FEATURE: %s
 
-        This is an experimental feature. It could change significantly or be removed
-        entirely in future versions of Flower.
+            This is an experimental feature. It could change significantly or be removed
+            entirely in future versions of Flower.
         """,
         name,
     )
@@ -182,11 +181,10 @@ def warn_deprecated_feature(name: str) -> None:
     """Warn the user when they use a deprecated feature."""
     log(
         WARN,
-        """
-        DEPRECATED FEATURE: %s
+        """DEPRECATED FEATURE: %s
 
-        This is a deprecated feature. It will be removed
-        entirely in future versions of Flower.
+            This is a deprecated feature. It will be removed
+            entirely in future versions of Flower.
         """,
         name,
     )


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

The indent for feature warnings is not aligned with the rest.

### Related issues/PRs

N/A

## Proposal

### Explanation

Use correct indent for these warnings.

### Checklist

- [x] Implement proposed change
- [x] Update the changelog entry below
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

<!--
Inside the following 'Changelog entry' section, you should put the description of your changes that will be added to the changelog alongside your PR title.

If the section is completely empty (without any token) or non-existant, the changelog will just contain the title of the PR for the changelog entry, without any description. If the section contains some text other than tokens, it will use it to add a description to the change. If the section contains one of the following tokens it will ignore any other text and put the PR under the corresponding section of the changelog:

<general> is for classifying a PR as a general improvement.
<skip> is to not add the PR to the changelog
<baselines> is to add a general baselines change to the PR
<examples> is to add a general examples change to the PR
<sdk> is to add a general sdk change to the PR
<simulations> is to add a general simulations change to the PR

Note that only one token should be used.
-->

### Changelog entry

<skip>

### Any other comments?

N/A
