### PR TITLE
Prepare `State` to enable `node_id` verification

### DIFF
--- a/src/py/flwr/server/superlink/state/in_memory_state.py
+++ b/src/py/flwr/server/superlink/state/in_memory_state.py
@@ -225,7 +225,7 @@ class InMemoryState(State):  # pylint: disable=R0902,R0904
             if public_key is not None:
                 if (
                     public_key in self.public_key_to_node_id
-                    or self.public_key_to_node_id.get(public_key) == node_id
+                    or node_id in self.public_key_to_node_id.values()
                 ):
                     log(ERROR, "Unexpected node registration failure.")
                     return 0
@@ -244,7 +244,7 @@ class InMemoryState(State):  # pylint: disable=R0902,R0904
             if public_key is not None:
                 if (
                     public_key not in self.public_key_to_node_id
-                    and self.public_key_to_node_id.get(public_key) != node_id
+                    or node_id not in self.public_key_to_node_id.values()
                 ):
                     raise ValueError("Public key or node_id not found")
 

--- a/src/py/flwr/server/superlink/state/in_memory_state.py
+++ b/src/py/flwr/server/superlink/state/in_memory_state.py
@@ -30,19 +30,24 @@ from flwr.server.utils import validate_task_ins_or_res
 from .utils import make_node_unavailable_taskres
 
 
-class InMemoryState(State):  # pylint: disable=R0902
+class InMemoryState(State):  # pylint: disable=R0902,R0904
     """In-memory State implementation."""
 
     def __init__(self) -> None:
+
         # Map node_id to (online_until, ping_interval)
         self.node_ids: Dict[int, Tuple[float, float]] = {}
+        self.public_key_to_node_id: Dict[bytes, int] = {}
+
         # Map run_id to (fab_id, fab_version)
         self.run_ids: Dict[int, Tuple[str, str]] = {}
         self.task_ins_store: Dict[UUID, TaskIns] = {}
         self.task_res_store: Dict[UUID, TaskRes] = {}
+
         self.client_public_keys: Set[bytes] = set()
         self.server_public_key: Optional[bytes] = None
         self.server_private_key: Optional[bytes] = None
+
         self.lock = threading.Lock()
 
     def store_task_ins(self, task_ins: TaskIns) -> Optional[UUID]:
@@ -205,23 +210,46 @@ class InMemoryState(State):  # pylint: disable=R0902
         """
         return len(self.task_res_store)
 
-    def create_node(self, ping_interval: float) -> int:
+    def create_node(
+        self, ping_interval: float, public_key: Optional[bytes] = None
+    ) -> int:
         """Create, store in state, and return `node_id`."""
         # Sample a random int64 as node_id
         node_id: int = int.from_bytes(os.urandom(8), "little", signed=True)
 
         with self.lock:
-            if node_id not in self.node_ids:
-                self.node_ids[node_id] = (time.time() + ping_interval, ping_interval)
-                return node_id
-        log(ERROR, "Unexpected node registration failure.")
-        return 0
+            if node_id in self.node_ids:
+                log(ERROR, "Unexpected node registration failure.")
+                return 0
 
-    def delete_node(self, node_id: int) -> None:
+            if public_key is not None:
+                if (
+                    public_key in self.public_key_to_node_id
+                    or self.public_key_to_node_id.get(public_key) == node_id
+                ):
+                    log(ERROR, "Unexpected node registration failure.")
+                    return 0
+
+                self.public_key_to_node_id[public_key] = node_id
+
+            self.node_ids[node_id] = (time.time() + ping_interval, ping_interval)
+            return node_id
+
+    def delete_node(self, node_id: int, public_key: Optional[bytes] = None) -> None:
         """Delete a client node."""
         with self.lock:
             if node_id not in self.node_ids:
                 raise ValueError(f"Node {node_id} not found")
+
+            if public_key is not None:
+                if (
+                    public_key not in self.public_key_to_node_id
+                    and self.public_key_to_node_id.get(public_key) != node_id
+                ):
+                    raise ValueError("Public key or node_id not found")
+
+                del self.public_key_to_node_id[public_key]
+
             del self.node_ids[node_id]
 
     def get_nodes(self, run_id: int) -> Set[int]:
@@ -241,6 +269,10 @@ class InMemoryState(State):  # pylint: disable=R0902
                 for node_id, (online_until, _) in self.node_ids.items()
                 if online_until > current_time
             }
+
+    def get_node_id(self, client_public_key: bytes) -> Optional[int]:
+        """Retrieve stored `node_id` filtered by `client_public_keys`."""
+        return self.public_key_to_node_id.get(client_public_key)
 
     def create_run(self, fab_id: str, fab_version: str) -> int:
         """Create a new run for the specified `fab_id` and `fab_version`."""

--- a/src/py/flwr/server/superlink/state/sqlite_state.py
+++ b/src/py/flwr/server/superlink/state/sqlite_state.py
@@ -542,6 +542,12 @@ class SqliteState(State):  # pylint: disable=R0904
         # Sample a random int64 as node_id
         node_id: int = int.from_bytes(os.urandom(8), "little", signed=True)
 
+        query = "SELECT node_id FROM node WHERE public_key = :public_key;"
+        row = self.query(query, {"public_key": public_key})
+
+        if len(row) > 0:
+            return 0
+
         query = (
             "INSERT INTO node "
             "(node_id, online_until, ping_interval, public_key) "
@@ -559,12 +565,21 @@ class SqliteState(State):  # pylint: disable=R0904
 
     def delete_node(self, node_id: int, public_key: Optional[bytes] = None) -> None:
         """Delete a client node."""
-        if public_key is None:
-            query = "DELETE FROM node WHERE node_id = ?;"
-            self.query(query, (node_id,))
-        else:
-            query = "DELETE FROM node WHERE node_id = ? AND public_key = ?;"
-            self.query(query, (node_id, public_key))
+        query = "SELECT node_id FROM node WHERE node_id = :node_id;"
+        row = self.query(query, {"node_id": node_id})
+
+        if len(row) == 0:
+            raise ValueError(f"Node {node_id} not found")
+
+        if public_key is not None:
+            query = "SELECT node_id FROM node WHERE public_key = :public_key;"
+            row = self.query(query, {"public_key": public_key})
+
+            if len(row) < 1 or row[0]["node_id"] != node_id:
+                raise ValueError("Public key or node_id not found")
+
+        query = "DELETE FROM node WHERE node_id = ?;"
+        self.query(query, (node_id,))
 
     def get_nodes(self, run_id: int) -> Set[int]:
         """Retrieve all currently stored node IDs as a set.

--- a/src/py/flwr/server/superlink/state/sqlite_state.py
+++ b/src/py/flwr/server/superlink/state/sqlite_state.py
@@ -546,6 +546,7 @@ class SqliteState(State):  # pylint: disable=R0904
         row = self.query(query, {"public_key": public_key})
 
         if len(row) > 0:
+            log(ERROR, "Unexpected node registration failure.")
             return 0
 
         query = (

--- a/src/py/flwr/server/superlink/state/sqlite_state.py
+++ b/src/py/flwr/server/superlink/state/sqlite_state.py
@@ -566,21 +566,23 @@ class SqliteState(State):  # pylint: disable=R0904
 
     def delete_node(self, node_id: int, public_key: Optional[bytes] = None) -> None:
         """Delete a client node."""
-        query = "SELECT node_id FROM node WHERE node_id = :node_id;"
-        row = self.query(query, {"node_id": node_id})
-
-        if len(row) == 0:
-            raise ValueError(f"Node {node_id} not found")
+        query = "DELETE FROM node WHERE node_id = ?"
+        params = (node_id,)
 
         if public_key is not None:
-            query = "SELECT node_id FROM node WHERE public_key = :public_key;"
-            row = self.query(query, {"public_key": public_key})
+            query += " AND public_key = ?"
+            params += (public_key,)  # type: ignore
 
-            if len(row) < 1 or row[0]["node_id"] != node_id:
-                raise ValueError("Public key or node_id not found")
+        if self.conn is None:
+            raise AttributeError("State is not initialized.")
 
-        query = "DELETE FROM node WHERE node_id = ?;"
-        self.query(query, (node_id,))
+        try:
+            with self.conn:
+                rows = self.conn.execute(query, params)
+                if rows.rowcount < 1:
+                    raise ValueError("Public key or node_id not found")
+        except KeyError as exc:
+            log(ERROR, {"query": query, "data": params, "exception": exc})
 
     def get_nodes(self, run_id: int) -> Set[int]:
         """Retrieve all currently stored node IDs as a set.

--- a/src/py/flwr/server/superlink/state/sqlite_state.py
+++ b/src/py/flwr/server/superlink/state/sqlite_state.py
@@ -36,7 +36,8 @@ SQL_CREATE_TABLE_NODE = """
 CREATE TABLE IF NOT EXISTS node(
     node_id         INTEGER UNIQUE,
     online_until    REAL,
-    ping_interval   REAL
+    ping_interval   REAL,
+    public_key      BLOB
 );
 """
 
@@ -534,26 +535,36 @@ class SqliteState(State):  # pylint: disable=R0904
 
         return None
 
-    def create_node(self, ping_interval: float) -> int:
+    def create_node(
+        self, ping_interval: float, public_key: Optional[bytes] = None
+    ) -> int:
         """Create, store in state, and return `node_id`."""
         # Sample a random int64 as node_id
         node_id: int = int.from_bytes(os.urandom(8), "little", signed=True)
 
         query = (
-            "INSERT INTO node (node_id, online_until, ping_interval) VALUES (?, ?, ?)"
+            "INSERT INTO node "
+            "(node_id, online_until, ping_interval, public_key) "
+            "VALUES (?, ?, ?, ?)"
         )
 
         try:
-            self.query(query, (node_id, time.time() + ping_interval, ping_interval))
+            self.query(
+                query, (node_id, time.time() + ping_interval, ping_interval, public_key)
+            )
         except sqlite3.IntegrityError:
             log(ERROR, "Unexpected node registration failure.")
             return 0
         return node_id
 
-    def delete_node(self, node_id: int) -> None:
+    def delete_node(self, node_id: int, public_key: Optional[bytes] = None) -> None:
         """Delete a client node."""
-        query = "DELETE FROM node WHERE node_id = :node_id;"
-        self.query(query, {"node_id": node_id})
+        if public_key is None:
+            query = "DELETE FROM node WHERE node_id = ?;"
+            self.query(query, (node_id,))
+        else:
+            query = "DELETE FROM node WHERE node_id = ? AND public_key = ?;"
+            self.query(query, (node_id, public_key))
 
     def get_nodes(self, run_id: int) -> Set[int]:
         """Retrieve all currently stored node IDs as a set.
@@ -573,6 +584,15 @@ class SqliteState(State):  # pylint: disable=R0904
         rows = self.query(query, (time.time(),))
         result: Set[int] = {row["node_id"] for row in rows}
         return result
+
+    def get_node_id(self, client_public_key: bytes) -> Optional[int]:
+        """Retrieve stored `node_id` filtered by `client_public_keys`."""
+        query = "SELECT node_id FROM node WHERE public_key = :public_key;"
+        row = self.query(query, {"public_key": client_public_key})
+        if len(row) > 0:
+            node_id: int = row[0]["node_id"]
+            return node_id
+        return None
 
     def create_run(self, fab_id: str, fab_version: str) -> int:
         """Create a new run for the specified `fab_id` and `fab_version`."""

--- a/src/py/flwr/server/superlink/state/state.py
+++ b/src/py/flwr/server/superlink/state/state.py
@@ -22,7 +22,7 @@ from uuid import UUID
 from flwr.proto.task_pb2 import TaskIns, TaskRes  # pylint: disable=E0611
 
 
-class State(abc.ABC):
+class State(abc.ABC):  # pylint: disable=R0904
     """Abstract State."""
 
     @abc.abstractmethod
@@ -132,11 +132,13 @@ class State(abc.ABC):
         """Delete all delivered TaskIns/TaskRes pairs."""
 
     @abc.abstractmethod
-    def create_node(self, ping_interval: float) -> int:
+    def create_node(
+        self, ping_interval: float, public_key: Optional[bytes] = None
+    ) -> int:
         """Create, store in state, and return `node_id`."""
 
     @abc.abstractmethod
-    def delete_node(self, node_id: int) -> None:
+    def delete_node(self, node_id: int, public_key: Optional[bytes] = None) -> None:
         """Remove `node_id` from state."""
 
     @abc.abstractmethod
@@ -148,6 +150,10 @@ class State(abc.ABC):
         If the provided `run_id` does not exist or has no matching nodes,
         an empty `Set` MUST be returned.
         """
+
+    @abc.abstractmethod
+    def get_node_id(self, client_public_key: bytes) -> Optional[int]:
+        """Retrieve stored `node_id` filtered by `client_public_keys`."""
 
     @abc.abstractmethod
     def create_run(self, fab_id: str, fab_version: str) -> int:

--- a/src/py/flwr/server/superlink/state/state_test.py
+++ b/src/py/flwr/server/superlink/state/state_test.py
@@ -362,6 +362,29 @@ class StateTest(unittest.TestCase):
         assert len(retrieved_node_ids) == 1
         assert retrieved_node_id == node_id
 
+    def test_create_node_public_key_twice(self) -> None:
+        """Test creating a client node with same public key twice."""
+        # Prepare
+        state: State = self.state_factory()
+        public_key = b"mock"
+        run_id = state.create_run("mock/mock", "v1.0.0")
+        node_id = state.create_node(ping_interval=10, public_key=public_key)
+
+        # Execute
+        new_node_id = state.create_node(ping_interval=10, public_key=public_key)
+        retrieved_node_ids = state.get_nodes(run_id)
+        retrieved_node_id = state.get_node_id(public_key)
+
+        # Assert
+        assert new_node_id == 0
+        assert len(retrieved_node_ids) == 1
+        assert retrieved_node_id == node_id
+
+        # Assert node_ids and public_key_to_node_id are synced
+        if isinstance(state, InMemoryState):
+            assert len(state.node_ids) == 1
+            assert len(state.public_key_to_node_id) == 1
+
     def test_delete_node(self) -> None:
         """Test deleting a client node."""
         # Prepare
@@ -391,6 +414,60 @@ class StateTest(unittest.TestCase):
 
         # Assert
         assert len(retrieved_node_ids) == 0
+        assert retrieved_node_id is None
+
+    def test_delete_node_public_key_none(self) -> None:
+        """Test deleting a client node with public key."""
+        # Prepare
+        state: State = self.state_factory()
+        public_key = b"mock"
+        run_id = state.create_run("mock/mock", "v1.0.0")
+        node_id = 0
+
+        # Execute & Assert
+        with self.assertRaises(ValueError):
+            state.delete_node(node_id, public_key=public_key)
+
+        retrieved_node_ids = state.get_nodes(run_id)
+        retrieved_node_id = state.get_node_id(public_key)
+
+        assert len(retrieved_node_ids) == 0
+        assert retrieved_node_id is None
+
+    def test_delete_node_wrong_public_key(self) -> None:
+        """Test deleting a client node with wrong public key."""
+        # Prepare
+        state: State = self.state_factory()
+        public_key = b"mock"
+        wrong_public_key = b"mock_mock"
+        run_id = state.create_run("mock/mock", "v1.0.0")
+        node_id = state.create_node(ping_interval=10, public_key=public_key)
+
+        # Execute & Assert
+        with self.assertRaises(ValueError):
+            state.delete_node(node_id, public_key=wrong_public_key)
+
+        retrieved_node_ids = state.get_nodes(run_id)
+        retrieved_node_id = state.get_node_id(public_key)
+
+        assert len(retrieved_node_ids) == 1
+        assert retrieved_node_id == node_id
+
+    def test_get_node_id_wrong_public_key(self) -> None:
+        """Test retrieving a client node with wrong public key."""
+        # Prepare
+        state: State = self.state_factory()
+        public_key = b"mock"
+        wrong_public_key = b"mock_mock"
+        run_id = state.create_run("mock/mock", "v1.0.0")
+
+        # Execute
+        state.create_node(ping_interval=10, public_key=public_key)
+        retrieved_node_ids = state.get_nodes(run_id)
+        retrieved_node_id = state.get_node_id(wrong_public_key)
+
+        # Assert
+        assert len(retrieved_node_ids) == 1
         assert retrieved_node_id is None
 
     def test_get_nodes_invalid_run_id(self) -> None:

--- a/src/py/flwr/server/superlink/state/state_test.py
+++ b/src/py/flwr/server/superlink/state/state_test.py
@@ -346,6 +346,22 @@ class StateTest(unittest.TestCase):
         for i in retrieved_node_ids:
             assert i in node_ids
 
+    def test_create_node_public_key(self) -> None:
+        """Test creating a client node with public key."""
+        # Prepare
+        state: State = self.state_factory()
+        public_key = b"mock"
+        run_id = state.create_run("mock/mock", "v1.0.0")
+
+        # Execute
+        node_id = state.create_node(ping_interval=10, public_key=public_key)
+        retrieved_node_ids = state.get_nodes(run_id)
+        retrieved_node_id = state.get_node_id(public_key)
+
+        # Assert
+        assert len(retrieved_node_ids) == 1
+        assert retrieved_node_id == node_id
+
     def test_delete_node(self) -> None:
         """Test deleting a client node."""
         # Prepare
@@ -359,6 +375,23 @@ class StateTest(unittest.TestCase):
 
         # Assert
         assert len(retrieved_node_ids) == 0
+
+    def test_delete_node_public_key(self) -> None:
+        """Test deleting a client node with public key."""
+        # Prepare
+        state: State = self.state_factory()
+        public_key = b"mock"
+        run_id = state.create_run("mock/mock", "v1.0.0")
+        node_id = state.create_node(ping_interval=10, public_key=public_key)
+
+        # Execute
+        state.delete_node(node_id, public_key=public_key)
+        retrieved_node_ids = state.get_nodes(run_id)
+        retrieved_node_id = state.get_node_id(public_key)
+
+        # Assert
+        assert len(retrieved_node_ids) == 0
+        assert retrieved_node_id is None
 
     def test_get_nodes_invalid_run_id(self) -> None:
         """Test retrieving all node_ids with invalid run_id."""


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->
Current client authentication implementation does not verify whether `node_id` is assigned to a given public key.

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->
Implement functions in `State` that enables verification of `node_id` assigned to a given public key.

### Checklist

- [ ] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [ ] Update the changelog entry below
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

<!--
Inside the following 'Changelog entry' section, you should put the description of your changes that will be added to the changelog alongside your PR title.

If the section is completely empty (without any token) or non-existant, the changelog will just contain the title of the PR for the changelog entry, without any description. If the section contains some text other than tokens, it will use it to add a description to the change. If the section contains one of the following tokens it will ignore any other text and put the PR under the corresponding section of the changelog:

<general> is for classifying a PR as a general improvement.
<skip> is to not add the PR to the changelog
<baselines> is to add a general baselines change to the PR
<examples> is to add a general examples change to the PR
<sdk> is to add a general sdk change to the PR
<simulations> is to add a general simulations change to the PR

Note that only one token should be used.
-->

### Changelog entry



### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.ai/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
