### PR TITLE
fix(framework) Pass `superlink` address when starting `supernode`

### DIFF
--- a/src/py/flwr/client/supernode/app.py
+++ b/src/py/flwr/client/supernode/app.py
@@ -56,7 +56,7 @@ def run_supernode() -> None:
     authentication_keys = _try_setup_client_authentication(args)
 
     _start_client_internal(
-        server_address=args.server,
+        server_address=args.superlink,
         load_client_app_fn=load_fn,
         transport="rest" if args.rest else "grpc-rere",
         root_certificates=root_certificates,


### PR DESCRIPTION
We have deprecated `--server` for the supernodes in favour of `--superlink`. Without this change, when launching the supernode via `flower-supernode` if the address of the superlink is specified via the expected `--superlink` the internal variable associated with `--server` is used (which isn't updated from that passed via the cli)