### PR TITLE
docs(*) Remove placeholder search text to Flower documentation

### DIFF
--- a/baselines/doc/source/_templates/sidebar/search.html
+++ b/baselines/doc/source/_templates/sidebar/search.html
@@ -1,6 +1,0 @@
-<form class="sidebar-search-container" method="get" action="{{ pathto('search') }}" role="search">
-  <input class="sidebar-search" placeholder="{{ _("Type / to search") }}" name="q" aria-label="{{ _("Search" ) }}">
-  <input type="hidden" name="check_keywords" value="yes">
-  <input type="hidden" name="area" value="default">
-</form>
-<div id="searchbox"></div>

--- a/datasets/doc/source/_templates/sidebar/search.html
+++ b/datasets/doc/source/_templates/sidebar/search.html
@@ -1,6 +1,0 @@
-<form class="sidebar-search-container" method="get" action="{{ pathto('search') }}" role="search">
-  <input class="sidebar-search" placeholder="{{ _("Type / to search") }}" name="q" aria-label="{{ _("Search" ) }}">
-  <input type="hidden" name="check_keywords" value="yes">
-  <input type="hidden" name="area" value="default">
-</form>
-<div id="searchbox"></div>

--- a/doc/source/_templates/sidebar/search.html
+++ b/doc/source/_templates/sidebar/search.html
@@ -1,6 +1,0 @@
-<form class="sidebar-search-container" method="get" action="{{ pathto('search') }}" role="search">
-  <input class="sidebar-search" placeholder="{{ _("Type / to search") }}" name="q" aria-label="{{ _("Search" ) }}">
-  <input type="hidden" name="check_keywords" value="yes">
-  <input type="hidden" name="area" value="default">
-</form>
-<div id="searchbox"></div>


### PR DESCRIPTION
Remove `search.html` that's preventing the correct version of docs to be built.