### PR TITLE
ci(*:skip) Build SuperExec Docker Image in CI

### DIFF
--- a/dev/build-docker-image-matrix.py
+++ b/dev/build-docker-image-matrix.py
@@ -168,6 +168,13 @@ if __name__ == "__main__":
             tag_latest_ubuntu_with_flwr_version,
             lambda image: image.distro.name == DistroName.UBUNTU,
         )
+        # ubuntu images for each supported python version
+        + generate_binary_images(
+            "superexec",
+            base_images,
+            tag_latest_ubuntu_with_flwr_version,
+            lambda image: image.distro.name == DistroName.UBUNTU,
+        )
     )
 
     print(


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

- Depends on: #3723 
- Test CI run: https://github.com/adap/flower/actions/runs/9856740485
- Add the SuperExec image to the Docker build CI. 

The following images are build:

- `py3.8-ubuntu22.04`
- `py3.9-ubuntu22.04`
- `py3.10-ubuntu22.04`
- `py3.11-ubuntu22.04`

<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

### Checklist

- [ ] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.ai/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
