### PR TITLE
Remove `poetry` mention in README files when using `flwr new`

### DIFF
--- a/src/py/flwr/cli/new/templates/app/README.md.tpl
+++ b/src/py/flwr/cli/new/templates/app/README.md.tpl
@@ -3,11 +3,7 @@
 ## Install dependencies
 
 ```bash
-# Using pip
 pip install .
-
-# Or using Poetry
-poetry install
 ```
 
 ## Run (Simulation Engine)


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

We removed `poetry` from the `pyproject.toml` files but still have a mention of it in the README.

### Related issues/PRs

N/A

## Proposal

### Explanation

Remove mention of `poetry` in the `README` template.

### Checklist

- [x] Implement proposed change
- [x] Update the changelog entry below
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

<!--
Inside the following 'Changelog entry' section, you should put the description of your changes that will be added to the changelog alongside your PR title.

If the section is completely empty (without any token) or non-existant, the changelog will just contain the title of the PR for the changelog entry, without any description. If the section contains some text other than tokens, it will use it to add a description to the change. If the section contains one of the following tokens it will ignore any other text and put the PR under the corresponding section of the changelog:

<general> is for classifying a PR as a general improvement.
<skip> is to not add the PR to the changelog
<baselines> is to add a general baselines change to the PR
<examples> is to add a general examples change to the PR
<sdk> is to add a general sdk change to the PR
<simulations> is to add a general simulations change to the PR

Note that only one token should be used.
-->

### Changelog entry

<skip>

### Any other comments?

N/A
