### PR TITLE
ci(*:skip) Update client_fn args in e2e tests

### DIFF
--- a/e2e/bare-client-auth/client.py
+++ b/e2e/bare-client-auth/client.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import numpy as np
 
 import flwr as fl
@@ -23,7 +25,7 @@ class FlowerClient(fl.client.NumPyClient):
         return loss, 1, {"accuracy": accuracy}
 
 
-def client_fn(cid):
+def client_fn(node_id: int, partition_id: Optional[int]):
     return FlowerClient().to_client()
 
 

--- a/e2e/bare-client-auth/client.py
+++ b/e2e/bare-client-auth/client.py
@@ -1,8 +1,6 @@
-from typing import Optional
-
 import numpy as np
 
-import flwr as fl
+from flwr.client import ClientApp, NumPyClient
 from flwr.common import Context
 
 model_params = np.array([1])
@@ -10,7 +8,7 @@ objective = 5
 
 
 # Define Flower client
-class FlowerClient(fl.client.NumPyClient):
+class FlowerClient(NumPyClient):
     def get_parameters(self, config):
         return model_params
 
@@ -30,6 +28,6 @@ def client_fn(context: Context):
     return FlowerClient().to_client()
 
 
-app = fl.client.ClientApp(
+app = ClientApp(
     client_fn=client_fn,
 )

--- a/e2e/bare-client-auth/client.py
+++ b/e2e/bare-client-auth/client.py
@@ -3,6 +3,7 @@ from typing import Optional
 import numpy as np
 
 import flwr as fl
+from flwr.common import Context
 
 model_params = np.array([1])
 objective = 5
@@ -25,7 +26,7 @@ class FlowerClient(fl.client.NumPyClient):
         return loss, 1, {"accuracy": accuracy}
 
 
-def client_fn(node_id: int, partition_id: Optional[int]):
+def client_fn(context: Context):
     return FlowerClient().to_client()
 
 

--- a/e2e/bare-https/client.py
+++ b/e2e/bare-https/client.py
@@ -4,6 +4,7 @@ from typing import Optional
 import numpy as np
 
 import flwr as fl
+from flwr.common import Context
 
 model_params = np.array([1])
 objective = 5
@@ -26,7 +27,7 @@ class FlowerClient(fl.client.NumPyClient):
         return loss, 1, {"accuracy": accuracy}
 
 
-def client_fn(node_id: int, partition_id: Optional[int]):
+def client_fn(context: Context):
     return FlowerClient().to_client()
 
 

--- a/e2e/bare-https/client.py
+++ b/e2e/bare-https/client.py
@@ -1,9 +1,8 @@
 from pathlib import Path
-from typing import Optional
 
 import numpy as np
 
-import flwr as fl
+from flwr.client import ClientApp, NumPyClient, start_client
 from flwr.common import Context
 
 model_params = np.array([1])
@@ -11,7 +10,7 @@ objective = 5
 
 
 # Define Flower client
-class FlowerClient(fl.client.NumPyClient):
+class FlowerClient(NumPyClient):
     def get_parameters(self, config):
         return model_params
 
@@ -31,13 +30,13 @@ def client_fn(context: Context):
     return FlowerClient().to_client()
 
 
-app = fl.client.ClientApp(
+app = ClientApp(
     client_fn=client_fn,
 )
 
 if __name__ == "__main__":
     # Start Flower client
-    fl.client.start_client(
+    start_client(
         server_address="127.0.0.1:8080",
         client=FlowerClient().to_client(),
         root_certificates=Path("certificates/ca.crt").read_bytes(),

--- a/e2e/bare-https/client.py
+++ b/e2e/bare-https/client.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Optional
 
 import numpy as np
 
@@ -25,7 +26,7 @@ class FlowerClient(fl.client.NumPyClient):
         return loss, 1, {"accuracy": accuracy}
 
 
-def client_fn(cid):
+def client_fn(node_id: int, partition_id: Optional[int]):
     return FlowerClient().to_client()
 
 

--- a/e2e/bare/client.py
+++ b/e2e/bare/client.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Optional
 
 import numpy as np
 
@@ -51,7 +52,7 @@ class FlowerClient(fl.client.NumPyClient):
         )
 
 
-def client_fn(cid):
+def client_fn(node_id: int, partition_id: Optional[int]):
     return FlowerClient().to_client()
 
 

--- a/e2e/bare/client.py
+++ b/e2e/bare/client.py
@@ -1,9 +1,8 @@
 from datetime import datetime
-from typing import Optional
 
 import numpy as np
 
-import flwr as fl
+from flwr.client import ClientApp, NumPyClient, start_client
 from flwr.common import ConfigsRecord, Context
 
 SUBSET_SIZE = 1000
@@ -15,7 +14,7 @@ objective = 5
 
 
 # Define Flower client
-class FlowerClient(fl.client.NumPyClient):
+class FlowerClient(NumPyClient):
     def get_parameters(self, config):
         return model_params
 
@@ -56,12 +55,10 @@ def client_fn(context: Context):
     return FlowerClient().to_client()
 
 
-app = fl.client.ClientApp(
+app = ClientApp(
     client_fn=client_fn,
 )
 
 if __name__ == "__main__":
     # Start Flower client
-    fl.client.start_client(
-        server_address="127.0.0.1:8080", client=FlowerClient().to_client()
-    )
+    start_client(server_address="127.0.0.1:8080", client=FlowerClient().to_client())

--- a/e2e/bare/client.py
+++ b/e2e/bare/client.py
@@ -4,7 +4,7 @@ from typing import Optional
 import numpy as np
 
 import flwr as fl
-from flwr.common import ConfigsRecord
+from flwr.common import ConfigsRecord, Context
 
 SUBSET_SIZE = 1000
 STATE_VAR = "timestamp"
@@ -52,7 +52,7 @@ class FlowerClient(fl.client.NumPyClient):
         )
 
 
-def client_fn(node_id: int, partition_id: Optional[int]):
+def client_fn(context: Context):
     return FlowerClient().to_client()
 
 

--- a/e2e/docker/client.py
+++ b/e2e/docker/client.py
@@ -10,6 +10,7 @@ from torch.utils.data import DataLoader, Subset
 from torchvision.transforms import Compose, Normalize, ToTensor
 
 from flwr.client import ClientApp, NumPyClient
+from flwr.common import Context
 
 # #############################################################################
 # 1. Regular PyTorch pipeline: nn.Module, train, test, and DataLoader
@@ -123,7 +124,7 @@ class FlowerClient(NumPyClient):
         return loss, len(testloader.dataset), {"accuracy": accuracy}
 
 
-def client_fn(node_id: int, partition_id: Optional[int]):
+def client_fn(context: Context):
     """Create and return an instance of Flower `Client`."""
     return FlowerClient().to_client()
 

--- a/e2e/docker/client.py
+++ b/e2e/docker/client.py
@@ -1,6 +1,5 @@
 import warnings
 from collections import OrderedDict
-from typing import Optional
 
 import torch
 import torch.nn as nn

--- a/e2e/docker/client.py
+++ b/e2e/docker/client.py
@@ -1,5 +1,6 @@
 import warnings
 from collections import OrderedDict
+from typing import Optional
 
 import torch
 import torch.nn as nn
@@ -122,7 +123,7 @@ class FlowerClient(NumPyClient):
         return loss, len(testloader.dataset), {"accuracy": accuracy}
 
 
-def client_fn(cid: str):
+def client_fn(node_id: int, partition_id: Optional[int]):
     """Create and return an instance of Flower `Client`."""
     return FlowerClient().to_client()
 

--- a/e2e/framework-fastai/client.py
+++ b/e2e/framework-fastai/client.py
@@ -1,5 +1,6 @@
 import warnings
 from collections import OrderedDict
+from typing import Optional
 
 import numpy as np
 import torch
@@ -49,7 +50,7 @@ class FlowerClient(fl.client.NumPyClient):
         return loss, len(dls.valid), {"accuracy": 1 - error_rate}
 
 
-def client_fn(cid):
+def client_fn(node_id: int, partition_id: Optional[int]):
     return FlowerClient().to_client()
 
 

--- a/e2e/framework-fastai/client.py
+++ b/e2e/framework-fastai/client.py
@@ -1,12 +1,11 @@
 import warnings
 from collections import OrderedDict
-from typing import Optional
 
 import numpy as np
 import torch
 from fastai.vision.all import *
 
-import flwr as fl
+from flwr.client import ClientApp, NumPyClient, start_client
 from flwr.common import Context
 
 warnings.filterwarnings("ignore", category=UserWarning)
@@ -31,7 +30,7 @@ learn = vision_learner(dls, squeezenet1_1, metrics=error_rate)
 
 
 # Define Flower client
-class FlowerClient(fl.client.NumPyClient):
+class FlowerClient(NumPyClient):
     def get_parameters(self, config):
         return [val.cpu().numpy() for _, val in learn.model.state_dict().items()]
 
@@ -55,14 +54,14 @@ def client_fn(context: Context):
     return FlowerClient().to_client()
 
 
-app = fl.client.ClientApp(
+app = ClientApp(
     client_fn=client_fn,
 )
 
 
 if __name__ == "__main__":
     # Start Flower client
-    fl.client.start_client(
+    start_client(
         server_address="127.0.0.1:8080",
         client=FlowerClient().to_client(),
     )

--- a/e2e/framework-fastai/client.py
+++ b/e2e/framework-fastai/client.py
@@ -7,6 +7,7 @@ import torch
 from fastai.vision.all import *
 
 import flwr as fl
+from flwr.common import Context
 
 warnings.filterwarnings("ignore", category=UserWarning)
 
@@ -50,7 +51,7 @@ class FlowerClient(fl.client.NumPyClient):
         return loss, len(dls.valid), {"accuracy": 1 - error_rate}
 
 
-def client_fn(node_id: int, partition_id: Optional[int]):
+def client_fn(context: Context):
     return FlowerClient().to_client()
 
 

--- a/e2e/framework-jax/client.py
+++ b/e2e/framework-jax/client.py
@@ -1,6 +1,6 @@
 """Flower client example using JAX for linear regression."""
 
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import jax
 import jax_training
@@ -48,7 +48,7 @@ class FlowerClient(fl.client.NumPyClient):
         return float(loss), num_examples, {"loss": float(loss)}
 
 
-def client_fn(cid):
+def client_fn(node_id: int, partition_id: Optional[int]):
     return FlowerClient().to_client()
 
 

--- a/e2e/framework-jax/client.py
+++ b/e2e/framework-jax/client.py
@@ -1,12 +1,12 @@
 """Flower client example using JAX for linear regression."""
 
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Tuple
 
 import jax
 import jax_training
 import numpy as np
 
-import flwr as fl
+from flwr.client import ClientApp, NumPyClient, start_client
 from flwr.common import Context
 
 # Load data and determine model shape
@@ -15,7 +15,7 @@ grad_fn = jax.grad(jax_training.loss_fn)
 model_shape = train_x.shape[1:]
 
 
-class FlowerClient(fl.client.NumPyClient):
+class FlowerClient(NumPyClient):
     def __init__(self):
         self.params = jax_training.load_model(model_shape)
 
@@ -53,12 +53,10 @@ def client_fn(context: Context):
     return FlowerClient().to_client()
 
 
-app = fl.client.ClientApp(
+app = ClientApp(
     client_fn=client_fn,
 )
 
 if __name__ == "__main__":
     # Start Flower client
-    fl.client.start_client(
-        server_address="127.0.0.1:8080", client=FlowerClient().to_client()
-    )
+    start_client(server_address="127.0.0.1:8080", client=FlowerClient().to_client())

--- a/e2e/framework-jax/client.py
+++ b/e2e/framework-jax/client.py
@@ -7,6 +7,7 @@ import jax_training
 import numpy as np
 
 import flwr as fl
+from flwr.common import Context
 
 # Load data and determine model shape
 train_x, train_y, test_x, test_y = jax_training.load_data()
@@ -48,7 +49,7 @@ class FlowerClient(fl.client.NumPyClient):
         return float(loss), num_examples, {"loss": float(loss)}
 
 
-def client_fn(node_id: int, partition_id: Optional[int]):
+def client_fn(context: Context):
     return FlowerClient().to_client()
 
 

--- a/e2e/framework-opacus/client.py
+++ b/e2e/framework-opacus/client.py
@@ -11,6 +11,7 @@ from torch.utils.data import DataLoader
 from torchvision.datasets import CIFAR10
 
 import flwr as fl
+from flwr.common import Context
 
 # Define parameters.
 PARAMS = {
@@ -140,7 +141,7 @@ class FlowerClient(fl.client.NumPyClient):
         return float(loss), len(testloader), {"accuracy": float(accuracy)}
 
 
-def client_fn(node_id: int, partition_id: Optional[int]):
+def client_fn(context: Context):
     model = Net()
     return FlowerClient(model).to_client()
 

--- a/e2e/framework-opacus/client.py
+++ b/e2e/framework-opacus/client.py
@@ -1,6 +1,5 @@
 import math
 from collections import OrderedDict
-from typing import Optional
 
 import torch
 import torch.nn as nn
@@ -10,7 +9,7 @@ from opacus import PrivacyEngine
 from torch.utils.data import DataLoader
 from torchvision.datasets import CIFAR10
 
-import flwr as fl
+from flwr.client import ClientApp, NumPyClient, start_client
 from flwr.common import Context
 
 # Define parameters.
@@ -97,7 +96,7 @@ trainloader, testloader, sample_rate = load_data()
 
 
 # Define Flower client.
-class FlowerClient(fl.client.NumPyClient):
+class FlowerClient(NumPyClient):
     def __init__(self, model) -> None:
         super().__init__()
         # Create a privacy engine which will add DP and keep track of the privacy budget.
@@ -146,11 +145,11 @@ def client_fn(context: Context):
     return FlowerClient(model).to_client()
 
 
-app = fl.client.ClientApp(
+app = ClientApp(
     client_fn=client_fn,
 )
 
 if __name__ == "__main__":
-    fl.client.start_client(
+    start_client(
         server_address="127.0.0.1:8080", client=FlowerClient(model).to_client()
     )

--- a/e2e/framework-opacus/client.py
+++ b/e2e/framework-opacus/client.py
@@ -1,5 +1,6 @@
 import math
 from collections import OrderedDict
+from typing import Optional
 
 import torch
 import torch.nn as nn
@@ -139,7 +140,7 @@ class FlowerClient(fl.client.NumPyClient):
         return float(loss), len(testloader), {"accuracy": float(accuracy)}
 
 
-def client_fn(cid):
+def client_fn(node_id: int, partition_id: Optional[int]):
     model = Net()
     return FlowerClient(model).to_client()
 

--- a/e2e/framework-pandas/client.py
+++ b/e2e/framework-pandas/client.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 import pandas as pd
@@ -32,7 +32,7 @@ class FlowerClient(fl.client.NumPyClient):
         )
 
 
-def client_fn(cid):
+def client_fn(node_id: int, partition_id: Optional[int]):
     return FlowerClient().to_client()
 
 

--- a/e2e/framework-pandas/client.py
+++ b/e2e/framework-pandas/client.py
@@ -4,6 +4,7 @@ import numpy as np
 import pandas as pd
 
 import flwr as fl
+from flwr.common import Context
 
 df = pd.read_csv("./data/client.csv")
 
@@ -32,7 +33,7 @@ class FlowerClient(fl.client.NumPyClient):
         )
 
 
-def client_fn(node_id: int, partition_id: Optional[int]):
+def client_fn(context: Context):
     return FlowerClient().to_client()
 
 

--- a/e2e/framework-pandas/client.py
+++ b/e2e/framework-pandas/client.py
@@ -1,9 +1,9 @@
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Tuple
 
 import numpy as np
 import pandas as pd
 
-import flwr as fl
+from flwr.client import ClientApp, NumPyClient, start_client
 from flwr.common import Context
 
 df = pd.read_csv("./data/client.csv")
@@ -17,7 +17,7 @@ def compute_hist(df: pd.DataFrame, col_name: str) -> np.ndarray:
 
 
 # Define Flower client
-class FlowerClient(fl.client.NumPyClient):
+class FlowerClient(NumPyClient):
     def fit(
         self, parameters: List[np.ndarray], config: Dict[str, str]
     ) -> Tuple[List[np.ndarray], int, Dict]:
@@ -37,13 +37,13 @@ def client_fn(context: Context):
     return FlowerClient().to_client()
 
 
-app = fl.client.ClientApp(
+app = ClientApp(
     client_fn=client_fn,
 )
 
 if __name__ == "__main__":
     # Start Flower client
-    fl.client.start_client(
+    start_client(
         server_address="127.0.0.1:8080",
         client=FlowerClient().to_client(),
     )

--- a/e2e/framework-pytorch-lightning/client.py
+++ b/e2e/framework-pytorch-lightning/client.py
@@ -1,15 +1,14 @@
 from collections import OrderedDict
-from typing import Optional
 
 import mnist
 import pytorch_lightning as pl
 import torch
 
-import flwr as fl
+from flwr.client import ClientApp, NumPyClient, start_client
 from flwr.common import Context
 
 
-class FlowerClient(fl.client.NumPyClient):
+class FlowerClient(NumPyClient):
     def __init__(self, model, train_loader, val_loader, test_loader):
         self.model = model
         self.train_loader = train_loader
@@ -61,7 +60,7 @@ def client_fn(context: Context):
     return FlowerClient(model, train_loader, val_loader, test_loader).to_client()
 
 
-app = fl.client.ClientApp(
+app = ClientApp(
     client_fn=client_fn,
 )
 
@@ -73,7 +72,7 @@ def main() -> None:
 
     # Flower client
     client = FlowerClient(model, train_loader, val_loader, test_loader).to_client()
-    fl.client.start_client(server_address="127.0.0.1:8080", client=client)
+    start_client(server_address="127.0.0.1:8080", client=client)
 
 
 if __name__ == "__main__":

--- a/e2e/framework-pytorch-lightning/client.py
+++ b/e2e/framework-pytorch-lightning/client.py
@@ -6,6 +6,7 @@ import pytorch_lightning as pl
 import torch
 
 import flwr as fl
+from flwr.common import Context
 
 
 class FlowerClient(fl.client.NumPyClient):
@@ -52,7 +53,7 @@ def _set_parameters(model, parameters):
     model.load_state_dict(state_dict, strict=True)
 
 
-def client_fn(node_id: int, partition_id: Optional[int]):
+def client_fn(context: Context):
     model = mnist.LitAutoEncoder()
     train_loader, val_loader, test_loader = mnist.load_data()
 

--- a/e2e/framework-pytorch-lightning/client.py
+++ b/e2e/framework-pytorch-lightning/client.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+from typing import Optional
 
 import mnist
 import pytorch_lightning as pl
@@ -51,7 +52,7 @@ def _set_parameters(model, parameters):
     model.load_state_dict(state_dict, strict=True)
 
 
-def client_fn(cid):
+def client_fn(node_id: int, partition_id: Optional[int]):
     model = mnist.LitAutoEncoder()
     train_loader, val_loader, test_loader = mnist.load_data()
 

--- a/e2e/framework-pytorch/client.py
+++ b/e2e/framework-pytorch/client.py
@@ -1,7 +1,6 @@
 import warnings
 from collections import OrderedDict
 from datetime import datetime
-from typing import Optional
 
 import torch
 import torch.nn as nn
@@ -11,7 +10,7 @@ from torchvision.datasets import CIFAR10
 from torchvision.transforms import Compose, Normalize, ToTensor
 from tqdm import tqdm
 
-import flwr as fl
+from flwr.client import ClientApp, NumPyClient, start_client
 from flwr.common import ConfigsRecord, Context
 
 # #############################################################################
@@ -90,7 +89,7 @@ trainloader, testloader = load_data()
 
 
 # Define Flower client
-class FlowerClient(fl.client.NumPyClient):
+class FlowerClient(NumPyClient):
     def get_parameters(self, config):
         return [val.cpu().numpy() for _, val in net.state_dict().items()]
 
@@ -141,14 +140,14 @@ def client_fn(context: Context):
     return FlowerClient().to_client()
 
 
-app = fl.client.ClientApp(
+app = ClientApp(
     client_fn=client_fn,
 )
 
 
 if __name__ == "__main__":
     # Start Flower client
-    fl.client.start_client(
+    start_client(
         server_address="127.0.0.1:8080",
         client=FlowerClient().to_client(),
     )

--- a/e2e/framework-pytorch/client.py
+++ b/e2e/framework-pytorch/client.py
@@ -12,7 +12,7 @@ from torchvision.transforms import Compose, Normalize, ToTensor
 from tqdm import tqdm
 
 import flwr as fl
-from flwr.common import ConfigsRecord
+from flwr.common import ConfigsRecord, Context
 
 # #############################################################################
 # 1. Regular PyTorch pipeline: nn.Module, train, test, and DataLoader
@@ -137,7 +137,7 @@ def set_parameters(model, parameters):
     return
 
 
-def client_fn(node_id: int, partition_id: Optional[int]):
+def client_fn(context: Context):
     return FlowerClient().to_client()
 
 

--- a/e2e/framework-pytorch/client.py
+++ b/e2e/framework-pytorch/client.py
@@ -1,6 +1,7 @@
 import warnings
 from collections import OrderedDict
 from datetime import datetime
+from typing import Optional
 
 import torch
 import torch.nn as nn
@@ -136,7 +137,7 @@ def set_parameters(model, parameters):
     return
 
 
-def client_fn(cid):
+def client_fn(node_id: int, partition_id: Optional[int]):
     return FlowerClient().to_client()
 
 

--- a/e2e/framework-scikit-learn/client.py
+++ b/e2e/framework-scikit-learn/client.py
@@ -7,6 +7,7 @@ from sklearn.linear_model import LogisticRegression
 from sklearn.metrics import log_loss
 
 import flwr as fl
+from flwr.common import Context
 
 # Load MNIST dataset from https://www.openml.org/d/554
 (X_train, y_train), (X_test, y_test) = utils.load_mnist()
@@ -46,7 +47,7 @@ class FlowerClient(fl.client.NumPyClient):
         return loss, len(X_test), {"accuracy": accuracy}
 
 
-def client_fn(node_id: int, partition_id: Optional[int]):
+def client_fn(context: Context):
     return FlowerClient().to_client()
 
 

--- a/e2e/framework-scikit-learn/client.py
+++ b/e2e/framework-scikit-learn/client.py
@@ -1,5 +1,4 @@
 import warnings
-from typing import Optional
 
 import numpy as np
 import utils

--- a/e2e/framework-scikit-learn/client.py
+++ b/e2e/framework-scikit-learn/client.py
@@ -6,7 +6,7 @@ import utils
 from sklearn.linear_model import LogisticRegression
 from sklearn.metrics import log_loss
 
-import flwr as fl
+from flwr.client import ClientApp, NumPyClient, start_client
 from flwr.common import Context
 
 # Load MNIST dataset from https://www.openml.org/d/554
@@ -28,7 +28,7 @@ utils.set_initial_params(model)
 
 
 # Define Flower client
-class FlowerClient(fl.client.NumPyClient):
+class FlowerClient(NumPyClient):
     def get_parameters(self, config):  # type: ignore
         return utils.get_model_parameters(model)
 
@@ -51,12 +51,10 @@ def client_fn(context: Context):
     return FlowerClient().to_client()
 
 
-app = fl.client.ClientApp(
+app = ClientApp(
     client_fn=client_fn,
 )
 
 if __name__ == "__main__":
     # Start Flower client
-    fl.client.start_client(
-        server_address="0.0.0.0:8080", client=FlowerClient().to_client()
-    )
+    start_client(server_address="0.0.0.0:8080", client=FlowerClient().to_client())

--- a/e2e/framework-scikit-learn/client.py
+++ b/e2e/framework-scikit-learn/client.py
@@ -1,4 +1,5 @@
 import warnings
+from typing import Optional
 
 import numpy as np
 import utils
@@ -45,7 +46,7 @@ class FlowerClient(fl.client.NumPyClient):
         return loss, len(X_test), {"accuracy": accuracy}
 
 
-def client_fn(cid):
+def client_fn(node_id: int, partition_id: Optional[int]):
     return FlowerClient().to_client()
 
 

--- a/e2e/framework-tensorflow/client.py
+++ b/e2e/framework-tensorflow/client.py
@@ -1,4 +1,5 @@
 import os
+from typing import Optional
 
 import tensorflow as tf
 
@@ -33,7 +34,7 @@ class FlowerClient(fl.client.NumPyClient):
         return loss, len(x_test), {"accuracy": accuracy}
 
 
-def client_fn(cid):
+def client_fn(node_id: int, partition_id: Optional[int]):
     return FlowerClient().to_client()
 
 

--- a/e2e/framework-tensorflow/client.py
+++ b/e2e/framework-tensorflow/client.py
@@ -1,9 +1,8 @@
 import os
-from typing import Optional
 
 import tensorflow as tf
 
-import flwr as fl
+from flwr.client import ClientApp, NumPyClient, start_client
 from flwr.common import Context
 
 SUBSET_SIZE = 1000
@@ -20,7 +19,7 @@ x_test, y_test = x_test[:10], y_test[:10]
 
 
 # Define Flower client
-class FlowerClient(fl.client.NumPyClient):
+class FlowerClient(NumPyClient):
     def get_parameters(self, config):
         return model.get_weights()
 
@@ -39,12 +38,10 @@ def client_fn(context: Context):
     return FlowerClient().to_client()
 
 
-app = fl.client.ClientApp(
+app = ClientApp(
     client_fn=client_fn,
 )
 
 if __name__ == "__main__":
     # Start Flower client
-    fl.client.start_client(
-        server_address="127.0.0.1:8080", client=FlowerClient().to_client()
-    )
+    start_client(server_address="127.0.0.1:8080", client=FlowerClient().to_client())

--- a/e2e/framework-tensorflow/client.py
+++ b/e2e/framework-tensorflow/client.py
@@ -4,6 +4,7 @@ from typing import Optional
 import tensorflow as tf
 
 import flwr as fl
+from flwr.common import Context
 
 SUBSET_SIZE = 1000
 
@@ -34,7 +35,7 @@ class FlowerClient(fl.client.NumPyClient):
         return loss, len(x_test), {"accuracy": accuracy}
 
 
-def client_fn(node_id: int, partition_id: Optional[int]):
+def client_fn(context: Context):
     return FlowerClient().to_client()
 
 

--- a/e2e/strategies/client.py
+++ b/e2e/strategies/client.py
@@ -4,6 +4,7 @@ from typing import Optional
 import tensorflow as tf
 
 import flwr as fl
+from flwr.common import Context
 
 SUBSET_SIZE = 1000
 
@@ -49,7 +50,7 @@ class FlowerClient(fl.client.NumPyClient):
         return loss, len(x_test), {"accuracy": accuracy}
 
 
-def client_fn(node_id: int, partition_id: Optional[int]):
+def client_fn(context: Context):
     return FlowerClient().to_client()
 
 

--- a/e2e/strategies/client.py
+++ b/e2e/strategies/client.py
@@ -1,9 +1,8 @@
 import os
-from typing import Optional
 
 import tensorflow as tf
 
-import flwr as fl
+from flwr.client import ClientApp, NumPyClient, start_client
 from flwr.common import Context
 
 SUBSET_SIZE = 1000
@@ -35,7 +34,7 @@ x_test, y_test = x_test[:SUBSET_SIZE], y_test[:SUBSET_SIZE]
 
 
 # Define Flower client
-class FlowerClient(fl.client.NumPyClient):
+class FlowerClient(NumPyClient):
     def get_parameters(self, config):
         return model.get_weights()
 
@@ -54,13 +53,11 @@ def client_fn(context: Context):
     return FlowerClient().to_client()
 
 
-app = fl.client.ClientApp(
+app = ClientApp(
     client_fn=client_fn,
 )
 
 
 if __name__ == "__main__":
     # Start Flower client
-    fl.client.start_client(
-        server_address="127.0.0.1:8080", client=FlowerClient().to_client()
-    )
+    start_client(server_address="127.0.0.1:8080", client=FlowerClient().to_client())

--- a/e2e/strategies/client.py
+++ b/e2e/strategies/client.py
@@ -1,4 +1,5 @@
 import os
+from typing import Optional
 
 import tensorflow as tf
 
@@ -48,7 +49,7 @@ class FlowerClient(fl.client.NumPyClient):
         return loss, len(x_test), {"accuracy": accuracy}
 
 
-def client_fn(cid):
+def client_fn(node_id: int, partition_id: Optional[int]):
     return FlowerClient().to_client()
 
 

--- a/e2e/strategies/test.py
+++ b/e2e/strategies/test.py
@@ -5,7 +5,7 @@ import tensorflow as tf
 from client import SUBSET_SIZE, FlowerClient, get_model
 
 import flwr as fl
-from flwr.common import ndarrays_to_parameters
+from flwr.common import Context, ndarrays_to_parameters
 from flwr.server.strategy import (
     FaultTolerantFedAvg,
     FedAdagrad,
@@ -43,7 +43,7 @@ def get_strat(name):
 init_model = get_model()
 
 
-def client_fn(node_id: int, partition_id: Optional[int]):
+def client_fn(context: Context):
     return FlowerClient()
 
 

--- a/e2e/strategies/test.py
+++ b/e2e/strategies/test.py
@@ -1,4 +1,5 @@
 from sys import argv
+from typing import Optional
 
 import tensorflow as tf
 from client import SUBSET_SIZE, FlowerClient, get_model
@@ -42,8 +43,7 @@ def get_strat(name):
 init_model = get_model()
 
 
-def client_fn(cid):
-    _ = cid
+def client_fn(node_id: int, partition_id: Optional[int]):
     return FlowerClient()
 
 

--- a/e2e/strategies/test.py
+++ b/e2e/strategies/test.py
@@ -1,11 +1,10 @@
 from sys import argv
-from typing import Optional
 
 import tensorflow as tf
 from client import SUBSET_SIZE, FlowerClient, get_model
 
-import flwr as fl
 from flwr.common import Context, ndarrays_to_parameters
+from flwr.server import ServerConfig
 from flwr.server.strategy import (
     FaultTolerantFedAvg,
     FedAdagrad,
@@ -16,6 +15,7 @@ from flwr.server.strategy import (
     FedYogi,
     QFedAvg,
 )
+from flwr.simulation import start_simulation
 
 STRATEGY_LIST = [
     FedMedian,
@@ -71,10 +71,10 @@ start_idx, strategy = get_strat(strat)
 if start_idx >= OPT_IDX:
     strat_args["tau"] = 0.01
 
-hist = fl.simulation.start_simulation(
+hist = start_simulation(
     client_fn=client_fn,
     num_clients=2,
-    config=fl.server.ServerConfig(num_rounds=3),
+    config=ServerConfig(num_rounds=3),
     strategy=strategy(**strat_args),
 )
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->
`client_fn(cid)` is deprecated, we need to update e2e tests to use latest args.

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->
Update e2e tests to use latest args.

### Checklist

- [ ] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.ai/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
