### PR TITLE
ci(*:skip) Enforce the skip flag on wildcard PRs

### DIFF
--- a/dev/check_pr_title.py
+++ b/dev/check_pr_title.py
@@ -43,16 +43,32 @@ if __name__ == "__main__":
 
     # Check for the pattern in the first argument given to the script
     match = re.search(pattern, pr_title)
-    if match and match.group(4).split()[0] in allowed_verbs:
-        print("PR title is valid")
-        sys.exit(0)
+
+    valid = True
+    error = "it doesn't have the correct format"
+
+    if not match:
+        valid = False
     else:
+        if not match.group(4).split()[0] in allowed_verbs:
+            valid = False
+            error = "the <PR_SUBJECT> doesn't start with a verb in the imperative mood"
+        elif match.group(2) == "*" and match.group(3) is None:
+            valid = False
+            error = "the <PR_PROJECT> cannot be '*' without using the ':skip' flag"
+
+    if not valid:
         print(
-            f"PR title `{pr_title}` is invalid, it should be of the form:\n\n\t<PR_TYPE>(<PR_PROJECT>) "
-            f"<PR_SUBJECT>\n\n with <PR_TYPE> in [{types}], and "
-            f"<PR_PROJECT> in [{'|'.join(config['project']) + '|*'}] (where '*' is used when modifying multiple projects), "
-            "and <PR_SUBJECT> starting with "
+            f"PR title `{pr_title}` is invalid, {error}.\n\n"
+            "A PR title should be of the form:\n\n\t<PR_TYPE>(<PR_PROJECT>) "
+            f"<PR_SUBJECT>\n\nOr, if the PR shouldn't appear in the changelog:\n\n\t"
+            f"<PR_TYPE>(<PR_PROJECT>:skip) <PR_SUBJECT>\n\nwith <PR_TYPE> in [{types}],\n"
+            f"<PR_PROJECT> in [{'|'.join(config['project']) + '|*'}] (where '*' is used "
+            "when modifying multiple projects and should be used in "
+            "conjunction with the ':skip' flag),\nand <PR_SUBJECT> starting with "
             "a capitalized verb in the imperative mood and without any punctuation at the end.\n\n"
-            "A valid example is:\n\n\t`feat(framework) Add flwr build CLI command`\n"
+            "A valid example is:\n\n\t`feat(framework) Add flwr build CLI command`\n\n"
+            "Or, if the PR shouldn't appear in the changelog:\n\n\t"
+            "`feat(framework:skip) Add new option to build CLI`\n"
         )
         sys.exit(1)


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

Currently the wildcard can be used for describing PRs modifying multiple projects, but the changelog doesn't support such PRs.

### Related issues/PRs

N/A

## Proposal

### Explanation

Those PRs should be marked as `:skip`, we therefore enforce the `:skip` flag to be used when `*` is used in the title.

### Checklist

- [x] Implement proposed change
- [x] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

N/A
