### PR TITLE
fix(framework:skip) Skip module checking for metadata extraction

### DIFF
--- a/src/py/flwr/cli/config_utils.py
+++ b/src/py/flwr/cli/config_utils.py
@@ -54,7 +54,7 @@ def get_fab_metadata(fab_file: Union[Path, bytes]) -> Tuple[str, str]:
         if conf is None:
             raise ValueError("Invalid TOML content in pyproject.toml")
 
-        is_valid, errors, _ = validate(conf)
+        is_valid, errors, _ = validate(conf, check_module=False)
         if not is_valid:
             raise ValueError(errors)
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

Currently, to extract the `fab_id` and `fab_version` from a FAB file (as path or bytes), it won't work if the FAB is not installed on the environment.

### Related issues/PRs

N/A

## Proposal

### Explanation

Use the `check_module` parameter to skip the module verification.

### Checklist

- [x] Implement proposed change
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

N/A
