### PR TITLE
docs(framework:skip) Add built-in mods to client doc

### DIFF
--- a/src/py/flwr/client/__init__.py
+++ b/src/py/flwr/client/__init__.py
@@ -33,4 +33,5 @@ __all__ = [
     "run_supernode",
     "start_client",
     "start_numpy_client",
+    "mod",
 ]

--- a/src/py/flwr/client/__init__.py
+++ b/src/py/flwr/client/__init__.py
@@ -28,10 +28,10 @@ __all__ = [
     "Client",
     "ClientApp",
     "ClientFn",
+    "mod",
     "NumPyClient",
     "run_client_app",
     "run_supernode",
     "start_client",
     "start_numpy_client",
-    "mod",
 ]

--- a/src/py/flwr/client/mod/__init__.py
+++ b/src/py/flwr/client/mod/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Mods."""
+"""Flower Built-in Mods."""
 
 
 from .centraldp_mods import adaptiveclipping_mod, fixedclipping_mod


### PR DESCRIPTION
This PR adds built-in mods to the flwr client docs: [page](https://flower.ai/docs/framework/ref-api/flwr.client.html#module-flwr.client)