### PR TITLE
feat(framework) Add additional user prompt for `flowertune` template in `flwr new`

### DIFF
--- a/src/py/flwr/cli/new/new.py
+++ b/src/py/flwr/cli/new/new.py
@@ -264,9 +264,11 @@ def new(
             bold=True,
         )
     )
+
+    _add = "	huggingface-cli login\n" if framework_str == "flowertune" else ""
     print(
         typer.style(
-            f"	cd {package_name}\n" + "	pip install -e .\n	flwr run\n",
+            f"	cd {package_name}\n" + "	pip install -e .\n" + _add + "	flwr run\n",
             fg=typer.colors.BRIGHT_CYAN,
             bold=True,
         )


### PR DESCRIPTION
## Proposal

Add additional user prompt for `flowertune` template when running `flwr new`.
Now info printed is as follows when using `flowertune` template:

```
cd proj_name
pip install -e .
huggingface-cli login
flwr run
```