### PR TITLE
fix(framework:skip) Handle no response for params init in workflow

### DIFF
--- a/src/py/flwr/server/workflow/default_workflows.py
+++ b/src/py/flwr/server/workflow/default_workflows.py
@@ -106,6 +106,7 @@ def default_init_params_workflow(driver: Driver, context: Context) -> None:
     if not isinstance(context, LegacyContext):
         raise TypeError(f"Expect a LegacyContext, but get {type(context).__name__}.")
 
+    paramsrecord = None
     parameters = context.strategy.initialize_parameters(
         client_manager=context.client_manager
     )
@@ -115,40 +116,47 @@ def default_init_params_workflow(driver: Driver, context: Context) -> None:
             parameters, keep_input=True
         )
     else:
-        # Get initial parameters from one of the clients
-        log(INFO, "Requesting initial parameters from one random client")
-        random_client = context.client_manager.sample(1)[0]
-        # Send GetParametersIns and get the response
-        content = compat.getparametersins_to_recordset(GetParametersIns({}))
-        messages = driver.send_and_receive(
-            [
-                driver.create_message(
-                    content=content,
-                    message_type=MessageTypeLegacy.GET_PARAMETERS,
-                    dst_node_id=random_client.node_id,
-                    group_id="0",
-                )
-            ]
-        )
-        log(INFO, "Received initial parameters from one random client")
-        msg = list(messages)[0]
-        paramsrecord = next(iter(msg.content.parameters_records.values()))
+        while True:
+            # Get initial parameters from one of the clients
+            log(INFO, "Requesting initial parameters from one random client")
+            random_client = context.client_manager.sample(1)[0]
+            # Send GetParametersIns and get the response
+            content = compat.getparametersins_to_recordset(GetParametersIns({}))
+            messages = driver.send_and_receive(
+                [
+                    driver.create_message(
+                        content=content,
+                        message_type=MessageTypeLegacy.GET_PARAMETERS,
+                        dst_node_id=random_client.node_id,
+                        group_id="0",
+                    )
+                ]
+            )
+            log(INFO, "Received initial parameters from one random client")
+            msg = list(messages)[0]
 
-    context.state.parameters_records[MAIN_PARAMS_RECORD] = paramsrecord
+            if msg.has_content():
+                paramsrecord = next(iter(msg.content.parameters_records.values()))
+                break
 
-    # Evaluate initial parameters
-    log(INFO, "Evaluating initial global parameters")
-    parameters = compat.parametersrecord_to_parameters(paramsrecord, keep_input=True)
-    res = context.strategy.evaluate(0, parameters=parameters)
-    if res is not None:
-        log(
-            INFO,
-            "initial parameters (loss, other metrics): %s, %s",
-            res[0],
-            res[1],
+    if paramsrecord is not None:
+        context.state.parameters_records[MAIN_PARAMS_RECORD] = paramsrecord
+
+        # Evaluate initial parameters
+        log(INFO, "Evaluating initial global parameters")
+        parameters = compat.parametersrecord_to_parameters(
+            paramsrecord, keep_input=True
         )
-        context.history.add_loss_centralized(server_round=0, loss=res[0])
-        context.history.add_metrics_centralized(server_round=0, metrics=res[1])
+        res = context.strategy.evaluate(0, parameters=parameters)
+        if res is not None:
+            log(
+                INFO,
+                "initial parameters (loss, other metrics): %s, %s",
+                res[0],
+                res[1],
+            )
+            context.history.add_loss_centralized(server_round=0, loss=res[0])
+            context.history.add_metrics_centralized(server_round=0, metrics=res[1])
 
 
 def default_centralized_evaluation_workflow(_: Driver, context: Context) -> None:

--- a/src/py/flwr/server/workflow/default_workflows.py
+++ b/src/py/flwr/server/workflow/default_workflows.py
@@ -116,9 +116,10 @@ def default_init_params_workflow(driver: Driver, context: Context) -> None:
             parameters, keep_input=True
         )
     else:
+        # Get initial parameters from one of the clients
+        log(INFO, "Requesting initial parameters from one random client")
+
         while True:
-            # Get initial parameters from one of the clients
-            log(INFO, "Requesting initial parameters from one random client")
             random_client = context.client_manager.sample(1)[0]
             # Send GetParametersIns and get the response
             content = compat.getparametersins_to_recordset(GetParametersIns({}))
@@ -132,10 +133,10 @@ def default_init_params_workflow(driver: Driver, context: Context) -> None:
                     )
                 ]
             )
-            log(INFO, "Received initial parameters from one random client")
             msg = list(messages)[0]
 
             if msg.has_content():
+                log(INFO, "Received initial parameters from one random client")
                 paramsrecord = next(iter(msg.content.parameters_records.values()))
                 break
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

Currently, if the sampled client for getting initial parameters fails or doesn't reply, we will get this error:

```py
  File "/Users/main/.pyenv/versions/flower-3.10/lib/python3.10/site-packages/flwr/server/workflow/default_workflows.py", line 63, in __call__
    default_init_params_workflow(driver, context)
  File "/Users/main/.pyenv/versions/flower-3.10/lib/python3.10/site-packages/flwr/server/workflow/default_workflows.py", line 135, in default_init_params_workflow
    paramsrecord = next(iter(msg.content.parameters_records.values()))
  File "/Users/main/.pyenv/versions/flower-3.10/lib/python3.10/site-packages/flwr/common/message.py", line 255, in content
    raise ValueError(
ValueError: Message content is None. Use <message>.has_content() to check if a message has content.
```

### Related issues/PRs

N/A

## Proposal

### Explanation

We instead want to resample another available client and send a get parameters request until it is successful.

### Checklist

- [x] Implement proposed change
- [x] Update the changelog entry below
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

<!--
Inside the following 'Changelog entry' section, you should put the description of your changes that will be added to the changelog alongside your PR title.

If the section is completely empty (without any token) or non-existant, the changelog will just contain the title of the PR for the changelog entry, without any description. If the section contains some text other than tokens, it will use it to add a description to the change. If the section contains one of the following tokens it will ignore any other text and put the PR under the corresponding section of the changelog:

<general> is for classifying a PR as a general improvement.
<skip> is to not add the PR to the changelog
<baselines> is to add a general baselines change to the PR
<examples> is to add a general examples change to the PR
<sdk> is to add a general sdk change to the PR
<simulations> is to add a general simulations change to the PR

Note that only one token should be used.
-->

### Changelog entry

<skip>

### Any other comments?

N/A
