### PR TITLE
ci(*:skip) Ignore dependabot PRs for title checks

### DIFF
--- a/dev/check_pr_title.py
+++ b/dev/check_pr_title.py
@@ -46,7 +46,10 @@ if __name__ == "__main__":
     valid = True
     error = "it doesn't have the correct format"
 
-    if not match:
+    # This check is there to ignore dependabot PRs from title checks
+    if pr_title.startswith("chore"):
+        sys.exit(0)
+    elif not match:
         valid = False
     else:
         if not match.group(4).split()[0] in allowed_verbs:


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

Currently all dependabot PRs will fail because we enforce a PR format and there is no configuration that allows us to modify dependabot's PR title format.

### Related issues/PRs

N/A

## Proposal

### Explanation

Ignore PRs that start with `chore` from being checked.

### Checklist

- [x] Implement proposed change
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

N/A
