### PR TITLE
docs(framework) Add Korean version

### DIFF
--- a/doc/source/_templates/sidebar/lang.html
+++ b/doc/source/_templates/sidebar/lang.html
@@ -1,9 +1,14 @@
 {% if versions or lang %}
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/0.8.2/css/flag-icon.min.css">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/0.8.2/css/flag-icon.min.css">
 
-  <div style="text-align: center; padding-bottom: 1rem;">
-    <a href="https://flower.ai/docs/framework/{{ current_version.url }}/en/{{ pagename }}.html" style="text-decoration:none; padding-right: 2rem; font-size: 150%;">&#127468;&#127463;</a>
-    <a href="https://flower.ai/docs/framework/{{ current_version.url }}/fr/{{ pagename }}.html" style="text-decoration:none; padding-right: 2rem; font-size: 150%;">&#127467;&#127479;</a>
-    <a href="https://flower.ai/docs/framework/{{ current_version.url }}/zh_Hans/{{ pagename }}.html" style="text-decoration:none; font-size: 150%;">&#x1F1E8;&#x1F1F3;</a>
-  </div>
+<div style="text-align: center; padding-bottom: 1rem;">
+  <a href="https://flower.ai/docs/framework/{{ current_version.url }}/en/{{ pagename }}.html"
+    style="text-decoration:none; padding-right: 2rem; font-size: 150%;">&#127468;&#127463;</a>
+  <a href="https://flower.ai/docs/framework/{{ current_version.url }}/fr/{{ pagename }}.html"
+    style="text-decoration:none; padding-right: 2rem; font-size: 150%;">&#127467;&#127479;</a>
+  <a href="https://flower.ai/docs/framework/{{ current_version.url }}/zh_Hans/{{ pagename }}.html"
+    style="text-decoration:none; padding-right: 2rem; font-size: 150%;">&#x1F1E8;&#x1F1F3;</a>
+  <a href="https://flower.ai/docs/framework/{{ current_version.url }}/ko/{{ pagename }}.html"
+    style="text-decoration:none; font-size: 150%;">&#x1F1F0;&#x1F1F7;</a>
+</div>
 {% endif %}


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

We have Korean translations but no button that redirects to it:

<img width="213" alt="image" src="https://github.com/adap/flower/assets/9378265/403c4495-ddd3-499c-9ec8-feaa11d62adf">

### Related issues/PRs

N/A

## Proposal

### Explanation

Add button that redirects to the Korean version of the docs:

<img width="232" alt="image" src="https://github.com/adap/flower/assets/9378265/ea31709c-5987-4da6-9131-5ad4af5a108d">

### Checklist

- [x] Implement proposed change
- [x] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

N/A
