### PR TITLE
Hide `run_simulation_from_cli`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ flower-superlink = "flwr.server:run_superlink"
 flower-supernode = "flwr.client:run_supernode"
 flower-client-app = "flwr.client:run_client_app"
 flower-server-app = "flwr.server:run_server_app"
-flower-simulation = "flwr.simulation:run_simulation_from_cli"
+flower-simulation = "flwr.simulation.run_simulation:run_simulation_from_cli"
 
 [tool.poetry.dependencies]
 python = "^3.8"

--- a/src/py/flwr/simulation/__init__.py
+++ b/src/py/flwr/simulation/__init__.py
@@ -17,7 +17,7 @@
 
 import importlib
 
-from flwr.simulation.run_simulation import run_simulation, run_simulation_from_cli
+from flwr.simulation.run_simulation import run_simulation
 
 is_ray_installed = importlib.util.find_spec("ray") is not None
 
@@ -36,4 +36,4 @@ To install the necessary dependencies, install `flwr` with the `simulation` extr
         raise ImportError(RAY_IMPORT_ERROR)
 
 
-__all__ = ["start_simulation", "run_simulation_from_cli", "run_simulation"]
+__all__ = ["start_simulation", "run_simulation"]


### PR DESCRIPTION
w/o this change users can do `flwr.simulation.run..` and it will autocomplete with options `run_simulation` and `run_simulation_from_cli`. The latter now is hidden.

