### PR TITLE
Only build versioned docs when publishing

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,7 +36,7 @@ jobs:
           cd datasets
           python -m poetry install
       - name: Build docs
-        run: ./dev/build-docs.sh
+        run: ./dev/build-docs.sh ${{ github.ref == 'refs/heads/main' && github.repository == 'adap/flower' && !github.event.pull_request.head.repo.fork }}
       - name: Deploy docs
         if: ${{ github.ref == 'refs/heads/main' && github.repository == 'adap/flower' && !github.event.pull_request.head.repo.fork }}
         env:

--- a/dev/build-docs.sh
+++ b/dev/build-docs.sh
@@ -17,4 +17,9 @@ cd $ROOT
 
 cd $ROOT
 cd doc
-./build-versioned-docs.sh
+
+if [ $1 ]; then
+    ./build-versioned-docs.sh
+else
+    make html
+fi


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

Currently, on every PR, we build full versioned docs to test the validity of the docs, this is not useful as previous versions of the docs won't be modified by `main`.

### Related issues/PRs

N/A

## Proposal

### Explanation

Modify the `dev/build-docs.sh` script to take a `versioned` boolean argument and modify the docs workflow to only build versioned docs when publishing.

### Checklist

- [x] Implement proposed change
- [x] Update the changelog entry below
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

<!--
Inside the following 'Changelog entry' section, you should put the description of your changes that will be added to the changelog alongside your PR title.

If the section is completely empty (without any token) or non-existant, the changelog will just contain the title of the PR for the changelog entry, without any description. If the section contains some text other than tokens, it will use it to add a description to the change. If the section contains one of the following tokens it will ignore any other text and put the PR under the corresponding section of the changelog:

<general> is for classifying a PR as a general improvement.
<skip> is to not add the PR to the changelog
<baselines> is to add a general baselines change to the PR
<examples> is to add a general examples change to the PR
<sdk> is to add a general sdk change to the PR
<simulations> is to add a general simulations change to the PR

Note that only one token should be used.
-->

### Changelog entry

<skip>

### Any other comments?

N/A
