### PR TITLE
feat(framework) Introduce `client_fn` adaptor

### DIFF
--- a/src/py/flwr/client/__init__.py
+++ b/src/py/flwr/client/__init__.py
@@ -23,11 +23,13 @@ from .numpy_client import NumPyClient as NumPyClient
 from .supernode import run_client_app as run_client_app
 from .supernode import run_supernode as run_supernode
 from .typing import ClientFn as ClientFn
+from .typing import ClientFnExt as ClientFnExt
 
 __all__ = [
     "Client",
     "ClientApp",
     "ClientFn",
+    "ClientFnExt",
     "NumPyClient",
     "mod",
     "run_client_app",

--- a/src/py/flwr/client/app.py
+++ b/src/py/flwr/client/app.py
@@ -92,7 +92,7 @@ def start_client(
         The IPv4 or IPv6 address of the server. If the Flower
         server runs on the same machine on port 8080, then `server_address`
         would be `"[::]:8080"`.
-    client_fn : Union[ClientFnExt]
+    client_fn : Optional[ClientFnExt]
         A callable that instantiates a Client. (default: None)
     client : Optional[flwr.client.Client]
         An implementation of the abstract base

--- a/src/py/flwr/client/client_app.py
+++ b/src/py/flwr/client/client_app.py
@@ -15,15 +15,16 @@
 """Flower ClientApp."""
 
 
-from typing import Callable, List, Optional
+from typing import Callable, List, Optional, Union
 
+from flwr.client.client import Client
 from flwr.client.message_handler.message_handler import (
     handle_legacy_message_from_msgtype,
 )
 from flwr.client.mod.utils import make_ffn
-from flwr.client.typing import ClientFnExt, Mod
+from flwr.client.typing import ClientFn, ClientFnExt, Mod
 from flwr.common import Context, Message, MessageType
-from flwr.common.logger import warn_preview_feature
+from flwr.common.logger import warn_deprecated_feature, warn_preview_feature
 
 from .typing import ClientAppCallable
 
@@ -35,6 +36,31 @@ class ClientAppException(Exception):
         ex_name = self.__class__.__name__
         self.message = f"\nException {ex_name} occurred. Message: " + message
         super().__init__(self.message)
+
+
+def _inspect_maybe_adapt_client_fn_signature(
+    client_fn: Union[ClientFn, ClientFnExt]
+) -> ClientFnExt:
+
+    if "cid" in client_fn.__annotations__:
+        warn_deprecated_feature(
+            "Passing a `client_fn` with signature `def client_fn(cid: str)` "
+            "is deprecated. Use instead signature `def client_fn(node_id: int, "
+            "partition_id: Optional[int])`.",
+        )
+
+        # Wrap depcreated client_fn inside a function with the expected signature
+        def adaptor_fn(
+            node_id: int, partition_id: Optional[int]  # pylint: disable=unused-argument
+        ) -> Client:
+            return client_fn(str(partition_id))  # type: ignore
+
+    else:
+
+        def adaptor_fn(node_id: int, partition_id: Optional[int]) -> Client:
+            return client_fn(node_id, partition_id)  # type: ignore
+
+    return adaptor_fn
 
 
 class ClientApp:
@@ -72,7 +98,9 @@ class ClientApp:
 
         # Create wrapper function for `handle`
         self._call: Optional[ClientAppCallable] = None
-        self.client_fn = client_fn
+        self.client_fn = (
+            _inspect_maybe_adapt_client_fn_signature(client_fn) if client_fn else None
+        )
 
         # Step functions
         self._train: Optional[ClientAppCallable] = None

--- a/src/py/flwr/client/message_handler/message_handler.py
+++ b/src/py/flwr/client/message_handler/message_handler.py
@@ -14,7 +14,7 @@
 # ==============================================================================
 """Client-side message handler."""
 
-from logging import DEBUG, WARN
+from logging import WARN
 from typing import Optional, Tuple, cast
 
 from flwr.client.client import (
@@ -24,7 +24,7 @@ from flwr.client.client import (
     maybe_call_get_properties,
 )
 from flwr.client.numpy_client import NumPyClient
-from flwr.client.typing import ClientFn
+from flwr.client.typing import ClientFnExt
 from flwr.common import ConfigsRecord, Context, Message, Metadata, RecordSet, log
 from flwr.common.constant import MessageType, MessageTypeLegacy
 from flwr.common.recordset_compat import (
@@ -89,15 +89,10 @@ def handle_control_message(message: Message) -> Tuple[Optional[Message], int]:
 
 
 def handle_legacy_message_from_msgtype(
-    client_fn: ClientFn, message: Message, context: Context
+    client_fn: ClientFnExt, message: Message, context: Context
 ) -> Message:
     """Handle legacy message in the inner most mod."""
-    try:
-        client = client_fn(message.metadata.dst_node_id, context.partition_id)
-    except Exception as ex:  # pylint: disable=broad-exception-caught
-        log(DEBUG, ex)
-        # Attempt execution `client_fn` as it was done before flwr 1.10.0
-        client = client_fn(str(context.partition_id))  # type: ignore
+    client = client_fn(message.metadata.dst_node_id, context.partition_id)
 
     # Check if NumPyClient is returend
     if isinstance(client, NumPyClient):

--- a/src/py/flwr/client/message_handler/message_handler_test.py
+++ b/src/py/flwr/client/message_handler/message_handler_test.py
@@ -22,7 +22,7 @@ from copy import copy
 from typing import List, Optional
 
 from flwr.client import Client
-from flwr.client.typing import ClientFn
+from flwr.client.typing import ClientFnExt
 from flwr.common import (
     DEFAULT_TTL,
     Code,
@@ -113,7 +113,7 @@ class ClientWithProps(Client):
         )
 
 
-def _get_client_fn(client: Client) -> ClientFn:
+def _get_client_fn(client: Client) -> ClientFnExt:
     def client_fn(
         node_id: int, partition_id: Optional[int]  # pylint: disable=unused-argument
     ) -> Client:

--- a/src/py/flwr/client/supernode/app.py
+++ b/src/py/flwr/client/supernode/app.py
@@ -39,7 +39,7 @@ from flwr.common.exit_handlers import register_exit_handlers
 from flwr.common.logger import log, warn_deprecated_feature
 from flwr.common.object_ref import load_app, validate
 
-from ..app import _inspect_maybe_adapt_client_fn_signature, _start_client_internal
+from ..app import _start_client_internal
 
 ADDRESS_FLEET_API_GRPC_RERE = "0.0.0.0:9092"
 
@@ -242,12 +242,6 @@ def _get_load_client_app_fn(
             raise LoadClientAppError(
                 f"Attribute {client_app_ref} is not of type {ClientApp}",
             ) from None
-
-        # Inspect client_fn signature and adapt to new format if needed.
-        if client_app.client_fn is not None:
-            client_app.client_fn = _inspect_maybe_adapt_client_fn_signature(
-                client_app.client_fn
-            )
 
         return client_app
 

--- a/src/py/flwr/client/supernode/app.py
+++ b/src/py/flwr/client/supernode/app.py
@@ -39,7 +39,7 @@ from flwr.common.exit_handlers import register_exit_handlers
 from flwr.common.logger import log, warn_deprecated_feature
 from flwr.common.object_ref import load_app, validate
 
-from ..app import _start_client_internal
+from ..app import _inspect_maybe_adapt_client_fn_signature, _start_client_internal
 
 ADDRESS_FLEET_API_GRPC_RERE = "0.0.0.0:9092"
 
@@ -242,6 +242,12 @@ def _get_load_client_app_fn(
             raise LoadClientAppError(
                 f"Attribute {client_app_ref} is not of type {ClientApp}",
             ) from None
+
+        # Inspect client_fn signature and adapt to new format if needed.
+        if client_app.client_fn is not None:
+            client_app.client_fn = _inspect_maybe_adapt_client_fn_signature(
+                client_app.client_fn
+            )
 
         return client_app
 

--- a/src/py/flwr/client/typing.py
+++ b/src/py/flwr/client/typing.py
@@ -22,7 +22,8 @@ from flwr.common import Context, Message
 from .client import Client as Client
 
 # Compatibility
-ClientFn = Callable[[int, Optional[int]], Client]
+ClientFn = Callable[[str], Client]
+ClientFnExt = Callable[[int, Optional[int]], Client]
 
 ClientAppCallable = Callable[[Message, Context], Message]
 Mod = Callable[[Message, Context, ClientAppCallable], Message]

--- a/src/py/flwr/simulation/app.py
+++ b/src/py/flwr/simulation/app.py
@@ -27,7 +27,7 @@ from typing import Any, Dict, List, Optional, Type, Union
 import ray
 from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 
-from flwr.client import ClientFn
+from flwr.client import ClientFnExt
 from flwr.common import EventType, event
 from flwr.common.logger import log, set_logger_propagation
 from flwr.server.client_manager import ClientManager
@@ -74,7 +74,7 @@ REASON:
 # pylint: disable=too-many-arguments,too-many-statements,too-many-branches
 def start_simulation(
     *,
-    client_fn: ClientFn,
+    client_fn: ClientFnExt,
     num_clients: Optional[int] = None,
     clients_ids: Optional[List[str]] = None,
     client_resources: Optional[Dict[str, float]] = None,
@@ -92,16 +92,16 @@ def start_simulation(
 
     Parameters
     ----------
-    client_fn : ClientFn
-        A function creating client instances. The function must take a single
-        `str` argument called `cid`. It should return a single client instance
-        of type Client. Note that the created client instances are ephemeral
-        and will often be destroyed after a single method invocation. Since client
-        instances are not long-lived, they should not attempt to carry state over
-        method invocations. Any state required by the instance (model, dataset,
-        hyperparameters, ...) should be (re-)created in either the call to `client_fn`
-        or the call to any of the client methods (e.g., load evaluation data in the
-        `evaluate` method itself).
+    client_fn : ClientFnExt
+        A function creating client instances. The function must has signature
+        `client_fn(node_id: int, partition_id: Optional[int]). It should return
+        a single client instance of type Client. Note that the created client
+        instances are ephemeral and will often be destroyed after a single method
+        invocation. Since clientinstances are not long-lived, they should not attempt
+        to carry state over method invocations. Any state required by the instance
+        (model, dataset, hyperparameters, ...) should be (re-)created in either the
+        call to `client_fn` or the call to any of the client methods (e.g., load
+        evaluation data in the `evaluate` method itself).
     num_clients : Optional[int]
         The total number of clients in this simulation. This must be set if
         `clients_ids` is not set and vice-versa.

--- a/src/py/flwr/simulation/ray_transport/ray_client_proxy.py
+++ b/src/py/flwr/simulation/ray_transport/ray_client_proxy.py
@@ -20,7 +20,7 @@ from logging import ERROR
 from typing import Optional
 
 from flwr import common
-from flwr.client import ClientFn
+from flwr.client import ClientFnExt
 from flwr.client.client_app import ClientApp
 from flwr.client.node_state import NodeState
 from flwr.common import DEFAULT_TTL, Message, Metadata, RecordSet
@@ -44,7 +44,7 @@ class RayActorClientProxy(ClientProxy):
     """Flower client proxy which delegates work using Ray."""
 
     def __init__(
-        self, client_fn: ClientFn, cid: str, actor_pool: VirtualClientEngineActorPool
+        self, client_fn: ClientFnExt, cid: str, actor_pool: VirtualClientEngineActorPool
     ):
         super().__init__(cid)
 


### PR DESCRIPTION
We are transitioning towards a `client_fn` with signature:
```
def client_fn(node_id: int, partition_id: Optional[int]) -> Client:
    ...
```

but without introducing breaking changes to existing codebases. In order to do that we need an "adaptor" that is capable of detecting a `client_fn` in the previous formant (i.e. expecting a single `cid:str` argument) and wrap it into a function matching the new `client_fn` signature. This PR accomplishes that.