### PR TITLE
Fix federated dataset docs

### DIFF
--- a/datasets/flwr_datasets/federated_dataset.py
+++ b/datasets/flwr_datasets/federated_dataset.py
@@ -54,9 +54,7 @@ class FederatedDataset:
         (representing the number of IID partitions that this split should be partitioned
         into). One or multiple `Partitioner` objects can be specified in that manner,
         but at most, one per split.
-    partition_division : Optional[Union[List[float], Tuple[float, ...],
-    Dict[str, float], Dict[str, Optional[Union[List[float], Tuple[float, ...],
-    Dict[str, float]]]]]]
+    partition_division : Optional[Union[List[float], Tuple[float, ...], Dict[str, float], Dict[str, Optional[Union[List[float], Tuple[float, ...], Dict[str, float]]]]]]
         Fractions specifing the division of the partition assiciated with certain split
         (and partitioner) that enable returning already divided partition from the
         `load_partition` method. You can think of this as on-edge division of the data

--- a/datasets/flwr_datasets/federated_dataset.py
+++ b/datasets/flwr_datasets/federated_dataset.py
@@ -84,6 +84,7 @@ class FederatedDataset:
     >>> centralized = mnist_fds.load_split("test")
 
     Automatically divde the data returned from `load_partition`
+
     >>> mnist_fds = FederatedDataset(
     >>>     dataset="mnist",
     >>>     partitioners={"train": 100},

--- a/datasets/flwr_datasets/partitioner/shard_partitioner.py
+++ b/datasets/flwr_datasets/partitioner/shard_partitioner.py
@@ -90,6 +90,7 @@ class ShardPartitioner(Partitioner):  # pylint: disable=R0902
     --------
     1) If you need same number of shards per nodes + the same shard size (and you know
     both of these values)
+
     >>> from flwr_datasets import FederatedDataset
     >>> from flwr_datasets.partitioner import ShardPartitioner
     >>>
@@ -106,6 +107,7 @@ class ShardPartitioner(Partitioner):  # pylint: disable=R0902
 
     2) If you want to use nearly all the data and do not need to have the number of
     shard per each node to be the same
+
     >>> from flwr_datasets import FederatedDataset
     >>> from flwr_datasets.partitioner import ShardPartitioner
     >>>
@@ -117,7 +119,8 @@ class ShardPartitioner(Partitioner):  # pylint: disable=R0902
     [7000, 7000, 7000, 7000, 7000, 7000, 6000, 6000, 6000]
 
     3) If you want to use all the data
-        >>> from flwr_datasets import FederatedDataset
+
+    >>> from flwr_datasets import FederatedDataset
     >>> from flwr_datasets.partitioner import ShardPartitioner
     >>>
     >>> partitioner = ShardPartitioner(num_partitions=10, partition_by="label",

--- a/datasets/flwr_datasets/utils.py
+++ b/datasets/flwr_datasets/utils.py
@@ -113,6 +113,7 @@ def divide_dataset(
     Examples
     --------
     Use `divide_dataset` with division specified as a list.
+
     >>> from flwr_datasets import FederatedDataset
     >>> from flwr_datasets.utils import divide_dataset
     >>>
@@ -122,6 +123,7 @@ def divide_dataset(
     >>> train, test = divide_dataset(dataset=partition, division=division)
 
     Use `divide_dataset` with division specified as a dict.
+
     >>> from flwr_datasets import FederatedDataset
     >>> from flwr_datasets.utils import divide_dataset
     >>>


### PR DESCRIPTION
## Issue

No newline before the code examples causes this kind of problem in the docs
<img width="722" alt="image" src="https://github.com/adap/flower/assets/51029327/bd028136-4ee9-4897-83c6-9b8987bfb766">

## Proposal
Add new lines before missing python code examples

### Changelog entry
<skip>
