### PR TITLE
docs(examples:skip) Use dict for framework and datasets links

### DIFF
--- a/dev/build-example-docs.py
+++ b/dev/build-example-docs.py
@@ -107,17 +107,18 @@ urls = {
 
 
 def _convert_to_link(search_result):
-    if "|" in search_result:
-        if "," in search_result:
-            result = ""
-            for part in search_result.split(","):
-                result += f"{_convert_to_link(part)}, "
-            return result[:-2]
-
-        name, url = search_result.replace('"', "").split("|")
-        return f"`{name.strip()} <{url.strip()}>`_"
-
-    return search_result
+    if "," in search_result:
+        result = ""
+        for part in search_result.split(","):
+            result += f"{_convert_to_link(part)}, "
+        return result[:-2]
+    else:
+        search_result = search_result.strip()
+        name, url = search_result, urls.get(search_result, None)
+        if url:
+            return f"`{name.strip()} <{url.strip()}>`_"
+        else:
+            return search_result
 
 
 def _read_metadata(example):
@@ -207,7 +208,7 @@ def _copy_images(example):
                 )
 
 
-def _add_all_entries(index_file):
+def _add_all_entries():
     examples_dir = os.path.join(ROOT, "examples")
     for example in sorted(os.listdir(examples_dir)):
         example_path = os.path.join(examples_dir, example)

--- a/dev/build-example-docs.py
+++ b/dev/build-example-docs.py
@@ -70,6 +70,7 @@ urls = {
     "Java": "https://www.java.com/",
     "Keras": "https://keras.io/",
     "Kotlin": "https://kotlinlang.org/",
+    "mlcube": "https://docs.mlcommons.org/mlcube/",
     "MLX": "https://ml-explore.github.io/mlx/build/html/index.html",
     "MONAI": "https://monai.io/",
     "PEFT": "https://huggingface.co/docs/peft/index",

--- a/dev/build-example-docs.py
+++ b/dev/build-example-docs.py
@@ -61,6 +61,50 @@ categories = {
     "other": {"table": table_headers, "list": ""},
 }
 
+urls = {
+    # Frameworks
+    "Android": "https://www.android.com/",
+    "C++": "https://isocpp.org/",
+    "Docker": "https://www.docker.com/",
+    "JAX": "https://jax.readthedocs.io/en/latest/",
+    "Java": "https://www.java.com/",
+    "Keras": "https://keras.io/",
+    "Kotlin": "https://kotlinlang.org/",
+    "MLX": "https://ml-explore.github.io/mlx/build/html/index.html",
+    "MONAI": "https://monai.io/",
+    "PEFT": "https://huggingface.co/docs/peft/index",
+    "Swift": "https://www.swift.org/",
+    "TensorFlowLite": "https://www.tensorflow.org/lite",
+    "fastai": "https://fast.ai/",
+    "lifelines": "https://lifelines.readthedocs.io/en/latest/index.html",
+    "lightning": "https://lightning.ai/docs/pytorch/stable/",
+    "numpy": "https://numpy.org/",
+    "opacus": "https://opacus.ai/",
+    "pandas": "https://pandas.pydata.org/",
+    "scikit-learn": "https://scikit-learn.org/",
+    "tabnet": "https://github.com/titu1994/tf-TabNet",
+    "tensorboard": "https://www.tensorflow.org/tensorboard",
+    "tensorflow": "https://www.tensorflow.org/",
+    "torch": "https://pytorch.org/",
+    "torchvision": "https://pytorch.org/vision/stable/index.html",
+    "transformers": "https://huggingface.co/docs/transformers/index",
+    "wandb": "https://wandb.ai/home",
+    "whisper": "https://huggingface.co/openai/whisper-tiny",
+    "xgboost": "https://xgboost.readthedocs.io/en/stable/",
+    # Datasets
+    "Adult Census Income": "https://www.kaggle.com/datasets/uciml/adult-census-income/data",
+    "Alpaca-GPT4": "https://huggingface.co/datasets/vicgalle/alpaca-gpt4",
+    "CIFAR-10": "https://huggingface.co/datasets/uoft-cs/cifar10",
+    "HIGGS": "https://archive.ics.uci.edu/dataset/280/higgs",
+    "IMDB": "https://huggingface.co/datasets/stanfordnlp/imdb",
+    "Iris": "https://scikit-learn.org/stable/auto_examples/datasets/plot_iris_dataset.html",
+    "MNIST": "https://huggingface.co/datasets/ylecun/mnist",
+    "MedNIST": "https://medmnist.com/",
+    "Oxford Flower-102": "https://www.robots.ox.ac.uk/~vgg/data/flowers/102/",
+    "SpeechCommands": "https://huggingface.co/datasets/google/speech_commands",
+    "Titanic": "https://www.kaggle.com/competitions/titanic",
+}
+
 
 def _convert_to_link(search_result):
     if "|" in search_result:

--- a/dev/build-example-docs.py
+++ b/dev/build-example-docs.py
@@ -256,7 +256,7 @@ def _main():
         )
         index_file.write(categories["other"]["table"])
 
-        _add_all_entries(index_file)
+        _add_all_entries()
 
         index_file.write(
             "\n.. toctree::\n  :maxdepth: 1\n  :caption: Quickstart\n  :hidden:\n\n"

--- a/examples/advanced-pytorch/README.md
+++ b/examples/advanced-pytorch/README.md
@@ -1,8 +1,8 @@
 ---
 title: Advanced Flower Example using PyTorch
 tags: [advanced, vision, fds]
-dataset: [CIFAR-10 | https://huggingface.co/datasets/uoft-cs/cifar10]
-framework: [torch | https://pytorch.org/, torchvision | https://pytorch.org/vision/stable/index.html]
+dataset: [CIFAR-10]
+framework: [torch, torchvision]
 ---
 
 # Advanced Flower Example (PyTorch)

--- a/examples/advanced-tensorflow/README.md
+++ b/examples/advanced-tensorflow/README.md
@@ -1,8 +1,8 @@
 ---
 title: Advanced Flower Example using TensorFlow/Keras
 tags: [advanced, vision, fds]
-dataset: [CIFAR-10 | https://huggingface.co/datasets/uoft-cs/cifar10]
-framework: [tensorflow | https://www.tensorflow.org/, Keras | https://keras.io/]
+dataset: [CIFAR-10]
+framework: [tensorflow, Keras]
 ---
 
 # Advanced Flower Example (TensorFlow/Keras)

--- a/examples/android-kotlin/README.md
+++ b/examples/android-kotlin/README.md
@@ -1,9 +1,8 @@
 ---
 title: Flower Android Example using Kotlin and TF Lite
-tags: [basic, vision, fds]
-dataset: [CIFAR-10 | https://huggingface.co/datasets/uoft-cs/cifar10]
-framework: [Android | https://www.android.com/, Kotlin | https://kotlinlang.org/,
-  TensorFlowLite | https://www.tensorflow.org/lite]
+tags: [mobile, vision, sdk]
+dataset: [CIFAR-10]
+framework: [Android, Kotlin, TensorFlowLite]
 ---
 
 # Flower Android Client Example with Kotlin and TensorFlow Lite 2022

--- a/examples/android/README.md
+++ b/examples/android/README.md
@@ -1,5 +1,4 @@
 ---
-title: Flower Android Example using Java and TF Lite
 tags: [mobile, vision, sdk]
 dataset: [CIFAR-10]
 framework: [Android, Java, TensorFlowLite]

--- a/examples/android/README.md
+++ b/examples/android/README.md
@@ -1,9 +1,8 @@
 ---
 title: Flower Android Example using Java and TF Lite
-tags: [basic, vision, fds]
-dataset: [CIFAR-10 | https://huggingface.co/datasets/uoft-cs/cifar10]
-framework: [Android | https://www.android.com/, Java | https://www.java.com/, TensorFlowLite
-      | https://www.tensorflow.org/lite]
+tags: [mobile, vision, sdk]
+dataset: [CIFAR-10]
+framework: [Android, Java, TensorFlowLite]
 ---
 
 # Flower Android Example (TensorFlowLite)

--- a/examples/app-pytorch/README.md
+++ b/examples/app-pytorch/README.md
@@ -1,8 +1,8 @@
 ---
 title: Example Flower App using PyTorch
 tags: [basic, vision, fds]
-dataset: [CIFAR-10 | https://huggingface.co/datasets/uoft-cs/cifar10]
-framework: [torch | https://pytorch.org/, torchvision | https://pytorch.org/vision/stable/index.html]
+dataset: [CIFAR-10]
+framework: [torch, torchvision]
 ---
 
 # Flower App (PyTorch) 🧪

--- a/examples/app-secure-aggregation/README.md
+++ b/examples/app-secure-aggregation/README.md
@@ -2,7 +2,7 @@
 title: Example Flower App with Secure Aggregation
 tags: [basic, vision, fds]
 dataset: []
-framework: [numpy | https://numpy.org/]
+framework: [numpy]
 ---
 
 # Secure aggregation with Flower (the SecAgg+ protocol) 🧪

--- a/examples/custom-metrics/README.md
+++ b/examples/custom-metrics/README.md
@@ -1,8 +1,8 @@
 ---
 title: Example Flower App with Custom Metrics
 tags: [basic, vision, fds]
-dataset: [CIFAR-10 | https://huggingface.co/datasets/uoft-cs/cifar10]
-framework: [tensorflow | https://www.tensorflow.org/]
+dataset: [CIFAR-10]
+framework: [tensorflow]
 ---
 
 # Flower Example using Custom Metrics
@@ -103,7 +103,7 @@ You will see that Keras is starting a federated training. Have a look to the [Fl
 Running `run.sh` will result in the following output (after 3 rounds):
 
 ```shell
-INFO flwr 2024-01-17 17:45:23,794 | app.py:228 | app_fit: metrics_distributed {
+INFO flwr 2024-01-17 17:45:23,794 
     'accuracy': [(1, 0.10000000149011612), (2, 0.10000000149011612), (3, 0.3393000066280365)],
     'acc': [(1, 0.1), (2, 0.1), (3, 0.3393)],
     'rec': [(1, 0.1), (2, 0.1), (3, 0.3393)],

--- a/examples/custom-metrics/README.md
+++ b/examples/custom-metrics/README.md
@@ -1,4 +1,5 @@
 ---
+title: Example Flower App with Custom Metrics
 tags: [basic, vision, fds]
 dataset: [CIFAR-10]
 framework: [tensorflow]
@@ -102,7 +103,7 @@ You will see that Keras is starting a federated training. Have a look to the [Fl
 Running `run.sh` will result in the following output (after 3 rounds):
 
 ```shell
-INFO flwr 2024-01-17 17:45:23,794 
+INFO flwr 2024-01-17 17:45:23,794 | app.py:228 | app_fit: metrics_distributed {
     'accuracy': [(1, 0.10000000149011612), (2, 0.10000000149011612), (3, 0.3393000066280365)],
     'acc': [(1, 0.1), (2, 0.1), (3, 0.3393)],
     'rec': [(1, 0.1), (2, 0.1), (3, 0.3393)],

--- a/examples/custom-mods/README.md
+++ b/examples/custom-mods/README.md
@@ -1,8 +1,8 @@
 ---
 title: Example Flower App with Custom Mods
 tags: [mods, monitoring, app]
-dataset: [CIFAR-10 | https://huggingface.co/datasets/uoft-cs/cifar10]
-framework: [wandb | https://wandb.ai/home, tensorboard | https://www.tensorflow.org/tensorboard]
+dataset: [CIFAR-10]
+framework: [wandb, tensorboard]
 ---
 
 # Using custom mods 🧪
@@ -214,7 +214,7 @@ app = fl.client.ClientApp(
     client_fn=client_fn,
     mods=[
         get_wandb_mod("Custom mods example"),
-     ],
+    ],
 )
 ```
 

--- a/examples/embedded-devices/README.md
+++ b/examples/embedded-devices/README.md
@@ -1,8 +1,8 @@
 ---
 title: Flower Embedded Devices Example
 tags: [basic, vision, fds]
-dataset: [CIFAR-10 | https://huggingface.co/datasets/uoft-cs/cifar10, MNIST | https://huggingface.co/datasets/ylecun/mnist]
-framework: [torch | https://pytorch.org/, tensorflow | https://www.tensorflow.org/]
+dataset: [CIFAR-10, MNIST]
+framework: [torch, tensorflow]
 ---
 
 # Federated Learning on Embedded Devices with Flower
@@ -187,7 +187,7 @@ If you are working on this tutorial on your laptop or desktop, it can host the F
 
 ## Running Embedded FL with Flower
 
-For this demo, we'll be using [CIFAR-10 | https://huggingface.co/datasets/uoft-cs/cifar10](https://www.cs.toronto.edu/~kriz/cifar.html), a popular dataset for image classification comprised of 10 classes (e.g. car, bird, airplane) and a total of 60K `32x32` RGB images. The training set contains 50K images. The server will automatically download the dataset should it not be found in `./data`. The clients do the same. The dataset is by default split into 50 partitions (each to be assigned to a different client). This can be controlled with the `NUM_CLIENTS` global variable in the client scripts. In this example, each device will play the role of a specific user (specified via `--cid` -- we'll show this later) and therefore only do local training with that portion of the data. For CIFAR-10, clients will be training a MobileNet-v2/3 model.
+For this demo, we'll be using [CIFAR-10](https://www.cs.toronto.edu/~kriz/cifar.html), a popular dataset for image classification comprised of 10 classes (e.g. car, bird, airplane) and a total of 60K `32x32` RGB images. The training set contains 50K images. The server will automatically download the dataset should it not be found in `./data`. The clients do the same. The dataset is by default split into 50 partitions (each to be assigned to a different client). This can be controlled with the `NUM_CLIENTS` global variable in the client scripts. In this example, each device will play the role of a specific user (specified via `--cid` -- we'll show this later) and therefore only do local training with that portion of the data. For CIFAR-10, clients will be training a MobileNet-v2/3 model.
 
 You can run this example using MNIST and a smaller CNN model by passing flag `--mnist`. This is useful if you are using devices with a very limited amount of memory (e.g. RaspberryPi Zero) or if you want the training taking place on the embedded devices to be much faster (specially if these are CPU-only). The partitioning of the dataset is done in the same way.
 

--- a/examples/federated-kaplan-meier-fitter/README.md
+++ b/examples/federated-kaplan-meier-fitter/README.md
@@ -1,9 +1,8 @@
 ---
 title: Flower Example using KaplanMeierFitter
 tags: [estimator, medical]
-dataset: [Waltons | 
-      https://lifelines.readthedocs.io/en/latest/lifelines.datasets.html#lifelines.datasets.load_waltons]
-framework: [lifelines | https://lifelines.readthedocs.io/en/latest/index.html]
+dataset: [Waltons]
+framework: [lifelines]
 ---
 
 # Flower Example using KaplanMeierFitter

--- a/examples/fl-dp-sa/README.md
+++ b/examples/fl-dp-sa/README.md
@@ -1,8 +1,8 @@
 ---
 title: Example of Flower App with DP and SA
 tags: [basic, vision, fds]
-dataset: [MNIST | https://huggingface.co/datasets/ylecun/mnist]
-framework: [torch | https://pytorch.org/, torchvision | https://pytorch.org/vision/stable/index.html]
+dataset: [MNIST]
+framework: [torch, torchvision]
 ---
 
 # Example of Flower App with DP and SA

--- a/examples/fl-tabular/README.md
+++ b/examples/fl-tabular/README.md
@@ -1,8 +1,8 @@
 ---
 title: Flower Example on Adult Census Income Tabular Dataset
 tags: [basic, tabular, fds]
-dataset: [Adult Census Income | https://www.kaggle.com/datasets/uciml/adult-census-income/data]
-framework: [scikit-learn | https://scikit-learn.org/, torch | https://pytorch.org/]
+dataset: [Adult Census Income]
+framework: [scikit-learn, torch]
 ---
 
 # Flower Example on Adult Census Income Tabular Dataset

--- a/examples/flower-authentication/README.md
+++ b/examples/flower-authentication/README.md
@@ -1,8 +1,8 @@
 ---
 title: Flower Example with Authentication
 tags: [advanced, vision, fds]
-dataset: [CIFAR-10 | https://huggingface.co/datasets/uoft-cs/cifar10]
-framework: [torch | https://pytorch.org/, torchvision | https://pytorch.org/vision/stable/index.html]
+dataset: [CIFAR-10]
+framework: [torch, torchvision]
 ---
 
 # Flower Authentication with PyTorch 🧪

--- a/examples/flower-in-30-minutes/README.md
+++ b/examples/flower-in-30-minutes/README.md
@@ -1,8 +1,8 @@
 ---
 title: 30-minute tutorial running Flower simulation with PyTorch
 tags: [colab, vision, simulation]
-dataset: [CIFAR-10 | https://huggingface.co/datasets/uoft-cs/cifar10]
-framework: [torch | https://pytorch.org/]
+dataset: [CIFAR-10]
+framework: [torch]
 ---
 
 # 30-minute tutorial running Flower simulation with PyTorch

--- a/examples/flower-simulation-step-by-step-pytorch/README.md
+++ b/examples/flower-simulation-step-by-step-pytorch/README.md
@@ -1,8 +1,8 @@
 ---
 title: Flower Simulation Step-by-Step
 tags: [basic, vision, simulation]
-dataset: [MNIST | https://huggingface.co/datasets/ylecun/mnist]
-framework: [torch | https://pytorch.org/]
+dataset: [MNIST]
+framework: [torch]
 ---
 
 # Flower Simulation Step-by-Step

--- a/examples/flower-via-docker-compose/README.md
+++ b/examples/flower-via-docker-compose/README.md
@@ -1,4 +1,5 @@
 ---
+title: Leveraging Flower and Docker for Device Heterogeneity Management in FL
 tags: [deployment, vision, tutorial]
 dataset: [CIFAR-10]
 framework: [Docker, tensorflow]
@@ -33,7 +34,7 @@ In this example, we tackle device heterogeneity in federated learning, arising f
            {"mem_limit": "6g", "batch_size": 256, "cpus": 1, "learning_rate": 0.05},
            {"mem_limit": "4g", "batch_size": 64, "cpus": 3, "learning_rate": 0.02},
            {"mem_limit": "5g", "batch_size": 128, "cpus": 2.5, "learning_rate": 0.09},
-    ]
+     ]
      ```
 
 ## Prerequisites

--- a/examples/flower-via-docker-compose/README.md
+++ b/examples/flower-via-docker-compose/README.md
@@ -1,8 +1,8 @@
 ---
 title: Leveraging Flower and Docker for Device Heterogeneity Management in FL
 tags: [deployment, vision, tutorial]
-dataset: [CIFAR-10 | https://huggingface.co/datasets/uoft-cs/cifar10]
-framework: [Docker | https://www.docker.com/, tensorflow | https://www.tensorflow.org/]
+dataset: [CIFAR-10]
+framework: [Docker, tensorflow]
 ---
 
 # Leveraging Flower and Docker for Device Heterogeneity Management in Federated Learning
@@ -34,7 +34,7 @@ In this example, we tackle device heterogeneity in federated learning, arising f
            {"mem_limit": "6g", "batch_size": 256, "cpus": 1, "learning_rate": 0.05},
            {"mem_limit": "4g", "batch_size": 64, "cpus": 3, "learning_rate": 0.02},
            {"mem_limit": "5g", "batch_size": 128, "cpus": 2.5, "learning_rate": 0.09},
-     ]
+    ]
      ```
 
 ## Prerequisites

--- a/examples/ios/README.md
+++ b/examples/ios/README.md
@@ -1,8 +1,8 @@
 ---
 title: Simple Flower Example on iOS
-tags: [mobile, vision, fds]
-dataset: [MNIST | https://huggingface.co/datasets/ylecun/mnist]
-framework: [Swift | https://www.swift.org/]
+tags: [mobile, vision, sdk]
+dataset: [MNIST]
+framework: [Swift]
 ---
 
 # FLiOS - A Flower SDK for iOS Devices with Example

--- a/examples/llm-flowertune/README.md
+++ b/examples/llm-flowertune/README.md
@@ -1,4 +1,5 @@
 ---
+title: Federated LLM Fine-tuning with Flower
 tags: [llm, nlp, LLama2]
 dataset: [Alpaca-GPT4]
 framework: [PEFT, torch]
@@ -78,9 +79,9 @@ python main.py --multirun model.name="openlm-research/open_llama_7b_v2","openlm-
 
 ## VRAM Consumption
 
-
-
-
+| Models | 7-billion (8-bit) | 7-billion (4-bit) | 3-billion (8-bit) | 3-billion (4-bit) |
+| :----: | :---------------: | :---------------: | :---------------: | :---------------: |
+|  VRAM  |     ~22.00 GB     |     ~16.50 GB     |     ~13.50 GB     |     ~10.60 GB     |
 
 We make use of the [bitsandbytes](https://huggingface.co/docs/bitsandbytes/main/en/index) library in conjunction with [PEFT](https://huggingface.co/docs/peft/en/index) to derive LLMs that can be fine-tuned efficiently.
 The above table shows the VRAM consumption per client for the different models considered in this example.

--- a/examples/llm-flowertune/README.md
+++ b/examples/llm-flowertune/README.md
@@ -1,8 +1,8 @@
 ---
 title: Federated LLM Fine-tuning with Flower
 tags: [llm, nlp, LLama2]
-dataset: [Alpaca-GPT4 | https://huggingface.co/datasets/vicgalle/alpaca-gpt4]
-framework: [PEFT | https://huggingface.co/docs/peft/index, torch | https://pytorch.org/]
+dataset: [Alpaca-GPT4]
+framework: [PEFT, torch]
 ---
 
 # LLM FlowerTune: Federated LLM Fine-tuning with Flower
@@ -79,9 +79,9 @@ python main.py --multirun model.name="openlm-research/open_llama_7b_v2","openlm-
 
 ## VRAM Consumption
 
-| Models | 7-billion (8-bit) | 7-billion (4-bit) | 3-billion (8-bit) | 3-billion (4-bit) |
-| :----: | :---------------: | :---------------: | :---------------: | :---------------: |
-|  VRAM  |     ~22.00 GB     |     ~16.50 GB     |     ~13.50 GB     |     ~10.60 GB     |
+
+
+
 
 We make use of the [bitsandbytes](https://huggingface.co/docs/bitsandbytes/main/en/index) library in conjunction with [PEFT](https://huggingface.co/docs/peft/en/index) to derive LLMs that can be fine-tuned efficiently.
 The above table shows the VRAM consumption per client for the different models considered in this example.

--- a/examples/opacus/README.md
+++ b/examples/opacus/README.md
@@ -1,8 +1,8 @@
 ---
 title: Sample-Level Differential Privacy using Opacus
 tags: [dp, security, fds]
-dataset: [CIFAR-10 | https://huggingface.co/datasets/uoft-cs/cifar10]
-framework: [opacus | https://opacus.ai/, torch | https://pytorch.org/]
+dataset: [CIFAR-10]
+framework: [opacus, torch]
 ---
 
 # Training with Sample-Level Differential Privacy using Opacus Privacy Engine

--- a/examples/pytorch-federated-variational-autoencoder/README.md
+++ b/examples/pytorch-federated-variational-autoencoder/README.md
@@ -1,8 +1,8 @@
 ---
 title: Federated Variational Autoencoder using Pytorch
 tags: [basic, vision, fds]
-dataset: [CIFAR-10 | https://huggingface.co/datasets/uoft-cs/cifar10]
-framework: [torch | https://pytorch.org/, torchvision | https://pytorch.org/vision/stable/index.html]
+dataset: [CIFAR-10]
+framework: [torch, torchvision]
 ---
 
 # Flower Example for Federated Variational Autoencoder using Pytorch

--- a/examples/pytorch-from-centralized-to-federated/README.md
+++ b/examples/pytorch-from-centralized-to-federated/README.md
@@ -1,8 +1,8 @@
 ---
 title: PyTorch, From Centralized To Federated
 tags: [basic, vision, fds]
-dataset: [CIFAR-10 | https://huggingface.co/datasets/uoft-cs/cifar10]
-framework: [torch | https://pytorch.org/]
+dataset: [CIFAR-10]
+framework: [torch]
 ---
 
 # PyTorch: From Centralized To Federated

--- a/examples/quickstart-cpp/README.md
+++ b/examples/quickstart-cpp/README.md
@@ -2,7 +2,7 @@
 title: Simple Flower Example using C++
 tags: [quickstart, linear regression, tabular]
 dataset: [Synthetic]
-framework: [C++ | https://isocpp.org/]
+framework: [C++]
 ---
 
 # Flower Clients in C++ (under development)

--- a/examples/quickstart-fastai/README.md
+++ b/examples/quickstart-fastai/README.md
@@ -1,8 +1,8 @@
 ---
 title: Simple Flower Example using fastai
 tags: [quickstart, vision]
-dataset: [MNIST | https://huggingface.co/datasets/ylecun/mnist]
-framework: [fastai | https://fast.ai]
+dataset: [MNIST]
+framework: [fastai]
 ---
 
 # Flower Example using fastai

--- a/examples/quickstart-huggingface/README.md
+++ b/examples/quickstart-huggingface/README.md
@@ -1,8 +1,8 @@
 ---
 title: Flower Transformers Example using HuggingFace
 tags: [quickstart, llm, nlp, sentiment]
-dataset: [IMDB | https://huggingface.co/datasets/stanfordnlp/imdb]
-framework: [transformers | https://huggingface.co/docs/transformers/index]
+dataset: [IMDB]
+framework: [transformers]
 ---
 
 # Federated HuggingFace Transformers using Flower and PyTorch

--- a/examples/quickstart-jax/README.md
+++ b/examples/quickstart-jax/README.md
@@ -2,7 +2,7 @@
 title: Simple Flower Example using Jax
 tags: [quickstart, linear regression]
 dataset: [Synthetic]
-framework: [JAX | https://jax.readthedocs.io/en/latest/]
+framework: [JAX]
 ---
 
 # JAX: From Centralized To Federated

--- a/examples/quickstart-mlcube/README.md
+++ b/examples/quickstart-mlcube/README.md
@@ -1,8 +1,8 @@
 ---
 title: Flower Example using TensorFlow/Keras + MLCube
 tags: [quickstart, vision, deployment]
-dataset: [MNIST | https://huggingface.co/datasets/ylecun/mnist]
-framework: [tensorflow | https://www.tensorflow.org/, Keras | https://keras.io/]
+dataset: [MNIST]
+framework: [tensorflow, Keras]
 ---
 
 # Flower Example using TensorFlow/Keras + MLCube

--- a/examples/quickstart-mlcube/README.md
+++ b/examples/quickstart-mlcube/README.md
@@ -1,7 +1,7 @@
 ---
 tags: [quickstart, vision, deployment]
 dataset: [MNIST]
-framework: [tensorflow, Keras]
+framework: [mlcube, tensorflow, Keras]
 ---
 
 # Flower Example using TensorFlow/Keras + MLCube

--- a/examples/quickstart-mlx/README.md
+++ b/examples/quickstart-mlx/README.md
@@ -1,8 +1,8 @@
 ---
 title: Simple Flower Example using MLX
 tags: [quickstart, vision]
-dataset: [MNIST | https://huggingface.co/datasets/ylecun/mnist]
-framework: [MLX | https://ml-explore.github.io/mlx/build/html/index.html]
+dataset: [MNIST]
+framework: [MLX]
 ---
 
 # Flower Example using MLX
@@ -148,7 +148,7 @@ class MLP(mlx.nn.Module):
         self.layers = [
             mlx.nn.Linear(idim, odim)
             for idim, odim in zip(layer_sizes[:-1], layer_sizes[1:])
-        ]
+       ]
 
     def __call__(self, x):
         for l in self.layers[:-1]:
@@ -192,7 +192,7 @@ The way MLX stores its parameters is as follows:
     {"weight": mlx.core.array, "bias": mlx.core.array},
     ...,
     {"weight": mlx.core.array, "bias": mlx.core.array}
-  ]
+ ]
 }
 ```
 
@@ -216,7 +216,7 @@ def set_parameters(self, parameters):
     new_params["layers"] = [
         {"weight": mlx.core.array(parameters[i]), "bias": mlx.core.array(parameters[i + 1])}
         for i in range(0, len(parameters), 2)
-    ]
+   ]
     self.model.update(new_params)
 ```
 
@@ -274,7 +274,7 @@ class FlowerClient(fl.client.NumPyClient):
         new_params["layers"] = [
             {"weight": mlx.core.array(parameters[i]), "bias": mlx.core.array(parameters[i + 1])}
             for i in range(0, len(parameters), 2)
-        ]
+       ]
         self.model.update(new_params)
 
     def fit(self, parameters, config):

--- a/examples/quickstart-mlx/README.md
+++ b/examples/quickstart-mlx/README.md
@@ -1,4 +1,5 @@
 ---
+title: Simple Flower Example using MLX
 tags: [quickstart, vision]
 dataset: [MNIST]
 framework: [MLX]
@@ -147,7 +148,7 @@ class MLP(mlx.nn.Module):
         self.layers = [
             mlx.nn.Linear(idim, odim)
             for idim, odim in zip(layer_sizes[:-1], layer_sizes[1:])
-       ]
+        ]
 
     def __call__(self, x):
         for l in self.layers[:-1]:
@@ -191,7 +192,7 @@ The way MLX stores its parameters is as follows:
     {"weight": mlx.core.array, "bias": mlx.core.array},
     ...,
     {"weight": mlx.core.array, "bias": mlx.core.array}
- ]
+  ]
 }
 ```
 
@@ -215,7 +216,7 @@ def set_parameters(self, parameters):
     new_params["layers"] = [
         {"weight": mlx.core.array(parameters[i]), "bias": mlx.core.array(parameters[i + 1])}
         for i in range(0, len(parameters), 2)
-   ]
+    ]
     self.model.update(new_params)
 ```
 
@@ -273,7 +274,7 @@ class FlowerClient(fl.client.NumPyClient):
         new_params["layers"] = [
             {"weight": mlx.core.array(parameters[i]), "bias": mlx.core.array(parameters[i + 1])}
             for i in range(0, len(parameters), 2)
-       ]
+        ]
         self.model.update(new_params)
 
     def fit(self, parameters, config):

--- a/examples/quickstart-monai/README.md
+++ b/examples/quickstart-monai/README.md
@@ -1,8 +1,8 @@
 ---
 title: Flower Example using MONAI
 tags: [quickstart, medical, vision]
-dataset: [MedNIST | https://medmnist.com/]
-framework: [MONAI | https://monai.io/]
+dataset: [MedNIST]
+framework: [MONAI]
 ---
 
 # Flower Example using MONAI

--- a/examples/quickstart-pandas/README.md
+++ b/examples/quickstart-pandas/README.md
@@ -1,8 +1,8 @@
 ---
 title: Simple Flower Example using Pandas
 tags: [quickstart, tabular, federated analytics]
-dataset: [Iris | https://scikit-learn.org/stable/auto_examples/datasets/plot_iris_dataset.html]
-framework: [pandas | https://pandas.pydata.org/]
+dataset: [Iris]
+framework: [pandas]
 ---
 
 # Flower Example using Pandas

--- a/examples/quickstart-pytorch-lightning/README.md
+++ b/examples/quickstart-pytorch-lightning/README.md
@@ -1,8 +1,8 @@
 ---
 title: Simple Flower Example using PyTorch-Lightning
 tags: [quickstart, vision, fds]
-dataset: [MNIST | https://huggingface.co/datasets/ylecun/mnist]
-framework: [lightning | https://lightning.ai/docs/pytorch/stable/]
+dataset: [MNIST]
+framework: [lightning]
 ---
 
 # Flower Example using PyTorch Lightning

--- a/examples/quickstart-pytorch/README.md
+++ b/examples/quickstart-pytorch/README.md
@@ -1,8 +1,8 @@
 ---
 title: Simple Flower Example using PyTorch
 tags: [quickstart, vision, fds]
-dataset: [CIFAR-10 | https://huggingface.co/datasets/uoft-cs/cifar10]
-framework: [torch | https://pytorch.org/, torchvision | https://pytorch.org/vision/stable/index.html]
+dataset: [CIFAR-10]
+framework: [torch, torchvision]
 ---
 
 # Flower Example using PyTorch

--- a/examples/quickstart-sklearn-tabular/README.md
+++ b/examples/quickstart-sklearn-tabular/README.md
@@ -1,8 +1,8 @@
 ---
 title: Flower Example using Scikit-Learn
 tags: [quickstart, tabular, fds]
-dataset: [Iris | https://scikit-learn.org/stable/auto_examples/datasets/plot_iris_dataset.html]
-framework: [scikit-learn | https://scikit-learn.org/]
+dataset: [Iris]
+framework: [scikit-learn]
 ---
 
 # Flower Example using scikit-learn

--- a/examples/quickstart-tabnet/README.md
+++ b/examples/quickstart-tabnet/README.md
@@ -1,8 +1,8 @@
 ---
 title: Simple Flower Example using Tabnet
 tags: [quickstart, tabular]
-dataset: [Iris | https://scikit-learn.org/stable/auto_examples/datasets/plot_iris_dataset.html]
-framework: [tabnet | https://github.com/titu1994/tf-TabNet]
+dataset: [Iris]
+framework: [tabnet]
 ---
 
 # Flower TabNet Example using TensorFlow

--- a/examples/quickstart-tensorflow/README.md
+++ b/examples/quickstart-tensorflow/README.md
@@ -1,8 +1,8 @@
 ---
 title: Simple Flower Example using TensorFlow
 tags: [quickstart, vision, fds]
-dataset: [CIFAR-10 | https://huggingface.co/datasets/uoft-cs/cifar10]
-framework: [tensorflow | https://www.tensorflow.org/]
+dataset: [CIFAR-10]
+framework: [tensorflow]
 ---
 
 # Flower Example using TensorFlow/Keras

--- a/examples/simulation-pytorch/README.md
+++ b/examples/simulation-pytorch/README.md
@@ -1,8 +1,8 @@
 ---
 title: Flower Simulation Example using PyTorch
 tags: [basic, vision, fds, simulation]
-dataset: [MNIST | https://huggingface.co/datasets/ylecun/mnist]
-framework: [torch | https://pytorch.org/, torchvision | https://pytorch.org/vision/stable/index.html]
+dataset: [MNIST]
+framework: [torch, torchvision]
 ---
 
 # Flower Simulation example using PyTorch

--- a/examples/simulation-tensorflow/README.md
+++ b/examples/simulation-tensorflow/README.md
@@ -1,8 +1,8 @@
 ---
 title: Flower Simulation Example using TensorFlow/Keras
 tags: [basic, vision, fds, simulation]
-dataset: [MNIST | https://huggingface.co/datasets/ylecun/mnist]
-framework: [tensorflow | https://www.tensorflow.org/, Keras | https://keras.io/]
+dataset: [MNIST]
+framework: [tensorflow, Keras]
 ---
 
 # Flower Simulation example using TensorFlow/Keras

--- a/examples/sklearn-logreg-mnist/README.md
+++ b/examples/sklearn-logreg-mnist/README.md
@@ -1,8 +1,8 @@
 ---
 title: Flower LogReg Example using Scikit-Learn
 tags: [basic, vision, logistic regression, fds]
-dataset: [MNIST | https://huggingface.co/datasets/ylecun/mnist]
-framework: [scikit-learn | https://scikit-learn.org/]
+dataset: [MNIST]
+framework: [scikit-learn]
 ---
 
 # Flower Example using scikit-learn

--- a/examples/tensorflow-privacy/README.md
+++ b/examples/tensorflow-privacy/README.md
@@ -1,8 +1,8 @@
 ---
 title: Sample-Level DP using TensorFlow-Privacy Engine
 tags: [basic, vision, fds, privacy, dp]
-dataset: [MNIST | https://huggingface.co/datasets/ylecun/mnist]
-framework: [tensorflow | https://www.tensorflow.org/]
+dataset: [MNIST]
+framework: [tensorflow]
 ---
 
 # Training with Sample-Level Differential Privacy using TensorFlow-Privacy Engine

--- a/examples/vertical-fl/README.md
+++ b/examples/vertical-fl/README.md
@@ -1,6 +1,7 @@
 ---
+title: Vertical FL Flower Example
 tags: [vertical, tabular, advanced]
-dataset: [Titanic]
+dataset: [Titanic | https://www.kaggle.com/competitions/titanic]
 framework: [torch, pandas, scikit-learn]
 ---
 
@@ -96,16 +97,16 @@ seconds to run as the model is very small.
 
 ### Vertical FL vs Horizontal FL
 
+|                       | Horizontal Federated Learning (HFL or just FL)                                                                                                                                                           | Vertical Federated Learning (VFL)                                                                                                                                                                                                                                                                                                                                        |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Data Distribution     | Clients have different data instances but share the same feature space.  Think of different hospitals having different patients' data (samples)  but recording the same types of information (features). | Each client holds different features for the same instances.  Imagine different institutions holding various tests or  measurements for the same group of patients.                                                                                                                                                                                                      |
+| Model Training        | Each client trains a model on their local data,  which contains all the feature columns for its samples.                                                                                                 | Clients train models on their respective features without  having access to the complete feature set.  Each model only sees a vertical slice of the data (hence the name 'Vertical').                                                                                                                                                                                    |
+| Aggregation           | The server aggregates these local models by averaging  the parameters or gradients to update a global model.                                                                                             | The server aggregates the updates such as gradients or parameters,  which are then used to update the global model.  However, since each client sees only a part of the features,  the server typically has a more complex role,  sometimes needing to coordinate more sophisticated aggregation strategies  that may involve secure multi-party computation techniques. |
+| Privacy Consideration | The raw data stays on the client's side, only model updates are shared,  which helps in maintaining privacy.                                                                                             | VFL is designed to ensure that no participant can access  the complete feature set of any sample,  thereby preserving the privacy of data.                                                                                                                                                                                                                               |
 
-
-
-
-
-
-
-
-
-](_static/hfl.jpg)](_static/vfl.jpg) 
+|               HFL               |               VFL               |
+| :-----------------------------: | :-----------------------------: |
+| ![HFL diagram](_static/hfl.jpg) | ![VFL diagram](_static/vfl.jpg) |
 
 Those diagrams illustrate HFL vs VFL using a simplified version of what we will be building in this example. Note that on the VFL side, the server holds the labels (the `Survived` column) and will be the only one capable of performing evaluation.
 
@@ -213,7 +214,7 @@ def _partition_data(df, all_keywords):
                         if kw in col or "Survived" in col
                     }
                 )
-           ]
+            ]
         )
 
     return partitions
@@ -340,7 +341,7 @@ def aggregate_fit(
     embedding_results = [
         torch.from_numpy(parameters_to_ndarrays(fit_res.parameters)[0])
         for _, fit_res in results
-   ]
+    ]
     embeddings_aggregated = torch.cat(embedding_results, dim=1)
     embedding_server = embeddings_aggregated.detach().requires_grad_()
     output = self.model(embedding_server)

--- a/examples/vertical-fl/README.md
+++ b/examples/vertical-fl/README.md
@@ -1,9 +1,8 @@
 ---
 title: Vertical FL Flower Example
 tags: [vertical, tabular, advanced]
-dataset: [Titanic | https://www.kaggle.com/competitions/titanic]
-framework: [torch | https://pytorch.org/, pandas | https://pandas.pydata.org/, scikit-learn
-      | https://scikit-learn.org/]
+dataset: [Titanic]
+framework: [torch, pandas, scikit-learn]
 ---
 
 # Vertical Federated Learning example
@@ -98,16 +97,16 @@ seconds to run as the model is very small.
 
 ### Vertical FL vs Horizontal FL
 
-|                       | Horizontal Federated Learning (HFL or just FL)                                                                                                                                                           | Vertical Federated Learning (VFL)                                                                                                                                                                                                                                                                                                                                        |
-| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Data Distribution     | Clients have different data instances but share the same feature space.  Think of different hospitals having different patients' data (samples)  but recording the same types of information (features). | Each client holds different features for the same instances.  Imagine different institutions holding various tests or  measurements for the same group of patients.                                                                                                                                                                                                      |
-| Model Training        | Each client trains a model on their local data,  which contains all the feature columns for its samples.                                                                                                 | Clients train models on their respective features without  having access to the complete feature set.  Each model only sees a vertical slice of the data (hence the name 'Vertical').                                                                                                                                                                                    |
-| Aggregation           | The server aggregates these local models by averaging  the parameters or gradients to update a global model.                                                                                             | The server aggregates the updates such as gradients or parameters,  which are then used to update the global model.  However, since each client sees only a part of the features,  the server typically has a more complex role,  sometimes needing to coordinate more sophisticated aggregation strategies  that may involve secure multi-party computation techniques. |
-| Privacy Consideration | The raw data stays on the client's side, only model updates are shared,  which helps in maintaining privacy.                                                                                             | VFL is designed to ensure that no participant can access  the complete feature set of any sample,  thereby preserving the privacy of data.                                                                                                                                                                                                                               |
 
-|               HFL               |               VFL               |
-| :-----------------------------: | :-----------------------------: |
-| ![HFL diagram](_static/hfl.jpg) | ![VFL diagram](_static/vfl.jpg) |
+
+
+
+
+
+
+
+
+](_static/hfl.jpg)](_static/vfl.jpg) 
 
 Those diagrams illustrate HFL vs VFL using a simplified version of what we will be building in this example. Note that on the VFL side, the server holds the labels (the `Survived` column) and will be the only one capable of performing evaluation.
 
@@ -215,7 +214,7 @@ def _partition_data(df, all_keywords):
                         if kw in col or "Survived" in col
                     }
                 )
-            ]
+           ]
         )
 
     return partitions
@@ -342,7 +341,7 @@ def aggregate_fit(
     embedding_results = [
         torch.from_numpy(parameters_to_ndarrays(fit_res.parameters)[0])
         for _, fit_res in results
-    ]
+   ]
     embeddings_aggregated = torch.cat(embedding_results, dim=1)
     embedding_server = embeddings_aggregated.detach().requires_grad_()
     output = self.model(embedding_server)

--- a/examples/vit-finetune/README.md
+++ b/examples/vit-finetune/README.md
@@ -1,4 +1,5 @@
 ---
+title: Federated finetuning of a ViT
 tags: [finetuneing, vision, fds]
 dataset: [Oxford Flower-102]
 framework: [torch, torchvision]
@@ -64,28 +65,28 @@ You can adjust the `client_resources` passed to `start_simulation()` so more/les
 
 ```bash
 +---------------------------------------------------------------------------------------+
-
-
-
-
-
-
-
-
-
+| NVIDIA-SMI 535.161.07             Driver Version: 535.161.07   CUDA Version: 12.2     |
+|-----------------------------------------+----------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id        Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |         Memory-Usage | GPU-Util  Compute M. |
+|                                         |                      |               MIG M. |
+|=========================================+======================+======================|
+|   0  NVIDIA GeForce RTX 3090 Ti     Off | 00000000:0B:00.0 Off |                  Off |
+| 44%   74C    P2             441W / 450W |   7266MiB / 24564MiB |    100%      Default |
+|                                         |                      |                  N/A |
 +-----------------------------------------+----------------------+----------------------+
 
 +---------------------------------------------------------------------------------------+
-
-
-
-
-
-
-
-
-
-
+| Processes:                                                                            |
+|  GPU   GI   CI        PID   Type   Process name                            GPU Memory |
+|        ID   ID                                                             Usage      |
+|=======================================================================================|
+|    0   N/A  N/A    173812      C   python                                     1966MiB |
+|    0   N/A  N/A    174510      C   ray::ClientAppActor.run                    1056MiB |
+|    0   N/A  N/A    174512      C   ray::ClientAppActor.run                    1056MiB |
+|    0   N/A  N/A    174513      C   ray::ClientAppActor.run                    1056MiB |
+|    0   N/A  N/A    174514      C   ray::ClientAppActor.run                    1056MiB |
+|    0   N/A  N/A    174516      C   ray::ClientAppActor.run                    1056MiB |
 +---------------------------------------------------------------------------------------+
 ```
 

--- a/examples/vit-finetune/README.md
+++ b/examples/vit-finetune/README.md
@@ -1,8 +1,8 @@
 ---
 title: Federated finetuning of a ViT
 tags: [finetuneing, vision, fds]
-dataset: [Oxford Flower-102 | https://www.robots.ox.ac.uk/~vgg/data/flowers/102/]
-framework: [torch | https://pytorch.org/, torchvision | https://pytorch.org/vision/stable/index.html]
+dataset: [Oxford Flower-102]
+framework: [torch, torchvision]
 ---
 
 # Federated finetuning of a ViT
@@ -65,28 +65,28 @@ You can adjust the `client_resources` passed to `start_simulation()` so more/les
 
 ```bash
 +---------------------------------------------------------------------------------------+
-| NVIDIA-SMI 535.161.07             Driver Version: 535.161.07   CUDA Version: 12.2     |
-|-----------------------------------------+----------------------+----------------------+
-| GPU  Name                 Persistence-M | Bus-Id        Disp.A | Volatile Uncorr. ECC |
-| Fan  Temp   Perf          Pwr:Usage/Cap |         Memory-Usage | GPU-Util  Compute M. |
-|                                         |                      |               MIG M. |
-|=========================================+======================+======================|
-|   0  NVIDIA GeForce RTX 3090 Ti     Off | 00000000:0B:00.0 Off |                  Off |
-| 44%   74C    P2             441W / 450W |   7266MiB / 24564MiB |    100%      Default |
-|                                         |                      |                  N/A |
+
+
+
+
+
+
+
+
+
 +-----------------------------------------+----------------------+----------------------+
 
 +---------------------------------------------------------------------------------------+
-| Processes:                                                                            |
-|  GPU   GI   CI        PID   Type   Process name                            GPU Memory |
-|        ID   ID                                                             Usage      |
-|=======================================================================================|
-|    0   N/A  N/A    173812      C   python                                     1966MiB |
-|    0   N/A  N/A    174510      C   ray::ClientAppActor.run                    1056MiB |
-|    0   N/A  N/A    174512      C   ray::ClientAppActor.run                    1056MiB |
-|    0   N/A  N/A    174513      C   ray::ClientAppActor.run                    1056MiB |
-|    0   N/A  N/A    174514      C   ray::ClientAppActor.run                    1056MiB |
-|    0   N/A  N/A    174516      C   ray::ClientAppActor.run                    1056MiB |
+
+
+
+
+
+
+
+
+
+
 +---------------------------------------------------------------------------------------+
 ```
 

--- a/examples/whisper-federated-finetuning/README.md
+++ b/examples/whisper-federated-finetuning/README.md
@@ -1,9 +1,8 @@
 ---
 title: On-device Federated Finetuning for Speech Classification
 tags: [finetuning, speech, transformers]
-dataset: [SpeechCommands | https://huggingface.co/datasets/google/speech_commands]
-framework: [transformers | https://huggingface.co/docs/transformers/index, whisper
-      | https://huggingface.co/openai/whisper-tiny]
+dataset: [SpeechCommands]
+framework: [transformers, whisper]
 ---
 
 # On-device Federated Finetuning for Speech Classification

--- a/examples/xgboost-comprehensive/README.md
+++ b/examples/xgboost-comprehensive/README.md
@@ -1,8 +1,8 @@
 ---
 title: Comprehensive Flower Example using XGBoost
 tags: [advanced, classification, tabular]
-dataset: [HIGGS | https://archive.ics.uci.edu/dataset/280/higgs]
-framework: [xgboost | https://xgboost.readthedocs.io/en/stable/]
+dataset: [HIGGS]
+framework: [xgboost]
 ---
 
 # Flower Example using XGBoost (Comprehensive)

--- a/examples/xgboost-quickstart/README.md
+++ b/examples/xgboost-quickstart/README.md
@@ -1,8 +1,8 @@
 ---
 title: Simple Flower Example using XGBoost
 tags: [quickstart, classification, tabular]
-dataset: [HIGGS | https://archive.ics.uci.edu/dataset/280/higgs]
-framework: [xgboost | https://xgboost.readthedocs.io/en/stable/]
+dataset: [HIGGS]
+framework: [xgboost]
 ---
 
 # Flower Example using XGBoost


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

We currently need to manually add the URL to the yaml metadata, this has many negatives:

- We need to use a weird custom format to not clash with YAML or Markdown
- To change a URL, we need to modify all instances of it
- It displays weirdly in the GitHub page 

### Related issues/PRs

N/A

## Proposal

### Explanation

Use a dict to find the corresponding URL of a framework or dataset

### Checklist

- [x] Implement proposed change
- [x] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

N/A
