### PR TITLE
fix(*:skip) Exclude `setuptools` version from `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ iterators = "^0.0.2"
 typer = { version = "^0.9.0", extras=["all"] }
 tomli = "^2.0.1"
 pathspec = "^0.12.1"
+setuptools = "!=70.0.0"
 # Optional dependencies (Simulation Engine)
 ray = { version = "==2.6.3", optional = true, python = ">=3.8,<3.12" }
 # Optional dependencies (REST transport layer)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,6 @@ ray = { version = "==2.6.3", optional = true, python = ">=3.8,<3.12" }
 requests = { version = "^2.31.0", optional = true }
 starlette = { version = "^0.31.0", optional = true }
 uvicorn = { version = "^0.23.0", extras = ["standard"], optional = true }
-setuptools = "69.5.1"
 
 [tool.poetry.extras]
 simulation = ["ray", "pydantic"]


### PR DESCRIPTION
Adjusts #3482.

A followup PR (https://github.com/adap/flower/pull/3501) will evaluate if excluding `setuptools==70.0.0` can be done if updating to a more recent version of `ray` is possible.