### PR TITLE
Change `AuthenticateServerInterceptor` arguments

### DIFF
--- a/src/py/flwr/server/superlink/fleet/grpc_rere/server_interceptor_test.py
+++ b/src/py/flwr/server/superlink/fleet/grpc_rere/server_interceptor_test.py
@@ -24,6 +24,7 @@ from flwr.common.secure_aggregation.crypto.symmetric_encryption import (
     compute_hmac,
     generate_key_pairs,
     generate_shared_key,
+    private_key_to_bytes,
     public_key_to_bytes,
 )
 from flwr.proto.fleet_pb2 import (  # pylint: disable=E0611
@@ -60,12 +61,16 @@ class TestServerInterceptor(unittest.TestCase):  # pylint: disable=R0902
         self._server_private_key, self._server_public_key = generate_key_pairs()
 
         state_factory = StateFactory(":flwr-in-memory-state:")
-
-        self._server_interceptor = AuthenticateServerInterceptor(
-            {public_key_to_bytes(self._client_public_key)},
-            self._server_private_key,
-            self._server_public_key,
+        self.state = state_factory.state()
+        self.state.store_server_private_public_key(
+            private_key_to_bytes(self._server_private_key),
+            public_key_to_bytes(self._server_public_key),
         )
+        self.state.store_client_public_keys(
+            {public_key_to_bytes(self._client_public_key)}
+        )
+
+        self._server_interceptor = AuthenticateServerInterceptor(self.state)
         self._server: grpc.Server = _run_fleet_api_grpc_rere(
             ADDRESS_FLEET_API_GRPC_RERE, state_factory, None, [self._server_interceptor]
         )


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->
AuthenticateServerInterceptor has expensive computations that can be optimized.

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

Change `AuthenticateServerInterceptor` initialization arguments by passing State and retrieve static values in memory.

### Checklist

- [ ] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [ ] Update the changelog entry below
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

<!--
Inside the following 'Changelog entry' section, you should put the description of your changes that will be added to the changelog alongside your PR title.

If the section is completely empty (without any token) or non-existant, the changelog will just contain the title of the PR for the changelog entry, without any description. If the section contains some text other than tokens, it will use it to add a description to the change. If the section contains one of the following tokens it will ignore any other text and put the PR under the corresponding section of the changelog:

<general> is for classifying a PR as a general improvement.
<skip> is to not add the PR to the changelog
<baselines> is to add a general baselines change to the PR
<examples> is to add a general examples change to the PR
<sdk> is to add a general sdk change to the PR
<simulations> is to add a general simulations change to the PR

Note that only one token should be used.
-->

### Changelog entry



### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.ai/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
