### PR TITLE
ci(framework:skip) Make isort and black compatible

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,12 +131,7 @@ licensecheck = "==2024"
 pre-commit = "==3.5.0"
 
 [tool.isort]
-line_length = 88
-indent = "    "
-multi_line_output = 3
-include_trailing_comma = true
-force_grid_wrap = 0
-use_parentheses = true
+profile = "black"
 known_first_party = ["flwr", "flwr_tool"]
 
 [tool.black]


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

`black` formats imports like this:

![image](https://github.com/adap/flower/assets/9378265/d5815224-d924-4b83-9a27-41a724f057f0)

While `isort` formats them like this:

![image](https://github.com/adap/flower/assets/9378265/1fa4a751-9d6a-41aa-ab99-757bc69a3a3e)


### Related issues/PRs

N/A

## Proposal

### Explanation

Set `isort` to `profile = "black"`

### Checklist

- [x] Implement proposed change
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

N/A
