### PR TITLE
Switch private and public key order in State

### DIFF
--- a/src/py/flwr/server/superlink/state/in_memory_state.py
+++ b/src/py/flwr/server/superlink/state/in_memory_state.py
@@ -254,16 +254,16 @@ class InMemoryState(State):  # pylint: disable=R0902
         log(ERROR, "Unexpected run creation failure.")
         return 0
 
-    def store_server_public_private_key(
-        self, public_key: bytes, private_key: bytes
+    def store_server_private_public_key(
+        self, private_key: bytes, public_key: bytes
     ) -> None:
-        """Store `server_public_key` and `server_private_key` in state."""
+        """Store `server_private_key` and `server_public_key` in state."""
         with self.lock:
             if self.server_private_key is None and self.server_public_key is None:
                 self.server_private_key = private_key
                 self.server_public_key = public_key
             else:
-                raise RuntimeError("Server public and private key already set")
+                raise RuntimeError("Server private and public key already set")
 
     def get_server_private_key(self) -> Optional[bytes]:
         """Retrieve `server_private_key` in urlsafe bytes."""

--- a/src/py/flwr/server/superlink/state/sqlite_state.py
+++ b/src/py/flwr/server/superlink/state/sqlite_state.py
@@ -42,8 +42,8 @@ CREATE TABLE IF NOT EXISTS node(
 
 SQL_CREATE_TABLE_CREDENTIAL = """
 CREATE TABLE IF NOT EXISTS credential(
-    public_key BLOB PRIMARY KEY,
-    private_key BLOB
+    private_key BLOB PRIMARY KEY,
+    public_key BLOB
 );
 """
 
@@ -589,20 +589,20 @@ class SqliteState(State):  # pylint: disable=R0904
         log(ERROR, "Unexpected run creation failure.")
         return 0
 
-    def store_server_public_private_key(
-        self, public_key: bytes, private_key: bytes
+    def store_server_private_public_key(
+        self, private_key: bytes, public_key: bytes
     ) -> None:
-        """Store `server_public_key` and `server_private_key` in state."""
+        """Store `server_private_key` and `server_public_key` in state."""
         query = "SELECT COUNT(*) FROM credential"
         count = self.query(query)[0]["COUNT(*)"]
         if count < 1:
             query = (
-                "INSERT OR REPLACE INTO credential (public_key, private_key) "
-                "VALUES (:public_key, :private_key)"
+                "INSERT OR REPLACE INTO credential (private_key, public_key) "
+                "VALUES (:private_key, :public_key)"
             )
-            self.query(query, {"public_key": public_key, "private_key": private_key})
+            self.query(query, {"private_key": private_key, "public_key": public_key})
         else:
-            raise RuntimeError("Server public and private key already set")
+            raise RuntimeError("Server private and public key already set")
 
     def get_server_private_key(self) -> Optional[bytes]:
         """Retrieve `server_private_key` in urlsafe bytes."""

--- a/src/py/flwr/server/superlink/state/state.py
+++ b/src/py/flwr/server/superlink/state/state.py
@@ -172,10 +172,10 @@ class State(abc.ABC):
         """
 
     @abc.abstractmethod
-    def store_server_public_private_key(
-        self, public_key: bytes, private_key: bytes
+    def store_server_private_public_key(
+        self, private_key: bytes, public_key: bytes
     ) -> None:
-        """Store `server_public_key` and `server_private_key` in state."""
+        """Store `server_private_key` and `server_public_key` in state."""
 
     @abc.abstractmethod
     def get_server_private_key(self) -> Optional[bytes]:

--- a/src/py/flwr/server/superlink/state/state_test.py
+++ b/src/py/flwr/server/superlink/state/state_test.py
@@ -414,8 +414,8 @@ class StateTest(unittest.TestCase):
         # Assert
         assert num == 2
 
-    def test_server_public_private_key(self) -> None:
-        """Test get server public and private key after inserting."""
+    def test_server_private_public_key(self) -> None:
+        """Test get server private and public key after inserting."""
         # Prepare
         state: State = self.state_factory()
         private_key, public_key = generate_key_pairs()
@@ -423,7 +423,7 @@ class StateTest(unittest.TestCase):
         public_key_bytes = public_key_to_bytes(public_key)
 
         # Execute
-        state.store_server_public_private_key(public_key_bytes, private_key_bytes)
+        state.store_server_private_public_key(private_key_bytes, public_key_bytes)
         server_private_key = state.get_server_private_key()
         server_public_key = state.get_server_public_key()
 
@@ -431,8 +431,8 @@ class StateTest(unittest.TestCase):
         assert server_private_key == private_key_bytes
         assert server_public_key == public_key_bytes
 
-    def test_server_public_private_key_none(self) -> None:
-        """Test get server public and private key without inserting."""
+    def test_server_private_public_key_none(self) -> None:
+        """Test get server private and public key without inserting."""
         # Prepare
         state: State = self.state_factory()
 
@@ -444,8 +444,8 @@ class StateTest(unittest.TestCase):
         assert server_private_key is None
         assert server_public_key is None
 
-    def test_store_server_public_private_key_twice(self) -> None:
-        """Test inserting public and private key twice."""
+    def test_store_server_private_public_key_twice(self) -> None:
+        """Test inserting private and public key twice."""
         # Prepare
         state: State = self.state_factory()
         private_key, public_key = generate_key_pairs()
@@ -456,12 +456,12 @@ class StateTest(unittest.TestCase):
         new_public_key_bytes = public_key_to_bytes(new_public_key)
 
         # Execute
-        state.store_server_public_private_key(public_key_bytes, private_key_bytes)
+        state.store_server_private_public_key(private_key_bytes, public_key_bytes)
 
         # Assert
         with self.assertRaises(RuntimeError):
-            state.store_server_public_private_key(
-                new_public_key_bytes, new_private_key_bytes
+            state.store_server_private_public_key(
+                new_private_key_bytes, new_public_key_bytes
             )
 
     def test_client_public_keys(self) -> None:


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->
The order of private and public keys is inconsistent.

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->
Reorder private and public key to private first, public second.

### Checklist

- [ ] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [ ] Update the changelog entry below
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

<!--
Inside the following 'Changelog entry' section, you should put the description of your changes that will be added to the changelog alongside your PR title.

If the section is completely empty (without any token) or non-existant, the changelog will just contain the title of the PR for the changelog entry, without any description. If the section contains some text other than tokens, it will use it to add a description to the change. If the section contains one of the following tokens it will ignore any other text and put the PR under the corresponding section of the changelog:

<general> is for classifying a PR as a general improvement.
<skip> is to not add the PR to the changelog
<baselines> is to add a general baselines change to the PR
<examples> is to add a general examples change to the PR
<sdk> is to add a general sdk change to the PR
<simulations> is to add a general simulations change to the PR

Note that only one token should be used.
-->

### Changelog entry



### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.ai/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
