### PR TITLE
Disable legacy client round logging

### DIFF
--- a/src/py/flwr/client/app.py
+++ b/src/py/flwr/client/app.py
@@ -456,12 +456,13 @@ def _start_client_internal(
                     continue
 
                 log(INFO, "")
-                log(
-                    INFO,
-                    "[RUN %s, ROUND %s]",
-                    message.metadata.run_id,
-                    message.metadata.group_id,
-                )
+                if len(message.metadata.group_id) > 0:
+                    log(
+                        INFO,
+                        "[RUN %s, ROUND %s]",
+                        message.metadata.run_id,
+                        message.metadata.group_id,
+                    )
                 log(
                     INFO,
                     "Received: %s message %s",


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

The legacy client would display an empty round number, which could be confused with an error:

![image](https://github.com/adap/flower/assets/9378265/c9987e2c-4c10-4425-85a9-6e565bfe695d)

### Related issues/PRs

N/A

## Proposal

### Explanation

Remove the logging line for legacy clients:

![image](https://github.com/adap/flower/assets/9378265/41c3e5e3-8987-4777-bdc2-009de67b0b1b)

### Checklist

- [x] Implement proposed change
- [x] Update the changelog entry below
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

<!--
Inside the following 'Changelog entry' section, you should put the description of your changes that will be added to the changelog alongside your PR title.

If the section is completely empty (without any token) or non-existant, the changelog will just contain the title of the PR for the changelog entry, without any description. If the section contains some text other than tokens, it will use it to add a description to the change. If the section contains one of the following tokens it will ignore any other text and put the PR under the corresponding section of the changelog:

<general> is for classifying a PR as a general improvement.
<skip> is to not add the PR to the changelog
<baselines> is to add a general baselines change to the PR
<examples> is to add a general examples change to the PR
<sdk> is to add a general sdk change to the PR
<simulations> is to add a general simulations change to the PR

Note that only one token should be used.
-->

### Changelog entry

<skip>

### Any other comments?

N/A