### PR TITLE
docs(framework) Update copybutton behaviour in Flower documentation

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -123,6 +123,12 @@ autosummary_ignore_module_all = False
 # The full name is still at the top of the page
 add_module_names = False
 
+# Customizations for the sphinx_copybutton extension
+# Omit prompt text when copying code blocks
+copybutton_prompt_text = "$ "
+# Copy all lines when line continuation character is detected
+copybutton_line_continuation_character = "\\"
+
 
 def find_test_modules(package_path):
     """Go through the python files and exclude every *_test.py file."""


### PR DESCRIPTION
Copying this code block
```
$ python server.py
```

Pasting before update: `$ python server.py`

Pasting after update: `python server.py`

---
Copying this code block
``` bash
# Flower 1.8
$ flower-simulation \
    --server-app=sim:server_app \
    --client-app=sim:client_app \
    --num-supernodes=100
```

Pasting before update: 
``` bash
# Flower 1.8
$ flower-simulation \
    --server-app=sim:server_app \
    --client-app=sim:client_app \
    --num-supernodes=100
```

Pasting after update:
``` bash
flower-simulation \
    --server-app=sim:server_app \
    --client-app=sim:client_app \
    --num-supernodes=100
```