### PR TITLE
ci(framework:skip) Add caching to speed up E2E CI tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -131,7 +131,7 @@ jobs:
           path: |
             ~/.config/pypoetry
             ~/.local
-          key: poetry-local-${{ runner.os }}-3.8-${{ hashFiles('**/poetry.lock') }}-${{ hashFiles('.github/workflows/*.yml') }}
+          key: poetry-local-${{ runner.os }}-3.8-${{ matrix.directory }}-${{ hashFiles('.github/workflows/*.yml') }}
           restore-keys: |
             poetry-local-${{ runner.os }}-3.8-
       - name: Install dependencies
@@ -147,7 +147,7 @@ jobs:
           path: |
             ~/.fastai
             ./data
-          key: datasets-${{ runner.os }}
+          key: datasets-${{ runner.os }}-${{ matrix.directory }}-${{ hashFiles('.github/workflows/*.yml') }}
           restore-keys: |
             datasets-
       - name: Download dataset

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -122,7 +122,6 @@ jobs:
         uses: ./.github/actions/bootstrap
         with:
           python-version: 3.8
-      # virtualenv cache should depends on OS, Python version and `poetry.lock` (and optionally workflow files).
       - name: Cache Packages
         id: cache-packages
         uses: actions/cache@v4
@@ -136,9 +135,7 @@ jobs:
           restore-keys: |
             poetry-local-${{ runner.os }}-3.8-
       - name: Install dependencies
-        run: |
-          python -m pip install 'setuptools==69.5.1'
-          python -m poetry install
+        run: python -m poetry install
       - name: Install Flower wheel from artifact store
         if: ${{ github.repository == 'adap/flower' && !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -126,16 +126,14 @@ jobs:
         run: |
             python -m pip install -U pip==23.3.1
         shell: bash
-      - name: Cache pip and Python location
-        id: cache-pip-python
+      - name: Cache Python location
+        id: cache-python
         uses: actions/cache@v4
         with:
-          path: |
-            ~/.cache/pip
-            ${{ env.pythonLocation }}
-          key: pip-${{ runner.os }}-${{ matrix.directory }}-${{ env.pythonLocation }}-${{ hashFiles('**/pyproject.toml') }}
+          path: ${{ env.pythonLocation }}
+          key: pythonloc-${{ runner.os }}-${{ matrix.directory }}-${{ env.pythonLocation }}-${{ hashFiles('**/pyproject.toml') }}
           restore-keys: |
-            pip-${{ runner.os }}-${{ matrix.directory }}
+            pythonloc-${{ runner.os }}-${{ matrix.directory }}-${{ env.pythonLocation }}
       - name: Install dependencies
         run: python -m pip install --upgrade .
       - name: Install Flower wheel from artifact store

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -132,8 +132,6 @@ jobs:
             ~/.config/pypoetry
             ~/.local
           key: poetry-local-${{ runner.os }}-3.8-${{ matrix.directory }}-${{ hashFiles('.github/workflows/*.yml') }}
-          restore-keys: |
-            poetry-local-${{ runner.os }}-3.8-
       - name: Install dependencies
         run: python -m poetry install
       - name: Install Flower wheel from artifact store
@@ -148,10 +146,8 @@ jobs:
             ~/.fastai
             ./data
           key: datasets-${{ runner.os }}-${{ matrix.directory }}-${{ hashFiles('.github/workflows/*.yml') }}
-          restore-keys: |
-            datasets-
       - name: Download dataset
-        if: ${{ (matrix.dataset) && (steps.cache-datasets.outputs.cache-hit != 'true') }}
+        if: ${{ matrix.dataset }}
         run: python -c "${{ matrix.dataset }}"
       - name: Run edge client test
         if: ${{ matrix.directory != 'bare-client-auth' }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -129,15 +129,17 @@ jobs:
         with:
           # Cache directory used by Poetry for Unix, described here:
           # https://python-poetry.org/docs/configuration/#cache-dir
-          path: ~/.config/pypoetry
+          path: |
+            ~/.config/pypoetry
+            ~/.local
           key: poetry-local-${{ runner.os }}-3.8-${{ hashFiles('**/poetry.lock') }}-${{ hashFiles('.github/workflows/*.yml') }}
           restore-keys: |
             poetry-local-${{ runner.os }}-3.8-
-      - name: Check cache hits
+      - name: Install dependencies if no cache hits
         if: ${{ steps.cache-packages.outputs.cache-hit != 'true' }}
-        run: echo "No cache hit, installing from scratch"
-      - name: Install dependencies
-        run: python -m poetry install
+        run: echo "No cache hit, installing from scratch" && python -m poetry install
+      # - name: Install dependencies
+      #   run: python -m poetry install
       - name: Install Flower wheel from artifact store
         if: ${{ github.repository == 'adap/flower' && !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -118,10 +118,22 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Bootstrap
-        uses: ./.github/actions/bootstrap
+      - name: Install poetry
+        run: pipx install poetry
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
           python-version: 3.8
+          cache: 'poetry'
+      - name: Install build tools
+        run: |
+            python -m pip install -U pip==23.3.1
+            python -m pip install -U setuptools==68.2.2
+        shell: bash
+      # - name: Bootstrap
+      #   uses: ./.github/actions/bootstrap
+      #   with:
+      #     python-version: 3.8
       - name: Cache Packages
         id: cache-packages
         uses: actions/cache@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -151,7 +151,7 @@ jobs:
           restore-keys: |
             datasets-
       - name: Download dataset
-        if: ${{ matrix.dataset }} && ${{ steps.cache-datasets.outputs.cache-hit != 'true' }}
+        if: ${{ (matrix.dataset) && (steps.cache-datasets.outputs.cache-hit != 'true') }}
         run: python -c "${{ matrix.dataset }}"
       - name: Run edge client test
         if: ${{ matrix.directory != 'bare-client-auth' }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -83,10 +83,10 @@ jobs:
               import tensorflow_datasets as tfds
               tfds.load(name='iris', split=tfds.Split.TRAIN)
 
-          - directory: opacus
-            dataset: |
-              from torchvision.datasets import CIFAR10
-              CIFAR10('./data', download=True)
+          # - directory: opacus
+          #   dataset: |
+          #     from torchvision.datasets import CIFAR10
+          #     CIFAR10('./data', download=True)
 
           - directory: pytorch-lightning
             dataset: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -136,7 +136,7 @@ jobs:
         with:
           path: ~/.cache/pip
           key: pip-${{ runner.os }}-${{ matrix.directory }}-${{ hashFiles('**/pyproject.toml') }}
-        restore-keys: |
+          restore-keys: |
             pip-${{ runner.os }}-${{ matrix.directory }}
       # - name: Cache Packages
       #   id: cache-packages

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -140,6 +140,16 @@ jobs:
         if: ${{ github.repository == 'adap/flower' && !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
         run: |
           python -m pip install https://${{ env.ARTIFACT_BUCKET }}/py/${{ needs.wheel.outputs.dir }}/${{ needs.wheel.outputs.short_sha }}/${{ needs.wheel.outputs.whl_path }}
+      - name: Cache datasets
+        id: cache-datasets
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.fastai
+            ./data
+          key: datasets-${{ runner.os }}
+          restore-keys: |
+            datasets-
       - name: Download dataset
         if: ${{ matrix.dataset }}
         run: python -c "${{ matrix.dataset }}"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -126,16 +126,18 @@ jobs:
         run: |
             python -m pip install -U pip==23.3.1
         shell: bash
-      - name: Cache pip
-        id: cache-pip
+      - name: Cache pip and Python location
+        id: cache-pip-python
         uses: actions/cache@v4
         with:
-          path: ~/.cache/pip
-          key: pip-${{ runner.os }}-${{ matrix.directory }}-${{ hashFiles('**/pyproject.toml') }}
+          path: |
+            ~/.cache/pip
+            ${{ env.pythonLocation }}
+          key: pip-${{ runner.os }}-${{ matrix.directory }}-${{ env.pythonLocation }}-${{ hashFiles('**/pyproject.toml') }}
           restore-keys: |
             pip-${{ runner.os }}-${{ matrix.directory }}
       - name: Install dependencies
-        run: python -m pip install .
+        run: python -m pip install --upgrade .
       - name: Install Flower wheel from artifact store
         if: ${{ github.repository == 'adap/flower' && !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -118,46 +118,43 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Install poetry
-        run: pipx install poetry
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: 3.8
-          cache: 'poetry'
+          cache: 'pip'
       - name: Install build tools
         run: |
             python -m pip install -U pip==23.3.1
-            python -m pip install -U setuptools==68.2.2
         shell: bash
       # - name: Bootstrap
       #   uses: ./.github/actions/bootstrap
       #   with:
       #     python-version: 3.8
-      - name: Cache Packages
-        id: cache-packages
-        uses: actions/cache@v4
-        with:
-          # Cache directory used by Poetry for Unix, described here:
-          # https://python-poetry.org/docs/configuration/#cache-dir
-          path: |
-            ~/.config/pypoetry
-            ~/.local
-          key: poetry-local-${{ runner.os }}-3.8-${{ matrix.directory }}-${{ hashFiles('.github/workflows/*.yml') }}
+      # - name: Cache Packages
+      #   id: cache-packages
+      #   uses: actions/cache@v4
+      #   with:
+      #     # Cache directory used by Poetry for Unix, described here:
+      #     # https://python-poetry.org/docs/configuration/#cache-dir
+      #     path: |
+      #       ~/.config/pypoetry
+      #       ~/.local
+      #     key: poetry-local-${{ runner.os }}-3.8-${{ matrix.directory }}-${{ hashFiles('.github/workflows/*.yml') }}
       - name: Install dependencies
-        run: python -m poetry install
+        run: python -m pip install .
       - name: Install Flower wheel from artifact store
         if: ${{ github.repository == 'adap/flower' && !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
         run: |
           python -m pip install https://${{ env.ARTIFACT_BUCKET }}/py/${{ needs.wheel.outputs.dir }}/${{ needs.wheel.outputs.short_sha }}/${{ needs.wheel.outputs.whl_path }}
-      - name: Cache datasets
-        id: cache-datasets
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.fastai
-            ./data
-          key: datasets-${{ runner.os }}-${{ matrix.directory }}-${{ hashFiles('.github/workflows/*.yml') }}
+      # - name: Cache datasets
+      #   id: cache-datasets
+      #   uses: actions/cache@v4
+      #   with:
+      #     path: |
+      #       ~/.fastai
+      #       ./data
+      #     key: datasets-${{ runner.os }}-${{ matrix.directory }}-${{ hashFiles('.github/workflows/*.yml') }}
       - name: Download dataset
         if: ${{ matrix.dataset }}
         run: python -c "${{ matrix.dataset }}"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -83,10 +83,10 @@ jobs:
               import tensorflow_datasets as tfds
               tfds.load(name='iris', split=tfds.Split.TRAIN)
 
-          # - directory: opacus
-          #   dataset: |
-          #     from torchvision.datasets import CIFAR10
-          #     CIFAR10('./data', download=True)
+          - directory: opacus
+            dataset: |
+              from torchvision.datasets import CIFAR10
+              CIFAR10('./data', download=True)
 
           - directory: pytorch-lightning
             dataset: |
@@ -122,6 +122,20 @@ jobs:
         uses: ./.github/actions/bootstrap
         with:
           python-version: 3.8
+      # virtualenv cache should depends on OS, Python version and `poetry.lock` (and optionally workflow files).
+      - name: Cache Packages
+        id: cache-packages
+        uses: actions/cache@v4
+        with:
+          # Cache directory used by Poetry for Unix, described here:
+          # https://python-poetry.org/docs/configuration/#cache-dir
+          path: ~/.config/pypoetry
+          key: poetry-local-${{ runner.os }}-3.8-${{ hashFiles('**/poetry.lock') }}-${{ hashFiles('.github/workflows/*.yml') }}
+          restore-keys: |
+            poetry-local-${{ runner.os }}-3.8-
+      - name: Check cache hits
+        if: ${{ steps.cache-packages.outputs.cache-hit != 'true' }}
+        run: echo "No cache hit, installing from scratch"
       - name: Install dependencies
         run: python -m poetry install
       - name: Install Flower wheel from artifact store

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -122,7 +122,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.8
-          cache: 'pip'
       - name: Install build tools
         run: |
             python -m pip install -U pip==23.3.1
@@ -131,6 +130,14 @@ jobs:
       #   uses: ./.github/actions/bootstrap
       #   with:
       #     python-version: 3.8
+      - name: Cache pip
+        id: cache-pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: pip-${{ runner.os }}-${{ matrix.directory }}-${{ hashFiles('**/pyproject.toml') }}
+        restore-keys: |
+            pip-${{ runner.os }}-${{ matrix.directory }}
       # - name: Cache Packages
       #   id: cache-packages
       #   uses: actions/cache@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -151,7 +151,7 @@ jobs:
           restore-keys: |
             datasets-
       - name: Download dataset
-        if: ${{ matrix.dataset }}
+        if: ${{ matrix.dataset }} && ${{ steps.cache-datasets.outputs.cache-hit != 'true' }}
         run: python -c "${{ matrix.dataset }}"
       - name: Run edge client test
         if: ${{ matrix.directory != 'bare-client-auth' }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -136,7 +136,9 @@ jobs:
           restore-keys: |
             poetry-local-${{ runner.os }}-3.8-
       - name: Install dependencies
-        run: python -m poetry install
+        run: |
+          python -m pip install 'setuptools==69.5.1'
+          python -m poetry install
       - name: Install Flower wheel from artifact store
         if: ${{ github.repository == 'adap/flower' && !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -126,10 +126,6 @@ jobs:
         run: |
             python -m pip install -U pip==23.3.1
         shell: bash
-      # - name: Bootstrap
-      #   uses: ./.github/actions/bootstrap
-      #   with:
-      #     python-version: 3.8
       - name: Cache pip
         id: cache-pip
         uses: actions/cache@v4
@@ -138,30 +134,12 @@ jobs:
           key: pip-${{ runner.os }}-${{ matrix.directory }}-${{ hashFiles('**/pyproject.toml') }}
           restore-keys: |
             pip-${{ runner.os }}-${{ matrix.directory }}
-      # - name: Cache Packages
-      #   id: cache-packages
-      #   uses: actions/cache@v4
-      #   with:
-      #     # Cache directory used by Poetry for Unix, described here:
-      #     # https://python-poetry.org/docs/configuration/#cache-dir
-      #     path: |
-      #       ~/.config/pypoetry
-      #       ~/.local
-      #     key: poetry-local-${{ runner.os }}-3.8-${{ matrix.directory }}-${{ hashFiles('.github/workflows/*.yml') }}
       - name: Install dependencies
         run: python -m pip install .
       - name: Install Flower wheel from artifact store
         if: ${{ github.repository == 'adap/flower' && !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
         run: |
           python -m pip install https://${{ env.ARTIFACT_BUCKET }}/py/${{ needs.wheel.outputs.dir }}/${{ needs.wheel.outputs.short_sha }}/${{ needs.wheel.outputs.whl_path }}
-      # - name: Cache datasets
-      #   id: cache-datasets
-      #   uses: actions/cache@v4
-      #   with:
-      #     path: |
-      #       ~/.fastai
-      #       ./data
-      #     key: datasets-${{ runner.os }}-${{ matrix.directory }}-${{ hashFiles('.github/workflows/*.yml') }}
       - name: Download dataset
         if: ${{ matrix.dataset }}
         run: python -c "${{ matrix.dataset }}"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -135,11 +135,8 @@ jobs:
           key: poetry-local-${{ runner.os }}-3.8-${{ hashFiles('**/poetry.lock') }}-${{ hashFiles('.github/workflows/*.yml') }}
           restore-keys: |
             poetry-local-${{ runner.os }}-3.8-
-      - name: Install dependencies if no cache hits
-        if: ${{ steps.cache-packages.outputs.cache-hit != 'true' }}
-        run: echo "No cache hit, installing from scratch" && python -m poetry install
-      # - name: Install dependencies
-      #   run: python -m poetry install
+      - name: Install dependencies
+        run: python -m poetry install
       - name: Install Flower wheel from artifact store
         if: ${{ github.repository == 'adap/flower' && !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -126,6 +126,8 @@ jobs:
         run: |
             python -m pip install -U pip==23.3.1
         shell: bash
+      # Using approach described here for Python location caching:
+      # https://blog.allenai.org/python-caching-in-github-actions-e9452698e98d
       - name: Cache Python location
         id: cache-python
         uses: actions/cache@v4

--- a/e2e/bare-client-auth/pyproject.toml
+++ b/e2e/bare-client-auth/pyproject.toml
@@ -1,13 +1,20 @@
 [build-system]
-requires = ["poetry-core>=1.4.0"]
-build-backend = "poetry.core.masonry.api"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
-[tool.poetry]
+[project]
 name = "bare_client_auth_test"
 version = "0.1.0"
 description = "Client-auth-enabled bare Federated Learning test with Flower"
-authors = ["The Flower Authors <hello@flower.ai>"]
+authors = [
+    { name = "The Flower Authors", email = "hello@flower.ai" },
+]
+dependencies = [
+    "flwr @ {root:parent:parent:uri}",
+]
 
-[tool.poetry.dependencies]
-python = "^3.8"
-flwr = { path = "../../", develop = true }
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.metadata]
+allow-direct-references = true

--- a/e2e/bare-https/pyproject.toml
+++ b/e2e/bare-https/pyproject.toml
@@ -1,13 +1,20 @@
 [build-system]
-requires = ["poetry-core>=1.4.0"]
-build-backend = "poetry.core.masonry.api"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
-[tool.poetry]
+[project]
 name = "bare_https_test"
 version = "0.1.0"
 description = "HTTPS-enabled bare Federated Learning test with Flower"
-authors = ["The Flower Authors <hello@flower.ai>"]
+authors = [
+    { name = "The Flower Authors", email = "hello@flower.ai" },
+]
+dependencies = [
+    "flwr @ {root:parent:parent:uri}",
+]
 
-[tool.poetry.dependencies]
-python = "^3.8"
-flwr = { path = "../../", develop = true }
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.metadata]
+allow-direct-references = true

--- a/e2e/bare/pyproject.toml
+++ b/e2e/bare/pyproject.toml
@@ -1,13 +1,20 @@
 [build-system]
-requires = ["poetry-core>=1.4.0"]
-build-backend = "poetry.core.masonry.api"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
-[tool.poetry]
+[project]
 name = "bare_test"
 version = "0.1.0"
 description = "Bare Federated Learning test with Flower"
-authors = ["The Flower Authors <hello@flower.ai>"]
+authors = [
+    { name = "The Flower Authors", email = "hello@flower.ai" },
+]
+dependencies = [
+    "flwr[simulation,rest] @ {root:parent:parent:uri}",
+]
 
-[tool.poetry.dependencies]
-python = "^3.8"
-flwr = { path = "../../", develop = true, extras = ["simulation", "rest"] }
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.metadata]
+allow-direct-references = true

--- a/e2e/fastai/pyproject.toml
+++ b/e2e/fastai/pyproject.toml
@@ -1,15 +1,22 @@
 [build-system]
-requires = ["poetry-core>=1.4.0"]
-build-backend = "poetry.core.masonry.api"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
-[tool.poetry]
+[project]
 name = "quickstart-fastai"
 version = "0.1.0"
 description = "Fastai Federated Learning E2E test with Flower"
-authors = ["The Flower Authors <hello@flower.ai>"]
+authors = [
+    { name = "The Flower Authors", email = "hello@flower.ai" },
+]
+dependencies = [
+    "flwr[simulation] @ {root:parent:parent:uri}",
+    "fastai>=2.7.12,<3.0.0",
+    "torch>=2.0.0,!=2.0.1,<2.1.0",
+]
 
-[tool.poetry.dependencies]
-python = ">=3.8,<3.10"
-flwr = { path = "../../", develop = true, extras = ["simulation"] }
-fastai = "^2.7.12"
-torch = ">=2.0.0, !=2.0.1, < 2.1.0"
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.metadata]
+allow-direct-references = true

--- a/e2e/jax/pyproject.toml
+++ b/e2e/jax/pyproject.toml
@@ -1,17 +1,24 @@
-[tool.poetry]
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
 name = "jax_example"
 version = "0.1.0"
 description = "JAX example training a linear regression model with federated learning"
-authors = ["The Flower Authors <hello@flower.ai>"]
+authors = [
+    { name = "The Flower Authors", email = "hello@flower.ai" },
+]
+dependencies = [
+    "flwr[simulation] @ {root:parent:parent:uri}",
+    "jax==0.4.13",
+    "jaxlib==0.4.13",
+    "scikit-learn>=1.1.1,<2.0.0",
+    "numpy>=1.21.4,<2.0.0",
+]
 
-[tool.poetry.dependencies]
-python = "^3.8"
-flwr = { path = "../../", develop = true, extras = ["simulation"] }
-jax = "==0.4.13"
-jaxlib = "==0.4.13"
-scikit-learn = "^1.1.1"
-numpy = "^1.21.4"
+[tool.hatch.build.targets.wheel]
+packages = ["."]
 
-[build-system]
-requires = ["poetry-core>=1.4.0"]
-build-backend = "poetry.core.masonry.api"
+[tool.hatch.metadata]
+allow-direct-references = true

--- a/e2e/opacus/pyproject.toml
+++ b/e2e/opacus/pyproject.toml
@@ -1,16 +1,23 @@
 [build-system]
-requires = ["poetry-core>=1.4.0"]
-build-backend = "poetry.core.masonry.api"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
-[tool.poetry]
+[project]
 name = "opacus_e2e"
 version = "0.1.0"
 description = "Opacus E2E testing"
-authors = ["The Flower Authors <hello@flower.ai>"]
+authors = [
+    { name = "The Flower Authors", email = "hello@flower.ai" },
+]
+dependencies = [
+    "flwr[simulation] @ {root:parent:parent:uri}",
+    "opacus>=1.4.0,<2.0.0",
+    "torch>=1.13.1,<2.0.0",
+    "torchvision>=0.14.0,<2.0.0",
+]
 
-[tool.poetry.dependencies]
-python = "^3.8"
-flwr = { path = "../../", develop = true, extras = ["simulation"] }
-opacus = "^1.4.0"
-torch = "^1.13.1"
-torchvision = "^0.14.0"
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.metadata]
+allow-direct-references = true

--- a/e2e/pandas/pyproject.toml
+++ b/e2e/pandas/pyproject.toml
@@ -1,17 +1,26 @@
 [build-system]
-requires = ["poetry-core>=1.4.0"]
-build-backend = "poetry.core.masonry.api"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
-[tool.poetry]
+[project]
 name = "quickstart-pandas"
 version = "0.1.0"
-description = "Pandas Federated Analytics Quickstart with Flower"
-authors = ["Ragy Haddad <ragy202@gmail.com>"]
-maintainers = ["The Flower Authors <hello@flower.ai>"]
+description = "Pandas E2E test with Flower"
+authors = [
+    { name = "Ragy Haddad", email = "ragy202@gmail.com" },
+]
+maintainers = [
+    { name = "The Flower Authors", email = "hello@flower.ai" },
+]
+dependencies = [
+    "flwr[simulation] @ {root:parent:parent:uri}",
+    "numpy>=1.21.0,<2.0.0",
+    "pandas>=2.0.0,<3.0.0",
+    "scikit-learn>=1.1.1,<2.0.0",
+]
 
-[tool.poetry.dependencies]
-python = "^3.8"
-flwr = { path = "../../", develop = true, extras = ["simulation"] }
-numpy = "^1.21.0"
-pandas = "^2.0.0"
-scikit-learn = "^1.1.1"
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.metadata]
+allow-direct-references = true

--- a/e2e/pytorch-lightning/pyproject.toml
+++ b/e2e/pytorch-lightning/pyproject.toml
@@ -1,15 +1,22 @@
 [build-system]
-requires = ["poetry-core>=1.4.0"]
-build-backend = "poetry.masonry.api"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
-[tool.poetry]
-name = "quickstart-pytorch-lightning"
+[project]
+name = "quickstart-pytorch-lightning-test"
 version = "0.1.0"
 description = "Federated Learning E2E test with Flower and PyTorch Lightning"
-authors = ["The Flower Authors <hello@flower.ai>"]
+authors = [
+    { name = "The Flower Authors", email = "hello@flower.ai" },
+]
+dependencies = [
+    "flwr[simulation] @ {root:parent:parent:uri}",
+    "pytorch-lightning==2.2.4",
+    "torchvision==0.14.1",
+]
 
-[tool.poetry.dependencies]
-python = "^3.8"
-flwr = { path = "../../", develop = true, extras = ["simulation"] }
-pytorch-lightning = "2.2.4"
-torchvision = "0.14.1"
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.metadata]
+allow-direct-references = true

--- a/e2e/pytorch/pyproject.toml
+++ b/e2e/pytorch/pyproject.toml
@@ -1,16 +1,23 @@
 [build-system]
-requires = ["poetry-core>=1.4.0"]
-build-backend = "poetry.core.masonry.api"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
-[tool.poetry]
-name = "quickstart-pytorch"
+[project]
+name = "pytorch_e2e"
 version = "0.1.0"
-description = "PyTorch Federated Learning Quickstart with Flower"
-authors = ["The Flower Authors <hello@flower.ai>"]
+description = "PyTorch Federated Learning E2E test with Flower"
+authors = [
+    { name = "The Flower Authors", email = "hello@flower.ai" },
+]
+dependencies = [
+    "flwr[simulation] @ {root:parent:parent:uri}",
+    "torch>=1.12.0,<2.0.0",
+    "torchvision>=0.14.1,<0.15.0",
+    "tqdm>=4.63.0,<5.0.0",
+]
 
-[tool.poetry.dependencies]
-python = "^3.8"
-flwr = { path = "../../", develop = true, extras = ["simulation"] }
-torch = "^1.12.0"
-torchvision = "^0.14.1"
-tqdm = "^4.63.0"
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.metadata]
+allow-direct-references = true

--- a/e2e/scikit-learn/pyproject.toml
+++ b/e2e/scikit-learn/pyproject.toml
@@ -1,18 +1,23 @@
 [build-system]
-requires = ["poetry-core>=1.4.0"]
-build-backend = "poetry.core.masonry.api"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
-[tool.poetry]
-name = "sklearn-mnist"
+[project]
+name = "sklearn-mnist-test"
 version = "0.1.0"
-description = "Federated learning with scikit-learn and Flower"
+description = "Federated learning E2E test with scikit-learn and Flower"
 authors = [
-    "The Flower Authors <hello@flower.ai>",
-    "Kaushik Amar Das <kaushik.das@iiitg.ac.in>",
+    { name = "The Flower Authors", email = "hello@flower.ai" },
+    { name = "Kaushik Amar Das", email = "kaushik.das@iiitg.ac.in"},
+]
+dependencies = [
+    "flwr[simulation,rest] @ {root:parent:parent:uri}",
+    "scikit-learn>=1.1.1,<2.0.0",
+    "openml>=0.14.0,<0.15.0"
 ]
 
-[tool.poetry.dependencies]
-python = "^3.8"
-flwr = { path = "../../", develop = true, extras = ["simulation"] }
-scikit-learn = "^1.1.1"
-openml = "^0.14.0"
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.metadata]
+allow-direct-references = true

--- a/e2e/tabnet/pyproject.toml
+++ b/e2e/tabnet/pyproject.toml
@@ -1,18 +1,25 @@
 [build-system]
-requires = ["poetry-core>=1.4.0"]
-build-backend = "poetry.core.masonry.api"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
-[tool.poetry]
-name = "quickstart-tabnet"
+[project]
+name = "quickstart-tabnet-test"
 version = "0.1.0"
-description = "Tabnet Federated Learning Quickstart with Flower"
-authors = ["The Flower Authors <hello@flower.ai>"]
+description = "Tabnet Federated Learning E2E test with Flower"
+authors = [
+    { name = "The Flower Authors", email = "hello@flower.ai" },
+]
+dependencies = [
+    "flwr[simulation] @ {root:parent:parent:uri}",
+    "tensorflow-cpu>=2.9.1,!=2.11.1; platform_machine == \"x86_64\"",
+    "tensorflow-macos>=2.9.1,!=2.11.1; sys_platform == \"darwin\" and platform_machine == \"arm64\"",
+    "tensorflow_datasets==4.9.2",
+    "tensorflow-io-gcs-filesystem<0.35.0",
+    "tabnet==0.1.6",
+]
 
-[tool.poetry.dependencies]
-python = ">=3.8,<3.11"
-flwr = { path = "../../", develop = true, extras = ["simulation"] }
-tensorflow-cpu = { version = ">=2.9.1,<2.11.1 || >2.11.1", markers = "platform_machine == \"x86_64\"" }
-tensorflow-macos = { version = ">=2.9.1,<2.11.1 || >2.11.1", markers = "sys_platform == \"darwin\" and platform_machine == \"arm64\"" }
-tensorflow_datasets = "4.9.2"
-tensorflow-io-gcs-filesystem = "<0.35.0"
-tabnet = "0.1.6"
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.metadata]
+allow-direct-references = true

--- a/e2e/tensorflow/pyproject.toml
+++ b/e2e/tensorflow/pyproject.toml
@@ -1,15 +1,22 @@
 [build-system]
-requires = ["poetry-core>=1.4.0"]
-build-backend = "poetry.core.masonry.api"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
-[tool.poetry]
-name = "quickstart-tensorflow"
+[project]
+name = "quickstart-tensorflow-test"
 version = "0.1.0"
-description = "Keras Federated Learning Quickstart with Flower"
-authors = ["The Flower Authors <hello@flower.ai>"]
+description = "Keras Federated Learning E2E test with Flower"
+authors = [
+    { name = "The Flower Authors", email = "hello@flower.ai" },
+]
+dependencies = [
+    "flwr[simulation] @ {root:parent:parent:uri}",
+    "tensorflow-cpu>=2.9.1,!=2.11.1",
+    "tensorflow-io-gcs-filesystem<0.35.0",
+]
 
-[tool.poetry.dependencies]
-python = ">=3.8,<3.11"
-flwr = { path = "../../", develop = true, extras = ["simulation"] }
-tensorflow-cpu = "^2.9.1, !=2.11.1"
-tensorflow-io-gcs-filesystem = "<0.35.0"
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.metadata]
+allow-direct-references = true


### PR DESCRIPTION
## Issue

### Description

This PR improves the speed of the CI for E2E tests.

### Related issues/PRs

This PR is inspired by #1975 and [this blogpost](https://blog.allenai.org/python-caching-in-github-actions-e9452698e98d) by Evan Pete Walsh. The CI should be triggered couple of times after that has happened to compare the impact of the caching. 

## Explanation

The CI cache works as follows:

### `main` branch

Whenever a new commit or PR is made to the main branch the `Cache Python location` job in `.github/workflows/e2e.yml` will run and cache the following directory:

* `${{ env.pythonLocation }}` (Note that caching only `~/.cache/pip` will cache the wheels, but not the installation itself)

The cache will be overwritten if there is a cache miss. It is retrieved by jobs in pull requests by the following key:

`pip-${{ runner.os }}-${{ matrix.directory }}-${{ env.pythonLocation }}-${{ hashFiles('**/pyproject.toml') }}`

We ensure that the job retrieving the cache must meet the following requirements:
1. Same OS
2. Same matrix directory (important because matrix is used in the E2E test)
3. Same Python location (which looks something like `/opt/hostedtoolcache/Python/3.8.18/x64`)
4. No changes to `pyproject.toml` in the project folders.

One significant update in this PR is that all `pyproject.toml`s in the E2E folder have been migrated to pure `pip` installation with `hatchling` backend without relying on `poetry` and `setuptools`.

In this PR, we only rely on `actions@cache` for caching the Python location instead of `actions@setup-python` because the latter does not yet work with matrix configurations due to cache key conflicts. This is explained by the `setup-python` maintainers in [this thread](https://github.com/actions/setup-python/issues/826#issuecomment-2021999109). 

### Pull Requests

Pull requests will try to use the cache by doing a lookup using the previously described key and pull the cache is available. 

### Preliminary results

E2E timings can reduce down to ~4 min 50+ secs by caching the Python location, compared to ~5 min 20+ secs if we cache only `~/.cache/pip`, and ~5 min 40+ secs without caching (see [this workflow run](https://github.com/adap/flower/actions/runs/9191558539)). 

### Checklist

- [X] Implement proposed change
- ~~[ ] Write tests~~
- [X] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [X] Update the changelog entry below
- [X] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.dev/join-slack/) (channel `#contributions`)

<!--
Inside the following 'Changelog entry' section, you should put the description of your changes that will be added to the changelog alongside your PR title.

If the section is completely empty (without any token) or non-existant, the changelog will just contain the title of the PR for the changelog entry, without any description. If the section contains some text other than tokens, it will use it to add a description to the change. If the section contains one of the following tokens it will ignore any other text and put the PR under the corresponding section of the changelog:

<general> is for classifying a PR as a general improvement.
<skip> is to not add the PR to the changelog
<baselines> is to add a general baselines change to the PR
<examples> is to add a general examples change to the PR
<sdk> is to add a general sdk change to the PR
<simulations> is to add a general simulations change to the PR

Note that only one token should be used.
-->

### Changelog entry

<skip>

### Any other comments?

N/A
<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.ai/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->