### PR TITLE
Bump up datasets version in Flower Datasets

### DIFF
--- a/datasets/pyproject.toml
+++ b/datasets/pyproject.toml
@@ -54,7 +54,7 @@ exclude = [
 [tool.poetry.dependencies]
 python = "^3.8"
 numpy = "^1.21.0"
-datasets = "^2.14.3"
+datasets = "^2.14.6"
 pillow = { version = ">=6.2.1", optional = true }
 soundfile = { version = ">=0.12.1", optional = true }
 librosa = { version = ">=0.10.0.post2", optional = true }


### PR DESCRIPTION
## Issue
When updating the Flower Dataset from an older version (with older datasets) version the datasets might be installed such that it shows the following error https://github.com/huggingface/datasets/issues/6352 `"NotImplementedError(f"Loading a dataset cached in a {type(self._fs).__name__} is not supported.")"`

### Description
This problem was solved in `2.14.6`. (The other packages that we have as dependencies for audio and images match the versions; no need for an update).


## Proposal
Update the version to prevent the installation of the version of the datasets library that has the bug.

### Changelog entry
<skip>
