### PR TITLE
fix(framework) Fix `grpcio` version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ flower-simulation = "flwr.simulation.run_simulation:run_simulation_from_cli"
 python = "^3.8"
 # Mandatory dependencies
 numpy = "^1.21.0"
-grpcio = "^1.60.0"
+grpcio = "^1.60.0,!=1.65.0"
 protobuf = "^4.25.2"
 cryptography = "^42.0.4"
 pycryptodome = "^3.18.0"


### PR DESCRIPTION
`grpcio` version 1.65.0 generates a lot of verbose warnings and is a known issue in 1.65.0RCx (see [this GitHub issue](https://github.com/grpc/grpc/issues/37178)). This PR fixes it.