### PR TITLE
Introduce `GrpcDriverClientProxy`

### DIFF
--- a/src/py/flwr/server/compat/app_utils.py
+++ b/src/py/flwr/server/compat/app_utils.py
@@ -19,7 +19,7 @@ import threading
 from typing import Dict, Tuple
 
 from ..client_manager import ClientManager
-from ..compat.driver_client_proxy import DriverClientProxy
+from ..compat.grpc_driver_client_proxy import GrpcDriverClientProxy
 from ..driver import Driver
 
 
@@ -30,7 +30,7 @@ def start_update_client_manager_thread(
     """Periodically update the nodes list in the client manager in a thread.
 
     This function starts a thread that periodically uses the associated driver to
-    get all node_ids. Each node_id is then converted into a `DriverClientProxy`
+    get all node_ids. Each node_id is then converted into a `GrpcDriverClientProxy`
     instance and stored in the `registered_nodes` dictionary with node_id as key.
 
     New nodes will be added to the ClientManager via `client_manager.register()`,
@@ -73,7 +73,7 @@ def _update_client_manager(
 ) -> None:
     """Update the nodes list in the client manager."""
     # Loop until the driver is disconnected
-    registered_nodes: Dict[int, DriverClientProxy] = {}
+    registered_nodes: Dict[int, GrpcDriverClientProxy] = {}
     while not f_stop.is_set():
         all_node_ids = set(driver.get_node_ids())
         dead_nodes = set(registered_nodes).difference(all_node_ids)
@@ -87,7 +87,7 @@ def _update_client_manager(
 
         # Register new nodes
         for node_id in new_nodes:
-            client_proxy = DriverClientProxy(
+            client_proxy = GrpcDriverClientProxy(
                 node_id=node_id,
                 driver=driver.grpc_driver_helper,  # type: ignore
                 anonymous=False,

--- a/src/py/flwr/server/compat/driver_client_proxy.py
+++ b/src/py/flwr/server/compat/driver_client_proxy.py
@@ -15,32 +15,35 @@
 """Flower ClientProxy implementation for Driver API."""
 
 
-import time
-from typing import List, Optional
+from typing import Optional
 
 from flwr import common
-from flwr.common import DEFAULT_TTL, MessageType, MessageTypeLegacy, RecordSet
+from flwr.common import MessageType, MessageTypeLegacy, RecordSet
 from flwr.common import recordset_compat as compat
-from flwr.common import serde
-from flwr.proto import driver_pb2, node_pb2, task_pb2  # pylint: disable=E0611
+from flwr.proto import task_pb2  # pylint: disable=E0611
 from flwr.server.client_proxy import ClientProxy
-
-from ..driver.grpc_driver import GrpcDriverHelper
 
 SLEEP_TIME = 1
 
 
 class DriverClientProxy(ClientProxy):
-    """Flower client proxy which delegates work using the Driver API."""
+    """Generic Flower client proxy which delegates work using the Driver API."""
 
-    def __init__(
-        self, node_id: int, driver: GrpcDriverHelper, anonymous: bool, run_id: int
-    ):
+    def __init__(self, node_id: int, anonymous: bool, run_id: int):
         super().__init__(str(node_id))
         self.node_id = node_id
-        self.driver = driver
         self.run_id = run_id
         self.anonymous = anonymous
+
+    def _send_receive_recordset(
+        self,
+        recordset: RecordSet,
+        task_type: str,
+        timeout: Optional[float],
+        group_id: Optional[int],
+    ) -> RecordSet:
+        _ = (recordset, task_type, timeout, group_id)
+        raise NotImplementedError()
 
     def get_properties(
         self,
@@ -108,79 +111,6 @@ class DriverClientProxy(ClientProxy):
     ) -> common.DisconnectRes:
         """Disconnect and (optionally) reconnect later."""
         return common.DisconnectRes(reason="")  # Nothing to do here (yet)
-
-    def _send_receive_recordset(
-        self,
-        recordset: RecordSet,
-        task_type: str,
-        timeout: Optional[float],
-        group_id: Optional[int],
-    ) -> RecordSet:
-        task_ins = task_pb2.TaskIns(  # pylint: disable=E1101
-            task_id="",
-            group_id=str(group_id) if group_id is not None else "",
-            run_id=self.run_id,
-            task=task_pb2.Task(  # pylint: disable=E1101
-                producer=node_pb2.Node(  # pylint: disable=E1101
-                    node_id=0,
-                    anonymous=True,
-                ),
-                consumer=node_pb2.Node(  # pylint: disable=E1101
-                    node_id=self.node_id,
-                    anonymous=self.anonymous,
-                ),
-                task_type=task_type,
-                recordset=serde.recordset_to_proto(recordset),
-                ttl=DEFAULT_TTL,
-            ),
-        )
-
-        # This would normally be recorded upon common.Message creation
-        # but this compatibility stack doesn't create Messages,
-        # so we need to inject `created_at` manually (needed for
-        # taskins validation by server.utils.validator)
-        task_ins.task.created_at = time.time()
-
-        push_task_ins_req = driver_pb2.PushTaskInsRequest(  # pylint: disable=E1101
-            task_ins_list=[task_ins]
-        )
-
-        # Send TaskIns to Driver API
-        push_task_ins_res = self.driver.push_task_ins(req=push_task_ins_req)
-
-        if len(push_task_ins_res.task_ids) != 1:
-            raise ValueError("Unexpected number of task_ids")
-
-        task_id = push_task_ins_res.task_ids[0]
-        if task_id == "":
-            raise ValueError(f"Failed to schedule task for node {self.node_id}")
-
-        if timeout:
-            start_time = time.time()
-
-        while True:
-            pull_task_res_req = driver_pb2.PullTaskResRequest(  # pylint: disable=E1101
-                node=node_pb2.Node(node_id=0, anonymous=True),  # pylint: disable=E1101
-                task_ids=[task_id],
-            )
-
-            # Ask Driver API for TaskRes
-            pull_task_res_res = self.driver.pull_task_res(req=pull_task_res_req)
-
-            task_res_list: List[task_pb2.TaskRes] = list(  # pylint: disable=E1101
-                pull_task_res_res.task_res_list
-            )
-            if len(task_res_list) == 1:
-                task_res = task_res_list[0]
-
-                # This will raise an Exception if task_res carries an `error`
-                validate_task_res(task_res=task_res)
-
-                return serde.recordset_from_proto(task_res.task.recordset)
-
-            if timeout is not None and time.time() > start_time + timeout:
-                raise RuntimeError("Timeout reached")
-            time.sleep(SLEEP_TIME)
 
 
 def validate_task_res(

--- a/src/py/flwr/server/compat/driver_client_proxy.py
+++ b/src/py/flwr/server/compat/driver_client_proxy.py
@@ -43,7 +43,9 @@ class DriverClientProxy(ClientProxy):
         group_id: Optional[int],
     ) -> RecordSet:
         _ = (recordset, task_type, timeout, group_id)
-        raise NotImplementedError()
+        raise NotImplementedError(
+            f"Use a {self.__class__.__name__} that implements this"
+        )
 
     def get_properties(
         self,
@@ -55,7 +57,7 @@ class DriverClientProxy(ClientProxy):
         # Ins to RecordSet
         out_recordset = compat.getpropertiesins_to_recordset(ins)
         # Fetch response
-        in_recordset = self._send_receive_recordset(
+        in_recordset = self._send_receive_recordset(  # pylint: disable=E1111
             out_recordset, MessageTypeLegacy.GET_PROPERTIES, timeout, group_id
         )
         # RecordSet to Res
@@ -71,7 +73,7 @@ class DriverClientProxy(ClientProxy):
         # Ins to RecordSet
         out_recordset = compat.getparametersins_to_recordset(ins)
         # Fetch response
-        in_recordset = self._send_receive_recordset(
+        in_recordset = self._send_receive_recordset(  # pylint: disable=E1111
             out_recordset, MessageTypeLegacy.GET_PARAMETERS, timeout, group_id
         )
         # RecordSet to Res
@@ -84,7 +86,7 @@ class DriverClientProxy(ClientProxy):
         # Ins to RecordSet
         out_recordset = compat.fitins_to_recordset(ins, keep_input=True)
         # Fetch response
-        in_recordset = self._send_receive_recordset(
+        in_recordset = self._send_receive_recordset(  # pylint: disable=E1111
             out_recordset, MessageType.TRAIN, timeout, group_id
         )
         # RecordSet to Res
@@ -97,7 +99,7 @@ class DriverClientProxy(ClientProxy):
         # Ins to RecordSet
         out_recordset = compat.evaluateins_to_recordset(ins, keep_input=True)
         # Fetch response
-        in_recordset = self._send_receive_recordset(
+        in_recordset = self._send_receive_recordset(  # pylint: disable=E1111
             out_recordset, MessageType.EVALUATE, timeout, group_id
         )
         # RecordSet to Res

--- a/src/py/flwr/server/compat/driver_client_proxy.py
+++ b/src/py/flwr/server/compat/driver_client_proxy.py
@@ -44,7 +44,7 @@ class DriverClientProxy(ClientProxy):
     ) -> RecordSet:
         _ = (recordset, task_type, timeout, group_id)
         raise NotImplementedError(
-            f"Use a {self.__class__.__name__} that implements this"
+            f"Use a {self.__class__.__name__} that implements this method."
         )
 
     def get_properties(

--- a/src/py/flwr/server/compat/grpc_driver_client_proxy.py
+++ b/src/py/flwr/server/compat/grpc_driver_client_proxy.py
@@ -1,0 +1,110 @@
+# Copyright 2024 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Flower ClientProxy implementation for gRPC Driver API."""
+
+
+import time
+from typing import List, Optional
+
+from flwr.common import DEFAULT_TTL, RecordSet, serde
+from flwr.proto import driver_pb2, node_pb2, task_pb2  # pylint: disable=E0611
+
+from ..driver.grpc_driver import GrpcDriverHelper
+from .driver_client_proxy import DriverClientProxy, validate_task_res
+
+SLEEP_TIME = 1
+
+
+class GrpcDriverClientProxy(DriverClientProxy):
+    """Flower client proxy which delegates work using the Driver API."""
+
+    def __init__(
+        self, node_id: int, driver: GrpcDriverHelper, anonymous: bool, run_id: int
+    ):
+        super().__init__(node_id=node_id, anonymous=anonymous, run_id=run_id)
+        self.driver = driver
+
+    def _send_receive_recordset(
+        self,
+        recordset: RecordSet,
+        task_type: str,
+        timeout: Optional[float],
+        group_id: Optional[int],
+    ) -> RecordSet:
+        task_ins = task_pb2.TaskIns(  # pylint: disable=E1101
+            task_id="",
+            group_id=str(group_id) if group_id is not None else "",
+            run_id=self.run_id,
+            task=task_pb2.Task(  # pylint: disable=E1101
+                producer=node_pb2.Node(  # pylint: disable=E1101
+                    node_id=0,
+                    anonymous=True,
+                ),
+                consumer=node_pb2.Node(  # pylint: disable=E1101
+                    node_id=self.node_id,
+                    anonymous=self.anonymous,
+                ),
+                task_type=task_type,
+                recordset=serde.recordset_to_proto(recordset),
+                ttl=DEFAULT_TTL,
+            ),
+        )
+
+        # This would normally be recorded upon common.Message creation
+        # but this compatibility stack doesn't create Messages,
+        # so we need to inject `created_at` manually (needed for
+        # taskins validation by server.utils.validator)
+        task_ins.task.created_at = time.time()
+
+        push_task_ins_req = driver_pb2.PushTaskInsRequest(  # pylint: disable=E1101
+            task_ins_list=[task_ins]
+        )
+
+        # Send TaskIns to Driver API
+        push_task_ins_res = self.driver.push_task_ins(req=push_task_ins_req)
+
+        if len(push_task_ins_res.task_ids) != 1:
+            raise ValueError("Unexpected number of task_ids")
+
+        task_id = push_task_ins_res.task_ids[0]
+        if task_id == "":
+            raise ValueError(f"Failed to schedule task for node {self.node_id}")
+
+        if timeout:
+            start_time = time.time()
+
+        while True:
+            pull_task_res_req = driver_pb2.PullTaskResRequest(  # pylint: disable=E1101
+                node=node_pb2.Node(node_id=0, anonymous=True),  # pylint: disable=E1101
+                task_ids=[task_id],
+            )
+
+            # Ask Driver API for TaskRes
+            pull_task_res_res = self.driver.pull_task_res(req=pull_task_res_req)
+
+            task_res_list: List[task_pb2.TaskRes] = list(  # pylint: disable=E1101
+                pull_task_res_res.task_res_list
+            )
+            if len(task_res_list) == 1:
+                task_res = task_res_list[0]
+
+                # This will raise an Exception if task_res carries an `error`
+                validate_task_res(task_res=task_res)
+
+                return serde.recordset_from_proto(task_res.task.recordset)
+
+            if timeout is not None and time.time() > start_time + timeout:
+                raise RuntimeError("Timeout reached")
+            time.sleep(SLEEP_TIME)

--- a/src/py/flwr/server/compat/grpc_driver_client_proxy_test.py
+++ b/src/py/flwr/server/compat/grpc_driver_client_proxy_test.py
@@ -45,7 +45,8 @@ from flwr.proto import (  # pylint: disable=E0611
     recordset_pb2,
     task_pb2,
 )
-from flwr.server.compat.driver_client_proxy import DriverClientProxy, validate_task_res
+from flwr.server.compat.driver_client_proxy import validate_task_res
+from flwr.server.compat.grpc_driver_client_proxy import GrpcDriverClientProxy
 
 MESSAGE_PARAMETERS = Parameters(tensors=[b"abc"], tensor_type="np")
 
@@ -114,7 +115,7 @@ class DriverClientProxyTestCase(unittest.TestCase):
                 ]
             )
         )
-        client = DriverClientProxy(
+        client = GrpcDriverClientProxy(
             node_id=1, driver=self.driver, anonymous=True, run_id=0
         )
         request_properties: Config = {"tensor_type": "str"}
@@ -155,7 +156,7 @@ class DriverClientProxyTestCase(unittest.TestCase):
                 ]
             )
         )
-        client = DriverClientProxy(
+        client = GrpcDriverClientProxy(
             node_id=1, driver=self.driver, anonymous=True, run_id=0
         )
         get_parameters_ins = GetParametersIns(config={})
@@ -195,7 +196,7 @@ class DriverClientProxyTestCase(unittest.TestCase):
                 ]
             )
         )
-        client = DriverClientProxy(
+        client = GrpcDriverClientProxy(
             node_id=1, driver=self.driver, anonymous=True, run_id=0
         )
         parameters = flwr.common.ndarrays_to_parameters([np.ones((2, 2))])
@@ -236,7 +237,7 @@ class DriverClientProxyTestCase(unittest.TestCase):
                 ]
             )
         )
-        client = DriverClientProxy(
+        client = GrpcDriverClientProxy(
             node_id=1, driver=self.driver, anonymous=True, run_id=0
         )
         parameters = Parameters(tensors=[], tensor_type="np")


### PR DESCRIPTION
This PR:
- strips the existing `DriverClientProxy` from Driver-specific components (i.e. the `_send_receive_recordset()` implementation)
- Introduces a new class, `GrpcDriverClientProxy`, that inherits from `DriverClientProxy` and defines `_send_receive_recordset` using a `GrpcDriverHelper`.

Decoupling the driver-specific components paves the way for re-using `DriverClientProxy` with another Driver (e.g. the upcoming in-memory Driver #3307 -- and a followup PR introducing a Helper)