### PR TITLE
Remove legacy check that leads to unregistered clients

### DIFF
--- a/src/py/flwr/server/superlink/fleet/message_handler/message_handler.py
+++ b/src/py/flwr/server/superlink/fleet/message_handler/message_handler.py
@@ -47,7 +47,7 @@ def create_node(
 def delete_node(request: DeleteNodeRequest, state: State) -> DeleteNodeResponse:
     """."""
     # Validate node_id
-    if request.node.anonymous:
+    if request.node.anonymous or request.node.node_id == 0:
         return DeleteNodeResponse()
 
     # Update state

--- a/src/py/flwr/server/superlink/fleet/message_handler/message_handler.py
+++ b/src/py/flwr/server/superlink/fleet/message_handler/message_handler.py
@@ -47,7 +47,7 @@ def create_node(
 def delete_node(request: DeleteNodeRequest, state: State) -> DeleteNodeResponse:
     """."""
     # Validate node_id
-    if request.node.anonymous or request.node.node_id <= 0:
+    if request.node.anonymous:
         return DeleteNodeResponse()
 
     # Update state


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

Nodes can now be negative but a check in the `message_handler` ignored this.

### Related issues/PRs

N/A

## Proposal

### Explanation

Remove the obsolete check.

### Checklist

- [x] Implement proposed change
- [x] Update the changelog entry below
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

<!--
Inside the following 'Changelog entry' section, you should put the description of your changes that will be added to the changelog alongside your PR title.

If the section is completely empty (without any token) or non-existant, the changelog will just contain the title of the PR for the changelog entry, without any description. If the section contains some text other than tokens, it will use it to add a description to the change. If the section contains one of the following tokens it will ignore any other text and put the PR under the corresponding section of the changelog:

<general> is for classifying a PR as a general improvement.
<skip> is to not add the PR to the changelog
<baselines> is to add a general baselines change to the PR
<examples> is to add a general examples change to the PR
<sdk> is to add a general sdk change to the PR
<simulations> is to add a general simulations change to the PR

Note that only one token should be used.
-->

### Changelog entry

<skip>

### Any other comments?

N/A
