### PR TITLE
Add delay to `Simulation Engine` termination

### DIFF
--- a/src/py/flwr/server/superlink/fleet/vce/vce_api.py
+++ b/src/py/flwr/server/superlink/fleet/vce/vce_api.py
@@ -223,6 +223,7 @@ async def run(
 
 
 # pylint: disable=too-many-arguments,unused-argument,too-many-locals,too-many-branches
+# pylint: disable=too-many-statements
 def start_vce(
     backend_name: str,
     backend_config_json_stream: str,
@@ -341,6 +342,13 @@ def start_vce(
             )
         )
     except LoadClientAppError as loadapp_ex:
+        f_stop_delay = 10
+        log(
+            ERROR,
+            "LoadClientAppError exception encountered. Terminating simulation in %is",
+            f_stop_delay,
+        )
+        time.sleep(f_stop_delay)
         f_stop.set()  # set termination event
         raise loadapp_ex
     except Exception as ex:


### PR DESCRIPTION
If a Simulation terminates very soon after launching it there is not enough time for the `ServerApp` to initialise itself fully. This makes it complex to terminate it. This PR adds a small time delay (10 seconds) before raising an exception in the Simulation Engine that will shut down everything.

This is an effective solution to the issue when the path to the `ClientApp` module is not found (a check done before actually starting the simulation)