### PR TITLE
feat(framework) Handle error message creation inside backend.

### DIFF
--- a/src/py/flwr/server/superlink/fleet/vce/backend/raybackend_test.py
+++ b/src/py/flwr/server/superlink/fleet/vce/backend/raybackend_test.py
@@ -36,6 +36,7 @@ from flwr.common import (
     RecordSet,
     Scalar,
 )
+from flwr.common.constant import ErrorCode
 from flwr.common.object_ref import load_app
 from flwr.common.recordset_compat import getpropertiesins_to_recordset
 from flwr.server.superlink.fleet.vce.backend.raybackend import RayBackend
@@ -164,6 +165,10 @@ class AsyncTestRayBackend(IsolatedAsyncioTestCase):
             raise AssertionError("This shouldn't happen")
 
         out_mssg, updated_context = res
+
+        if out_mssg.has_error():
+            if out_mssg.error.code == ErrorCode.LOAD_CLIENT_APP_EXCEPTION:
+                raise LoadClientAppError()
 
         # Verify message content is as expected
         content = out_mssg.content


### PR DESCRIPTION
The `RayBackend` executes a `ClientApp` by passing it a `Message`. This is done with a Ray Actor. If an exception is raised when running the `ClientApp`, the creation of a `Message` that embeds an `Error` is done later, in the body of the `VCE`. This isn't ideal.

What this PR proposes is to fully process a `Message`, creating an error if needed, as part of the processing done by the Ray Actor. This better mirrors what the Deployment Engine does in [`client/app.py`](https://github.com/adap/flower/blob/412eb2c3f1e0f0b2c397c19a46585948ae6d0e3f/src/py/flwr/client/app.py#L363)