### PR TITLE
ci(framework:skip) Test docstring formats

### DIFF
--- a/src/py/flwr/client/app.py
+++ b/src/py/flwr/client/app.py
@@ -82,7 +82,7 @@ def start_client(
     max_retries: Optional[int] = None,
     max_wait_time: Optional[float] = None,
 ) -> None:
-    """Start a Flower client node which connects to a Flower server.
+    """Start a Flower client. Node which connects to a Flower server.
 
     Parameters
     ----------

--- a/src/py/flwr/client/app.py
+++ b/src/py/flwr/client/app.py
@@ -82,7 +82,80 @@ def start_client(
     max_retries: Optional[int] = None,
     max_wait_time: Optional[float] = None,
 ) -> None:
-    """Start a Flower client. Node which connects to a Flower server."""
+    """Start a Flower client. Node which connects to a Flower server.
+
+    And I probably can't do multiline summary right? Otherwise it would be
+    weird I think. What do you think?
+
+    Parameters
+    ----------
+    server_address : str
+        The IPv4 or IPv6 address of the server. If the Flower
+        server runs on the same machine on port 8080, then `server_address`
+        would be `"[::]:8080"`.
+    client_fn : Optional[ClientFn]
+        A callable that instantiates a Client. (default: None)
+    client : Optional[flwr.client.Client]
+        An implementation of the abstract base
+        class `flwr.client.Client` (default: None)
+    grpc_max_message_length : int (default: 536_870_912, this equals 512MB)
+        The maximum length of gRPC messages that can be exchanged with the
+        Flower server. The default should be sufficient for most models.
+        Users who train very large models might need to increase this
+        value. Note that the Flower server needs to be started with the
+        same value (see `flwr.server.start_server`), otherwise it will not
+        know about the increased limit and block larger messages.
+    root_certificates : Optional[Union[bytes, str]] (default: None)
+        The PEM-encoded root certificates as a byte string or a path string.
+        If provided, a secure connection using the certificates will be
+        established to an SSL-enabled Flower server.
+    insecure : bool (default: True)
+        Starts an insecure gRPC connection when True. Enables HTTPS connection
+        when False, using system certificates if `root_certificates` is None.
+    transport : Optional[str] (default: None)
+        Configure the transport layer. Allowed values:
+        - 'grpc-bidi': gRPC, bidirectional streaming
+        - 'grpc-rere': gRPC, request-response (experimental)
+        - 'rest': HTTP (experimental)
+    max_retries: Optional[int] (default: None)
+        The maximum number of times the client will try to connect to the
+        server before giving up in case of a connection error. If set to None,
+        there is no limit to the number of tries.
+    max_wait_time: Optional[float] (default: None)
+        The maximum duration before the client stops trying to
+        connect to the server in case of connection error.
+        If set to None, there is no limit to the total time.
+
+    Examples
+    --------
+    Starting a gRPC client with an insecure server connection:
+
+    >>> start_client(
+    >>>     server_address=localhost:8080,
+    >>>     client_fn=client_fn,
+    >>> )
+
+    Starting an SSL-enabled gRPC client using system certificates:
+
+    >>> def client_fn(cid: str):
+    >>>     return FlowerClient()
+    >>>
+    >>> start_client(
+    >>>     server_address=localhost:8080,
+    >>>     client_fn=client_fn,
+    >>>     insecure=False,
+    >>> )
+
+    Starting an SSL-enabled gRPC client using provided certificates:
+
+    >>> from pathlib import Path
+    >>>
+    >>> start_client(
+    >>>     server_address=localhost:8080,
+    >>>     client_fn=client_fn,
+    >>>     root_certificates=Path("/crts/root.pem").read_bytes(),
+    >>> )
+    """
     event(EventType.START_CLIENT_ENTER)
     _start_client_internal(
         server_address=server_address,

--- a/src/py/flwr/client/app.py
+++ b/src/py/flwr/client/app.py
@@ -82,77 +82,7 @@ def start_client(
     max_retries: Optional[int] = None,
     max_wait_time: Optional[float] = None,
 ) -> None:
-    """Start a Flower client. Node which connects to a Flower server.
-
-    Parameters
-    ----------
-    server_address : str
-        The IPv4 or IPv6 address of the server. If the Flower
-        server runs on the same machine on port 8080, then `server_address`
-        would be `"[::]:8080"`.
-    client_fn : Optional[ClientFn]
-        A callable that instantiates a Client. (default: None)
-    client : Optional[flwr.client.Client]
-        An implementation of the abstract base
-        class `flwr.client.Client` (default: None)
-    grpc_max_message_length : int (default: 536_870_912, this equals 512MB)
-        The maximum length of gRPC messages that can be exchanged with the
-        Flower server. The default should be sufficient for most models.
-        Users who train very large models might need to increase this
-        value. Note that the Flower server needs to be started with the
-        same value (see `flwr.server.start_server`), otherwise it will not
-        know about the increased limit and block larger messages.
-    root_certificates : Optional[Union[bytes, str]] (default: None)
-        The PEM-encoded root certificates as a byte string or a path string.
-        If provided, a secure connection using the certificates will be
-        established to an SSL-enabled Flower server.
-    insecure : bool (default: True)
-        Starts an insecure gRPC connection when True. Enables HTTPS connection
-        when False, using system certificates if `root_certificates` is None.
-    transport : Optional[str] (default: None)
-        Configure the transport layer. Allowed values:
-        - 'grpc-bidi': gRPC, bidirectional streaming
-        - 'grpc-rere': gRPC, request-response (experimental)
-        - 'rest': HTTP (experimental)
-    max_retries: Optional[int] (default: None)
-        The maximum number of times the client will try to connect to the
-        server before giving up in case of a connection error. If set to None,
-        there is no limit to the number of tries.
-    max_wait_time: Optional[float] (default: None)
-        The maximum duration before the client stops trying to
-        connect to the server in case of connection error.
-        If set to None, there is no limit to the total time.
-
-    Examples
-    --------
-    Starting a gRPC client with an insecure server connection:
-
-    >>> start_client(
-    >>>     server_address=localhost:8080,
-    >>>     client_fn=client_fn,
-    >>> )
-
-    Starting an SSL-enabled gRPC client using system certificates:
-
-    >>> def client_fn(cid: str):
-    >>>     return FlowerClient()
-    >>>
-    >>> start_client(
-    >>>     server_address=localhost:8080,
-    >>>     client_fn=client_fn,
-    >>>     insecure=False,
-    >>> )
-
-    Starting an SSL-enabled gRPC client using provided certificates:
-
-    >>> from pathlib import Path
-    >>>
-    >>> start_client(
-    >>>     server_address=localhost:8080,
-    >>>     client_fn=client_fn,
-    >>>     root_certificates=Path("/crts/root.pem").read_bytes(),
-    >>> )
-    """
+    """Start a Flower client. Node which connects to a Flower server."""
     event(EventType.START_CLIENT_ENTER)
     _start_client_internal(
         server_address=server_address,

--- a/src/py/flwr/client/client.py
+++ b/src/py/flwr/client/client.py
@@ -36,7 +36,9 @@ from flwr.common import (
 
 
 class Client(ABC):
-    """Abstract base class for Flower clients."""
+    """Abstract base class for Flower clients. and now if I want multiple
+    lines is it possible? Maybe I need to do something else, I'm not quite
+    sure."""
 
     context: Context
 

--- a/src/py/flwr/client/client.py
+++ b/src/py/flwr/client/client.py
@@ -36,9 +36,11 @@ from flwr.common import (
 
 
 class Client(ABC):
-    """Abstract base class for Flower clients. and now if I want multiple
-    lines is it possible? Maybe I need to do something else, I'm not quite
-    sure."""
+    """Abstract base class for Flower clients.
+
+    and now if I want multiple lines is it possible? Maybe I need to do something else,
+    I'm not quite sure.
+    """
 
     context: Context
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

### Checklist

- [ ] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.ai/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
