### PR TITLE
ci(*:skip) Use isort for `benchmarks`

### DIFF
--- a/dev/format.sh
+++ b/dev/format.sh
@@ -19,6 +19,7 @@ python -m black -q examples
 python -m docformatter -i -r examples
 
 # Benchmarks
+python -m isort benchmarks
 python -m black -q benchmarks
 python -m docformatter -i -r benchmarks
 

--- a/dev/test.sh
+++ b/dev/test.sh
@@ -11,7 +11,7 @@ clang-format --Werror --dry-run src/proto/flwr/proto/*
 echo "- clang-format:  done"
 
 echo "- isort: start"
-python -m isort --check-only --skip src/py/flwr/proto src/py/flwr e2e
+python -m isort --check-only --skip src/py/flwr/proto src/py/flwr benchmarks e2e
 echo "- isort: done"
 
 echo "- black: start"


### PR DESCRIPTION
## Proposal

Add `isort` to `dev/test.sh` and `dev/format.sh` for `benchmarks` directory.