### PR TITLE
Add function to validate Flower App project directory

### DIFF
--- a/src/py/flwr/cli/config_utils.py
+++ b/src/py/flwr/cli/config_utils.py
@@ -15,11 +15,44 @@
 """Utility to validate the `pyproject.toml` file."""
 
 import os
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 import tomli
+import typer
 
 from flwr.common import object_ref
+
+
+def validate_project_dir(project_dir: Path) -> Optional[Dict[str, Any]]:
+    """Check if a Flower App directory is valid."""
+    config = load(str(project_dir / "pyproject.toml"))
+    if config is None:
+        typer.secho(
+            "❌ Project configuration could not be loaded. "
+            "`pyproject.toml` does not exist.",
+            fg=typer.colors.RED,
+            bold=True,
+        )
+        return None
+
+    if not validate(config):
+        typer.secho(
+            "❌ Project configuration is invalid.",
+            fg=typer.colors.RED,
+            bold=True,
+        )
+        return None
+
+    if "provider" not in config["flower"]:
+        typer.secho(
+            "❌ Project configuration is missing required `provider` field.",
+            fg=typer.colors.RED,
+            bold=True,
+        )
+        return None
+
+    return config
 
 
 def load_and_validate_with_defaults(


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

We have no function to check if a given directory is a valid Flower App project. This function will be needed in follow up PRs.

### Related issues/PRs

N/A

## Proposal

### Explanation

Add a new function to check if a directory is a valid Flower App project.

### Checklist

- [x] Implement proposed change
- [x] Update the changelog entry below
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

<!--
Inside the following 'Changelog entry' section, you should put the description of your changes that will be added to the changelog alongside your PR title.

If the section is completely empty (without any token) or non-existant, the changelog will just contain the title of the PR for the changelog entry, without any description. If the section contains some text other than tokens, it will use it to add a description to the change. If the section contains one of the following tokens it will ignore any other text and put the PR under the corresponding section of the changelog:

<general> is for classifying a PR as a general improvement.
<skip> is to not add the PR to the changelog
<baselines> is to add a general baselines change to the PR
<examples> is to add a general examples change to the PR
<sdk> is to add a general sdk change to the PR
<simulations> is to add a general simulations change to the PR

Note that only one token should be used.
-->

### Changelog entry

<skip>

### Any other comments?

N/A
