### PR TITLE
Add project name validation to `flwr new`

### DIFF
--- a/src/py/flwr/cli/new/new.py
+++ b/src/py/flwr/cli/new/new.py
@@ -22,7 +22,12 @@ from typing import Dict, Optional
 import typer
 from typing_extensions import Annotated
 
-from ..utils import prompt_options, prompt_text
+from ..utils import (
+    is_valid_project_name,
+    prompt_options,
+    prompt_text,
+    sanitize_project_name,
+)
 
 
 class MlFramework(str, Enum):
@@ -81,6 +86,16 @@ def new(
     ] = None,
 ) -> None:
     """Create new Flower project."""
+    if project_name is None:
+        project_name = prompt_text("Please provide project name")
+    if not is_valid_project_name(project_name):
+        project_name = prompt_text(
+            "Please provide a name that only contains "
+            "characters in {'_', 'a-zA-Z', '0-9'}",
+            predicate=is_valid_project_name,
+            default=sanitize_project_name(project_name),
+        )
+
     print(
         typer.style(
             f"🔨 Creating Flower project {project_name}...",
@@ -88,9 +103,6 @@ def new(
             bold=True,
         )
     )
-
-    if project_name is None:
-        project_name = prompt_text("Please provide project name")
 
     if framework is not None:
         framework_str = str(framework.value)

--- a/src/py/flwr/cli/utils.py
+++ b/src/py/flwr/cli/utils.py
@@ -73,11 +73,10 @@ def prompt_options(text: str, options: List[str]) -> str:
 
 
 def is_valid_project_name(name: str) -> bool:
-    """
-    Check if the given string is a valid Python module name.
+    """Check if the given string is a valid Python module name.
 
-    A valid module name must start with a letter or an underscore,
-    and can only contain letters, digits, and underscores.
+    A valid module name must start with a letter or an underscore, and can only contain
+    letters, digits, and underscores.
     """
 
     if not name:
@@ -96,11 +95,11 @@ def is_valid_project_name(name: str) -> bool:
 
 
 def sanitize_project_name(name: str) -> str:
-    """
-    Sanitize the given string to make it a valid Python module name.
-    This version replaces hyphens with underscores, removes any characters
-    not allowed in Python module names, makes the string lowercase, and
-    ensures it starts with a valid character.
+    """Sanitize the given string to make it a valid Python module name.
+
+    This version replaces hyphens with underscores, removes any characters not allowed
+    in Python module names, makes the string lowercase, and ensures it starts with a
+    valid character.
     """
     # Replace '-' with '_'
     name_with_underscores = name.replace("-", "_").replace(" ", "_")

--- a/src/py/flwr/cli/utils.py
+++ b/src/py/flwr/cli/utils.py
@@ -103,7 +103,7 @@ def sanitize_project_name(name: str) -> str:
     ensures it starts with a valid character.
     """
     # Replace '-' with '_'
-    name_with_underscores = name.replace("-", "_")
+    name_with_underscores = name.replace("-", "_").replace(" ", "_")
 
     # Allowed characters in a module name: letters, digits, underscore
     allowed_chars = set(

--- a/src/py/flwr/cli/utils.py
+++ b/src/py/flwr/cli/utils.py
@@ -14,18 +14,23 @@
 # ==============================================================================
 """Flower command line interface utils."""
 
-from typing import List, cast
+from typing import Callable, List, Optional, cast
 
 import typer
 
 
-def prompt_text(text: str) -> str:
+def prompt_text(
+    text: str,
+    predicate: Callable[[str], bool] = lambda _: True,
+    default: Optional[str] = None,
+) -> str:
     """Ask user to enter text input."""
     while True:
         result = typer.prompt(
-            typer.style(f"\n💬 {text}", fg=typer.colors.MAGENTA, bold=True)
+            typer.style(f"\n💬 {text}", fg=typer.colors.MAGENTA, bold=True),
+            default=default,
         )
-        if len(result) > 0:
+        if predicate(result) and len(result) > 0:
             break
         print(typer.style("❌ Invalid entry", fg=typer.colors.RED, bold=True))
 
@@ -65,3 +70,56 @@ def prompt_options(text: str, options: List[str]) -> str:
 
     result = options[int(index)]
     return result
+
+
+def is_valid_project_name(name: str) -> bool:
+    """
+    Check if the given string is a valid Python module name.
+
+    A valid module name must start with a letter or an underscore,
+    and can only contain letters, digits, and underscores.
+    """
+
+    if not name:
+        return False
+
+    # Check if the first character is a letter or underscore
+    if not (name[0].isalpha() or name[0] == "_"):
+        return False
+
+    # Check if the rest of the characters are valid (letter, digit, or underscore)
+    for char in name[1:]:
+        if not (char.isalnum() or char == "_"):
+            return False
+
+    return True
+
+
+def sanitize_project_name(name: str) -> str:
+    """
+    Sanitize the given string to make it a valid Python module name.
+    This version replaces hyphens with underscores, removes any characters
+    not allowed in Python module names, makes the string lowercase, and
+    ensures it starts with a valid character.
+    """
+    # Replace '-' with '_'
+    name_with_underscores = name.replace("-", "_")
+
+    # Allowed characters in a module name: letters, digits, underscore
+    allowed_chars = set(
+        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_"
+    )
+
+    # Make the string lowercase
+    sanitized_name = name_with_underscores.lower()
+
+    # Remove any characters not allowed in Python module names
+    sanitized_name = "".join(c for c in sanitized_name if c in allowed_chars)
+
+    # Ensure the first character is a letter or underscore
+    if sanitized_name and (
+        sanitized_name[0].isdigit() or sanitized_name[0] not in allowed_chars
+    ):
+        sanitized_name = "_" + sanitized_name
+
+    return sanitized_name

--- a/src/py/flwr/cli/utils.py
+++ b/src/py/flwr/cli/utils.py
@@ -78,7 +78,6 @@ def is_valid_project_name(name: str) -> bool:
     A valid module name must start with a letter or an underscore, and can only contain
     letters, digits, and underscores.
     """
-
     if not name:
         return False
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

Currently, we can successfully create an invalid project with `flwr new` if we use a name that isn't a valid Python module string.

### Related issues/PRs

N/A

## Proposal

### Explanation

Check if `project_name` contains characters other than `a-zA-Z0-9_`, if so, prompt the user for a new name (with the initial `project_name` sanitized as default).

### Checklist

- [x] Implement proposed change
- [x] Update the changelog entry below
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

<!--
Inside the following 'Changelog entry' section, you should put the description of your changes that will be added to the changelog alongside your PR title.

If the section is completely empty (without any token) or non-existant, the changelog will just contain the title of the PR for the changelog entry, without any description. If the section contains some text other than tokens, it will use it to add a description to the change. If the section contains one of the following tokens it will ignore any other text and put the PR under the corresponding section of the changelog:

<general> is for classifying a PR as a general improvement.
<skip> is to not add the PR to the changelog
<baselines> is to add a general baselines change to the PR
<examples> is to add a general examples change to the PR
<sdk> is to add a general sdk change to the PR
<simulations> is to add a general simulations change to the PR

Note that only one token should be used.
-->

### Changelog entry

<skip>

### Any other comments?

N/A
