### PR TITLE
fix(framework) Fix the metadata type in `MessageContainer`

### DIFF
--- a/src/proto/flwr/proto/grpcadapter.proto
+++ b/src/proto/flwr/proto/grpcadapter.proto
@@ -22,7 +22,7 @@ service GrpcAdapter {
 }
 
 message MessageContainer {
-  map<string, bytes> metadata = 1;
+  map<string, string> metadata = 1;
   string grpc_message_name = 2;
   bytes grpc_message_content = 3;
 }

--- a/src/py/flwr/proto/grpcadapter_pb2.py
+++ b/src/py/flwr/proto/grpcadapter_pb2.py
@@ -14,7 +14,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x1c\x66lwr/proto/grpcadapter.proto\x12\nflwr.proto\"\xba\x01\n\x10MessageContainer\x12<\n\x08metadata\x18\x01 \x03(\x0b\x32*.flwr.proto.MessageContainer.MetadataEntry\x12\x19\n\x11grpc_message_name\x18\x02 \x01(\t\x12\x1c\n\x14grpc_message_content\x18\x03 \x01(\x0c\x1a/\n\rMetadataEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x0c:\x02\x38\x01\x32Z\n\x0bGrpcAdapter\x12K\n\x0bSendReceive\x12\x1c.flwr.proto.MessageContainer\x1a\x1c.flwr.proto.MessageContainer\"\x00\x62\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x1c\x66lwr/proto/grpcadapter.proto\x12\nflwr.proto\"\xba\x01\n\x10MessageContainer\x12<\n\x08metadata\x18\x01 \x03(\x0b\x32*.flwr.proto.MessageContainer.MetadataEntry\x12\x19\n\x11grpc_message_name\x18\x02 \x01(\t\x12\x1c\n\x14grpc_message_content\x18\x03 \x01(\x0c\x1a/\n\rMetadataEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x32Z\n\x0bGrpcAdapter\x12K\n\x0bSendReceive\x12\x1c.flwr.proto.MessageContainer\x1a\x1c.flwr.proto.MessageContainer\"\x00\x62\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)

--- a/src/py/flwr/proto/grpcadapter_pb2.pyi
+++ b/src/py/flwr/proto/grpcadapter_pb2.pyi
@@ -18,11 +18,11 @@ class MessageContainer(google.protobuf.message.Message):
         KEY_FIELD_NUMBER: builtins.int
         VALUE_FIELD_NUMBER: builtins.int
         key: typing.Text
-        value: builtins.bytes
+        value: typing.Text
         def __init__(self,
             *,
             key: typing.Text = ...,
-            value: builtins.bytes = ...,
+            value: typing.Text = ...,
             ) -> None: ...
         def ClearField(self, field_name: typing_extensions.Literal["key",b"key","value",b"value"]) -> None: ...
 
@@ -30,12 +30,12 @@ class MessageContainer(google.protobuf.message.Message):
     GRPC_MESSAGE_NAME_FIELD_NUMBER: builtins.int
     GRPC_MESSAGE_CONTENT_FIELD_NUMBER: builtins.int
     @property
-    def metadata(self) -> google.protobuf.internal.containers.ScalarMap[typing.Text, builtins.bytes]: ...
+    def metadata(self) -> google.protobuf.internal.containers.ScalarMap[typing.Text, typing.Text]: ...
     grpc_message_name: typing.Text
     grpc_message_content: builtins.bytes
     def __init__(self,
         *,
-        metadata: typing.Optional[typing.Mapping[typing.Text, builtins.bytes]] = ...,
+        metadata: typing.Optional[typing.Mapping[typing.Text, typing.Text]] = ...,
         grpc_message_name: typing.Text = ...,
         grpc_message_content: builtins.bytes = ...,
         ) -> None: ...


### PR DESCRIPTION
As we discussed previously with NVFlare team, the metadata should be a `Dict[str, str]`.