### PR TITLE
Add flags to `InMemoryState` for the simulation engine

### DIFF
--- a/src/py/flwr/server/superlink/state/in_memory_state.py
+++ b/src/py/flwr/server/superlink/state/in_memory_state.py
@@ -43,7 +43,7 @@ class InMemoryState(State):  # pylint: disable=R0902
         self.client_public_keys: Set[bytes] = set()
         self.server_public_key: Optional[bytes] = None
         self.server_private_key: Optional[bytes] = None
-        self.lock = threading.RLock()
+        self.lock = threading.Lock()
 
         # For simulation only
         self.new_task_ins = False


### PR DESCRIPTION
In simulation mode, In`MemoryDriver` and `vce_api.py` must periodically check for new `TaskIns`/`TaskRes` in the `InMemoryState`. Due to performance concerns, we now have `State.get_task_res` called by `InMemoryDriver` every 3 seconds and `State.get_task_ins` called by `vce_api.py` every 1 second.

@jafermarq and I aimed to increase the efficiency of the simulation engine by minimizing the interval without extensive engineering work. This serves as a temporary solution to accelerate the Flower Next simulation. With the two flags, we can safely reduce the interval to 0.01s or lower. We should revisit this topic in the future to explore a more robust approach.