### PR TITLE
Bump up the release version to 0.1.0 in docs

### DIFF
--- a/datasets/doc/source/conf.py
+++ b/datasets/doc/source/conf.py
@@ -38,7 +38,7 @@ copyright = f"{datetime.date.today().year} Flower Labs GmbH"
 author = "The Flower Authors"
 
 # The full version, including alpha/beta/rc tags
-release = "0.0.2"
+release = "0.1.0"
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
## Issue
The docs website is showing the `0.0.2` version.

## Proposal
Update the version that is displayed on the website to `0.1.0`

### Changelog entry
<skip>
