### PR TITLE
refactor(datasets) Rename the private attributes in InnerDirichlet

### DIFF
--- a/datasets/flwr_datasets/partitioner/inner_dirichlet_partitioner.py
+++ b/datasets/flwr_datasets/partitioner/inner_dirichlet_partitioner.py
@@ -77,8 +77,8 @@ class InnerDirichletPartitioner(Partitioner):  # pylint: disable=R0902
         super().__init__()
         # Attributes based on the constructor
         self._partition_sizes = _instantiate_partition_sizes(partition_sizes)
-        self._initial_alpha = alpha
-        self._alpha: Optional[NDArrayFloat] = None
+        self._alpha = alpha
+        self._full_alpha: Optional[NDArrayFloat] = None
         self._partition_by = partition_by
         self._shuffle = shuffle
         self._seed = seed
@@ -91,7 +91,6 @@ class InnerDirichletPartitioner(Partitioner):  # pylint: disable=R0902
         self._num_unique_classes: Optional[int] = None
         self._num_partitions = len(self._partition_sizes)
 
-        self._partition_id_to_indices: Dict[int, List[int]] = {}
         self._partition_id_to_indices_determined = False
 
     def load_partition(self, partition_id: int) -> datasets.Dataset:
@@ -114,7 +113,7 @@ class InnerDirichletPartitioner(Partitioner):  # pylint: disable=R0902
         self._check_partition_sizes_correctness_if_needed()
         self._check_the_sum_of_partition_sizes()
         self._determine_num_unique_classes_if_needed()
-        self._alpha = self._initialize_alpha_if_needed(self._initial_alpha)
+        self._full_alpha = self._initialize_alpha_if_needed(self._alpha)
         self._determine_partition_id_to_indices_if_needed()
         return self.dataset.select(self._partition_id_to_indices[partition_id])
 
@@ -125,9 +124,20 @@ class InnerDirichletPartitioner(Partitioner):  # pylint: disable=R0902
         self._check_partition_sizes_correctness_if_needed()
         self._check_the_sum_of_partition_sizes()
         self._determine_num_unique_classes_if_needed()
-        self._alpha = self._initialize_alpha_if_needed(self._initial_alpha)
+        self._full_alpha = self._initialize_alpha_if_needed(self._alpha)
         self._determine_partition_id_to_indices_if_needed()
         return self._num_partitions
+
+    @property
+    def partition_id_to_indices(self) -> Dict[int, List[int]]:
+        """Partition id to indices (the result of partitioning)."""
+        self._check_num_partitions_correctness_if_needed()
+        self._check_partition_sizes_correctness_if_needed()
+        self._check_the_sum_of_partition_sizes()
+        self._determine_num_unique_classes_if_needed()
+        self._full_alpha = self._initialize_alpha_if_needed(self._alpha)
+        self._determine_partition_id_to_indices_if_needed()
+        return self._partition_id_to_indices
 
     def _initialize_alpha_if_needed(
         self, alpha: Union[int, float, List[float], NDArrayFloat]
@@ -149,8 +159,8 @@ class InnerDirichletPartitioner(Partitioner):  # pylint: disable=R0902
             Concentration parameter in a format ready to used in computation.
         """
         if self._initialized_alpha:
-            assert self._alpha is not None
-            return self._alpha
+            assert self._full_alpha is not None
+            return self._full_alpha
         if isinstance(alpha, int):
             assert self._num_unique_classes is not None
             alpha = np.array([float(alpha)], dtype=float).repeat(
@@ -197,8 +207,8 @@ class InnerDirichletPartitioner(Partitioner):  # pylint: disable=R0902
             return
 
         # Create class priors for the whole partitioning process
-        assert self._alpha is not None
-        class_priors = self._rng.dirichlet(alpha=self._alpha, size=self._num_partitions)
+        assert self._full_alpha is not None
+        class_priors = self._rng.dirichlet(alpha=self._full_alpha, size=self._num_partitions)
         targets = np.asarray(self.dataset[self._partition_by])
         # List representing indices of each class
         assert self._num_unique_classes is not None

--- a/datasets/flwr_datasets/partitioner/inner_dirichlet_partitioner.py
+++ b/datasets/flwr_datasets/partitioner/inner_dirichlet_partitioner.py
@@ -208,7 +208,9 @@ class InnerDirichletPartitioner(Partitioner):  # pylint: disable=R0902
 
         # Create class priors for the whole partitioning process
         assert self._full_alpha is not None
-        class_priors = self._rng.dirichlet(alpha=self._full_alpha, size=self._num_partitions)
+        class_priors = self._rng.dirichlet(
+            alpha=self._full_alpha, size=self._num_partitions
+        )
         targets = np.asarray(self.dataset[self._partition_by])
         # List representing indices of each class
         assert self._num_unique_classes is not None


### PR DESCRIPTION
## Issue
The naming of the class attributes resulting from the constructor paramters is not consistent.
The `alpha` is named `_initial_alpha`.

### Description
There are two _alpha attributes: initial alpha (which can be as simple as an int or float) and fully transformed alpha (proper shape for sampling from dirichlet).
The issue with inconsistent naming is trouble with saving this class in automatic manner to a config. The `_alpha` is save which is `None` but instead the `_initial_alpha` should be saved (to be albe to later on instantiate the object based on the config).

## Proposal

Rename:
* `_alpha` to `_full_alpha`
* `_initial_alpha` to `_alpha`

Related PRs
This is needed for: https://github.com/adap/flower/pull/3659