### PR TITLE
Add license to pyproject.toml files when using `flwr new`

### DIFF
--- a/src/py/flwr/cli/new/templates/app/pyproject.numpy.toml.tpl
+++ b/src/py/flwr/cli/new/templates/app/pyproject.numpy.toml.tpl
@@ -9,6 +9,7 @@ description = ""
 authors = [
     { name = "The Flower Authors", email = "hello@flower.ai" },
 ]
+license = {text = "Apache License (2.0)"}
 dependencies = [
     "flwr[simulation]>=1.8.0,<2.0",
     "numpy>=1.21.0",

--- a/src/py/flwr/cli/new/templates/app/pyproject.pytorch.toml.tpl
+++ b/src/py/flwr/cli/new/templates/app/pyproject.pytorch.toml.tpl
@@ -9,6 +9,7 @@ description = ""
 authors = [
     { name = "The Flower Authors", email = "hello@flower.ai" },
 ]
+license = {text = "Apache License (2.0)"}
 dependencies = [
     "flwr[simulation]>=1.8.0,<2.0",
     "flwr-datasets[vision]>=0.0.2,<1.0.0",

--- a/src/py/flwr/cli/new/templates/app/pyproject.tensorflow.toml.tpl
+++ b/src/py/flwr/cli/new/templates/app/pyproject.tensorflow.toml.tpl
@@ -9,6 +9,7 @@ description = ""
 authors = [
     { name = "The Flower Authors", email = "hello@flower.ai" },
 ]
+license = {text = "Apache License (2.0)"}
 dependencies = [
     "flwr[simulation]>=1.8.0,<2.0",
     "flwr-datasets[vision]>=0.0.2,<1.0.0",


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

Having the license for the projects by default makes it easier for users that don't know much about licensing.

### Related issues/PRs

N/A

## Proposal

### Explanation

Add license in `pyproject.toml`

### Checklist

- [x] Implement proposed change
- [x] Update the changelog entry below
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

<!--
Inside the following 'Changelog entry' section, you should put the description of your changes that will be added to the changelog alongside your PR title.

If the section is completely empty (without any token) or non-existant, the changelog will just contain the title of the PR for the changelog entry, without any description. If the section contains some text other than tokens, it will use it to add a description to the change. If the section contains one of the following tokens it will ignore any other text and put the PR under the corresponding section of the changelog:

<general> is for classifying a PR as a general improvement.
<skip> is to not add the PR to the changelog
<baselines> is to add a general baselines change to the PR
<examples> is to add a general examples change to the PR
<sdk> is to add a general sdk change to the PR
<simulations> is to add a general simulations change to the PR

Note that only one token should be used.
-->

### Changelog entry

<skip>

### Any other comments?

N/A
