### PR TITLE
Set `console_handler` based on `verbose` value for simulations

### DIFF
--- a/src/py/flwr/simulation/run_simulation.py
+++ b/src/py/flwr/simulation/run_simulation.py
@@ -28,7 +28,7 @@ import grpc
 
 from flwr.client import ClientApp
 from flwr.common import EventType, event, log
-from flwr.common.logger import console_handler, set_logger_propagation
+from flwr.common.logger import set_logger_propagation, update_console_handler
 from flwr.common.typing import ConfigsRecordValues
 from flwr.server.driver import Driver, GrpcDriver
 from flwr.server.run_serverapp import run
@@ -320,8 +320,7 @@ def _run_simulation(
     # Set logging level
     logger = logging.getLogger("flwr")
     if verbose_logging:
-        logger.setLevel(DEBUG)
-        console_handler.setLevel(DEBUG)
+        update_console_handler(level=DEBUG, timestamps=True, colored=True)
 
     if backend_config is None:
         backend_config = {}

--- a/src/py/flwr/simulation/run_simulation.py
+++ b/src/py/flwr/simulation/run_simulation.py
@@ -28,7 +28,7 @@ import grpc
 
 from flwr.client import ClientApp
 from flwr.common import EventType, event, log
-from flwr.common.logger import set_logger_propagation
+from flwr.common.logger import console_handler, set_logger_propagation
 from flwr.common.typing import ConfigsRecordValues
 from flwr.server.driver import Driver, GrpcDriver
 from flwr.server.run_serverapp import run
@@ -318,9 +318,10 @@ def _run_simulation(
         enabled, DEBUG-level logs will be displayed.
     """
     # Set logging level
-    if not verbose_logging:
-        logger = logging.getLogger("flwr")
-        logger.setLevel(INFO)
+    logger = logging.getLogger("flwr")
+    if verbose_logging:
+        logger.setLevel(DEBUG)
+        console_handler.setLevel(DEBUG)
 
     if backend_config is None:
         backend_config = {}


### PR DESCRIPTION
After the new logging formatting was added, it's not sufficient to just change the Level of a log (e.g. via `logger.setLevel(DEBUG)`) to see on the terminal logs associated to that particular level (and higher). It is needed to also set the level to the `console_handler`. 