### PR TITLE
fix(datasets) Limit the datasets versions

### DIFF
--- a/datasets/pyproject.toml
+++ b/datasets/pyproject.toml
@@ -54,7 +54,7 @@ exclude = [
 [tool.poetry.dependencies]
 python = "^3.8"
 numpy = "^1.21.0"
-datasets = "^2.14.6"
+datasets = ">=2.14.6 <2.20.0"
 pillow = { version = ">=6.2.1", optional = true }
 soundfile = { version = ">=0.12.1", optional = true }
 librosa = { version = ">=0.10.0.post2", optional = true }


### PR DESCRIPTION
## Issue
The CI is failing when the dependency: `datasets` version is 2.20.0 (released on June 13th 2024). 

### Description
The default value of the `trust_remote_code` in `load_dataset` (that is used under the hood in `FederatedDataset`) is no longer `True`. 

Why and when is this a problem? 

Some dataset in HF are added as files and some as python scripts that handle downloads (and preprocessing).

In the case of the script, now the `trust_remote_code` must be set explicitly as `True`. 
It affects us bc many dataset are script-based e.g. `mnist`.

## Proposal
Cap the version of the datasets.

`datasets = ">=2.14.6 <2.20.0"`

### Explanation
That's a short term solution. In longer term we want to expose more eaisly passign all the arguments (as kwargs) to the dataset library.
