### PR TITLE
refactor(datasets) Refactor creation of partition_id_to_indices in ShardPartitioner

### DIFF
--- a/datasets/flwr_datasets/partitioner/shard_partitioner.py
+++ b/datasets/flwr_datasets/partitioner/shard_partitioner.py
@@ -226,15 +226,15 @@ class ShardPartitioner(Partitioner):  # pylint: disable=R0902
                 assert self._shard_size is not None
                 if self._keep_incomplete_shard:
                     num_usable_shards_in_dataset = int(
-                        math.ceil(len(self._sorted_dataset) / self._shard_size)
+                        math.ceil(len(self.dataset) / self._shard_size)
                     )
                 else:
                     num_usable_shards_in_dataset = int(
-                        math.floor(len(self._sorted_dataset) / self._shard_size)
+                        math.floor(len(self.dataset) / self._shard_size)
                     )
             else:
                 num_usable_shards_in_dataset = int(
-                    math.floor(len(self._sorted_dataset) / self._shard_size)
+                    math.floor(len(self.dataset) / self._shard_size)
                 )
         elif self._num_shards_per_partition is None:
             if self._shard_size is None:
@@ -244,12 +244,12 @@ class ShardPartitioner(Partitioner):  # pylint: disable=R0902
                 )
             if self._keep_incomplete_shard is False:
                 self._num_shards_used = int(
-                    math.floor(len(self._sorted_dataset) / self._shard_size)
+                    math.floor(len(self.dataset) / self._shard_size)
                 )
                 num_usable_shards_in_dataset = self._num_shards_used
             elif self._keep_incomplete_shard is True:
                 self._num_shards_used = int(
-                    math.ceil(len(self._sorted_dataset) / self._shard_size)
+                    math.ceil(len(self.dataset) / self._shard_size)
                 )
                 num_usable_shards_in_dataset = self._num_shards_used
                 if num_usable_shards_in_dataset < self._num_partitions:
@@ -307,9 +307,7 @@ class ShardPartitioner(Partitioner):  # pylint: disable=R0902
         for partition_id in range(self._num_partitions):
             for shard_idx in nid_to_shard_indices[partition_id]:
                 start_id = int(shard_idx * self._shard_size)
-                end_id = min(
-                    int((shard_idx + 1) * self._shard_size), len(self._sorted_dataset)
-                )
+                end_id = min(int((shard_idx + 1) * self._shard_size), len(self.dataset))
                 partition_id_to_indices[partition_id].extend(
                     list(range(start_id, end_id))
                 )

--- a/datasets/flwr_datasets/partitioner/shard_partitioner.py
+++ b/datasets/flwr_datasets/partitioner/shard_partitioner.py
@@ -15,7 +15,7 @@
 """Shard partitioner class."""
 
 
-# pylint: disable=R0912, R0914
+# pylint: disable=R0912, R0914, R0915
 import math
 from typing import Dict, List, Optional
 
@@ -313,8 +313,9 @@ class ShardPartitioner(Partitioner):  # pylint: disable=R0902
                 )
         # Remap the partition_id_to_indices (which reflect on the sorted dataset) back
         # to the assigned given dataset
-        new_id_to_original_id = self._sorted_dataset["original_index"]
-        partition_id_to_indices_remapped = {
+        assert self._sorted_dataset is not None
+        new_id_to_original_id: List[int] = self._sorted_dataset["original_index"]
+        partition_id_to_indices_remapped: Dict[int, List[int]] = {
             pid: [] for pid in range(self._num_partitions)
         }
         for partition_id, indices in partition_id_to_indices.items():


### PR DESCRIPTION
## Issue
The`partition_id_to_indices` should have consistent behavior over all partitioners. However, `partition_id_to_indices` has currenlty slightly different meaning than the rest.

### Description
The `partition_id_to_indices`  in `ShardPartiioner` reflect the state of sorted dataset not the original passed dataset. Indices reflecting the sorted dataset (not the original dataset) makes the `partition_id_to_indices` incosistent among the Partitioners and does not allow for an easy config support.

## Proposal
Do not modify the state of the assigned dataset and and have the `partition_id_to_indices` reflect the state of the given datasets (not the sorted version of it).

### Explanation

Keep a `_sorted_dataset` and create the original indices to accomplish this goal.

## Relate PRs
This is needed for: https://github.com/adap/flower/pull/3659