### PR TITLE
refactor(framework:skip) Add `run_config` as required `Context` parameter

### DIFF
--- a/src/py/flwr/client/message_handler/message_handler_test.py
+++ b/src/py/flwr/client/message_handler/message_handler_test.py
@@ -145,7 +145,7 @@ def test_client_without_get_properties() -> None:
     actual_msg = handle_legacy_message_from_msgtype(
         client_fn=_get_client_fn(client),
         message=message,
-        context=Context(state=RecordSet()),
+        context=Context(state=RecordSet(), run_config={}),
     )
 
     # Assert
@@ -209,7 +209,7 @@ def test_client_with_get_properties() -> None:
     actual_msg = handle_legacy_message_from_msgtype(
         client_fn=_get_client_fn(client),
         message=message,
-        context=Context(state=RecordSet()),
+        context=Context(state=RecordSet(), run_config={}),
     )
 
     # Assert

--- a/src/py/flwr/client/mod/secure_aggregation/secaggplus_mod_test.py
+++ b/src/py/flwr/client/mod/secure_aggregation/secaggplus_mod_test.py
@@ -73,7 +73,7 @@ def get_test_handler(
 
 def _make_ctxt() -> Context:
     cfg = ConfigsRecord(SecAggPlusState().to_dict())
-    return Context(RecordSet(configs_records={RECORD_KEY_STATE: cfg}))
+    return Context(RecordSet(configs_records={RECORD_KEY_STATE: cfg}), run_config={})
 
 
 def _make_set_state_fn(

--- a/src/py/flwr/client/mod/utils_test.py
+++ b/src/py/flwr/client/mod/utils_test.py
@@ -104,7 +104,7 @@ class TestMakeApp(unittest.TestCase):
 
         state = RecordSet()
         state.metrics_records[METRIC] = MetricsRecord({COUNTER: 0.0})
-        context = Context(state=state)
+        context = Context(state=state, run_config={})
         message = _get_dummy_flower_message()
 
         # Execute
@@ -129,7 +129,7 @@ class TestMakeApp(unittest.TestCase):
         # Prepare
         footprint: List[str] = []
         mock_app = make_mock_app("app", footprint)
-        context = Context(state=RecordSet())
+        context = Context(state=RecordSet(), run_config={})
         message = _get_dummy_flower_message()
 
         def filter_mod(

--- a/src/py/flwr/client/node_state.py
+++ b/src/py/flwr/client/node_state.py
@@ -32,7 +32,7 @@ class NodeState:
         """Register new run context for this node."""
         if run_id not in self.run_contexts:
             self.run_contexts[run_id] = Context(
-                state=RecordSet(), partition_id=self._partition_id
+                state=RecordSet(), run_config={}, partition_id=self._partition_id
             )
 
     def retrieve_context(self, run_id: int) -> Context:

--- a/src/py/flwr/common/context.py
+++ b/src/py/flwr/common/context.py
@@ -34,6 +34,10 @@ class Context:
         executing mods. It can also be used as a memory to access
         at different points during the lifecycle of this entity (e.g. across
         multiple rounds)
+    run_config : Dict[str, str]
+        A config (key/value mapping) held by the entity in a given run and that will
+        stay local. It can be used at any point during the lifecycle of this entity
+        (e.g. across multiple rounds)
     partition_id : Optional[int] (default: None)
         An index that specifies the data partition that the ClientApp using this Context
         object should make use of. Setting this attribute is better suited for
@@ -47,8 +51,9 @@ class Context:
     def __init__(
         self,
         state: RecordSet,
+        run_config: Dict[str, str],
         partition_id: Optional[int] = None,
     ) -> None:
         self.state = state
+        self.run_config = run_config
         self.partition_id = partition_id
-        self.run_config = {}

--- a/src/py/flwr/server/compat/legacy_context.py
+++ b/src/py/flwr/server/compat/legacy_context.py
@@ -52,4 +52,4 @@ class LegacyContext(Context):
         self.strategy = strategy
         self.client_manager = client_manager
         self.history = History()
-        super().__init__(state)
+        super().__init__(state, run_config={})

--- a/src/py/flwr/server/run_serverapp.py
+++ b/src/py/flwr/server/run_serverapp.py
@@ -72,7 +72,7 @@ def run(
     server_app = _load()
 
     # Initialize Context
-    context = Context(state=RecordSet())
+    context = Context(state=RecordSet(), run_config={})
 
     # Call ServerApp
     server_app(driver=driver, context=context)

--- a/src/py/flwr/server/server_app.py
+++ b/src/py/flwr/server/server_app.py
@@ -80,7 +80,7 @@ class ServerApp:
             return
 
         # New execution mode
-        context = Context(state=RecordSet())
+        context = Context(state=RecordSet(), run_config={})
         self._main(driver, context)
 
     def main(self) -> Callable[[ServerAppCallable], ServerAppCallable]:

--- a/src/py/flwr/server/server_app_test.py
+++ b/src/py/flwr/server/server_app_test.py
@@ -29,7 +29,7 @@ def test_server_app_custom_mode() -> None:
     # Prepare
     app = ServerApp()
     driver = MagicMock()
-    context = Context(state=RecordSet())
+    context = Context(state=RecordSet(), run_config={})
 
     called = {"called": False}
 

--- a/src/py/flwr/server/superlink/fleet/vce/backend/raybackend_test.py
+++ b/src/py/flwr/server/superlink/fleet/vce/backend/raybackend_test.py
@@ -121,7 +121,7 @@ def _create_message_and_context() -> Tuple[Message, Context, float]:
     )
 
     # Construct emtpy Context
-    context = Context(state=RecordSet())
+    context = Context(state=RecordSet(), run_config={})
 
     # Expected output
     expected_output = pi * mult_factor

--- a/src/py/flwr/simulation/ray_transport/ray_client_proxy_test.py
+++ b/src/py/flwr/simulation/ray_transport/ray_client_proxy_test.py
@@ -218,7 +218,7 @@ def test_cid_consistency_without_proxies() -> None:
                 _load_app,
                 message,
                 str(node_id),
-                Context(state=RecordSet(), partition_id=node_id),
+                Context(state=RecordSet(), run_config={}, partition_id=node_id),
             ),
         )
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

### Checklist

- [ ] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.ai/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
