### PR TITLE
feat(framework) Limit TaskRes TTL when saving it.

### DIFF
--- a/doc/source/how-to-run-flower-using-docker.rst
+++ b/doc/source/how-to-run-flower-using-docker.rst
@@ -86,7 +86,7 @@ container. Furthermore, we use the flag ``--database`` to specify the name of th
 .. code-block:: bash
 
   $ mkdir state
-  $ sudo chmod -R 49999:49999 state
+  $ sudo chown -R 49999:49999 state
   $ docker run --rm \
     -p 9091:9091 -p 9092:9092 --volume ./state/:/app/state flwr/superlink:1.8.0 \
     --insecure \

--- a/src/py/flwr/cli/install.py
+++ b/src/py/flwr/cli/install.py
@@ -19,8 +19,9 @@ import os
 import shutil
 import tempfile
 import zipfile
+from io import BytesIO
 from pathlib import Path
-from typing import Optional
+from typing import IO, Optional, Union
 
 import typer
 from typing_extensions import Annotated
@@ -80,11 +81,24 @@ def install(
 
 
 def install_from_fab(
-    fab_file: Path, flwr_dir: Optional[Path], skip_prompt: bool = False
+    fab_file: Union[Path, bytes],
+    flwr_dir: Optional[Path],
+    skip_prompt: bool = False,
 ) -> None:
     """Install from a FAB file after extracting and validating."""
+    fab_file_archive: Union[Path, IO[bytes]]
+    fab_name: Optional[str]
+    if isinstance(fab_file, bytes):
+        fab_file_archive = BytesIO(fab_file)
+        fab_name = None
+    elif isinstance(fab_file, Path):
+        fab_file_archive = fab_file
+        fab_name = fab_file.stem
+    else:
+        raise ValueError("fab_file must be either a Path or bytes")
+
     with tempfile.TemporaryDirectory() as tmpdir:
-        with zipfile.ZipFile(fab_file, "r") as zipf:
+        with zipfile.ZipFile(fab_file_archive, "r") as zipf:
             zipf.extractall(tmpdir)
             tmpdir_path = Path(tmpdir)
             info_dir = tmpdir_path / ".info"
@@ -110,12 +124,12 @@ def install_from_fab(
 
             shutil.rmtree(info_dir)
 
-            validate_and_install(tmpdir_path, fab_file.stem, flwr_dir, skip_prompt)
+            validate_and_install(tmpdir_path, fab_name, flwr_dir, skip_prompt)
 
 
 def validate_and_install(
     project_dir: Path,
-    fab_name: str,
+    fab_name: Optional[str],
     flwr_dir: Optional[Path],
     skip_prompt: bool = False,
 ) -> None:
@@ -134,7 +148,10 @@ def validate_and_install(
     project_name = config["project"]["name"]
     version = config["project"]["version"]
 
-    if fab_name != f"{publisher}.{project_name}.{version.replace('.', '-')}":
+    if (
+        fab_name
+        and fab_name != f"{publisher}.{project_name}.{version.replace('.', '-')}"
+    ):
         typer.secho(
             "❌ FAB file has incorrect name. The file name must follow the format "
             "`<publisher>.<project_name>.<version>.fab`.",

--- a/src/py/flwr/server/superlink/state/in_memory_state.py
+++ b/src/py/flwr/server/superlink/state/in_memory_state.py
@@ -129,8 +129,10 @@ class InMemoryState(State):  # pylint: disable=R0902,R0904
                 log(ERROR, "TaskIns with task_id %s is expired.", task_ins_id)
                 return None
 
-            # Limit the TaskRes TTL to not exceed the expiration time of the TaskIns it replies to
-            # Condition: TaskIns.created_at + TaskIns.ttl ≥ TaskRes.created_at + TaskRes.ttl
+            # Limit the TaskRes TTL to not exceed the
+            # expiration time of the TaskIns it replies to.
+            # Condition: TaskIns.created_at + TaskIns.ttl ≥
+            #            TaskRes.created_at + TaskRes.ttl
             if (
                 task_res.task.ttl
                 > task_ins.task.created_at

--- a/src/py/flwr/server/superlink/state/in_memory_state.py
+++ b/src/py/flwr/server/superlink/state/in_memory_state.py
@@ -116,6 +116,19 @@ class InMemoryState(State):  # pylint: disable=R0902,R0904
             log(ERROR, errors)
             return None
 
+        with self.lock:
+            # Check if the TaskIns it is replying to exists and is valid
+            task_ins_id = task_res.task.ancestry[0]
+            task_ins = self.task_ins_store.get(UUID(task_ins_id))
+
+            if task_ins is None:
+                log(ERROR, "TaskIns with task_id %s does not exist.", task_ins_id)
+                return None
+
+            if task_ins.task.created_at + task_ins.task.ttl <= time.time():
+                log(ERROR, "TaskIns with task_id %s is expired.", task_ins_id)
+                return None
+
         # Validate run_id
         if task_res.run_id not in self.run_ids:
             log(ERROR, "`run_id` is invalid")

--- a/src/py/flwr/server/superlink/state/in_memory_state.py
+++ b/src/py/flwr/server/superlink/state/in_memory_state.py
@@ -129,6 +129,20 @@ class InMemoryState(State):  # pylint: disable=R0902,R0904
                 log(ERROR, "TaskIns with task_id %s is expired.", task_ins_id)
                 return None
 
+            # Limit the TaskRes TTL to not exceed the expiration time of the TaskIns it replies to
+            # Condition: TaskIns.created_at + TaskIns.ttl ≥ TaskRes.created_at + TaskRes.ttl
+            if (
+                task_res.task.ttl
+                > task_ins.task.created_at
+                + task_ins.task.ttl
+                - task_res.task.created_at
+            ):
+                task_res.task.ttl = (
+                    task_ins.task.created_at
+                    + task_ins.task.ttl
+                    - task_res.task.created_at
+                )
+
         # Validate run_id
         if task_res.run_id not in self.run_ids:
             log(ERROR, "`run_id` is invalid")

--- a/src/py/flwr/server/superlink/state/sqlite_state.py
+++ b/src/py/flwr/server/superlink/state/sqlite_state.py
@@ -356,8 +356,10 @@ class SqliteState(State):  # pylint: disable=R0904
             )
             return None
 
-        # Limit the TaskRes TTL to not exceed the expiration time of the TaskIns it replies to
-        # Condition: TaskIns.created_at + TaskIns.ttl ≥ TaskRes.created_at + TaskRes.ttl
+        # Limit the TaskRes TTL to not exceed the
+        # expiration time of the TaskIns it replies to.
+        # Condition: TaskIns.created_at + TaskIns.ttl ≥
+        #            TaskRes.created_at + TaskRes.ttl
         if (
             task_res.task.ttl
             > task_ins["created_at"] + task_ins["ttl"] - task_res.task.created_at

--- a/src/py/flwr/server/superlink/state/sqlite_state.py
+++ b/src/py/flwr/server/superlink/state/sqlite_state.py
@@ -711,7 +711,7 @@ class SqliteState(State):  # pylint: disable=R0904
             log(ERROR, "`node_id` does not exist.")
             return False
 
-    def get_valid_task_ins(self, task_id: str) -> Optional[dict[str, any]]:
+    def get_valid_task_ins(self, task_id: str) -> Optional[Dict[str, any]]:
         """Check if the TaskIns exists and is valid (not expired).
 
         Return TaskIns if valid.

--- a/src/py/flwr/server/superlink/state/sqlite_state.py
+++ b/src/py/flwr/server/superlink/state/sqlite_state.py
@@ -356,6 +356,16 @@ class SqliteState(State):  # pylint: disable=R0904
             )
             return None
 
+        # Limit the TaskRes TTL to not exceed the expiration time of the TaskIns it replies to
+        # Condition: TaskIns.created_at + TaskIns.ttl ≥ TaskRes.created_at + TaskRes.ttl
+        if (
+            task_res.task.ttl
+            > task_ins["created_at"] + task_ins["ttl"] - task_res.task.created_at
+        ):
+            task_res.task.ttl = (
+                task_ins["created_at"] + task_ins["ttl"] - task_res.task.created_at
+            )
+
         # Store TaskRes
         task_res.task_id = str(task_id)
         data = (task_res_to_dict(task_res),)

--- a/src/py/flwr/server/superlink/state/sqlite_state.py
+++ b/src/py/flwr/server/superlink/state/sqlite_state.py
@@ -712,7 +712,10 @@ class SqliteState(State):  # pylint: disable=R0904
             return False
 
     def get_valid_task_ins(self, task_id: str) -> Optional[dict]:
-        """Check if the TaskIns exists and is valid (not expired). Return TaskIns if valid."""
+        """Check if the TaskIns exists and is valid (not expired).
+
+        Return TaskIns if valid.
+        """
         query = """
             SELECT *
             FROM task_ins

--- a/src/py/flwr/server/superlink/state/sqlite_state.py
+++ b/src/py/flwr/server/superlink/state/sqlite_state.py
@@ -346,7 +346,17 @@ class SqliteState(State):  # pylint: disable=R0904
         # Create task_id
         task_id = uuid4()
 
-        # Store TaskIns
+        task_ins_id = task_res.task.ancestry[0]
+        task_ins = self.get_valid_task_ins(task_ins_id)
+        if task_ins is None:
+            log(
+                ERROR,
+                "TaskIns with task_id %s does not exist or is expired.",
+                task_ins_id,
+            )
+            return None
+
+        # Store TaskRes
         task_res.task_id = str(task_id)
         data = (task_res_to_dict(task_res),)
         columns = ", ".join([f":{key}" for key in data[0]])
@@ -700,6 +710,30 @@ class SqliteState(State):  # pylint: disable=R0904
         except sqlite3.IntegrityError:
             log(ERROR, "`node_id` does not exist.")
             return False
+
+    def get_valid_task_ins(self, task_id: str) -> Optional[dict]:
+        """Check if the TaskIns exists and is valid (not expired). Return TaskIns if valid."""
+        query = """
+            SELECT *
+            FROM task_ins
+            WHERE task_id = :task_id
+        """
+        data = {"task_id": task_id}
+        rows = self.query(query, data)
+        if not rows:
+            # TaskIns does not exist
+            return None
+
+        task_ins = rows[0]
+        created_at = task_ins["created_at"]
+        ttl = task_ins["ttl"]
+        current_time = time.time()
+
+        # Check if TaskIns is expired
+        if ttl is not None and created_at + ttl <= current_time:
+            return None
+
+        return task_ins
 
 
 def dict_factory(

--- a/src/py/flwr/server/superlink/state/sqlite_state.py
+++ b/src/py/flwr/server/superlink/state/sqlite_state.py
@@ -711,7 +711,7 @@ class SqliteState(State):  # pylint: disable=R0904
             log(ERROR, "`node_id` does not exist.")
             return False
 
-    def get_valid_task_ins(self, task_id: str) -> Optional[dict]:
+    def get_valid_task_ins(self, task_id: str) -> Optional[dict[str, any]]:
         """Check if the TaskIns exists and is valid (not expired).
 
         Return TaskIns if valid.

--- a/src/py/flwr/server/superlink/state/sqlite_state.py
+++ b/src/py/flwr/server/superlink/state/sqlite_state.py
@@ -711,7 +711,7 @@ class SqliteState(State):  # pylint: disable=R0904
             log(ERROR, "`node_id` does not exist.")
             return False
 
-    def get_valid_task_ins(self, task_id: str) -> Optional[Dict[str, any]]:
+    def get_valid_task_ins(self, task_id: str) -> Optional[Dict[str, Any]]:
         """Check if the TaskIns exists and is valid (not expired).
 
         Return TaskIns if valid.

--- a/src/py/flwr/server/superlink/state/state_test.py
+++ b/src/py/flwr/server/superlink/state/state_test.py
@@ -22,7 +22,6 @@ from abc import abstractmethod
 from datetime import datetime, timezone
 from typing import List
 from unittest.mock import patch
-from uuid import uuid4
 
 from flwr.common import DEFAULT_TTL
 from flwr.common.constant import ErrorCode
@@ -703,7 +702,7 @@ class StateTest(unittest.TestCase):
         result = state.store_task_res(task)
 
         # Assert
-        assert result == None
+        assert result is None
 
 
 def create_task_ins(

--- a/src/py/flwr/server/superlink/state/state_test.py
+++ b/src/py/flwr/server/superlink/state/state_test.py
@@ -35,6 +35,8 @@ from flwr.proto.recordset_pb2 import RecordSet  # pylint: disable=E0611
 from flwr.proto.task_pb2 import Task, TaskIns, TaskRes  # pylint: disable=E0611
 from flwr.server.superlink.state import InMemoryState, SqliteState, State
 
+import uuid
+
 
 class StateTest(unittest.TestCase):
     """Test all state implementations."""
@@ -302,6 +304,7 @@ class StateTest(unittest.TestCase):
         state: State = self.state_factory()
         run_id = state.create_run("mock/mock", "v1.0.0")
 
+        # pylint: disable=unsubscriptable-object
         task_ins = create_task_ins(consumer_node_id=0, anonymous=True, run_id=run_id)
         task_ins_id = state.store_task_ins(task_ins)
 

--- a/src/py/flwr/server/superlink/state/state_test.py
+++ b/src/py/flwr/server/superlink/state/state_test.py
@@ -302,7 +302,6 @@ class StateTest(unittest.TestCase):
         state: State = self.state_factory()
         run_id = state.create_run("mock/mock", "v1.0.0")
 
-        # pylint: disable=unsubscriptable-object
         task_ins = create_task_ins(consumer_node_id=0, anonymous=True, run_id=run_id)
         task_ins_id = state.store_task_ins(task_ins)
 
@@ -315,6 +314,7 @@ class StateTest(unittest.TestCase):
 
         # Execute
         task_res_uuid = state.store_task_res(task_res)
+        # pylint: disable=unsubscriptable-object
         task_res_list = state.get_task_res(task_ids={task_ins_id}, limit=None)
 
         # Assert

--- a/src/py/flwr/server/superlink/state/state_test.py
+++ b/src/py/flwr/server/superlink/state/state_test.py
@@ -35,8 +35,6 @@ from flwr.proto.recordset_pb2 import RecordSet  # pylint: disable=E0611
 from flwr.proto.task_pb2 import Task, TaskIns, TaskRes  # pylint: disable=E0611
 from flwr.server.superlink.state import InMemoryState, SqliteState, State
 
-import uuid
-
 
 class StateTest(unittest.TestCase):
     """Test all state implementations."""

--- a/src/py/flwr/server/superlink/state/state_test.py
+++ b/src/py/flwr/server/superlink/state/state_test.py
@@ -314,8 +314,9 @@ class StateTest(unittest.TestCase):
 
         # Execute
         task_res_uuid = state.store_task_res(task_res)
-        # pylint: disable=all
-        task_res_list = state.get_task_res(task_ids={task_ins_id}, limit=None)
+
+        if task_ins_id is not None:
+            task_res_list = state.get_task_res(task_ids={task_ins_id}, limit=None)
 
         # Assert
         retrieved_task_res = task_res_list[0]

--- a/src/py/flwr/server/superlink/state/state_test.py
+++ b/src/py/flwr/server/superlink/state/state_test.py
@@ -727,7 +727,7 @@ class StateTest(unittest.TestCase):
         task_res.task.ttl = 8
 
         # Execute
-        result = state.store_task_res(task_res)
+        state.store_task_res(task_res)
         res = state.get_task_res(task_ids={task_ins_id}, limit=None)[0]
 
         # Assert

--- a/src/py/flwr/server/superlink/state/state_test.py
+++ b/src/py/flwr/server/superlink/state/state_test.py
@@ -314,7 +314,7 @@ class StateTest(unittest.TestCase):
 
         # Execute
         task_res_uuid = state.store_task_res(task_res)
-        # pylint: disable=unsubscriptable-object
+        # pylint: disable=all
         task_res_list = state.get_task_res(task_ids={task_ins_id}, limit=None)
 
         # Assert


### PR DESCRIPTION
### Description
This PR limits TaskRes TTL with respect to `TaskRes.created_at`, `TaskIns.created_at`, and `TaskIns.ttl`. The condition is:
`TaskIns.created_at + TaskIns.ttl ≥ TaskRes.created_at + TaskRes.ttl`. 
Please merge it after #3609 
