### PR TITLE
Add `model_max_length` to AutoTokenizer in quickstart Hugging Face example

### DIFF
--- a/examples/quickstart-huggingface/client.py
+++ b/examples/quickstart-huggingface/client.py
@@ -24,7 +24,7 @@ def load_data(partition_id):
     # Divide data: 80% train, 20% test
     partition_train_test = partition.train_test_split(test_size=0.2, seed=42)
 
-    tokenizer = AutoTokenizer.from_pretrained(CHECKPOINT)
+    tokenizer = AutoTokenizer.from_pretrained(CHECKPOINT, model_max_length=512)
 
     def tokenize_function(examples):
         return tokenizer(examples["text"], truncation=True)


### PR DESCRIPTION
## Before

``` shell
➜ flower-client-app client:app --insecure
INFO :      Long-running Flower client starting
WARNING :   Option `--insecure` was set. Starting insecure HTTP client connected to 0.0.0.0:9092.
INFO :
INFO :      [RUN -6209049818153668731, ROUND 1]
INFO :      Received: train message 72d4a2c3-a7b4-404c-a329-ff045dba4118
Some weights of DistilBertForSequenceClassification were not initialized from the model checkpoint at distilbert-base-uncased and are newly initialized: ['classifier.bias', 'classifier.weight', 'pre_classifier.bias', 'pre_classifier.weight']
You should probably TRAIN this model on a down-stream task to be able to use it for predictions and inference.
Map:   0%|                                                            | 0/5 [00:00<?, ? examples/s]Asking to truncate to max_length but no maximum length is provided and the model has no predefined maximum length. Default to no truncation.
Map: 100%|███████████████████████████████████████████████████| 5/5 [00:00<00:00, 870.91 examples/s]
Training Started...
ERROR :     ClientApp raised an exception
Traceback (most recent call last):
... {long 
...  stack
...  trace}
  File "/Users/csng/.pyenv/versions/3.10.9/envs/flwr-huggingface-3.10.9/lib/python3.10/site-packages/transformers/models/distilbert/modeling_distilbert.py", line 144, in forward
    embeddings = input_embeds + position_embeddings  # (bs, max_seq_length, dim)
RuntimeError: The size of tensor a (991) must match the size of tensor b (512) at non-singleton dimension 1
INFO :      Sent reply
INFO :
INFO :      [RUN -6209049818153668731, ROUND 1]
INFO :      Received: evaluate message 912473c1-99b6-4c80-9306-5848544a2d6b
...
```

## After

``` shell
➜ flower-client-app client:app --insecure
INFO :      Long-running Flower client starting
WARNING :   Option `--insecure` was set. Starting insecure HTTP client connected to 0.0.0.0:9092.
INFO :
INFO :      [RUN 8120599664984316875, ROUND 0]
INFO :      Received: get_parameters message 87e18141-886c-4ff9-b5c1-7d70dd66a183
Some weights of DistilBertForSequenceClassification were not initialized from the model checkpoint at distilbert-base-uncased and are newly initialized: ['classifier.bias', 'classifier.weight', 'pre_classifier.bias', 'pre_classifier.weight']
You should probably TRAIN this model on a down-stream task to be able to use it for predictions and inference.
INFO :      Sent reply
INFO :
INFO :      [RUN 8120599664984316875, ROUND 1]
INFO :      Received: train message 3bbbb63d-1048-4dfc-929e-8f08a1eb4c3b
Training Started...
Training Finished.
INFO :      Sent reply
INFO :
INFO :      [RUN 8120599664984316875, ROUND 1]
INFO :      Received: evaluate message 1b08c84e-0081-477b-8ce0-7556a87a32b6
```
