### PR TITLE
[feat] Validate the name property in `pyproject.toml` file

### DIFF
--- a/src/py/flwr/common/pyproject.py
+++ b/src/py/flwr/common/pyproject.py
@@ -1,0 +1,46 @@
+# Copyright 2024 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for the validation function of name property."""
+
+
+import re
+
+
+def validate_project_name(name: str) -> bool:
+    """
+    Validates the project name against the specifications outlined in PEP 621
+    and PEP 503 for pyproject.toml `name` property. Conventions at a glance:
+    - Must be lowercase
+    - Should use hyphens instead of spaces or underscores
+    - Should not contain special characters
+    - Recommended to be no more than 40 characters long (But it can be)
+
+    Parameters
+    ----------
+    name : str
+        The project name to validate.
+
+    Returns
+    -------
+    bool
+        True if the name is valid, False otherwise.
+    """
+    if (
+        not name
+        or len(name) > 40
+        or not re.match(r"^[a-z0-9-]+$", name)
+    ):
+        return False
+    return True

--- a/src/py/flwr/common/pyproject.py
+++ b/src/py/flwr/common/pyproject.py
@@ -12,19 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Tests for the validation function of name property."""
-
+"""Validates the project's name property."""
 
 import re
 
 
 def validate_project_name(name: str) -> bool:
-    """
-    Validates the project name against the specifications outlined in PEP 621
-    and PEP 503 for pyproject.toml `name` property. Conventions at a glance:
+    """Validate the project name against PEP 621 and PEP 503 specifications.
+
+    Conventions at a glance:
     - Must be lowercase
-    - Should use hyphens instead of spaces or underscores
-    - Should not contain special characters
+    - Must not contain special characters
+    - Must use hyphens(recommended) or underscores. No spaces.
     - Recommended to be no more than 40 characters long (But it can be)
 
     Parameters
@@ -37,6 +36,6 @@ def validate_project_name(name: str) -> bool:
     bool
         True if the name is valid, False otherwise.
     """
-    if not name or len(name) > 40 or not re.match(r"^[a-z0-9-]+$", name):
+    if not name or len(name) > 40 or not re.match(r"^[a-z0-9-_]+$", name):
         return False
     return True

--- a/src/py/flwr/common/pyproject.py
+++ b/src/py/flwr/common/pyproject.py
@@ -37,10 +37,6 @@ def validate_project_name(name: str) -> bool:
     bool
         True if the name is valid, False otherwise.
     """
-    if (
-        not name
-        or len(name) > 40
-        or not re.match(r"^[a-z0-9-]+$", name)
-    ):
+    if not name or len(name) > 40 or not re.match(r"^[a-z0-9-]+$", name):
         return False
     return True

--- a/src/py/flwr/common/pyproject_test.py
+++ b/src/py/flwr/common/pyproject_test.py
@@ -1,0 +1,67 @@
+# Copyright 2024 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for the validation function of name property."""
+
+from pyproject import validate_project_name
+
+
+def test_valid_name_with_dashes():
+    assert validate_project_name(
+        "valid-project-name",
+        "Expected 'valid-project-name' to be valid",
+    )
+
+
+def test_valid_name_with_underscores():
+    assert validate_project_name(
+        "valid_project_name"
+    ), "Expected 'valid_project_name' to be valid"
+
+
+def test_invalid_name_with_upper_letters():
+    assert not validate_project_name(
+        "Invalid Project Name"
+    ), "Upper Case and Spaces are not allowed"
+
+
+def test_name_with_spaces():
+    assert not validate_project_name(
+        "name with spaces"
+    ), "Spaces are not allowed"
+
+
+def test_empty_name():
+    assert not validate_project_name(""), "Empty name is not valid"
+
+
+def test_long_name():
+    # It can be more than 40 but generally 
+    # it is recommended not to be more than 40
+    long_name = "a" * 41
+    assert not validate_project_name(
+        long_name
+    ), f"Name longer than 40 characters is not recommended"
+
+
+def test_name_with_special_characters():
+    assert not validate_project_name(
+        "name!@#"
+    ), "Special characters are not allowed"
+
+
+def test_name_with_special_characters():
+    assert not validate_project_name(
+        "name!@#"
+    ), "Special characters are not allowed"

--- a/src/py/flwr/common/pyproject_test.py
+++ b/src/py/flwr/common/pyproject_test.py
@@ -19,8 +19,7 @@ from pyproject import validate_project_name
 
 def test_valid_name_with_dashes():
     assert validate_project_name(
-        "valid-project-name",
-        "Expected 'valid-project-name' to be valid",
+        "valid-project-name", "Expected 'valid-project-name' to be valid"
     )
 
 
@@ -37,9 +36,7 @@ def test_invalid_name_with_upper_letters():
 
 
 def test_name_with_spaces():
-    assert not validate_project_name(
-        "name with spaces"
-    ), "Spaces are not allowed"
+    assert not validate_project_name("name with spaces"), "Spaces are not allowed"
 
 
 def test_empty_name():
@@ -47,21 +44,13 @@ def test_empty_name():
 
 
 def test_long_name():
-    # It can be more than 40 but generally 
+    # It can be more than 40 but generally
     # it is recommended not to be more than 40
     long_name = "a" * 41
     assert not validate_project_name(
         long_name
-    ), f"Name longer than 40 characters is not recommended"
+    ), "Name longer than 40 characters is not recommended"
 
 
 def test_name_with_special_characters():
-    assert not validate_project_name(
-        "name!@#"
-    ), "Special characters are not allowed"
-
-
-def test_name_with_special_characters():
-    assert not validate_project_name(
-        "name!@#"
-    ), "Special characters are not allowed"
+    assert not validate_project_name("name!@#"), "Special characters are not allowed"

--- a/src/py/flwr/common/pyproject_test.py
+++ b/src/py/flwr/common/pyproject_test.py
@@ -12,45 +12,97 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Tests for the validation function of name property."""
+"""Tests for the function that validates name property."""
 
-from pyproject import validate_project_name
-
-
-def test_valid_name_with_dashes():
-    assert validate_project_name(
-        "valid-project-name", "Expected 'valid-project-name' to be valid"
-    )
+from .pyproject import validate_project_name
 
 
-def test_valid_name_with_underscores():
-    assert validate_project_name(
-        "valid_project_name"
-    ), "Expected 'valid_project_name' to be valid"
+# Happy Flow
+def test_valid_name_with_lower_case() -> None:
+    """Test a valid single-word project name with all lower case."""
+    # Prepare
+    name = "myproject"
+    expected = True
+    # Execute
+    actual = validate_project_name(name)
+    # Assert
+    assert actual == expected, f"Expected {name} to be valid"
 
 
-def test_invalid_name_with_upper_letters():
-    assert not validate_project_name(
-        "Invalid Project Name"
-    ), "Upper Case and Spaces are not allowed"
+def test_valid_name_with_dashes() -> None:
+    """Test a valid project name with hyphens inbetween."""
+    # Prepare
+    name = "valid-project-name"
+    expected = True
+    # Execute
+    actual = validate_project_name(name)
+    # Assert
+    assert actual == expected, f"Expected {name} to be valid"
 
 
-def test_name_with_spaces():
-    assert not validate_project_name("name with spaces"), "Spaces are not allowed"
+def test_valid_name_with_underscores() -> None:
+    """Test a valid project name with underscores inbetween."""
+    # Prepare
+    name = "valid_project_name"
+    expected = True
+    # Execute
+    actual = validate_project_name(name)
+    # Assert
+    assert actual == expected, f"Expected {name} to be valid"
 
 
-def test_empty_name():
-    assert not validate_project_name(""), "Empty name is not valid"
+def test_invalid_name_with_upper_letters() -> None:
+    """Tests a project name with Spaces and Uppercase letter."""
+    # Prepare
+    name = "Invalid Project Name"
+    expected = False
+    # Execute
+    actual = validate_project_name(name)
+    # Assert
+    assert actual == expected, "Upper Case and Spaces are not allowed"
 
 
-def test_long_name():
+def test_name_with_spaces() -> None:
+    """Tests a project name with spaces inbetween."""
+    # Prepare
+    name = "name with spaces"
+    expected = False
+    # Execute
+    actual = validate_project_name(name)
+    # Assert
+    assert actual == expected, "Spaces are not allowed"
+
+
+def test_empty_name() -> None:
+    """Tests use-case for an empty project name."""
+    # Prepare
+    name = ""
+    expected = False
+    # Execute
+    actual = validate_project_name(name)
+    # Assert
+    assert actual == expected, "Empty name is not valid"
+
+
+def test_long_name() -> None:
+    """Tests for long project names."""
+    # Prepare
+    name = "a" * 41
+    expected = False
+    # Execute
+    actual = validate_project_name(name)
+    # Assert
     # It can be more than 40 but generally
     # it is recommended not to be more than 40
-    long_name = "a" * 41
-    assert not validate_project_name(
-        long_name
-    ), "Name longer than 40 characters is not recommended"
+    assert actual == expected, "Name longer than 40 characters is not recommended"
 
 
-def test_name_with_special_characters():
-    assert not validate_project_name("name!@#"), "Special characters are not allowed"
+def test_name_with_special_characters() -> None:
+    """Tests for project names with special characters."""
+    # Prepare
+    name = "name!@#"
+    expected = False
+    # Execute
+    actual = validate_project_name(name)
+    # Assert
+    assert actual == expected, "Special characters are not allowed"


### PR DESCRIPTION
## Proposal
For the Flower CLI new command we are asking the user for a project name. We expect that project name to be compatible with the `pyproject.toml` file's `name` property as its based on the same PEP

### Explanation
Add a new module in src/py/flwr/common to the Flower project. Name the module `pyproject.py` (as well as wrting tests for it in the `pyproject_test.py`) and add a function to it which can validate the name property. Reference the respective PEP in the function description.
