### PR TITLE
feat(framework) Unify `ClientApp` execution for simulation and deployment

### DIFF
--- a/doc/build-versioned-docs.sh
+++ b/doc/build-versioned-docs.sh
@@ -73,6 +73,9 @@ END
     # Actually building the docs for a given language and version
     sphinx-build -b html source/ build/html/${current_version}/${current_language} -A lang=True -D language=${current_language}
 
+    # Clean the history of the checked-out branch to remove conflicts
+    git clean -fd
+
   done
 done
   

--- a/src/py/flwr/server/superlink/fleet/vce/backend/raybackend_test.py
+++ b/src/py/flwr/server/superlink/fleet/vce/backend/raybackend_test.py
@@ -36,6 +36,7 @@ from flwr.common import (
     RecordSet,
     Scalar,
 )
+from flwr.common.constant import ErrorCode
 from flwr.common.object_ref import load_app
 from flwr.common.recordset_compat import getpropertiesins_to_recordset
 from flwr.server.superlink.fleet.vce.backend.raybackend import RayBackend
@@ -164,6 +165,10 @@ class AsyncTestRayBackend(IsolatedAsyncioTestCase):
             raise AssertionError("This shouldn't happen")
 
         out_mssg, updated_context = res
+
+        if out_mssg.has_error():
+            if out_mssg.error.code == ErrorCode.LOAD_CLIENT_APP_EXCEPTION:
+                raise LoadClientAppError()
 
         # Verify message content is as expected
         content = out_mssg.content


### PR DESCRIPTION
This PR is based on the following two PRs, merge them before this one:
- #3459
- #3457.

It makes the Ray Actor use the same function as that used by a supernode to process a `ClientApp`+`Message`.