### PR TITLE
Improve `RetryInvoker`

### DIFF
--- a/src/py/flwr/client/app.py
+++ b/src/py/flwr/client/app.py
@@ -397,7 +397,7 @@ def _start_client_internal(
     )
 
     retry_invoker = RetryInvoker(
-        wait_factory=exponential,
+        wait_time_gen_factory=exponential,
         recoverable_exceptions=connection_error_type,
         max_tries=max_retries,
         max_time=max_wait_time,

--- a/src/py/flwr/client/app.py
+++ b/src/py/flwr/client/app.py
@@ -397,7 +397,7 @@ def _start_client_internal(
     )
 
     retry_invoker = RetryInvoker(
-        wait_time_gen_factory=exponential,
+        wait_gen_factory=exponential,
         recoverable_exceptions=connection_error_type,
         max_tries=max_retries,
         max_time=max_wait_time,

--- a/src/py/flwr/client/grpc_client/connection_test.py
+++ b/src/py/flwr/client/grpc_client/connection_test.py
@@ -132,7 +132,7 @@ def test_integration_connection() -> None:
             server_address=f"[::]:{port}",
             insecure=True,
             retry_invoker=RetryInvoker(
-                wait_time_gen_factory=exponential,
+                wait_gen_factory=exponential,
                 recoverable_exceptions=grpc.RpcError,
                 max_tries=1,
                 max_time=None,

--- a/src/py/flwr/client/grpc_client/connection_test.py
+++ b/src/py/flwr/client/grpc_client/connection_test.py
@@ -132,7 +132,7 @@ def test_integration_connection() -> None:
             server_address=f"[::]:{port}",
             insecure=True,
             retry_invoker=RetryInvoker(
-                wait_factory=exponential,
+                wait_time_gen_factory=exponential,
                 recoverable_exceptions=grpc.RpcError,
                 max_tries=1,
                 max_time=None,

--- a/src/py/flwr/common/retry_invoker.py
+++ b/src/py/flwr/common/retry_invoker.py
@@ -187,6 +187,8 @@ class RetryInvoker:
         self.on_giveup = on_giveup
         self.jitter = jitter
         self.should_giveup = should_giveup
+        if wait_function is None:
+            wait_function = time.sleep
         self.wait_function = wait_function
 
     # pylint: disable-next=too-many-locals
@@ -241,12 +243,12 @@ class RetryInvoker:
 
         try_cnt = 0
         wait_generator = self.wait_gen_factory()
-        start = time.time()
+        start = time.monotonic()
         ref_state: List[Optional[RetryState]] = [None]
 
         while True:
             try_cnt += 1
-            elapsed_time = time.time() - start
+            elapsed_time = time.monotonic() - start
             state = RetryState(
                 target=target,
                 args=args,

--- a/src/py/flwr/common/retry_invoker.py
+++ b/src/py/flwr/common/retry_invoker.py
@@ -282,7 +282,7 @@ class RetryInvoker:
                 try_call_event_handler(self.on_backoff)
 
                 # Sleep
-                time.sleep(wait_time)
+                time.sleep(state.actual_wait)
             else:
                 # Trigger success event
                 try_call_event_handler(self.on_success)

--- a/src/py/flwr/common/retry_invoker.py
+++ b/src/py/flwr/common/retry_invoker.py
@@ -107,7 +107,7 @@ class RetryInvoker:
 
     Parameters
     ----------
-    wait_factory: Callable[[], Generator[float, None, None]]
+    wait_gen_factory: Callable[[], Generator[float, None, None]]
         A generator yielding successive wait times in seconds. If the generator
         is finite, the giveup event will be triggered when the generator raises
         `StopIteration`.
@@ -129,12 +129,12 @@ class RetryInvoker:
         data class object detailing the invocation.
     on_giveup: Optional[Callable[[RetryState], None]] (default: None)
         A callable to be executed in the event that `max_tries` or `max_time` is
-        exceeded, `should_giveup` returns True, or `wait_factory()` generator raises
+        exceeded, `should_giveup` returns True, or `wait_gen_factory()` generator raises
         `StopInteration`. The parameter is a data class object detailing the
         invocation.
     jitter: Optional[Callable[[float], float]] (default: full_jitter)
-        A function of the value yielded by `wait_factory()` returning the actual time
-        to wait. This function helps distribute wait times stochastically to avoid
+        A function of the value yielded by `wait_gen_factory()` returning the actual
+        time to wait. This function helps distribute wait times stochastically to avoid
         timing collisions across concurrent clients. Wait times are jittered by
         default using the `full_jitter` function. To disable jittering, pass
         `jitter=None`.
@@ -166,7 +166,7 @@ class RetryInvoker:
     # pylint: disable-next=too-many-arguments
     def __init__(
         self,
-        wait_time_gen_factory: Callable[[], Generator[float, None, None]],
+        wait_gen_factory: Callable[[], Generator[float, None, None]],
         recoverable_exceptions: Union[Type[Exception], Tuple[Type[Exception], ...]],
         max_tries: Optional[int],
         max_time: Optional[float],
@@ -178,7 +178,7 @@ class RetryInvoker:
         should_giveup: Optional[Callable[[Exception], bool]] = None,
         wait_function: Optional[Callable[[float], None]] = None,
     ) -> None:
-        self.wait_time_gen_factory = wait_time_gen_factory
+        self.wait_gen_factory = wait_gen_factory
         self.recoverable_exceptions = recoverable_exceptions
         self.max_tries = max_tries
         self.max_time = max_time
@@ -221,13 +221,13 @@ class RetryInvoker:
         Raises
         ------
         Exception
-            If the number of tries exceeds `max_tries`, if the total time
-            exceeds `max_time`, if `wait_factory()` generator raises `StopInteration`,
+            If the number of tries exceeds `max_tries`, if the total time exceeds
+            `max_time`, if `wait_gen_factory()` generator raises `StopInteration`,
             or if the `should_giveup` returns True for a raised exception.
 
         Notes
         -----
-        The time between retries is determined by the provided `wait_factory()`
+        The time between retries is determined by the provided `wait_gen_factory()`
         generator and can optionally be jittered using the `jitter` function.
         The recoverable exceptions that trigger a retry, as well as conditions to
         stop retries, are also determined by the class's initialization parameters.
@@ -240,7 +240,7 @@ class RetryInvoker:
                 handler(cast(RetryState, ref_state[0]))
 
         try_cnt = 0
-        wait_generator = self.wait_time_gen_factory()
+        wait_generator = self.wait_gen_factory()
         start = time.time()
         ref_state: List[Optional[RetryState]] = [None]
 

--- a/src/py/flwr/common/retry_invoker_test.py
+++ b/src/py/flwr/common/retry_invoker_test.py
@@ -35,8 +35,8 @@ def failing_function() -> None:
 
 @pytest.fixture(name="mock_time")
 def fixture_mock_time() -> Generator[MagicMock, None, None]:
-    """Mock time.time for controlled testing."""
-    with patch("time.time") as mock_time:
+    """Mock time.monotonic for controlled testing."""
+    with patch("time.monotonic") as mock_time:
         yield mock_time
 
 


### PR DESCRIPTION
- Allow overwriting `actual_wait_time` in event handlers.
- Support custom wait functions.
- Replace `time.time` with `time.monotonic` 