### PR TITLE
fix(framework:skip) Remove `pydantic` from list of extras in `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ starlette = { version = "^0.31.0", optional = true }
 uvicorn = { version = "^0.23.0", extras = ["standard"], optional = true }
 
 [tool.poetry.extras]
-simulation = ["ray", "pydantic"]
+simulation = ["ray"]
 rest = ["requests", "starlette", "uvicorn"]
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
It was added first here last year due to an issue with Ray (https://github.com/adap/flower/pull/2002), but it got removed from the dependencies list last month (https://github.com/adap/flower/pull/3265). It doesn't seem to be needed anymore?