### PR TITLE
Make DP noise logs shorter

### DIFF
--- a/src/py/flwr/client/mod/localdp_mod.py
+++ b/src/py/flwr/client/mod/localdp_mod.py
@@ -145,7 +145,7 @@ class LocalDpMod:
         )
         log(
             INFO,
-            "LocalDpMod: local DP noise with %.4f stedv added to parameters.",
+            "LocalDpMod: local DP noise with %.4f stedv added to parameters",
             noise_value_sd,
         )
 

--- a/src/py/flwr/client/mod/localdp_mod.py
+++ b/src/py/flwr/client/mod/localdp_mod.py
@@ -145,8 +145,7 @@ class LocalDpMod:
         )
         log(
             INFO,
-            "LocalDpMod: local DP noise with "
-            "standard deviation: %.4f added to parameters.",
+            "LocalDpMod: local DP noise with %.4f stedv added to parameters.",
             noise_value_sd,
         )
 

--- a/src/py/flwr/server/strategy/dp_adaptive_clipping.py
+++ b/src/py/flwr/server/strategy/dp_adaptive_clipping.py
@@ -234,7 +234,7 @@ class DifferentialPrivacyServerSideAdaptiveClipping(Strategy):
             )
             log(
                 INFO,
-                "aggregate_fit: central DP noise with %.4f stdev added.",
+                "aggregate_fit: central DP noise with %.4f stdev added",
                 compute_stdv(
                     self.noise_multiplier, self.clipping_norm, self.num_sampled_clients
                 ),
@@ -424,7 +424,7 @@ class DifferentialPrivacyClientSideAdaptiveClipping(Strategy):
             )
             log(
                 INFO,
-                "aggregate_fit: central DP noise with %.4f stdev added.",
+                "aggregate_fit: central DP noise with %.4f stdev added",
                 compute_stdv(
                     self.noise_multiplier, self.clipping_norm, self.num_sampled_clients
                 ),

--- a/src/py/flwr/server/strategy/dp_adaptive_clipping.py
+++ b/src/py/flwr/server/strategy/dp_adaptive_clipping.py
@@ -234,8 +234,7 @@ class DifferentialPrivacyServerSideAdaptiveClipping(Strategy):
             )
             log(
                 INFO,
-                "aggregate_fit: central DP noise with "
-                "standard deviation: %.4f added to parameters.",
+                "aggregate_fit: central DP noise with %.4f stdev added.",
                 compute_stdv(
                     self.noise_multiplier, self.clipping_norm, self.num_sampled_clients
                 ),
@@ -425,8 +424,7 @@ class DifferentialPrivacyClientSideAdaptiveClipping(Strategy):
             )
             log(
                 INFO,
-                "aggregate_fit: central DP noise with "
-                "standard deviation: %.4f added to parameters.",
+                "aggregate_fit: central DP noise with %.4f stdev added.",
                 compute_stdv(
                     self.noise_multiplier, self.clipping_norm, self.num_sampled_clients
                 ),

--- a/src/py/flwr/server/strategy/dp_fixed_clipping.py
+++ b/src/py/flwr/server/strategy/dp_fixed_clipping.py
@@ -180,7 +180,7 @@ class DifferentialPrivacyServerSideFixedClipping(Strategy):
 
             log(
                 INFO,
-                "aggregate_fit: central DP noise with %.4f stdev added.",
+                "aggregate_fit: central DP noise with %.4f stdev added",
                 compute_stdv(
                     self.noise_multiplier, self.clipping_norm, self.num_sampled_clients
                 ),
@@ -337,7 +337,7 @@ class DifferentialPrivacyClientSideFixedClipping(Strategy):
             )
             log(
                 INFO,
-                "aggregate_fit: central DP noise with %.4f stdev added.",
+                "aggregate_fit: central DP noise with %.4f stdev added",
                 compute_stdv(
                     self.noise_multiplier, self.clipping_norm, self.num_sampled_clients
                 ),

--- a/src/py/flwr/server/strategy/dp_fixed_clipping.py
+++ b/src/py/flwr/server/strategy/dp_fixed_clipping.py
@@ -180,8 +180,7 @@ class DifferentialPrivacyServerSideFixedClipping(Strategy):
 
             log(
                 INFO,
-                "aggregate_fit: central DP noise with "
-                "standard deviation: %.4f added to parameters.",
+                "aggregate_fit: central DP noise with %.4f stdev added.",
                 compute_stdv(
                     self.noise_multiplier, self.clipping_norm, self.num_sampled_clients
                 ),
@@ -338,8 +337,7 @@ class DifferentialPrivacyClientSideFixedClipping(Strategy):
             )
             log(
                 INFO,
-                "aggregate_fit: central DP noise with "
-                "standard deviation: %.4f added to parameters.",
+                "aggregate_fit: central DP noise with %.4f stdev added.",
                 compute_stdv(
                     self.noise_multiplier, self.clipping_norm, self.num_sampled_clients
                 ),


### PR DESCRIPTION
Keeping the logs a bit shorter.

before:
```
INFO :      aggregate_fit: central DP noise with standard deviation: %.4f added to parameters
```

proposed change:
```
INFO :      aggregate_fit: central DP noise with %.4f stdev added.
```