### PR TITLE
refactor(framework:skip) Add return types to certain CLI functions

### DIFF
--- a/src/py/flwr/cli/build.py
+++ b/src/py/flwr/cli/build.py
@@ -33,7 +33,7 @@ def build(
         Optional[Path],
         typer.Option(help="The Flower project directory to bundle into a FAB"),
     ] = None,
-) -> None:
+) -> str:
     """Build a Flower project into a Flower App Bundle (FAB).
 
     You can run `flwr build` without any argument to bundle the current directory:
@@ -124,6 +124,8 @@ def build(
     typer.secho(
         f"🎊 Successfully built {fab_filename}.", fg=typer.colors.GREEN, bold=True
     )
+
+    return fab_filename
 
 
 def _load_gitignore(directory: Path) -> pathspec.PathSpec:

--- a/src/py/flwr/cli/install.py
+++ b/src/py/flwr/cli/install.py
@@ -84,7 +84,7 @@ def install_from_fab(
     fab_file: Union[Path, bytes],
     flwr_dir: Optional[Path],
     skip_prompt: bool = False,
-) -> None:
+) -> Path:
     """Install from a FAB file after extracting and validating."""
     fab_file_archive: Union[Path, IO[bytes]]
     fab_name: Optional[str]
@@ -124,7 +124,11 @@ def install_from_fab(
 
             shutil.rmtree(info_dir)
 
-            validate_and_install(tmpdir_path, fab_name, flwr_dir, skip_prompt)
+            installed_path = validate_and_install(
+                tmpdir_path, fab_name, flwr_dir, skip_prompt
+            )
+
+    return installed_path
 
 
 def validate_and_install(
@@ -132,7 +136,7 @@ def validate_and_install(
     fab_name: Optional[str],
     flwr_dir: Optional[Path],
     skip_prompt: bool = False,
-) -> None:
+) -> Path:
     """Validate TOML files and install the project to the desired directory."""
     config, _, _ = load_and_validate(project_dir / "pyproject.toml", check_module=False)
 
@@ -185,7 +189,7 @@ def validate_and_install(
                 bold=True,
             )
         ):
-            return
+            return install_dir
 
     install_dir.mkdir(parents=True, exist_ok=True)
 
@@ -201,6 +205,8 @@ def validate_and_install(
         fg=typer.colors.GREEN,
         bold=True,
     )
+
+    return install_dir
 
 
 def _verify_hashes(list_content: str, tmpdir: Path) -> bool:


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

We need the installed directory and the filename back from the `install` and `build` functions.

### Related issues/PRs

N/A

## Proposal

### Explanation

Modify return types.

### Checklist

- [x] Implement proposed change
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

N/A
