### PR TITLE
feat(framework:skip) Add delete node on shutdown

### DIFF
--- a/src/py/flwr/client/app.py
+++ b/src/py/flwr/client/app.py
@@ -268,6 +268,7 @@ def _start_client_internal(
     run_tracker = _RunTracker()
 
     def _on_sucess(retry_state: RetryState) -> None:
+        run_tracker.is_connected = True
         if retry_state.tries > 1:
             log(
                 INFO,
@@ -279,6 +280,7 @@ def _start_client_internal(
                 run_tracker.create_node()
 
     def _on_backoff(retry_state: RetryState) -> None:
+        run_tracker.is_connected = False
         if retry_state.tries == 1:
             log(WARN, "Connection attempt failed, retrying...")
         else:
@@ -425,6 +427,10 @@ def _start_client_internal(
                 except StopIteration:
                     sleep_duration = 0
                     break
+
+            # Unregister node
+            if delete_node is not None and run_tracker.is_connected:
+                delete_node()  # pylint: disable=not-callable
 
         if sleep_duration == 0:
             log(INFO, "Disconnect and shut down")
@@ -605,6 +611,7 @@ def _init_connection(transport: Optional[str], server_address: str) -> Tuple[
 class _RunTracker:
     create_node: Optional[Callable[[], None]] = None
     interrupt: bool = False
+    is_connected: bool = False
 
     def register_signal_handler(self) -> None:
         """Register handlers for exit signals."""

--- a/src/py/flwr/client/grpc_rere_client/connection.py
+++ b/src/py/flwr/client/grpc_rere_client/connection.py
@@ -189,9 +189,9 @@ def grpc_request_response(  # pylint: disable=R0913, R0914, R0915
             return
 
         # Stop the ping-loop thread
-        ping_stop_event.set()
-        if ping_thread is not None:
-            ping_thread.join()
+        # ping_stop_event.set()
+        # if ping_thread is not None:
+        #     ping_thread.join()
 
         # Call FleetAPI
         delete_node_request = DeleteNodeRequest(node=node)

--- a/src/py/flwr/client/grpc_rere_client/connection.py
+++ b/src/py/flwr/client/grpc_rere_client/connection.py
@@ -188,11 +188,6 @@ def grpc_request_response(  # pylint: disable=R0913, R0914, R0915
             log(ERROR, "Node instance missing")
             return
 
-        # Stop the ping-loop thread
-        # ping_stop_event.set()
-        # if ping_thread is not None:
-        #     ping_thread.join()
-
         # Call FleetAPI
         delete_node_request = DeleteNodeRequest(node=node)
         retry_invoker.invoke(stub.DeleteNode, request=delete_node_request)


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

With #3090 we allow clients to exit gracefully but they are not deleted directly on the SuperLink, this can cause "phantom clients" being sampled.

### Related issues/PRs

#3090 

## Proposal

### Explanation

- Send a `delete_node` request on shutdown
- Let the daemon thread exit without trying to join (https://stackoverflow.com/a/47443226)

### Checklist

- [x] Implement proposed change
- [x] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

N/A
