### PR TITLE
fix(framework:skip) Include flwr_tool package in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ classifiers = [
 ]
 packages = [
     { include = "flwr", from = "src/py" },
+    { include = "flwr_tool", from = "src/py" },
 ]
 exclude = [
     "src/py/**/*_test.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,6 @@ classifiers = [
 ]
 packages = [
     { include = "flwr", from = "src/py" },
-    { include = "flwr_tool", from = "src/py" },
 ]
 exclude = [
     "src/py/**/*_test.py",


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

I was never able to use the `flwr_tool` scripts.

### Related issues/PRs

N/A

## Proposal

### Explanation

Add the `flwr_tool` package to the `pyproject.toml`. Now, running `pip install .` also installs the `flwr_tool` package.

### Checklist

- [x] Implement proposed change
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

N/A
