### PR TITLE
docs(framework:skip) Add details about the ownership of mounted volumes

### DIFF
--- a/src/docker/base/alpine/Dockerfile
+++ b/src/docker/base/alpine/Dockerfile
@@ -34,10 +34,10 @@ RUN apk add --no-cache \
     g++ \
     libffi-dev \
     # create virtual env
-    && python -m venv /app/venv
+    && python -m venv /python/venv
 
 # Make sure we use the virtualenv
-ENV PATH=/app/venv/bin:$PATH
+ENV PATH=/python/venv/bin:$PATH
 
 # Install specific version of pip, setuptools and flwr
 ARG PIP_VERSION
@@ -59,12 +59,14 @@ RUN apk add --no-cache \
     --no-create-home \
     --disabled-password \
     --gecos "" \
-    --uid 49999 app
+    --uid 49999 app \
+    && mkdir -p /app \
+    && chown -R app:app /app
 
-COPY --from=compile --chown=app:app /app/venv /app/venv
+COPY --from=compile --chown=app:app /python/venv /python/venv
 
 # Make sure we use the virtualenv
-ENV PATH=/app/venv/bin:$PATH \
+ENV PATH=/python/venv/bin:$PATH \
     # Send stdout and stderr stream directly to the terminal. Ensures that no
     # output is retained in a buffer if the application crashes.
     PYTHONUNBUFFERED=1 \

--- a/src/docker/base/ubuntu/Dockerfile
+++ b/src/docker/base/ubuntu/Dockerfile
@@ -74,8 +74,8 @@ ENV PATH=/usr/local/bin/python/bin:$PATH \
 
 # Use a virtual environment to ensure that Python packages are installed in the same location
 # regardless of whether the subsequent image build is run with the app or the root user
-RUN python -m venv /app/venv
-ENV PATH=/app/venv/bin:$PATH
+RUN python -m venv /python/venv
+ENV PATH=/python/venv/bin:$PATH
 
 ARG PIP_VERSION
 ARG SETUPTOOLS_VERSION
@@ -92,6 +92,8 @@ RUN adduser \
     --disabled-password \
     --gecos "" \
     --uid 49999 app \
+    && mkdir -p /app \
+    && chown -R app:app /python \
     && chown -R app:app /app
 
 WORKDIR /app


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

- Adds details about the ownership of mounted volumes.
- Removes another forgotten `client:app` argument.
- Moves the virtual environment from `/app/venv` to `/python` to ensure that the venv is not overridden when a local directory is mounted into `/app` directory of the container.

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

### Checklist

- [ ] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.ai/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
