### PR TITLE
doc(framework:skip) Fix versioned docs by forcing checkout

### DIFF
--- a/doc/build-versioned-docs.sh
+++ b/doc/build-versioned-docs.sh
@@ -26,7 +26,7 @@ for current_version in ${versions}; do
  
   # Make the current language available to conf.py
   export current_version
-  git switch --discard-changes ${current_version}
+  git switch --discard-changes ${current_version} --detach
   echo "INFO: Building sites for ${current_version}"
  
   for current_language in ${languages}; do

--- a/doc/build-versioned-docs.sh
+++ b/doc/build-versioned-docs.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
 # Store the current branch in a variable
 current_branch=$(git rev-parse --abbrev-ref HEAD)
@@ -25,7 +26,7 @@ for current_version in ${versions}; do
  
   # Make the current language available to conf.py
   export current_version
-  git checkout ${current_version}
+  git switch --discard-changes ${current_version}
   echo "INFO: Building sites for ${current_version}"
  
   changed=false
@@ -73,18 +74,6 @@ END
  
     # Actually building the docs for a given language and version
     sphinx-build -b html source/ build/html/${current_version}/${current_language} -A lang=True -D language=${current_language}
-
-    # Restore branch as it was to avoid conflicts
-    git restore source/_templates
-    git restore source/_templates/autosummary || rm -rf source/_templates/autosummary
-    rm source/ref-api/*.rst
-
-    if [ "$current_version" = "v1.5.0" ]; then
-      git restore source/conf.py
-    fi
-    if [ changed ]; then
-      git restore locales/${current_language} || rm -rf locales/${current_language}
-    fi
 
   done
 done

--- a/doc/build-versioned-docs.sh
+++ b/doc/build-versioned-docs.sh
@@ -29,8 +29,6 @@ for current_version in ${versions}; do
   git switch --discard-changes ${current_version}
   echo "INFO: Building sites for ${current_version}"
  
-  changed=false
- 
   for current_language in ${languages}; do
 
     # Make the current language available to conf.py
@@ -49,7 +47,7 @@ for current_version in ${versions}; do
 
       # Copy updated version of locales
       cp -r ${tmp_dir}/locales/$current_language locales/
-      changed=true
+
     fi
 
     # Only for v1.5.0, update the versions listed in the switcher

--- a/doc/build-versioned-docs.sh
+++ b/doc/build-versioned-docs.sh
@@ -26,7 +26,7 @@ for current_version in ${versions}; do
  
   # Make the current language available to conf.py
   export current_version
-  git switch --discard-changes ${current_version} --detach
+  git checkout --force ${current_version}
   echo "INFO: Building sites for ${current_version}"
  
   for current_language in ${languages}; do


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

The current implementation of `build-version-docs.sh` can break silently and make the framework docs outdated in production.

### Related issues/PRs

N/A

## Proposal

### Explanation

Make sure that an error will make the CI fail, and force checkout to discard changes.

### Checklist

- [x] Implement proposed change
- [x] Update the changelog entry below
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

<!--
Inside the following 'Changelog entry' section, you should put the description of your changes that will be added to the changelog alongside your PR title.

If the section is completely empty (without any token) or non-existant, the changelog will just contain the title of the PR for the changelog entry, without any description. If the section contains some text other than tokens, it will use it to add a description to the change. If the section contains one of the following tokens it will ignore any other text and put the PR under the corresponding section of the changelog:

<general> is for classifying a PR as a general improvement.
<skip> is to not add the PR to the changelog
<baselines> is to add a general baselines change to the PR
<examples> is to add a general examples change to the PR
<sdk> is to add a general sdk change to the PR
<simulations> is to add a general simulations change to the PR

Note that only one token should be used.
-->

### Changelog entry

<skip>

### Any other comments?

N/A
