### PR TITLE
Improve flower-client-app logs

### DIFF
--- a/examples/app-pytorch/task.py
+++ b/examples/app-pytorch/task.py
@@ -1,8 +1,10 @@
 from collections import OrderedDict
+from logging import INFO
 
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from flwr.common.logger import log
 from torch.utils.data import DataLoader
 from torchvision.datasets import CIFAR10
 from torchvision.transforms import Compose, Normalize, ToTensor
@@ -42,7 +44,7 @@ def load_data():
 
 def train(net, trainloader, valloader, epochs, device):
     """Train the model on the training set."""
-    print("Starting training...")
+    log(INFO, "Starting training...")
     net.to(device)  # move model to GPU if available
     criterion = torch.nn.CrossEntropyLoss().to(device)
     optimizer = torch.optim.SGD(net.parameters(), lr=0.001, momentum=0.9)

--- a/src/py/flwr/client/app.py
+++ b/src/py/flwr/client/app.py
@@ -456,7 +456,14 @@ def _start_client_internal(
                     time.sleep(3)  # Wait for 3s before asking again
                     continue
 
-                log(INFO, "Received message")
+                log(
+                    INFO,
+                    "Received: %s message %s for group %s of run %s",
+                    message.metadata.message_type,
+                    message.metadata.message_id,
+                    message.metadata.group_id,
+                    message.metadata.run_id,
+                )
 
                 # Handle control message
                 out_message, sleep_duration = handle_control_message(message)
@@ -484,7 +491,14 @@ def _start_client_internal(
 
                 # Send
                 send(out_message)
-                log(INFO, "Sent reply")
+                log(
+                    INFO,
+                    "Sent: %s reply %s for group %s of run %s",
+                    out_message.metadata.message_type,
+                    out_message.metadata.message_id,
+                    out_message.metadata.group_id,
+                    out_message.metadata.run_id,
+                )
 
             # Unregister node
             if delete_node is not None:

--- a/src/py/flwr/client/app.py
+++ b/src/py/flwr/client/app.py
@@ -456,6 +456,7 @@ def _start_client_internal(
                     time.sleep(3)  # Wait for 3s before asking again
                     continue
 
+                log(INFO, "")
                 log(
                     INFO,
                     "[RUN %s, ROUND %s]",

--- a/src/py/flwr/client/app.py
+++ b/src/py/flwr/client/app.py
@@ -458,11 +458,15 @@ def _start_client_internal(
 
                 log(
                     INFO,
-                    "Received: %s message %s for group %s of run %s",
+                    "[RUN %s, ROUND %s]",
+                    message.metadata.run_id,
+                    message.metadata.group_id,
+                )
+                log(
+                    INFO,
+                    "Received: %s message %s",
                     message.metadata.message_type,
                     message.metadata.message_id,
-                    message.metadata.group_id,
-                    message.metadata.run_id,
                 )
 
                 # Handle control message
@@ -493,11 +497,15 @@ def _start_client_internal(
                 send(out_message)
                 log(
                     INFO,
-                    "Sent: %s reply %s for group %s of run %s",
-                    out_message.metadata.message_type,
-                    out_message.metadata.message_id,
-                    out_message.metadata.group_id,
+                    "[RUN %s, ROUND %s]",
                     out_message.metadata.run_id,
+                    out_message.metadata.group_id,
+                )
+                log(
+                    INFO,
+                    "Sent: %s reply to message %s",
+                    out_message.metadata.message_type,
+                    message.metadata.message_id,
                 )
 
             # Unregister node


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

`flower-client-app` logs are not particularly useful.

![image](https://github.com/adap/flower/assets/9378265/06250462-d095-4d7f-b4c6-f8185eb8a98a)

### Related issues/PRs

N/A

## Proposal

### Explanation

Add `group_id`, `run_id`, `msg_id`, and `msg_type` to logs.

![image](https://github.com/adap/flower/assets/9378265/ffb3e696-f1d8-40c0-9029-9916333b2453)

### Checklist

- [x] Implement proposed change
- [x] Update the changelog entry below
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

<!--
Inside the following 'Changelog entry' section, you should put the description of your changes that will be added to the changelog alongside your PR title.

If the section is completely empty (without any token) or non-existant, the changelog will just contain the title of the PR for the changelog entry, without any description. If the section contains some text other than tokens, it will use it to add a description to the change. If the section contains one of the following tokens it will ignore any other text and put the PR under the corresponding section of the changelog:

<general> is for classifying a PR as a general improvement.
<skip> is to not add the PR to the changelog
<baselines> is to add a general baselines change to the PR
<examples> is to add a general examples change to the PR
<sdk> is to add a general sdk change to the PR
<simulations> is to add a general simulations change to the PR

Note that only one token should be used.
-->

### Changelog entry

<skip>

### Any other comments?

N/A
