### PR TITLE
ci(framework:skip) Check copyright notices correctness

### DIFF
--- a/.github/workflows/framework.yml
+++ b/.github/workflows/framework.yml
@@ -31,6 +31,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Bootstrap
         uses: ./.github/actions/bootstrap
         with:

--- a/dev/format.sh
+++ b/dev/format.sh
@@ -3,6 +3,7 @@ set -e
 cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"/../
 
 # Python
+python -m flwr_tool.check_copyright src/py/flwr
 python -m flwr_tool.init_py_fix src/py/flwr
 python -m isort --skip src/py/flwr/proto src/py
 python -m black -q --exclude src/py/flwr/proto src/py

--- a/dev/test.sh
+++ b/dev/test.sh
@@ -58,6 +58,10 @@ echo "- All Markdown checks passed"
 
 echo "- Start license checks"
 
+echo "- copyright: start"
+python -m flwr_tool.check_copyright src/py/flwr
+echo "- copyright: done"
+
 echo "- licensecheck: start"
 python -m licensecheck -u poetry --fail-licenses gpl --zero
 echo "- licensecheck: done"

--- a/src/py/flwr_tool/check_copyright.py
+++ b/src/py/flwr_tool/check_copyright.py
@@ -1,0 +1,76 @@
+# Copyright 2024 Flower Labs GmbH. All Rights Reserved.
+"""Check if copyright notices are present in all Python files.
+
+Example:
+    python -m flwr_tool.check_copyright src/py/flwr
+"""
+
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import List
+
+from flwr_tool.init_py_check import get_init_dir_list_and_warnings
+
+COPYRIGHT_FORMAT = """# Copyright {} Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================="""
+
+
+def _get_file_creation_year(filepath: str) -> str:
+    result = subprocess.run(
+        ["git", "log", "--diff-filter=A", "--format=%ai", "--", filepath],
+        stdout=subprocess.PIPE,
+        text=True,
+        check=True,
+    )
+    date_str = result.stdout.splitlines()[-1]  # Get the first commit date
+    creation_year = date_str.split("-")[0]  # Extract the year
+    return creation_year
+
+
+def _check_copyright(dir_list: List[str]) -> None:
+    warning_list = []
+    for valid_dir in dir_list:
+        if "proto" in valid_dir:
+            continue
+
+        dir_path = Path(valid_dir)
+        for py_file in dir_path.glob("*.py"):
+            creation_year = _get_file_creation_year(str(py_file.absolute()))
+            expected_copyright = COPYRIGHT_FORMAT.format(creation_year)
+
+            if expected_copyright not in py_file.read_text():
+                warning_message = "- " + str(py_file)
+                warning_list.append(warning_message)
+
+    if len(warning_list) > 0:
+        print("Missing or incorrect copyright notice in the following files:")
+        for warning in warning_list:
+            print(warning)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) == 0:
+        raise Exception(  # pylint: disable=W0719
+            "Please provide at least one directory path relative "
+            "to your current working directory."
+        )
+    for i, _ in enumerate(sys.argv):
+        abs_path: str = os.path.abspath(os.path.join(os.getcwd(), sys.argv[i]))
+        __, init_dirs = get_init_dir_list_and_warnings(abs_path)
+        _check_copyright(init_dirs)

--- a/src/py/flwr_tool/fix_copyright.py
+++ b/src/py/flwr_tool/fix_copyright.py
@@ -1,0 +1,59 @@
+# Copyright 2024 Flower Labs GmbH. All Rights Reserved.
+"""Fix copyright notices in all Python files of a given directory.
+
+Example:
+    python -m flwr_tool.fix_copyright src/py/flwr
+"""
+
+
+import os
+import sys
+from pathlib import Path
+from typing import List
+
+from flwr_tool.check_copyright import COPYRIGHT_FORMAT, _get_file_creation_year
+from flwr_tool.init_py_check import get_init_dir_list_and_warnings
+
+
+def _insert_or_edit_copyright(py_file: Path) -> None:
+    contents = py_file.read_text()
+    lines = contents.splitlines()
+    creation_year = _get_file_creation_year(str(py_file.absolute()))
+    expected_copyright = COPYRIGHT_FORMAT.format(creation_year)
+
+    if expected_copyright not in contents:
+        if "Copyright" in lines[0]:
+            end_index = 0
+            for idx, line in enumerate(lines):
+                if (
+                    line.strip()
+                    == COPYRIGHT_FORMAT.rsplit("\n", maxsplit=1)[-1].strip()
+                ):
+                    end_index = idx + 1
+                    break
+            lines = lines[end_index:]
+
+        lines.insert(0, expected_copyright)
+        py_file.write_text("\n".join(lines) + "\n")
+
+
+def _fix_copyright(dir_list: List[str]) -> None:
+    for valid_dir in dir_list:
+        if "proto" in valid_dir:
+            continue
+
+        dir_path = Path(valid_dir)
+        for py_file in dir_path.glob("*.py"):
+            _insert_or_edit_copyright(py_file)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) == 0:
+        raise Exception(  # pylint: disable=W0719
+            "Please provide at least one directory path relative "
+            "to your current working directory."
+        )
+    for i, _ in enumerate(sys.argv):
+        abs_path: str = os.path.abspath(os.path.join(os.getcwd(), sys.argv[i]))
+        __, init_dirs = get_init_dir_list_and_warnings(abs_path)
+        _fix_copyright(init_dirs)


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

We currently don't check if all files contain valid copyright notices (especially we don't check if the date of the copyright is the one of the creation of the file).

### Related issues/PRs

N/A

## Proposal

### Explanation

- Add file to check copyright notices
- Add file to fix copyright notices
- Add calls in `dev/format.sh` and `dev/test.sh`

### Checklist

- [x] Implement proposed change
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

N/A