### PR TITLE
fix(framework:skip) Remove setting `init_args` for Backend in  `run_simulation` entry point

### DIFF
--- a/src/py/flwr/simulation/run_simulation.py
+++ b/src/py/flwr/simulation/run_simulation.py
@@ -337,7 +337,6 @@ def _run_simulation(
         update_console_handler(level=DEBUG, timestamps=True, colored=True)
     else:
         backend_config["init_args"]["logging_level"] = WARNING
-        backend_config["init_args"]["log_to_driver"] = True
 
     if enable_tf_gpu_growth:
         # Check that Backend config has also enabled using GPU growth


### PR DESCRIPTION
In #3543 , we made it possible to easily pass `init_args` to the Backend. These are designed to be backend-agnostic. In the case of the `RayBackend` the `log_to_driver` setting can be use to "silence" all logs coming from ray actors (e.g. the `ClientApp` objs. This is useful in some settings.

The change in the PR removes setting this to True (it's True by default anyway in Ray), allowing users to changing it to false via the `backend_config` argument if desired.