### PR TITLE
Add `pushed_at` into `Task`

### DIFF
--- a/src/proto/flwr/proto/task.proto
+++ b/src/proto/flwr/proto/task.proto
@@ -27,11 +27,12 @@ message Task {
   Node consumer = 2;
   string created_at = 3;
   string delivered_at = 4;
-  double ttl = 5;
-  repeated string ancestry = 6;
-  string task_type = 7;
-  RecordSet recordset = 8;
-  Error error = 9;
+  double pushed_at = 5;
+  double ttl = 6;
+  repeated string ancestry = 7;
+  string task_type = 8;
+  RecordSet recordset = 9;
+  Error error = 10;
 }
 
 message TaskIns {

--- a/src/py/flwr/proto/task_pb2.py
+++ b/src/py/flwr/proto/task_pb2.py
@@ -18,7 +18,7 @@ from flwr.proto import transport_pb2 as flwr_dot_proto_dot_transport__pb2
 from flwr.proto import error_pb2 as flwr_dot_proto_dot_error__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x15\x66lwr/proto/task.proto\x12\nflwr.proto\x1a\x15\x66lwr/proto/node.proto\x1a\x1a\x66lwr/proto/recordset.proto\x1a\x1a\x66lwr/proto/transport.proto\x1a\x16\x66lwr/proto/error.proto\"\xf6\x01\n\x04Task\x12\"\n\x08producer\x18\x01 \x01(\x0b\x32\x10.flwr.proto.Node\x12\"\n\x08\x63onsumer\x18\x02 \x01(\x0b\x32\x10.flwr.proto.Node\x12\x12\n\ncreated_at\x18\x03 \x01(\t\x12\x14\n\x0c\x64\x65livered_at\x18\x04 \x01(\t\x12\x0b\n\x03ttl\x18\x05 \x01(\x01\x12\x10\n\x08\x61ncestry\x18\x06 \x03(\t\x12\x11\n\ttask_type\x18\x07 \x01(\t\x12(\n\trecordset\x18\x08 \x01(\x0b\x32\x15.flwr.proto.RecordSet\x12 \n\x05\x65rror\x18\t \x01(\x0b\x32\x11.flwr.proto.Error\"\\\n\x07TaskIns\x12\x0f\n\x07task_id\x18\x01 \x01(\t\x12\x10\n\x08group_id\x18\x02 \x01(\t\x12\x0e\n\x06run_id\x18\x03 \x01(\x12\x12\x1e\n\x04task\x18\x04 \x01(\x0b\x32\x10.flwr.proto.Task\"\\\n\x07TaskRes\x12\x0f\n\x07task_id\x18\x01 \x01(\t\x12\x10\n\x08group_id\x18\x02 \x01(\t\x12\x0e\n\x06run_id\x18\x03 \x01(\x12\x12\x1e\n\x04task\x18\x04 \x01(\x0b\x32\x10.flwr.proto.Taskb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x15\x66lwr/proto/task.proto\x12\nflwr.proto\x1a\x15\x66lwr/proto/node.proto\x1a\x1a\x66lwr/proto/recordset.proto\x1a\x1a\x66lwr/proto/transport.proto\x1a\x16\x66lwr/proto/error.proto\"\x89\x02\n\x04Task\x12\"\n\x08producer\x18\x01 \x01(\x0b\x32\x10.flwr.proto.Node\x12\"\n\x08\x63onsumer\x18\x02 \x01(\x0b\x32\x10.flwr.proto.Node\x12\x12\n\ncreated_at\x18\x03 \x01(\t\x12\x14\n\x0c\x64\x65livered_at\x18\x04 \x01(\t\x12\x11\n\tpushed_at\x18\x05 \x01(\x01\x12\x0b\n\x03ttl\x18\x06 \x01(\x01\x12\x10\n\x08\x61ncestry\x18\x07 \x03(\t\x12\x11\n\ttask_type\x18\x08 \x01(\t\x12(\n\trecordset\x18\t \x01(\x0b\x32\x15.flwr.proto.RecordSet\x12 \n\x05\x65rror\x18\n \x01(\x0b\x32\x11.flwr.proto.Error\"\\\n\x07TaskIns\x12\x0f\n\x07task_id\x18\x01 \x01(\t\x12\x10\n\x08group_id\x18\x02 \x01(\t\x12\x0e\n\x06run_id\x18\x03 \x01(\x12\x12\x1e\n\x04task\x18\x04 \x01(\x0b\x32\x10.flwr.proto.Task\"\\\n\x07TaskRes\x12\x0f\n\x07task_id\x18\x01 \x01(\t\x12\x10\n\x08group_id\x18\x02 \x01(\t\x12\x0e\n\x06run_id\x18\x03 \x01(\x12\x12\x1e\n\x04task\x18\x04 \x01(\x0b\x32\x10.flwr.proto.Taskb\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -26,9 +26,9 @@ _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'flwr.proto.task_pb2', _glob
 if _descriptor._USE_C_DESCRIPTORS == False:
   DESCRIPTOR._options = None
   _globals['_TASK']._serialized_start=141
-  _globals['_TASK']._serialized_end=387
-  _globals['_TASKINS']._serialized_start=389
-  _globals['_TASKINS']._serialized_end=481
-  _globals['_TASKRES']._serialized_start=483
-  _globals['_TASKRES']._serialized_end=575
+  _globals['_TASK']._serialized_end=406
+  _globals['_TASKINS']._serialized_start=408
+  _globals['_TASKINS']._serialized_end=500
+  _globals['_TASKRES']._serialized_start=502
+  _globals['_TASKRES']._serialized_end=594
 # @@protoc_insertion_point(module_scope)

--- a/src/py/flwr/proto/task_pb2.pyi
+++ b/src/py/flwr/proto/task_pb2.pyi
@@ -20,6 +20,7 @@ class Task(google.protobuf.message.Message):
     CONSUMER_FIELD_NUMBER: builtins.int
     CREATED_AT_FIELD_NUMBER: builtins.int
     DELIVERED_AT_FIELD_NUMBER: builtins.int
+    PUSHED_AT_FIELD_NUMBER: builtins.int
     TTL_FIELD_NUMBER: builtins.int
     ANCESTRY_FIELD_NUMBER: builtins.int
     TASK_TYPE_FIELD_NUMBER: builtins.int
@@ -31,6 +32,7 @@ class Task(google.protobuf.message.Message):
     def consumer(self) -> flwr.proto.node_pb2.Node: ...
     created_at: typing.Text
     delivered_at: typing.Text
+    pushed_at: builtins.float
     ttl: builtins.float
     @property
     def ancestry(self) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[typing.Text]: ...
@@ -45,6 +47,7 @@ class Task(google.protobuf.message.Message):
         consumer: typing.Optional[flwr.proto.node_pb2.Node] = ...,
         created_at: typing.Text = ...,
         delivered_at: typing.Text = ...,
+        pushed_at: builtins.float = ...,
         ttl: builtins.float = ...,
         ancestry: typing.Optional[typing.Iterable[typing.Text]] = ...,
         task_type: typing.Text = ...,
@@ -52,7 +55,7 @@ class Task(google.protobuf.message.Message):
         error: typing.Optional[flwr.proto.error_pb2.Error] = ...,
         ) -> None: ...
     def HasField(self, field_name: typing_extensions.Literal["consumer",b"consumer","error",b"error","producer",b"producer","recordset",b"recordset"]) -> builtins.bool: ...
-    def ClearField(self, field_name: typing_extensions.Literal["ancestry",b"ancestry","consumer",b"consumer","created_at",b"created_at","delivered_at",b"delivered_at","error",b"error","producer",b"producer","recordset",b"recordset","task_type",b"task_type","ttl",b"ttl"]) -> None: ...
+    def ClearField(self, field_name: typing_extensions.Literal["ancestry",b"ancestry","consumer",b"consumer","created_at",b"created_at","delivered_at",b"delivered_at","error",b"error","producer",b"producer","pushed_at",b"pushed_at","recordset",b"recordset","task_type",b"task_type","ttl",b"ttl"]) -> None: ...
 global___Task = Task
 
 class TaskIns(google.protobuf.message.Message):

--- a/src/py/flwr/server/superlink/driver/driver_servicer.py
+++ b/src/py/flwr/server/superlink/driver/driver_servicer.py
@@ -15,6 +15,7 @@
 """Driver API servicer."""
 
 
+import time
 from logging import DEBUG, INFO
 from typing import List, Optional, Set
 from uuid import UUID
@@ -84,6 +85,8 @@ class DriverServicer(driver_pb2_grpc.DriverServicer):
         # Store each TaskIns
         task_ids: List[Optional[UUID]] = []
         for task_ins in request.task_ins_list:
+            # Set pushed_at (timestamp in seconds)
+            task_ins.task.pushed_at = time.time()
             task_id: Optional[UUID] = state.store_task_ins(task_ins=task_ins)
             task_ids.append(task_id)
 

--- a/src/py/flwr/server/superlink/driver/driver_servicer.py
+++ b/src/py/flwr/server/superlink/driver/driver_servicer.py
@@ -73,6 +73,11 @@ class DriverServicer(driver_pb2_grpc.DriverServicer):
         """Push a set of TaskIns."""
         log(DEBUG, "DriverServicer.PushTaskIns")
 
+        # Set pushed_at (timestamp in seconds)
+        pushed_at = time.time()
+        for task_ins in request.task_ins_list:
+            task_ins.task.pushed_at = pushed_at
+
         # Validate request
         _raise_if(len(request.task_ins_list) == 0, "`task_ins_list` must not be empty")
         for task_ins in request.task_ins_list:
@@ -85,8 +90,6 @@ class DriverServicer(driver_pb2_grpc.DriverServicer):
         # Store each TaskIns
         task_ids: List[Optional[UUID]] = []
         for task_ins in request.task_ins_list:
-            # Set pushed_at (timestamp in seconds)
-            task_ins.task.pushed_at = time.time()
             task_id: Optional[UUID] = state.store_task_ins(task_ins=task_ins)
             task_ids.append(task_id)
 

--- a/src/py/flwr/server/superlink/fleet/message_handler/message_handler.py
+++ b/src/py/flwr/server/superlink/fleet/message_handler/message_handler.py
@@ -15,6 +15,7 @@
 """Fleet API message handlers."""
 
 
+import time
 from typing import List, Optional
 from uuid import UUID
 
@@ -86,6 +87,9 @@ def push_task_res(request: PushTaskResRequest, state: State) -> PushTaskResRespo
     # pylint: disable=no-member
     task_res: TaskRes = request.task_res_list[0]
     # pylint: enable=no-member
+
+    # Set pushed_at (timestamp in seconds)
+    task_res.task.pushed_at = time.time()
 
     # Store TaskRes in State
     task_id: Optional[UUID] = state.store_task_res(task_res=task_res)

--- a/src/py/flwr/server/superlink/fleet/vce/vce_api_test.py
+++ b/src/py/flwr/server/superlink/fleet/vce/vce_api_test.py
@@ -17,6 +17,7 @@
 
 import asyncio
 import threading
+import time
 from itertools import cycle
 from json import JSONDecodeError
 from math import pi
@@ -113,6 +114,9 @@ def register_messages_into_state(
         )
         # Convert Message to TaskIns
         taskins = message_to_taskins(message)
+        # Normally recorded by the driver servicer
+        # but since we don't have one in this test, we do this manually
+        taskins.task.pushed_at = time.time()
         # Instert in state
         task_id = state.store_task_ins(taskins)
         if task_id:

--- a/src/py/flwr/server/superlink/state/in_memory_state.py
+++ b/src/py/flwr/server/superlink/state/in_memory_state.py
@@ -17,7 +17,6 @@
 
 import os
 import threading
-import time
 from datetime import datetime
 from logging import ERROR
 from typing import Dict, List, Optional, Set
@@ -54,13 +53,10 @@ class InMemoryState(State):
         # Create task_id and created_at
         task_id = uuid4()
         created_at: datetime = now()
-        # Timestamp in seconds with nanosecond resolution
-        pushed_at = time.time_ns() / 1e9
 
         # Store TaskIns
         task_ins.task_id = str(task_id)
         task_ins.task.created_at = created_at.isoformat()
-        task_ins.task.pushed_at = pushed_at
         with self.lock:
             self.task_ins_store[task_id] = task_ins
 
@@ -118,13 +114,10 @@ class InMemoryState(State):
         # Create task_id and created_at
         task_id = uuid4()
         created_at: datetime = now()
-        # Timestamp in seconds with nanosecond resolution
-        pushed_at = time.time_ns() / 1e9
 
         # Store TaskRes
         task_res.task_id = str(task_id)
         task_res.task.created_at = created_at.isoformat()
-        task_res.task.pushed_at = pushed_at
         with self.lock:
             self.task_res_store[task_id] = task_res
 

--- a/src/py/flwr/server/superlink/state/in_memory_state.py
+++ b/src/py/flwr/server/superlink/state/in_memory_state.py
@@ -17,6 +17,7 @@
 
 import os
 import threading
+import time
 from datetime import datetime
 from logging import ERROR
 from typing import Dict, List, Optional, Set
@@ -53,10 +54,13 @@ class InMemoryState(State):
         # Create task_id and created_at
         task_id = uuid4()
         created_at: datetime = now()
+        # Timestamp in seconds with nanosecond resolution
+        pushed_at = time.time_ns() / 1e9
 
         # Store TaskIns
         task_ins.task_id = str(task_id)
         task_ins.task.created_at = created_at.isoformat()
+        task_ins.task.pushed_at = pushed_at
         with self.lock:
             self.task_ins_store[task_id] = task_ins
 
@@ -114,10 +118,13 @@ class InMemoryState(State):
         # Create task_id and created_at
         task_id = uuid4()
         created_at: datetime = now()
+        # Timestamp in seconds with nanosecond resolution
+        pushed_at = time.time_ns() / 1e9
 
         # Store TaskRes
         task_res.task_id = str(task_id)
         task_res.task.created_at = created_at.isoformat()
+        task_res.task.pushed_at = pushed_at
         with self.lock:
             self.task_res_store[task_id] = task_res
 

--- a/src/py/flwr/server/superlink/state/sqlite_state.py
+++ b/src/py/flwr/server/superlink/state/sqlite_state.py
@@ -18,7 +18,6 @@
 import os
 import re
 import sqlite3
-import time
 from datetime import datetime
 from logging import DEBUG, ERROR
 from typing import Any, Dict, List, Optional, Set, Tuple, Union, cast
@@ -191,13 +190,10 @@ class SqliteState(State):
         # Create task_id and created_at
         task_id = uuid4()
         created_at: datetime = now()
-        # Timestamp in seconds with nanosecond resolution
-        pushed_at = time.time_ns() / 1e9
 
         # Store TaskIns
         task_ins.task_id = str(task_id)
         task_ins.task.created_at = created_at.isoformat()
-        task_ins.task.pushed_at = pushed_at
         data = (task_ins_to_dict(task_ins),)
         columns = ", ".join([f":{key}" for key in data[0]])
         query = f"INSERT INTO task_ins VALUES({columns});"
@@ -327,13 +323,10 @@ class SqliteState(State):
         # Create task_id
         task_id = uuid4()
         created_at: datetime = now()
-        # Timestamp in seconds with nanosecond resolution
-        pushed_at = time.time_ns() / 1e9
 
         # Store TaskIns
         task_res.task_id = str(task_id)
         task_res.task.created_at = created_at.isoformat()
-        task_res.task.pushed_at = pushed_at
         data = (task_res_to_dict(task_res),)
         columns = ", ".join([f":{key}" for key in data[0]])
         query = f"INSERT INTO task_res VALUES({columns});"

--- a/src/py/flwr/server/superlink/state/sqlite_state_test.py
+++ b/src/py/flwr/server/superlink/state/sqlite_state_test.py
@@ -38,6 +38,7 @@ class SqliteStateTest(unittest.TestCase):
             "consumer_node_id",
             "created_at",
             "delivered_at",
+            "pushed_at",
             "ttl",
             "ancestry",
             "task_type",

--- a/src/py/flwr/server/superlink/state/state_test.py
+++ b/src/py/flwr/server/superlink/state/state_test.py
@@ -16,6 +16,7 @@
 # pylint: disable=invalid-name, disable=R0904
 
 import tempfile
+import time
 import unittest
 from abc import abstractmethod
 from datetime import datetime, timezone
@@ -420,6 +421,7 @@ def create_task_ins(
             ttl=DEFAULT_TTL,
         ),
     )
+    task.task.pushed_at = time.time()
     return task
 
 
@@ -443,6 +445,7 @@ def create_task_res(
             ttl=DEFAULT_TTL,
         ),
     )
+    task_res.task.pushed_at = time.time()
     return task_res
 
 

--- a/src/py/flwr/server/utils/validator.py
+++ b/src/py/flwr/server/utils/validator.py
@@ -38,7 +38,7 @@ def validate_task_ins_or_res(tasks_ins_res: Union[TaskIns, TaskRes]) -> List[str
         validation_errors.append("`delivered_at` must be an empty str")
     if tasks_ins_res.task.ttl <= 0:
         validation_errors.append("`ttl` must be higher than zero")
-    if tasks_ins_res.task.pushed_at > 1711497600.0:
+    if tasks_ins_res.task.pushed_at < 1711497600.0:
         # unix timestamp of 27 March 2024 00h:00m:00s UTC
         validation_errors.append("`pushed_at` is not a recent timestamp")
 

--- a/src/py/flwr/server/utils/validator.py
+++ b/src/py/flwr/server/utils/validator.py
@@ -38,9 +38,9 @@ def validate_task_ins_or_res(tasks_ins_res: Union[TaskIns, TaskRes]) -> List[str
         validation_errors.append("`delivered_at` must be an empty str")
     if tasks_ins_res.task.ttl <= 0:
         validation_errors.append("`ttl` must be higher than zero")
-    if tasks_ins_res.task.pushed_at != 0.0:
-        # default value of an unset protobuf double is 0.0
-        validation_errors.append("`pushed_at` must be unset")
+    if tasks_ins_res.task.pushed_at > 1711497600.0:
+        # unix timestamp of 27 March 2024 00h:00m:00s UTC
+        validation_errors.append("`pushed_at` is not a recent timestamp")
 
     # TaskIns specific
     if isinstance(tasks_ins_res, TaskIns):

--- a/src/py/flwr/server/utils/validator.py
+++ b/src/py/flwr/server/utils/validator.py
@@ -31,13 +31,16 @@ def validate_task_ins_or_res(tasks_ins_res: Union[TaskIns, TaskRes]) -> List[str
     if not tasks_ins_res.HasField("task"):
         validation_errors.append("`task` does not set field `task`")
 
-    # Created/delivered/TTL
+    # Created/delivered/TTL/Pushed
     if tasks_ins_res.task.created_at != "":
         validation_errors.append("`created_at` must be an empty str")
     if tasks_ins_res.task.delivered_at != "":
         validation_errors.append("`delivered_at` must be an empty str")
     if tasks_ins_res.task.ttl <= 0:
         validation_errors.append("`ttl` must be higher than zero")
+    if tasks_ins_res.task.pushed_at != 0.0:
+        # default value of an unset protobuf double is 0.0
+        validation_errors.append("`pushed_at` must be unset")
 
     # TaskIns specific
     if isinstance(tasks_ins_res, TaskIns):

--- a/src/py/flwr/server/utils/validator_test.py
+++ b/src/py/flwr/server/utils/validator_test.py
@@ -15,6 +15,7 @@
 """Validator tests."""
 
 
+import time
 import unittest
 from typing import List, Tuple
 
@@ -100,6 +101,8 @@ def create_task_ins(
             ttl=DEFAULT_TTL,
         ),
     )
+
+    task.task.pushed_at = time.time()
     return task
 
 
@@ -122,4 +125,6 @@ def create_task_res(
             ttl=DEFAULT_TTL,
         ),
     )
+
+    task_res.task.pushed_at = time.time()
     return task_res


### PR DESCRIPTION
- Adds `pushed_at` into `Task` protobuf definition
- Its value is set at the `SuperLink` (same behaviour as `created_at` but now using timestamps as opposed to iso-dates)
- `created_at` remains, since a follow up PR (https://github.com/adap/flower/pull/3174) will replace it:
    - will be defined upon `Message creation`
    - All tests associated with existing `created_at` will need to be revisited then.