### PR TITLE
ci(*:skip) Fix PR title check regex

### DIFF
--- a/dev/changelog_config.toml
+++ b/dev/changelog_config.toml
@@ -7,7 +7,7 @@ project = ["framework", "baselines", "datasets", "examples"]
 
 scope = "skip"
 
-pattern_template = "^({types})\\(({projects})(?::({scope}))?\\) ([A-Z][^\\.\\n]*(?:\\.(?=[^\\.\\n]))*[^\\.\\n]*)$"
+pattern_template = "^({types})\\(({projects})(?::({scope}))?\\) ([A-Z][^\\n]*[^\\.\\n])$"
 
 allowed_verbs=[
   "Abandon",


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

Currently, any dots inside the subject of the PR title would result in a failing CI.

### Related issues/PRs

N/A

## Proposal

### Explanation

Only fail when a dot is present at the end of the subject.

### Checklist

- [x] Implement proposed change
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

N/A
