### PR TITLE
Update required `flwr-datasets` version for xgboost-comprehensive example

### DIFF
--- a/examples/xgboost-comprehensive/pyproject.toml
+++ b/examples/xgboost-comprehensive/pyproject.toml
@@ -10,6 +10,6 @@ authors = ["The Flower Authors <hello@flower.ai>"]
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.11"
-flwr-nightly = { extras = ["simulation"], version = ">=1.7.0,<2.0" }
-flwr-datasets = ">=0.0.2,<1.0.0"
+flwr = { extras = ["simulation"], version = ">=1.7.0,<2.0" }
+flwr-datasets = ">=0.1.0,<1.0.0"
 xgboost = ">=2.0.0,<3.0.0"

--- a/examples/xgboost-comprehensive/requirements.txt
+++ b/examples/xgboost-comprehensive/requirements.txt
@@ -1,3 +1,3 @@
 flwr[simulation]>=1.7.0, <2.0
-flwr-datasets>=0.0.2, <1.0.0
+flwr-datasets>=0.1.0, <1.0.0
 xgboost>=2.0.0, <3.0.0


### PR DESCRIPTION
## Issue

### Description
`flwr-datasets==0.2.0` in xgboost-comprehensive example will cause naming issue for `partition_id/node_id`.


## Proposal
Update required `flwr-datasets` version to `0.1.0`.


### Changelog entry
<examples>

