### PR TITLE
docs(examples:skip) Use more consistent naming for tags

### DIFF
--- a/dev/build-example-docs.py
+++ b/dev/build-example-docs.py
@@ -90,10 +90,10 @@ def _read_metadata(example):
         raise ValueError("Title not found in metadata")
     title = title_match.group(1).strip()
 
-    labels_match = re.search(r"^labels:\s*\[(.+?)\]$", metadata, re.MULTILINE)
-    if not labels_match:
-        raise ValueError("Labels not found in metadata")
-    labels = labels_match.group(1).strip()
+    tags_match = re.search(r"^tags:\s*\[(.+?)\]$", metadata, re.MULTILINE)
+    if not tags_match:
+        raise ValueError("Tags not found in metadata")
+    tags = tags_match.group(1).strip()
 
     dataset_match = re.search(
         r"^dataset:\s*\[(.*?)\]$", metadata, re.DOTALL | re.MULTILINE
@@ -111,17 +111,17 @@ def _read_metadata(example):
 
     dataset = _convert_to_link(re.sub(r"\s+", " ", dataset).strip())
     framework = _convert_to_link(re.sub(r"\s+", " ", framework).strip())
-    return title, labels, dataset, framework
+    return title, tags, dataset, framework
 
 
-def _add_table_entry(example, label, table_var):
-    title, labels, dataset, framework = _read_metadata(example)
+def _add_table_entry(example, tag, table_var):
+    title, tags, dataset, framework = _read_metadata(example)
     example_name = Path(example).stem
     table_entry = (
         f"   * - `{title} <{example_name}.html>`_ \n     "
-        f"- {framework} \n     - {dataset} \n     - {labels}\n\n"
+        f"- {framework} \n     - {dataset} \n     - {tags}\n\n"
     )
-    if label in labels:
+    if tag in tags:
         categories[table_var]["table"] += table_entry
         categories[table_var]["list"] += f"  {example_name}\n"
         return True

--- a/examples/advanced-pytorch/README.md
+++ b/examples/advanced-pytorch/README.md
@@ -1,6 +1,6 @@
 ---
 title: Advanced Flower Example using PyTorch
-labels: [advanced, vision, fds]
+tags: [advanced, vision, fds]
 dataset: [CIFAR-10 | https://huggingface.co/datasets/uoft-cs/cifar10]
 framework: [torch | https://pytorch.org/, torchvision | https://pytorch.org/vision/stable/index.html]
 ---

--- a/examples/advanced-tensorflow/README.md
+++ b/examples/advanced-tensorflow/README.md
@@ -1,6 +1,6 @@
 ---
 title: Advanced Flower Example using TensorFlow/Keras
-labels: [advanced, vision, fds]
+tags: [advanced, vision, fds]
 dataset: [CIFAR-10 | https://huggingface.co/datasets/uoft-cs/cifar10]
 framework: [tensorflow | https://www.tensorflow.org/, Keras | https://keras.io/]
 ---

--- a/examples/android-kotlin/README.md
+++ b/examples/android-kotlin/README.md
@@ -1,6 +1,6 @@
 ---
 title: Flower Android Example using Kotlin and TF Lite
-labels: [basic, vision, fds]
+tags: [basic, vision, fds]
 dataset: [CIFAR-10 | https://huggingface.co/datasets/uoft-cs/cifar10]
 framework: [Android | https://www.android.com/, Kotlin | https://kotlinlang.org/,
   TensorFlowLite | https://www.tensorflow.org/lite]

--- a/examples/android/README.md
+++ b/examples/android/README.md
@@ -1,6 +1,6 @@
 ---
 title: Flower Android Example using Java and TF Lite
-labels: [basic, vision, fds]
+tags: [basic, vision, fds]
 dataset: [CIFAR-10 | https://huggingface.co/datasets/uoft-cs/cifar10]
 framework: [Android | https://www.android.com/, Java | https://www.java.com/, TensorFlowLite
       | https://www.tensorflow.org/lite]

--- a/examples/app-pytorch/README.md
+++ b/examples/app-pytorch/README.md
@@ -1,6 +1,6 @@
 ---
 title: Example Flower App using PyTorch
-labels: [basic, vision, fds]
+tags: [basic, vision, fds]
 dataset: [CIFAR-10 | https://huggingface.co/datasets/uoft-cs/cifar10]
 framework: [torch | https://pytorch.org/, torchvision | https://pytorch.org/vision/stable/index.html]
 ---

--- a/examples/app-secure-aggregation/README.md
+++ b/examples/app-secure-aggregation/README.md
@@ -1,6 +1,6 @@
 ---
 title: Example Flower App with Secure Aggregation
-labels: [basic, vision, fds]
+tags: [basic, vision, fds]
 dataset: []
 framework: [numpy | https://numpy.org/]
 ---

--- a/examples/custom-metrics/README.md
+++ b/examples/custom-metrics/README.md
@@ -1,6 +1,6 @@
 ---
 title: Example Flower App with Custom Metrics
-labels: [basic, vision, fds]
+tags: [basic, vision, fds]
 dataset: [CIFAR-10 | https://huggingface.co/datasets/uoft-cs/cifar10]
 framework: [tensorflow | https://www.tensorflow.org/]
 ---

--- a/examples/custom-mods/README.md
+++ b/examples/custom-mods/README.md
@@ -1,6 +1,6 @@
 ---
 title: Example Flower App with Custom Mods
-labels: [mods, monitoring, app]
+tags: [mods, monitoring, app]
 dataset: [CIFAR-10 | https://huggingface.co/datasets/uoft-cs/cifar10]
 framework: [wandb | https://wandb.ai/home, tensorboard | https://www.tensorflow.org/tensorboard]
 ---

--- a/examples/embedded-devices/README.md
+++ b/examples/embedded-devices/README.md
@@ -1,6 +1,6 @@
 ---
 title: Flower Embedded Devices Example
-labels: [basic, vision, fds]
+tags: [basic, vision, fds]
 dataset: [CIFAR-10 | https://huggingface.co/datasets/uoft-cs/cifar10, MNIST | https://huggingface.co/datasets/ylecun/mnist]
 framework: [torch | https://pytorch.org/, tensorflow | https://www.tensorflow.org/]
 ---

--- a/examples/federated-kaplan-meier-fitter/README.md
+++ b/examples/federated-kaplan-meier-fitter/README.md
@@ -1,6 +1,6 @@
 ---
 title: Flower Example using KaplanMeierFitter
-labels: [estimator, medical]
+tags: [estimator, medical]
 dataset: [Waltons | 
       https://lifelines.readthedocs.io/en/latest/lifelines.datasets.html#lifelines.datasets.load_waltons]
 framework: [lifelines | https://lifelines.readthedocs.io/en/latest/index.html]

--- a/examples/fl-dp-sa/README.md
+++ b/examples/fl-dp-sa/README.md
@@ -1,6 +1,6 @@
 ---
 title: Example of Flower App with DP and SA
-labels: [basic, vision, fds]
+tags: [basic, vision, fds]
 dataset: [MNIST | https://huggingface.co/datasets/ylecun/mnist]
 framework: [torch | https://pytorch.org/, torchvision | https://pytorch.org/vision/stable/index.html]
 ---

--- a/examples/fl-tabular/README.md
+++ b/examples/fl-tabular/README.md
@@ -1,6 +1,6 @@
 ---
 title: Flower Example on Adult Census Income Tabular Dataset
-labels: [basic, tabular, fds]
+tags: [basic, tabular, fds]
 dataset: [Adult Census Income | https://www.kaggle.com/datasets/uciml/adult-census-income/data]
 framework: [scikit-learn | https://scikit-learn.org/, torch | https://pytorch.org/]
 ---

--- a/examples/flower-authentication/README.md
+++ b/examples/flower-authentication/README.md
@@ -1,6 +1,6 @@
 ---
 title: Flower Example with Authentication
-labels: [advanced, vision, fds]
+tags: [advanced, vision, fds]
 dataset: [CIFAR-10 | https://huggingface.co/datasets/uoft-cs/cifar10]
 framework: [torch | https://pytorch.org/, torchvision | https://pytorch.org/vision/stable/index.html]
 ---

--- a/examples/flower-in-30-minutes/README.md
+++ b/examples/flower-in-30-minutes/README.md
@@ -1,6 +1,6 @@
 ---
 title: 30-minute tutorial running Flower simulation with PyTorch
-labels: [colab, vision, simulation]
+tags: [colab, vision, simulation]
 dataset: [CIFAR-10 | https://huggingface.co/datasets/uoft-cs/cifar10]
 framework: [torch | https://pytorch.org/]
 ---

--- a/examples/flower-simulation-step-by-step-pytorch/README.md
+++ b/examples/flower-simulation-step-by-step-pytorch/README.md
@@ -1,6 +1,6 @@
 ---
 title: Flower Simulation Step-by-Step
-labels: [basic, vision, simulation]
+tags: [basic, vision, simulation]
 dataset: [MNIST | https://huggingface.co/datasets/ylecun/mnist]
 framework: [torch | https://pytorch.org/]
 ---

--- a/examples/flower-via-docker-compose/README.md
+++ b/examples/flower-via-docker-compose/README.md
@@ -1,6 +1,6 @@
 ---
 title: Leveraging Flower and Docker for Device Heterogeneity Management in FL
-labels: [deployment, vision, tutorial]
+tags: [deployment, vision, tutorial]
 dataset: [CIFAR-10 | https://huggingface.co/datasets/uoft-cs/cifar10]
 framework: [Docker | https://www.docker.com/, tensorflow | https://www.tensorflow.org/]
 ---

--- a/examples/ios/README.md
+++ b/examples/ios/README.md
@@ -1,6 +1,6 @@
 ---
 title: Simple Flower Example on iOS
-labels: [mobile, vision, fds]
+tags: [mobile, vision, fds]
 dataset: [MNIST | https://huggingface.co/datasets/ylecun/mnist]
 framework: [Swift | https://www.swift.org/]
 ---

--- a/examples/llm-flowertune/README.md
+++ b/examples/llm-flowertune/README.md
@@ -1,6 +1,6 @@
 ---
 title: Federated LLM Fine-tuning with Flower
-labels: [llm, nlp, LLama2]
+tags: [llm, nlp, LLama2]
 dataset: [Alpaca-GPT4 | https://huggingface.co/datasets/vicgalle/alpaca-gpt4]
 framework: [PEFT | https://huggingface.co/docs/peft/index, torch | https://pytorch.org/]
 ---

--- a/examples/opacus/README.md
+++ b/examples/opacus/README.md
@@ -1,6 +1,6 @@
 ---
 title: Sample-Level Differential Privacy using Opacus
-labels: [dp, security, fds]
+tags: [dp, security, fds]
 dataset: [CIFAR-10 | https://huggingface.co/datasets/uoft-cs/cifar10]
 framework: [opacus | https://opacus.ai/, torch | https://pytorch.org/]
 ---

--- a/examples/pytorch-federated-variational-autoencoder/README.md
+++ b/examples/pytorch-federated-variational-autoencoder/README.md
@@ -1,6 +1,6 @@
 ---
 title: Federated Variational Autoencoder using Pytorch
-labels: [basic, vision, fds]
+tags: [basic, vision, fds]
 dataset: [CIFAR-10 | https://huggingface.co/datasets/uoft-cs/cifar10]
 framework: [torch | https://pytorch.org/, torchvision | https://pytorch.org/vision/stable/index.html]
 ---

--- a/examples/pytorch-from-centralized-to-federated/README.md
+++ b/examples/pytorch-from-centralized-to-federated/README.md
@@ -1,6 +1,6 @@
 ---
 title: PyTorch, From Centralized To Federated
-labels: [basic, vision, fds]
+tags: [basic, vision, fds]
 dataset: [CIFAR-10 | https://huggingface.co/datasets/uoft-cs/cifar10]
 framework: [torch | https://pytorch.org/]
 ---

--- a/examples/quickstart-cpp/README.md
+++ b/examples/quickstart-cpp/README.md
@@ -1,6 +1,6 @@
 ---
 title: Simple Flower Example using C++
-labels: [quickstart, linear regression, tabular]
+tags: [quickstart, linear regression, tabular]
 dataset: [Synthetic]
 framework: [C++ | https://isocpp.org/]
 ---

--- a/examples/quickstart-fastai/README.md
+++ b/examples/quickstart-fastai/README.md
@@ -1,6 +1,6 @@
 ---
 title: Simple Flower Example using fastai
-labels: [quickstart, vision]
+tags: [quickstart, vision]
 dataset: [MNIST | https://huggingface.co/datasets/ylecun/mnist]
 framework: [fastai | https://fast.ai]
 ---

--- a/examples/quickstart-huggingface/README.md
+++ b/examples/quickstart-huggingface/README.md
@@ -1,6 +1,6 @@
 ---
 title: Flower Transformers Example using HuggingFace
-labels: [quickstart, llm, nlp, sentiment]
+tags: [quickstart, llm, nlp, sentiment]
 dataset: [IMDB | https://huggingface.co/datasets/stanfordnlp/imdb]
 framework: [transformers | https://huggingface.co/docs/transformers/index]
 ---

--- a/examples/quickstart-jax/README.md
+++ b/examples/quickstart-jax/README.md
@@ -1,6 +1,6 @@
 ---
 title: Simple Flower Example using Jax
-labels: [quickstart, linear regression]
+tags: [quickstart, linear regression]
 dataset: [Synthetic]
 framework: [JAX | https://jax.readthedocs.io/en/latest/]
 ---

--- a/examples/quickstart-mlcube/README.md
+++ b/examples/quickstart-mlcube/README.md
@@ -1,6 +1,6 @@
 ---
 title: Flower Example using TensorFlow/Keras + MLCube
-labels: [quickstart, vision, deployment]
+tags: [quickstart, vision, deployment]
 dataset: [MNIST | https://huggingface.co/datasets/ylecun/mnist]
 framework: [tensorflow | https://www.tensorflow.org/, Keras | https://keras.io/]
 ---

--- a/examples/quickstart-mlx/README.md
+++ b/examples/quickstart-mlx/README.md
@@ -1,6 +1,6 @@
 ---
 title: Simple Flower Example using MLX
-labels: [quickstart, vision]
+tags: [quickstart, vision]
 dataset: [MNIST | https://huggingface.co/datasets/ylecun/mnist]
 framework: [MLX | https://ml-explore.github.io/mlx/build/html/index.html]
 ---

--- a/examples/quickstart-monai/README.md
+++ b/examples/quickstart-monai/README.md
@@ -1,6 +1,6 @@
 ---
 title: Flower Example using MONAI
-labels: [quickstart, medical, vision]
+tags: [quickstart, medical, vision]
 dataset: [MedNIST | https://medmnist.com/]
 framework: [MONAI | https://monai.io/]
 ---

--- a/examples/quickstart-pandas/README.md
+++ b/examples/quickstart-pandas/README.md
@@ -1,6 +1,6 @@
 ---
 title: Simple Flower Example using Pandas
-labels: [quickstart, tabular, federated analytics]
+tags: [quickstart, tabular, federated analytics]
 dataset: [Iris | https://scikit-learn.org/stable/auto_examples/datasets/plot_iris_dataset.html]
 framework: [pandas | https://pandas.pydata.org/]
 ---

--- a/examples/quickstart-pytorch-lightning/README.md
+++ b/examples/quickstart-pytorch-lightning/README.md
@@ -1,6 +1,6 @@
 ---
 title: Simple Flower Example using PyTorch-Lightning
-labels: [quickstart, vision, fds]
+tags: [quickstart, vision, fds]
 dataset: [MNIST | https://huggingface.co/datasets/ylecun/mnist]
 framework: [lightning | https://lightning.ai/docs/pytorch/stable/]
 ---

--- a/examples/quickstart-pytorch/README.md
+++ b/examples/quickstart-pytorch/README.md
@@ -1,6 +1,6 @@
 ---
 title: Simple Flower Example using PyTorch
-labels: [quickstart, vision, fds]
+tags: [quickstart, vision, fds]
 dataset: [CIFAR-10 | https://huggingface.co/datasets/uoft-cs/cifar10]
 framework: [torch | https://pytorch.org/, torchvision | https://pytorch.org/vision/stable/index.html]
 ---

--- a/examples/quickstart-sklearn-tabular/README.md
+++ b/examples/quickstart-sklearn-tabular/README.md
@@ -1,6 +1,6 @@
 ---
 title: Flower Example using Scikit-Learn
-labels: [quickstart, tabular, fds]
+tags: [quickstart, tabular, fds]
 dataset: [Iris | https://scikit-learn.org/stable/auto_examples/datasets/plot_iris_dataset.html]
 framework: [scikit-learn | https://scikit-learn.org/]
 ---

--- a/examples/quickstart-tabnet/README.md
+++ b/examples/quickstart-tabnet/README.md
@@ -1,6 +1,6 @@
 ---
 title: Simple Flower Example using Tabnet
-labels: [quickstart, tabular]
+tags: [quickstart, tabular]
 dataset: [Iris | https://scikit-learn.org/stable/auto_examples/datasets/plot_iris_dataset.html]
 framework: [tabnet | https://github.com/titu1994/tf-TabNet]
 ---

--- a/examples/quickstart-tensorflow/README.md
+++ b/examples/quickstart-tensorflow/README.md
@@ -1,6 +1,6 @@
 ---
 title: Simple Flower Example using TensorFlow
-labels: [quickstart, vision, fds]
+tags: [quickstart, vision, fds]
 dataset: [CIFAR-10 | https://huggingface.co/datasets/uoft-cs/cifar10]
 framework: [tensorflow | https://www.tensorflow.org/]
 ---

--- a/examples/simulation-pytorch/README.md
+++ b/examples/simulation-pytorch/README.md
@@ -1,6 +1,6 @@
 ---
 title: Flower Simulation Example using PyTorch
-labels: [basic, vision, fds, simulation]
+tags: [basic, vision, fds, simulation]
 dataset: [MNIST | https://huggingface.co/datasets/ylecun/mnist]
 framework: [torch | https://pytorch.org/, torchvision | https://pytorch.org/vision/stable/index.html]
 ---

--- a/examples/simulation-tensorflow/README.md
+++ b/examples/simulation-tensorflow/README.md
@@ -1,6 +1,6 @@
 ---
 title: Flower Simulation Example using TensorFlow/Keras
-labels: [basic, vision, fds, simulation]
+tags: [basic, vision, fds, simulation]
 dataset: [MNIST | https://huggingface.co/datasets/ylecun/mnist]
 framework: [tensorflow | https://www.tensorflow.org/, Keras | https://keras.io/]
 ---

--- a/examples/sklearn-logreg-mnist/README.md
+++ b/examples/sklearn-logreg-mnist/README.md
@@ -1,6 +1,6 @@
 ---
 title: Flower LogReg Example using Scikit-Learn
-labels: [basic, vision, logistic regression, fds]
+tags: [basic, vision, logistic regression, fds]
 dataset: [MNIST | https://huggingface.co/datasets/ylecun/mnist]
 framework: [scikit-learn | https://scikit-learn.org/]
 ---

--- a/examples/tensorflow-privacy/README.md
+++ b/examples/tensorflow-privacy/README.md
@@ -1,6 +1,6 @@
 ---
 title: Sample-Level DP using TensorFlow-Privacy Engine
-labels: [basic, vision, fds, privacy, dp]
+tags: [basic, vision, fds, privacy, dp]
 dataset: [MNIST | https://huggingface.co/datasets/ylecun/mnist]
 framework: [tensorflow | https://www.tensorflow.org/]
 ---

--- a/examples/vertical-fl/README.md
+++ b/examples/vertical-fl/README.md
@@ -1,6 +1,6 @@
 ---
 title: Vertical FL Flower Example
-labels: [vertical, tabular, advanced]
+tags: [vertical, tabular, advanced]
 dataset: [Titanic | https://www.kaggle.com/competitions/titanic]
 framework: [torch | https://pytorch.org/, pandas | https://pandas.pydata.org/, scikit-learn
       | https://scikit-learn.org/]

--- a/examples/vit-finetune/README.md
+++ b/examples/vit-finetune/README.md
@@ -1,6 +1,6 @@
 ---
 title: Federated finetuning of a ViT
-labels: [finetuneing, vision, fds]
+tags: [finetuneing, vision, fds]
 dataset: [Oxford Flower-102 | https://www.robots.ox.ac.uk/~vgg/data/flowers/102/]
 framework: [torch | https://pytorch.org/, torchvision | https://pytorch.org/vision/stable/index.html]
 ---

--- a/examples/whisper-federated-finetuning/README.md
+++ b/examples/whisper-federated-finetuning/README.md
@@ -1,6 +1,6 @@
 ---
 title: On-device Federated Finetuning for Speech Classification
-labels: [finetuning, speech, transformers]
+tags: [finetuning, speech, transformers]
 dataset: [SpeechCommands | https://huggingface.co/datasets/google/speech_commands]
 framework: [transformers | https://huggingface.co/docs/transformers/index, whisper
       | https://huggingface.co/openai/whisper-tiny]

--- a/examples/xgboost-comprehensive/README.md
+++ b/examples/xgboost-comprehensive/README.md
@@ -1,6 +1,6 @@
 ---
 title: Flower Example using XGBoost
-labels: [advanced, classification, tabular]
+tags: [advanced, classification, tabular]
 dataset: [HIGGS | https://archive.ics.uci.edu/dataset/280/higgs]
 framework: [xgboost | https://xgboost.readthedocs.io/en/stable/]
 ---

--- a/examples/xgboost-quickstart/README.md
+++ b/examples/xgboost-quickstart/README.md
@@ -1,6 +1,6 @@
 ---
 title: Flower Example using PyTorch
-labels: [quickstart, classification, tabular]
+tags: [quickstart, classification, tabular]
 dataset: [HIGGS | https://archive.ics.uci.edu/dataset/280/higgs]
 framework: [xgboost | https://xgboost.readthedocs.io/en/stable/]
 ---


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

Currently, inside the Flower Example docs, we sometimes use the word `tags` and other times the word `labels`.

### Related issues/PRs

N/A

## Proposal

### Explanation

Use `tags` everywhere

### Checklist

- [x] Implement proposed change
- [x] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

N/A
