### PR TITLE
Add ping tests to client authentication

### DIFF
--- a/src/py/flwr/server/superlink/fleet/grpc_rere/server_interceptor_test.py
+++ b/src/py/flwr/server/superlink/fleet/grpc_rere/server_interceptor_test.py
@@ -33,6 +33,8 @@ from flwr.proto.fleet_pb2 import (  # pylint: disable=E0611
     DeleteNodeResponse,
     GetRunRequest,
     GetRunResponse,
+    PingRequest,
+    PingResponse,
     PullTaskInsRequest,
     PullTaskInsResponse,
     PushTaskResRequest,
@@ -93,6 +95,11 @@ class TestServerInterceptor(unittest.TestCase):  # pylint: disable=R0902
             "/flwr.proto.Fleet/GetRun",
             request_serializer=GetRunRequest.SerializeToString,
             response_deserializer=GetRunResponse.FromString,
+        )
+        self._ping = self._channel.unary_unary(
+            "/flwr.proto.Fleet/Ping",
+            request_serializer=PingRequest.SerializeToString,
+            response_deserializer=PingResponse.FromString,
         )
 
     def tearDown(self) -> None:
@@ -331,6 +338,56 @@ class TestServerInterceptor(unittest.TestCase):  # pylint: disable=R0902
         # Execute & Assert
         with self.assertRaises(grpc.RpcError):
             self._get_run.with_call(
+                request=request,
+                metadata=(
+                    (_PUBLIC_KEY_HEADER, public_key_bytes),
+                    (_AUTH_TOKEN_HEADER, hmac_value),
+                ),
+            )
+
+    def test_successful_ping_with_metadata(self) -> None:
+        """Test server interceptor for pull task ins."""
+        # Prepare
+        request = PingRequest()
+        shared_secret = generate_shared_key(
+            self._client_private_key, self._server_public_key
+        )
+        hmac_value = base64.urlsafe_b64encode(
+            compute_hmac(shared_secret, request.SerializeToString(True))
+        )
+        public_key_bytes = base64.urlsafe_b64encode(
+            public_key_to_bytes(self._client_public_key)
+        )
+
+        # Execute
+        response, call = self._ping.with_call(
+            request=request,
+            metadata=(
+                (_PUBLIC_KEY_HEADER, public_key_bytes),
+                (_AUTH_TOKEN_HEADER, hmac_value),
+            ),
+        )
+
+        # Assert
+        assert isinstance(response, PingResponse)
+        assert grpc.StatusCode.OK == call.code()
+
+    def test_unsuccessful_ping_with_metadata(self) -> None:
+        """Test server interceptor for pull task ins unsuccessfully."""
+        # Prepare
+        request = PingRequest()
+        client_private_key, _ = generate_key_pairs()
+        shared_secret = generate_shared_key(client_private_key, self._server_public_key)
+        hmac_value = base64.urlsafe_b64encode(
+            compute_hmac(shared_secret, request.SerializeToString(True))
+        )
+        public_key_bytes = base64.urlsafe_b64encode(
+            public_key_to_bytes(self._client_public_key)
+        )
+
+        # Execute & Assert
+        with self.assertRaises(grpc.RpcError):
+            self._ping.with_call(
                 request=request,
                 metadata=(
                     (_PUBLIC_KEY_HEADER, public_key_bytes),


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->
There is no ping tests in client authentication.

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->
Add ping tests to client authentication.

### Checklist

- [ ] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [ ] Update the changelog entry below
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

<!--
Inside the following 'Changelog entry' section, you should put the description of your changes that will be added to the changelog alongside your PR title.

If the section is completely empty (without any token) or non-existant, the changelog will just contain the title of the PR for the changelog entry, without any description. If the section contains some text other than tokens, it will use it to add a description to the change. If the section contains one of the following tokens it will ignore any other text and put the PR under the corresponding section of the changelog:

<general> is for classifying a PR as a general improvement.
<skip> is to not add the PR to the changelog
<baselines> is to add a general baselines change to the PR
<examples> is to add a general examples change to the PR
<sdk> is to add a general sdk change to the PR
<simulations> is to add a general simulations change to the PR

Note that only one token should be used.
-->

### Changelog entry
<sdk>


### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.ai/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
