### PR TITLE
Improve formatting for changelog generating script

### DIFF
--- a/src/py/flwr_tool/update_changelog.py
+++ b/src/py/flwr_tool/update_changelog.py
@@ -50,7 +50,7 @@ def _get_pull_requests_since_tag(gh_api, tag):
 
 def _format_pr_reference(title, number, url):
     """Format a pull request reference as a markdown list item."""
-    return f"- **{title}** ([#{number}]({url}))"
+    return f"- **{title.replace('*', '')}** ([#{number}]({url}))"
 
 
 def _extract_changelog_entry(pr_info):
@@ -193,11 +193,24 @@ def _insert_new_entry(content, pr_info, pr_reference, pr_entry_text, unreleased_
         content = content[:pr_ref_end] + updated_entry + content[existing_entry_start:]
     else:
         insert_index = content.find("\n", unreleased_index) + 1
+
+        # Split the pr_entry_text into paragraphs
+        paragraphs = pr_entry_text.split("\n")
+
+        # Indent each paragraph
+        indented_paragraphs = [
+            "    " + paragraph if paragraph else paragraph for paragraph in paragraphs
+        ]
+
+        # Join the paragraphs back together, ensuring each is separated by a newline
+        indented_pr_entry_text = "\n".join(indented_paragraphs)
+
         content = (
             content[:insert_index]
+            + "\n"
             + pr_reference
-            + "\n  "
-            + pr_entry_text
+            + "\n\n"
+            + indented_pr_entry_text
             + "\n"
             + content[insert_index:]
         )


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

The script to generate the changelog broke with certain characters in titles, and some of the formatting was wrong with some description formats.

### Related issues/PRs

N/A

## Proposal

### Explanation

Remove breaking characters and add indent consistently.

### Checklist

- [x] Implement proposed change
- [x] Update the changelog entry below
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

<!--
Inside the following 'Changelog entry' section, you should put the description of your changes that will be added to the changelog alongside your PR title.

If the section is completely empty (without any token) or non-existant, the changelog will just contain the title of the PR for the changelog entry, without any description. If the section contains some text other than tokens, it will use it to add a description to the change. If the section contains one of the following tokens it will ignore any other text and put the PR under the corresponding section of the changelog:

<general> is for classifying a PR as a general improvement.
<skip> is to not add the PR to the changelog
<baselines> is to add a general baselines change to the PR
<examples> is to add a general examples change to the PR
<sdk> is to add a general sdk change to the PR
<simulations> is to add a general simulations change to the PR

Note that only one token should be used.
-->

### Changelog entry

<skip>

### Any other comments?

N/A
