### PR TITLE
Refactor `DriverClientProxy`

### DIFF
--- a/src/py/flwr/server/compat/driver_client_proxy.py
+++ b/src/py/flwr/server/compat/driver_client_proxy.py
@@ -16,16 +16,15 @@
 
 
 import time
-from typing import List, Optional
+from typing import Optional
 
 from flwr import common
-from flwr.common import DEFAULT_TTL, MessageType, MessageTypeLegacy, RecordSet
+from flwr.common import DEFAULT_TTL, Message, MessageType, MessageTypeLegacy, RecordSet
 from flwr.common import recordset_compat as compat
-from flwr.common import serde
-from flwr.proto import driver_pb2, node_pb2, task_pb2  # pylint: disable=E0611
+from flwr.proto import task_pb2  # pylint: disable=E0611
 from flwr.server.client_proxy import ClientProxy
 
-from ..driver.grpc_driver import GrpcDriverHelper
+from ..driver.driver import Driver
 
 SLEEP_TIME = 1
 
@@ -33,9 +32,7 @@ SLEEP_TIME = 1
 class DriverClientProxy(ClientProxy):
     """Flower client proxy which delegates work using the Driver API."""
 
-    def __init__(
-        self, node_id: int, driver: GrpcDriverHelper, anonymous: bool, run_id: int
-    ):
+    def __init__(self, node_id: int, driver: Driver, anonymous: bool, run_id: int):
         super().__init__(str(node_id))
         self.node_id = node_id
         self.driver = driver
@@ -116,42 +113,22 @@ class DriverClientProxy(ClientProxy):
         timeout: Optional[float],
         group_id: Optional[int],
     ) -> RecordSet:
-        task_ins = task_pb2.TaskIns(  # pylint: disable=E1101
-            task_id="",
-            group_id=str(group_id) if group_id is not None else "",
-            run_id=self.run_id,
-            task=task_pb2.Task(  # pylint: disable=E1101
-                producer=node_pb2.Node(  # pylint: disable=E1101
-                    node_id=0,
-                    anonymous=True,
-                ),
-                consumer=node_pb2.Node(  # pylint: disable=E1101
-                    node_id=self.node_id,
-                    anonymous=self.anonymous,
-                ),
-                task_type=task_type,
-                recordset=serde.recordset_to_proto(recordset),
-                ttl=DEFAULT_TTL,
-            ),
+
+        # Create message
+        message = self.driver.create_message(
+            content=recordset,
+            message_type=task_type,
+            dst_node_id=self.node_id,
+            group_id=str(group_id) if group_id else "",
+            ttl=DEFAULT_TTL,
         )
 
-        # This would normally be recorded upon common.Message creation
-        # but this compatibility stack doesn't create Messages,
-        # so we need to inject `created_at` manually (needed for
-        # taskins validation by server.utils.validator)
-        task_ins.task.created_at = time.time()
-
-        push_task_ins_req = driver_pb2.PushTaskInsRequest(  # pylint: disable=E1101
-            task_ins_list=[task_ins]
-        )
-
-        # Send TaskIns to Driver API
-        push_task_ins_res = self.driver.push_task_ins(req=push_task_ins_req)
-
-        if len(push_task_ins_res.task_ids) != 1:
+        # Push message
+        task_id_list = list(self.driver.push_messages(messages=[message]))
+        if len(task_id_list) != 1:
             raise ValueError("Unexpected number of task_ids")
 
-        task_id = push_task_ins_res.task_ids[0]
+        task_id = task_id_list[0]
         if task_id == "":
             raise ValueError(f"Failed to schedule task for node {self.node_id}")
 
@@ -159,24 +136,10 @@ class DriverClientProxy(ClientProxy):
             start_time = time.time()
 
         while True:
-            pull_task_res_req = driver_pb2.PullTaskResRequest(  # pylint: disable=E1101
-                node=node_pb2.Node(node_id=0, anonymous=True),  # pylint: disable=E1101
-                task_ids=[task_id],
-            )
-
-            # Ask Driver API for TaskRes
-            pull_task_res_res = self.driver.pull_task_res(req=pull_task_res_req)
-
-            task_res_list: List[task_pb2.TaskRes] = list(  # pylint: disable=E1101
-                pull_task_res_res.task_res_list
-            )
-            if len(task_res_list) == 1:
-                task_res = task_res_list[0]
-
-                # This will raise an Exception if task_res carries an `error`
-                validate_task_res(task_res=task_res)
-
-                return serde.recordset_from_proto(task_res.task.recordset)
+            messages = list(self.driver.pull_messages(task_id_list))
+            if len(messages) == 1:
+                msg: Message = messages[0]
+                return msg.content
 
             if timeout is not None and time.time() > start_time + timeout:
                 raise RuntimeError("Timeout reached")

--- a/src/py/flwr/server/compat/driver_client_proxy_test.py
+++ b/src/py/flwr/server/compat/driver_client_proxy_test.py
@@ -46,6 +46,7 @@ from flwr.proto import (  # pylint: disable=E0611
     task_pb2,
 )
 from flwr.server.compat.driver_client_proxy import DriverClientProxy, validate_task_res
+from flwr.server.driver import GrpcDriver
 
 MESSAGE_PARAMETERS = Parameters(tensors=[b"abc"], tensor_type="np")
 
@@ -81,8 +82,10 @@ class DriverClientProxyTestCase(unittest.TestCase):
 
     def setUp(self) -> None:
         """Set up mocks for tests."""
-        self.driver = MagicMock()
-        self.driver.get_nodes.return_value = (
+        self.driver = GrpcDriver()
+        self.driver.driver_helper = MagicMock()
+        self.driver.run_id = 0
+        self.driver.driver_helper.get_nodes.return_value = (
             driver_pb2.GetNodesResponse(  # pylint: disable=E1101
                 nodes=[
                     node_pb2.Node(node_id=1, anonymous=False)  # pylint: disable=E1101
@@ -93,12 +96,14 @@ class DriverClientProxyTestCase(unittest.TestCase):
     def test_get_properties(self) -> None:
         """Test positive case."""
         # Prepare
-        self.driver.push_task_ins.return_value = (
+        if self.driver.driver_helper is None:
+            raise ValueError()
+        self.driver.driver_helper.push_task_ins.return_value = (  # type: ignore
             driver_pb2.PushTaskInsResponse(  # pylint: disable=E1101
                 task_ids=["19341fd7-62e1-4eb4-beb4-9876d3acda32"]
             )
         )
-        self.driver.pull_task_res.return_value = (
+        self.driver.driver_helper.pull_task_res.return_value = (  # type: ignore
             driver_pb2.PullTaskResResponse(  # pylint: disable=E1101
                 task_res_list=[
                     task_pb2.TaskRes(  # pylint: disable=E1101
@@ -133,12 +138,14 @@ class DriverClientProxyTestCase(unittest.TestCase):
     def test_get_parameters(self) -> None:
         """Test positive case."""
         # Prepare
-        self.driver.push_task_ins.return_value = (
+        if self.driver.driver_helper is None:
+            raise ValueError()
+        self.driver.driver_helper.push_task_ins.return_value = (  # type: ignore
             driver_pb2.PushTaskInsResponse(  # pylint: disable=E1101
                 task_ids=["19341fd7-62e1-4eb4-beb4-9876d3acda32"]
             )
         )
-        self.driver.pull_task_res.return_value = (
+        self.driver.driver_helper.pull_task_res.return_value = (  # type: ignore
             driver_pb2.PullTaskResResponse(  # pylint: disable=E1101
                 task_res_list=[
                     task_pb2.TaskRes(  # pylint: disable=E1101
@@ -171,12 +178,14 @@ class DriverClientProxyTestCase(unittest.TestCase):
     def test_fit(self) -> None:
         """Test positive case."""
         # Prepare
-        self.driver.push_task_ins.return_value = (
+        if self.driver.driver_helper is None:
+            raise ValueError()
+        self.driver.driver_helper.push_task_ins.return_value = (  # type: ignore
             driver_pb2.PushTaskInsResponse(  # pylint: disable=E1101
                 task_ids=["19341fd7-62e1-4eb4-beb4-9876d3acda32"]
             )
         )
-        self.driver.pull_task_res.return_value = (
+        self.driver.driver_helper.pull_task_res.return_value = (  # type: ignore
             driver_pb2.PullTaskResResponse(  # pylint: disable=E1101
                 task_res_list=[
                     task_pb2.TaskRes(  # pylint: disable=E1101
@@ -212,12 +221,14 @@ class DriverClientProxyTestCase(unittest.TestCase):
     def test_evaluate(self) -> None:
         """Test positive case."""
         # Prepare
-        self.driver.push_task_ins.return_value = (
+        if self.driver.driver_helper is None:
+            raise ValueError()
+        self.driver.driver_helper.push_task_ins.return_value = (  # type: ignore
             driver_pb2.PushTaskInsResponse(  # pylint: disable=E1101
                 task_ids=["19341fd7-62e1-4eb4-beb4-9876d3acda32"]
             )
         )
-        self.driver.pull_task_res.return_value = (
+        self.driver.driver_helper.pull_task_res.return_value = (  # type: ignore
             driver_pb2.PullTaskResResponse(  # pylint: disable=E1101
                 task_res_list=[
                     task_pb2.TaskRes(  # pylint: disable=E1101

--- a/src/py/flwr/server/driver/grpc_driver.py
+++ b/src/py/flwr/server/driver/grpc_driver.py
@@ -160,22 +160,22 @@ class GrpcDriver(Driver):
     ) -> None:
         self.addr = driver_service_address
         self.root_certificates = root_certificates
-        self.grpc_driver_helper: Optional[GrpcDriverHelper] = None
+        self.driver_helper: Optional[GrpcDriverHelper] = None
         self.run_id: Optional[int] = None
         self.node = Node(node_id=0, anonymous=True)
 
     def _get_grpc_driver_helper_and_run_id(self) -> Tuple[GrpcDriverHelper, int]:
         # Check if the GrpcDriverHelper is initialized
-        if self.grpc_driver_helper is None or self.run_id is None:
+        if self.driver_helper is None or self.run_id is None:
             # Connect and create run
-            self.grpc_driver_helper = GrpcDriverHelper(
+            self.driver_helper = GrpcDriverHelper(
                 driver_service_address=self.addr,
                 root_certificates=self.root_certificates,
             )
-            self.grpc_driver_helper.connect()
-            res = self.grpc_driver_helper.create_run(CreateRunRequest())
+            self.driver_helper.connect()
+            res = self.driver_helper.create_run(CreateRunRequest())
             self.run_id = res.run_id
-        return self.grpc_driver_helper, self.run_id
+        return self.driver_helper, self.run_id
 
     def _check_message(self, message: Message) -> None:
         # Check if the message is valid
@@ -300,7 +300,7 @@ class GrpcDriver(Driver):
     def close(self) -> None:
         """Disconnect from the SuperLink if connected."""
         # Check if GrpcDriverHelper is initialized
-        if self.grpc_driver_helper is None:
+        if self.driver_helper is None:
             return
         # Disconnect
-        self.grpc_driver_helper.disconnect()
+        self.driver_helper.disconnect()

--- a/src/py/flwr/server/driver/grpc_driver_test.py
+++ b/src/py/flwr/server/driver/grpc_driver_test.py
@@ -55,7 +55,7 @@ class TestGrpcDriver(unittest.TestCase):
     def test_check_and_init_grpc_driver_already_initialized(self) -> None:
         """Test that GrpcDriverHelper doesn't initialize if run is created."""
         # Prepare
-        self.driver.grpc_driver_helper = self.mock_grpc_driver
+        self.driver.driver_helper = self.mock_grpc_driver
         self.driver.run_id = 61016
 
         # Execute


### PR DESCRIPTION
This PR:
- modifies the `DriverClientProxy` so it now receives a full `Driver` object
   - It's `_send_receive_recordset()` therefore makes use of the Driver's object it embeds, operating directly on `common.Message` objects
- The `GrpcDriver`'s helper is renamed to `driver_helper` (with the idea of other driver instances to have helpers as well)
- The tests in `DriverClientProxyTestCase` have been updated to reflect then changes above 