### PR TITLE
fix(examples:skip) Fix main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Other [examples](https://github.com/adap/flower/tree/main/examples):
 - [Flower with KaplanMeierFitter from the lifelines library](https://github.com/adap/flower/tree/main/examples/federated-kaplan-meier-fitter)
 - [Sample Level Privacy with Opacus](https://github.com/adap/flower/tree/main/examples/opacus)
 - [Sample Level Privacy with TensorFlow-Privacy](https://github.com/adap/flower/tree/main/examples/tensorflow-privacy)
-- [Flower with a Tabular Dataset] (https://github.com/adap/flower/tree/main/examples/fl-tabular)
+- [Flower with a Tabular Dataset](https://github.com/adap/flower/tree/main/examples/fl-tabular)
 
 ## Community
 


### PR DESCRIPTION
### Description
It removes the extra space in main README file.

