### PR TITLE
fix(framework:cli): Allow hypens in flwr new CLI

### DIFF
--- a/src/py/flwr/cli/new/new.py
+++ b/src/py/flwr/cli/new/new.py
@@ -127,18 +127,18 @@ def new(
     cwd = os.getcwd()
     package_name = re.sub(r"[-_.]+", "-", project_name).lower()
     import_name = package_name.replace("-", "_")
-    project_dir = os.path.join(cwd, project_name)
+    project_dir = os.path.join(cwd, package_name)
 
     # List of files to render
     files = {
         ".gitignore": {"template": "app/.gitignore.tpl"},
         "README.md": {"template": "app/README.md.tpl"},
         "pyproject.toml": {"template": f"app/pyproject.{framework_str}.toml.tpl"},
-        f"{package_name}/__init__.py": {"template": "app/code/__init__.py.tpl"},
-        f"{package_name}/server.py": {
+        f"{import_name}/__init__.py": {"template": "app/code/__init__.py.tpl"},
+        f"{import_name}/server.py": {
             "template": f"app/code/server.{framework_str}.py.tpl"
         },
-        f"{package_name}/client.py": {
+        f"{import_name}/client.py": {
             "template": f"app/code/client.{framework_str}.py.tpl"
         },
     }
@@ -148,7 +148,7 @@ def new(
         MlFramework.PYTORCH.value.lower(),
     ]
     if framework_str in frameworks_with_tasks:
-        files[f"{package_name}/task.py"] = {
+        files[f"{import_name}/task.py"] = {
             "template": f"app/code/task.{framework_str}.py.tpl"
         }
 

--- a/src/py/flwr/cli/new/new.py
+++ b/src/py/flwr/cli/new/new.py
@@ -94,7 +94,7 @@ def new(
     if not is_valid_project_name(project_name):
         project_name = prompt_text(
             "Please provide a name that only contains "
-            "characters in {'_', '-', '.', a-zA-Z', '0-9'}",
+            "characters in {'_', '-', a-zA-Z', '0-9'}",
             predicate=is_valid_project_name,
             default=sanitize_project_name(project_name),
         )

--- a/src/py/flwr/cli/new/new.py
+++ b/src/py/flwr/cli/new/new.py
@@ -126,7 +126,7 @@ def new(
     # Set project directory path
     cwd = os.getcwd()
     module_name = re.sub(r"[-_.]+", "-", project_name).lower()
-    project_dir = os.path.join(cwd, module_name)
+    project_dir = os.path.join(cwd, project_name)
 
     # List of files to render
     files = {
@@ -151,7 +151,11 @@ def new(
             "template": f"app/code/task.{framework_str}.py.tpl"
         }
 
-    context = {"project_name": project_name, "module_name": module_name}
+    context = {
+        "project_name": project_name,
+        "module_name": module_name,
+        "import_name": module_name.replace("-", "_"),
+    }
 
     for file_path, value in files.items():
         render_and_create(

--- a/src/py/flwr/cli/new/new.py
+++ b/src/py/flwr/cli/new/new.py
@@ -125,7 +125,9 @@ def new(
 
     # Set project directory path
     cwd = os.getcwd()
-    module_name = re.sub(r"[-_.]+", "-", project_name).lower()
+    package_name = project_name
+    distribution_name = re.sub(r"[-_.]+", "-", package_name).lower()
+    import_name = package_name.replace("-", "_")
     project_dir = os.path.join(cwd, project_name)
 
     # List of files to render
@@ -133,11 +135,11 @@ def new(
         ".gitignore": {"template": "app/.gitignore.tpl"},
         "README.md": {"template": "app/README.md.tpl"},
         "pyproject.toml": {"template": f"app/pyproject.{framework_str}.toml.tpl"},
-        f"{module_name}/__init__.py": {"template": "app/code/__init__.py.tpl"},
-        f"{module_name}/server.py": {
+        f"{distribution_name}/__init__.py": {"template": "app/code/__init__.py.tpl"},
+        f"{distribution_name}/server.py": {
             "template": f"app/code/server.{framework_str}.py.tpl"
         },
-        f"{module_name}/client.py": {
+        f"{distribution_name}/client.py": {
             "template": f"app/code/client.{framework_str}.py.tpl"
         },
     }
@@ -147,14 +149,14 @@ def new(
         MlFramework.PYTORCH.value.lower(),
     ]
     if framework_str in frameworks_with_tasks:
-        files[f"{module_name}/task.py"] = {
+        files[f"{distribution_name}/task.py"] = {
             "template": f"app/code/task.{framework_str}.py.tpl"
         }
 
     context = {
         "project_name": project_name,
-        "module_name": module_name,
-        "import_name": module_name.replace("-", "_"),
+        "distribution_name": distribution_name,
+        "import_name": import_name.replace("-", "_"),
     }
 
     for file_path, value in files.items():

--- a/src/py/flwr/cli/new/new.py
+++ b/src/py/flwr/cli/new/new.py
@@ -124,7 +124,7 @@ def new(
 
     # Set project directory path
     cwd = os.getcwd()
-    pnl = project_name.lower().replace("-", "_")
+    pnl = project_name.lower()
     project_dir = os.path.join(cwd, pnl)
 
     # List of files to render
@@ -144,7 +144,7 @@ def new(
     if framework_str in frameworks_with_tasks:
         files[f"{pnl}/task.py"] = {"template": f"app/code/task.{framework_str}.py.tpl"}
 
-    context = {"project_name": project_name}
+    context = {"project_name": project_name, "module_name": pnl.replace("-", "_")}
 
     for file_path, value in files.items():
         render_and_create(

--- a/src/py/flwr/cli/new/new.py
+++ b/src/py/flwr/cli/new/new.py
@@ -94,7 +94,7 @@ def new(
     if not is_valid_project_name(project_name):
         project_name = prompt_text(
             "Please provide a name that only contains "
-            "characters in {'_', '-', a-zA-Z', '0-9'}",
+            "characters in {'-', a-zA-Z', '0-9'}",
             predicate=is_valid_project_name,
             default=sanitize_project_name(project_name),
         )
@@ -125,8 +125,7 @@ def new(
 
     # Set project directory path
     cwd = os.getcwd()
-    package_name = project_name
-    distribution_name = re.sub(r"[-_.]+", "-", package_name).lower()
+    package_name = re.sub(r"[-_.]+", "-", project_name).lower()
     import_name = package_name.replace("-", "_")
     project_dir = os.path.join(cwd, project_name)
 
@@ -135,11 +134,11 @@ def new(
         ".gitignore": {"template": "app/.gitignore.tpl"},
         "README.md": {"template": "app/README.md.tpl"},
         "pyproject.toml": {"template": f"app/pyproject.{framework_str}.toml.tpl"},
-        f"{distribution_name}/__init__.py": {"template": "app/code/__init__.py.tpl"},
-        f"{distribution_name}/server.py": {
+        f"{package_name}/__init__.py": {"template": "app/code/__init__.py.tpl"},
+        f"{package_name}/server.py": {
             "template": f"app/code/server.{framework_str}.py.tpl"
         },
-        f"{distribution_name}/client.py": {
+        f"{package_name}/client.py": {
             "template": f"app/code/client.{framework_str}.py.tpl"
         },
     }
@@ -149,13 +148,13 @@ def new(
         MlFramework.PYTORCH.value.lower(),
     ]
     if framework_str in frameworks_with_tasks:
-        files[f"{distribution_name}/task.py"] = {
+        files[f"{package_name}/task.py"] = {
             "template": f"app/code/task.{framework_str}.py.tpl"
         }
 
     context = {
         "project_name": project_name,
-        "distribution_name": distribution_name,
+        "package_name": package_name,
         "import_name": import_name.replace("-", "_"),
     }
 

--- a/src/py/flwr/cli/new/new.py
+++ b/src/py/flwr/cli/new/new.py
@@ -93,7 +93,7 @@ def new(
     if not is_valid_project_name(project_name):
         project_name = prompt_text(
             "Please provide a name that only contains "
-            "characters in {'_', 'a-zA-Z', '0-9'}",
+            "characters in {'_', '-', 'a-zA-Z', '0-9'}",
             predicate=is_valid_project_name,
             default=sanitize_project_name(project_name),
         )
@@ -124,7 +124,7 @@ def new(
 
     # Set project directory path
     cwd = os.getcwd()
-    pnl = project_name.lower()
+    pnl = project_name.lower().replace("-", "_")
     project_dir = os.path.join(cwd, pnl)
 
     # List of files to render

--- a/src/py/flwr/cli/new/new_test.py
+++ b/src/py/flwr/cli/new/new_test.py
@@ -15,6 +15,7 @@
 """Test for Flower command line interface `new` command."""
 
 import os
+
 import pytest
 
 from .new import MlFramework, create_file, load_template, new, render_template

--- a/src/py/flwr/cli/new/new_test.py
+++ b/src/py/flwr/cli/new/new_test.py
@@ -15,6 +15,7 @@
 """Test for Flower command line interface `new` command."""
 
 import os
+from unittest.mock import patch
 
 from .new import MlFramework, create_file, load_template, new, render_template
 
@@ -64,12 +65,12 @@ def test_create_file(tmp_path: str) -> None:
     assert text == "Foobar"
 
 
-def test_new(tmp_path: str) -> None:
+def test_new_correct_name(tmp_path: str) -> None:
     """Test if project is created for framework."""
     # Prepare
     expected_names = [
         ("FedGPT", "FedGPT", "fedgpt"),
-        ("My_Flower-App", "my-flower-app", "my_flower_app"),
+        ("My-Flower-App", "my-flower-app", "my_flower_app"),
     ]
 
     for project_name, expected_top_level_dir, expected_module_dir in expected_names:
@@ -96,6 +97,62 @@ def test_new(tmp_path: str) -> None:
 
             # Execute
             new(project_name=project_name, framework=framework)
+
+            # Assert
+            file_list = os.listdir(os.path.join(tmp_path, expected_top_level_dir))
+            assert set(file_list) == expected_files_top_level
+
+            file_list = os.listdir(
+                os.path.join(tmp_path, expected_top_level_dir, expected_module_dir)
+            )
+            assert set(file_list) == expected_files_module
+        finally:
+            os.chdir(origin)
+
+
+def test_new_incorrect_name(tmp_path: str) -> None:
+    """Test if project is created for framework."""
+    # Prepare
+    expected_names = [
+        ("My_Flower_App", "my-flower-app", "my_flower_app"),
+        ("My.Flower App", "my-flower-app", "my_flower_app"),
+    ]
+
+    for project_name, expected_top_level_dir, expected_module_dir in expected_names:
+        framework = MlFramework.PYTORCH
+        expected_files_top_level = {
+            expected_module_dir,
+            "README.md",
+            "pyproject.toml",
+            ".gitignore",
+        }
+        expected_files_module = {
+            "__init__.py",
+            "server.py",
+            "client.py",
+            "task.py",
+        }
+
+        # Current directory
+        origin = os.getcwd()
+
+        try:
+            # Change into the temprorary directory
+            os.chdir(tmp_path)
+
+            with patch(
+                "builtins.input", return_value=expected_top_level_dir
+            ) as mock_input:
+
+                # Execute
+                new(project_name=project_name, framework=framework)
+
+                # Assert that input() was called with the correct prompt
+                mock_input.assert_called_once_with(
+                    "💬 Please provide a name that only "
+                    "contains characters in {'-', a-zA-Z', '0-9'} "
+                    f"[{expected_top_level_dir}]: "
+                )
 
             # Assert
             file_list = os.listdir(os.path.join(tmp_path, expected_top_level_dir))

--- a/src/py/flwr/cli/new/new_test.py
+++ b/src/py/flwr/cli/new/new_test.py
@@ -35,7 +35,11 @@ def test_render_template() -> None:
     """Test if a string is correctly substituted."""
     # Prepare
     filename = "app/README.md.tpl"
-    data = {"project_name": "FedGPT", "module_name": "fedgpt", "import_name": "fedgpt"}
+    data = {
+        "project_name": "FedGPT",
+        "distribution_name": "fedgpt",
+        "import_name": "fedgpt",
+    }
 
     # Execute
     result = render_template(filename, data)
@@ -63,38 +67,43 @@ def test_create_file(tmp_path: str) -> None:
 def test_new(tmp_path: str) -> None:
     """Test if project is created for framework."""
     # Prepare
-    project_name = "FedGPT"
-    framework = MlFramework.PYTORCH
-    expected_files_top_level = {
-        "fedgpt",
-        "README.md",
-        "pyproject.toml",
-        ".gitignore",
-    }
-    expected_files_module = {
-        "__init__.py",
-        "server.py",
-        "client.py",
-        "task.py",
-    }
+    expected_names = [
+        ("FedGPT", "FedGPT", "fedgpt"),
+        ("My_Flower-App", "My_Flower-App", "my-flower-app"),
+    ]
 
-    # Current directory
-    origin = os.getcwd()
+    for project_name, expected_top_level_dir, expected_module_dir in expected_names:
+        framework = MlFramework.PYTORCH
+        expected_files_top_level = {
+            expected_module_dir,
+            "README.md",
+            "pyproject.toml",
+            ".gitignore",
+        }
+        expected_files_module = {
+            "__init__.py",
+            "server.py",
+            "client.py",
+            "task.py",
+        }
 
-    try:
-        # Change into the temprorary directory
-        os.chdir(tmp_path)
+        # Current directory
+        origin = os.getcwd()
 
-        # Execute
-        new(project_name=project_name, framework=framework)
+        try:
+            # Change into the temprorary directory
+            os.chdir(tmp_path)
 
-        # Assert
-        file_list = os.listdir(os.path.join(tmp_path, project_name))
-        assert set(file_list) == expected_files_top_level
+            # Execute
+            new(project_name=project_name, framework=framework)
 
-        file_list = os.listdir(
-            os.path.join(tmp_path, project_name, project_name.lower())
-        )
-        assert set(file_list) == expected_files_module
-    finally:
-        os.chdir(origin)
+            # Assert
+            file_list = os.listdir(os.path.join(tmp_path, expected_top_level_dir))
+            assert set(file_list) == expected_files_top_level
+
+            file_list = os.listdir(
+                os.path.join(tmp_path, expected_top_level_dir, expected_module_dir)
+            )
+            assert set(file_list) == expected_files_module
+        finally:
+            os.chdir(origin)

--- a/src/py/flwr/cli/new/new_test.py
+++ b/src/py/flwr/cli/new/new_test.py
@@ -112,7 +112,6 @@ def test_new_correct_name(tmp_path: str) -> None:
 
 def test_new_incorrect_name(tmp_path: str) -> None:
     """Test if project with incorrect name is created for framework."""
-
     for project_name in ["My_Flower_App", "My.Flower App"]:
 
         framework = MlFramework.PYTORCH

--- a/src/py/flwr/cli/new/new_test.py
+++ b/src/py/flwr/cli/new/new_test.py
@@ -35,7 +35,7 @@ def test_render_template() -> None:
     """Test if a string is correctly substituted."""
     # Prepare
     filename = "app/README.md.tpl"
-    data = {"project_name": "FedGPT"}
+    data = {"project_name": "FedGPT", "module_name": "fedgpt", "import_name": "fedgpt"}
 
     # Execute
     result = render_template(filename, data)
@@ -89,11 +89,11 @@ def test_new(tmp_path: str) -> None:
         new(project_name=project_name, framework=framework)
 
         # Assert
-        file_list = os.listdir(os.path.join(tmp_path, project_name.lower()))
+        file_list = os.listdir(os.path.join(tmp_path, project_name))
         assert set(file_list) == expected_files_top_level
 
         file_list = os.listdir(
-            os.path.join(tmp_path, project_name.lower(), project_name.lower())
+            os.path.join(tmp_path, project_name, project_name.lower())
         )
         assert set(file_list) == expected_files_module
     finally:

--- a/src/py/flwr/cli/new/new_test.py
+++ b/src/py/flwr/cli/new/new_test.py
@@ -37,7 +37,7 @@ def test_render_template() -> None:
     filename = "app/README.md.tpl"
     data = {
         "project_name": "FedGPT",
-        "distribution_name": "fedgpt",
+        "package_name": "fedgpt",
         "import_name": "fedgpt",
     }
 
@@ -69,7 +69,7 @@ def test_new(tmp_path: str) -> None:
     # Prepare
     expected_names = [
         ("FedGPT", "FedGPT", "fedgpt"),
-        ("My_Flower-App", "My_Flower-App", "my-flower-app"),
+        ("My_Flower-App", "my-flower-app", "my_flower_app"),
     ]
 
     for project_name, expected_top_level_dir, expected_module_dir in expected_names:

--- a/src/py/flwr/cli/new/templates/app/README.md.tpl
+++ b/src/py/flwr/cli/new/templates/app/README.md.tpl
@@ -8,7 +8,7 @@ pip install .
 
 ## Run (Simulation Engine)
 
-In the `$module_name` directory, use `flwr run` to run a local simulation:
+In the `$distribution_name` directory, use `flwr run` to run a local simulation:
 
 ```bash
 flwr run

--- a/src/py/flwr/cli/new/templates/app/README.md.tpl
+++ b/src/py/flwr/cli/new/templates/app/README.md.tpl
@@ -8,7 +8,7 @@ pip install .
 
 ## Run (Simulation Engine)
 
-In the `$project_name` directory, use `flwr run` to run a local simulation:
+In the `$module_name` directory, use `flwr run` to run a local simulation:
 
 ```bash
 flwr run

--- a/src/py/flwr/cli/new/templates/app/README.md.tpl
+++ b/src/py/flwr/cli/new/templates/app/README.md.tpl
@@ -8,7 +8,7 @@ pip install .
 
 ## Run (Simulation Engine)
 
-In the `$distribution_name` directory, use `flwr run` to run a local simulation:
+In the `$import_name` directory, use `flwr run` to run a local simulation:
 
 ```bash
 flwr run

--- a/src/py/flwr/cli/new/templates/app/code/client.pytorch.py.tpl
+++ b/src/py/flwr/cli/new/templates/app/code/client.pytorch.py.tpl
@@ -2,7 +2,7 @@
 
 from flwr.client import NumPyClient, ClientApp
 
-from $module_name.task import (
+from $import_name.task import (
     Net,
     DEVICE,
     load_data,

--- a/src/py/flwr/cli/new/templates/app/code/client.pytorch.py.tpl
+++ b/src/py/flwr/cli/new/templates/app/code/client.pytorch.py.tpl
@@ -2,7 +2,7 @@
 
 from flwr.client import NumPyClient, ClientApp
 
-from $project_name.task import (
+from $module_name.task import (
     Net,
     DEVICE,
     load_data,

--- a/src/py/flwr/cli/new/templates/app/code/server.pytorch.py.tpl
+++ b/src/py/flwr/cli/new/templates/app/code/server.pytorch.py.tpl
@@ -4,7 +4,7 @@ from flwr.common import ndarrays_to_parameters
 from flwr.server import ServerApp, ServerConfig
 from flwr.server.strategy import FedAvg
 
-from $project_name.task import Net, get_weights
+from $module_name.task import Net, get_weights
 
 
 # Initialize model parameters

--- a/src/py/flwr/cli/new/templates/app/code/server.pytorch.py.tpl
+++ b/src/py/flwr/cli/new/templates/app/code/server.pytorch.py.tpl
@@ -4,7 +4,7 @@ from flwr.common import ndarrays_to_parameters
 from flwr.server import ServerApp, ServerConfig
 from flwr.server.strategy import FedAvg
 
-from $module_name.task import Net, get_weights
+from $import_name.task import Net, get_weights
 
 
 # Initialize model parameters

--- a/src/py/flwr/cli/new/templates/app/pyproject.numpy.toml.tpl
+++ b/src/py/flwr/cli/new/templates/app/pyproject.numpy.toml.tpl
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "$project_name"
+name = "$module_name"
 version = "1.0.0"
 description = ""
 authors = [

--- a/src/py/flwr/cli/new/templates/app/pyproject.numpy.toml.tpl
+++ b/src/py/flwr/cli/new/templates/app/pyproject.numpy.toml.tpl
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "$module_name"
+name = "$distribution_name"
 version = "1.0.0"
 description = ""
 authors = [
@@ -19,5 +19,5 @@ dependencies = [
 packages = ["."]
 
 [flower.components]
-serverapp = "$module_name.server:app"
-clientapp = "$module_name.client:app"
+serverapp = "$distribution_name.server:app"
+clientapp = "$distribution_name.client:app"

--- a/src/py/flwr/cli/new/templates/app/pyproject.numpy.toml.tpl
+++ b/src/py/flwr/cli/new/templates/app/pyproject.numpy.toml.tpl
@@ -19,5 +19,5 @@ dependencies = [
 packages = ["."]
 
 [flower.components]
-serverapp = "$project_name.server:app"
-clientapp = "$project_name.client:app"
+serverapp = "$module_name.server:app"
+clientapp = "$module_name.client:app"

--- a/src/py/flwr/cli/new/templates/app/pyproject.numpy.toml.tpl
+++ b/src/py/flwr/cli/new/templates/app/pyproject.numpy.toml.tpl
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "$distribution_name"
+name = "$package_name"
 version = "1.0.0"
 description = ""
 authors = [
@@ -19,5 +19,5 @@ dependencies = [
 packages = ["."]
 
 [flower.components]
-serverapp = "$distribution_name.server:app"
-clientapp = "$distribution_name.client:app"
+serverapp = "$import_name.server:app"
+clientapp = "$import_name.client:app"

--- a/src/py/flwr/cli/new/templates/app/pyproject.pytorch.toml.tpl
+++ b/src/py/flwr/cli/new/templates/app/pyproject.pytorch.toml.tpl
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "$distribution_name"
+name = "$package_name"
 version = "1.0.0"
 description = ""
 authors = [
@@ -21,5 +21,5 @@ dependencies = [
 packages = ["."]
 
 [flower.components]
-serverapp = "$distribution_name.server:app"
-clientapp = "$distribution_name.client:app"
+serverapp = "$import_name.server:app"
+clientapp = "$import_name.client:app"

--- a/src/py/flwr/cli/new/templates/app/pyproject.pytorch.toml.tpl
+++ b/src/py/flwr/cli/new/templates/app/pyproject.pytorch.toml.tpl
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "$module_name"
+name = "$distribution_name"
 version = "1.0.0"
 description = ""
 authors = [
@@ -21,5 +21,5 @@ dependencies = [
 packages = ["."]
 
 [flower.components]
-serverapp = "$module_name.server:app"
-clientapp = "$module_name.client:app"
+serverapp = "$distribution_name.server:app"
+clientapp = "$distribution_name.client:app"

--- a/src/py/flwr/cli/new/templates/app/pyproject.pytorch.toml.tpl
+++ b/src/py/flwr/cli/new/templates/app/pyproject.pytorch.toml.tpl
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "$project_name"
+name = "$module_name"
 version = "1.0.0"
 description = ""
 authors = [

--- a/src/py/flwr/cli/new/templates/app/pyproject.pytorch.toml.tpl
+++ b/src/py/flwr/cli/new/templates/app/pyproject.pytorch.toml.tpl
@@ -21,5 +21,5 @@ dependencies = [
 packages = ["."]
 
 [flower.components]
-serverapp = "$project_name.server:app"
-clientapp = "$project_name.client:app"
+serverapp = "$module_name.server:app"
+clientapp = "$module_name.client:app"

--- a/src/py/flwr/cli/new/templates/app/pyproject.sklearn.toml.tpl
+++ b/src/py/flwr/cli/new/templates/app/pyproject.sklearn.toml.tpl
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "$project_name"
+name = "$module_name"
 version = "1.0.0"
 description = ""
 authors = [

--- a/src/py/flwr/cli/new/templates/app/pyproject.sklearn.toml.tpl
+++ b/src/py/flwr/cli/new/templates/app/pyproject.sklearn.toml.tpl
@@ -18,3 +18,7 @@ dependencies = [
 
 [tool.hatch.build.targets.wheel]
 packages = ["."]
+
+[flower.components]
+serverapp = "$module_name.server:app"
+clientapp = "$module_name.client:app"

--- a/src/py/flwr/cli/new/templates/app/pyproject.sklearn.toml.tpl
+++ b/src/py/flwr/cli/new/templates/app/pyproject.sklearn.toml.tpl
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "$distribution_name"
+name = "$package_name"
 version = "1.0.0"
 description = ""
 authors = [
@@ -20,5 +20,5 @@ dependencies = [
 packages = ["."]
 
 [flower.components]
-serverapp = "$distribution_name.server:app"
-clientapp = "$distribution_name.client:app"
+serverapp = "$import_name.server:app"
+clientapp = "$import_name.client:app"

--- a/src/py/flwr/cli/new/templates/app/pyproject.sklearn.toml.tpl
+++ b/src/py/flwr/cli/new/templates/app/pyproject.sklearn.toml.tpl
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "$module_name"
+name = "$distribution_name"
 version = "1.0.0"
 description = ""
 authors = [
@@ -20,5 +20,5 @@ dependencies = [
 packages = ["."]
 
 [flower.components]
-serverapp = "$module_name.server:app"
-clientapp = "$module_name.client:app"
+serverapp = "$distribution_name.server:app"
+clientapp = "$distribution_name.client:app"

--- a/src/py/flwr/cli/new/templates/app/pyproject.tensorflow.toml.tpl
+++ b/src/py/flwr/cli/new/templates/app/pyproject.tensorflow.toml.tpl
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "$project_name"
+name = "$module_name"
 version = "1.0.0"
 description = ""
 authors = [

--- a/src/py/flwr/cli/new/templates/app/pyproject.tensorflow.toml.tpl
+++ b/src/py/flwr/cli/new/templates/app/pyproject.tensorflow.toml.tpl
@@ -20,5 +20,5 @@ dependencies = [
 packages = ["."]
 
 [flower.components]
-serverapp = "$project_name.server:app"
-clientapp = "$project_name.client:app"
+serverapp = "$module_name.server:app"
+clientapp = "$module_name.client:app"

--- a/src/py/flwr/cli/new/templates/app/pyproject.tensorflow.toml.tpl
+++ b/src/py/flwr/cli/new/templates/app/pyproject.tensorflow.toml.tpl
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "$distribution_name"
+name = "$package_name"
 version = "1.0.0"
 description = ""
 authors = [
@@ -20,5 +20,5 @@ dependencies = [
 packages = ["."]
 
 [flower.components]
-serverapp = "$distribution_name.server:app"
-clientapp = "$distribution_name.client:app"
+serverapp = "$import_name.server:app"
+clientapp = "$import_name.client:app"

--- a/src/py/flwr/cli/new/templates/app/pyproject.tensorflow.toml.tpl
+++ b/src/py/flwr/cli/new/templates/app/pyproject.tensorflow.toml.tpl
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "$module_name"
+name = "$distribution_name"
 version = "1.0.0"
 description = ""
 authors = [
@@ -20,5 +20,5 @@ dependencies = [
 packages = ["."]
 
 [flower.components]
-serverapp = "$module_name.server:app"
-clientapp = "$module_name.client:app"
+serverapp = "$distribution_name.server:app"
+clientapp = "$distribution_name.client:app"

--- a/src/py/flwr/cli/utils.py
+++ b/src/py/flwr/cli/utils.py
@@ -76,7 +76,7 @@ def is_valid_project_name(name: str) -> bool:
     """Check if the given string is a valid Python project name.
 
     A valid project name must start with a letter or an underscore, and can only contain
-    letters, digits, hyphens, dots, and underscores.
+    letters, digits, hyphens, and underscores.
     """
     if not name:
         return False
@@ -87,7 +87,7 @@ def is_valid_project_name(name: str) -> bool:
 
     # Check if the rest of the characters are valid (letter, digit, or underscore)
     for char in name[1:]:
-        if not (char.isalnum() or char in "_-."):
+        if not (char.isalnum() or char in "_-"):
             return False
 
     return True
@@ -101,11 +101,11 @@ def sanitize_project_name(name: str) -> str:
     character.
     """
     # Replace whitespace with '_'
-    name_with_underscores = name.replace(" ", "_")
+    name_with_underscores = name.replace(" ", "_").replace(".", "-")
 
     # Allowed characters in a module name: letters, digits, underscore
     allowed_chars = set(
-        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-."
+        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-"
     )
 
     # Make the string lowercase

--- a/src/py/flwr/cli/utils.py
+++ b/src/py/flwr/cli/utils.py
@@ -96,7 +96,7 @@ def is_valid_project_name(name: str) -> bool:
 def sanitize_project_name(name: str) -> str:
     """Sanitize the given string to make it a valid Python module name.
 
-    This version replaces whitespace with underscores, removes any characters not allowed
+    This version replaces spaces with underscores, removes any characters not allowed
     in Python module names, makes the string lowercase, and ensures it starts with a
     valid character.
     """

--- a/src/py/flwr/cli/utils.py
+++ b/src/py/flwr/cli/utils.py
@@ -87,7 +87,7 @@ def is_valid_project_name(name: str) -> bool:
 
     # Check if the rest of the characters are valid (letter, digit, or underscore)
     for char in name[1:]:
-        if not (char.isalnum() or char in "_-"):
+        if not (char.isalnum() or char in "_-."):
             return False
 
     return True
@@ -105,7 +105,7 @@ def sanitize_project_name(name: str) -> str:
 
     # Allowed characters in a module name: letters, digits, underscore
     allowed_chars = set(
-        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-"
+        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-."
     )
 
     # Make the string lowercase

--- a/src/py/flwr/cli/utils.py
+++ b/src/py/flwr/cli/utils.py
@@ -87,7 +87,7 @@ def is_valid_project_name(name: str) -> bool:
 
     # Check if the rest of the characters are valid (letter, digit, or underscore)
     for char in name[1:]:
-        if not (char.isalnum() or char == "_"):
+        if not (char.isalnum() or char in "_-"):
             return False
 
     return True
@@ -96,16 +96,16 @@ def is_valid_project_name(name: str) -> bool:
 def sanitize_project_name(name: str) -> str:
     """Sanitize the given string to make it a valid Python module name.
 
-    This version replaces hyphens with underscores, removes any characters not allowed
+    This version replaces whitespace with underscores, removes any characters not allowed
     in Python module names, makes the string lowercase, and ensures it starts with a
     valid character.
     """
-    # Replace '-' with '_'
-    name_with_underscores = name.replace("-", "_").replace(" ", "_")
+    # Replace whitespace with '_'
+    name_with_underscores = name.replace(" ", "_")
 
     # Allowed characters in a module name: letters, digits, underscore
     allowed_chars = set(
-        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_"
+        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-"
     )
 
     # Make the string lowercase

--- a/src/py/flwr/cli/utils.py
+++ b/src/py/flwr/cli/utils.py
@@ -83,7 +83,7 @@ def is_valid_project_name(name: str) -> bool:
         return False
 
     # Check if the first character is a letter
-    if not (name[0].isalpha()):
+    if not name[0].isalpha():
         return False
 
     # Check if the rest of the characters are valid (letter, digit, or dash)

--- a/src/py/flwr/cli/utils.py
+++ b/src/py/flwr/cli/utils.py
@@ -73,10 +73,10 @@ def prompt_options(text: str, options: List[str]) -> str:
 
 
 def is_valid_project_name(name: str) -> bool:
-    """Check if the given string is a valid Python module name.
+    """Check if the given string is a valid Python project name.
 
-    A valid module name must start with a letter or an underscore, and can only contain
-    letters, digits, and underscores.
+    A valid project name must start with a letter or an underscore, and can only contain
+    letters, digits, hyphens, dots, and underscores.
     """
     if not name:
         return False
@@ -94,11 +94,11 @@ def is_valid_project_name(name: str) -> bool:
 
 
 def sanitize_project_name(name: str) -> str:
-    """Sanitize the given string to make it a valid Python module name.
+    """Sanitize the given string to make it a valid Python project name.
 
-    This version replaces spaces with underscores, removes any characters not allowed
-    in Python module names, makes the string lowercase, and ensures it starts with a
-    valid character.
+    This version replaces spaces with underscores, removes any characters not allowed in
+    Python project names, makes the string lowercase, and ensures it starts with a valid
+    character.
     """
     # Replace whitespace with '_'
     name_with_underscores = name.replace(" ", "_")

--- a/src/py/flwr/cli/utils.py
+++ b/src/py/flwr/cli/utils.py
@@ -14,6 +14,7 @@
 # ==============================================================================
 """Flower command line interface utils."""
 
+import re
 from typing import Callable, List, Optional, cast
 
 import typer
@@ -75,19 +76,19 @@ def prompt_options(text: str, options: List[str]) -> str:
 def is_valid_project_name(name: str) -> bool:
     """Check if the given string is a valid Python project name.
 
-    A valid project name must start with a letter or an underscore, and can only contain
-    letters, digits, hyphens, and underscores.
+    A valid project name must start with a letter and can only contain letters, digits,
+    and hyphens.
     """
     if not name:
         return False
 
-    # Check if the first character is a letter or underscore
-    if not (name[0].isalpha() or name[0] == "_"):
+    # Check if the first character is a letter
+    if not (name[0].isalpha()):
         return False
 
-    # Check if the rest of the characters are valid (letter, digit, or underscore)
+    # Check if the rest of the characters are valid (letter, digit, or dash)
     for char in name[1:]:
-        if not (char.isalnum() or char in "_-"):
+        if not (char.isalnum() or char in "-"):
             return False
 
     return True
@@ -96,28 +97,28 @@ def is_valid_project_name(name: str) -> bool:
 def sanitize_project_name(name: str) -> str:
     """Sanitize the given string to make it a valid Python project name.
 
-    This version replaces spaces with underscores, removes any characters not allowed in
-    Python project names, makes the string lowercase, and ensures it starts with a valid
-    character.
+    This version replaces spaces, dots, slashes, and underscores with dashes, removes
+    any characters not allowed in Python project names, makes the string lowercase, and
+    ensures it starts with a valid character.
     """
     # Replace whitespace with '_'
-    name_with_underscores = name.replace(" ", "_").replace(".", "-")
+    name_with_hyphens = re.sub(r"[ ./_]", "-", name)
 
     # Allowed characters in a module name: letters, digits, underscore
     allowed_chars = set(
-        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-"
+        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-"
     )
 
     # Make the string lowercase
-    sanitized_name = name_with_underscores.lower()
+    sanitized_name = name_with_hyphens.lower()
 
     # Remove any characters not allowed in Python module names
     sanitized_name = "".join(c for c in sanitized_name if c in allowed_chars)
 
     # Ensure the first character is a letter or underscore
-    if sanitized_name and (
+    while sanitized_name and (
         sanitized_name[0].isdigit() or sanitized_name[0] not in allowed_chars
     ):
-        sanitized_name = "_" + sanitized_name
+        sanitized_name = sanitized_name[1:]
 
     return sanitized_name


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

From [this discussion](https://github.com/adap/flower/pull/3256#discussion_r1573178415):

```
The directory name of the project should allow - (quite common in Python library names). The Python package inside will then use _ instead of - to make it a valid Python package name.
Example:

Project name: flwr-datasets (e.g., pip install flwr-datasets)
Package name: flwr_datasets
```

### Related issues/PRs

#3256 

## Proposal

### Explanation

Allow project names with hyphens and replace hyphens with underscores when creating the package.

### Checklist

- [x] Implement proposed change
- [x] Update the changelog entry below
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

<!--
Inside the following 'Changelog entry' section, you should put the description of your changes that will be added to the changelog alongside your PR title.

If the section is completely empty (without any token) or non-existant, the changelog will just contain the title of the PR for the changelog entry, without any description. If the section contains some text other than tokens, it will use it to add a description to the change. If the section contains one of the following tokens it will ignore any other text and put the PR under the corresponding section of the changelog:

<general> is for classifying a PR as a general improvement.
<skip> is to not add the PR to the changelog
<baselines> is to add a general baselines change to the PR
<examples> is to add a general examples change to the PR
<sdk> is to add a general sdk change to the PR
<simulations> is to add a general simulations change to the PR

Note that only one token should be used.
-->

### Changelog entry

<skip>

### Any other comments?

N/A
