### PR TITLE
feat(framework) Introduce a new deprecation function that warns users and provides an code example

### DIFF
--- a/src/py/flwr/common/logger.py
+++ b/src/py/flwr/common/logger.py
@@ -200,8 +200,7 @@ def warn_deprecated_feature(name: str) -> None:
 def warn_deprecated_feature_with_example(
     deprecation_message: str, example_message: str, code_example: str
 ) -> None:
-    """Warn if a feature is deprecated and show code example of preferred
-    alternative."""
+    """Warn if a feature is deprecated and show code example."""
     log(
         WARN,
         """DEPRECATED FEATURE: %s

--- a/src/py/flwr/common/logger.py
+++ b/src/py/flwr/common/logger.py
@@ -16,7 +16,7 @@
 
 
 import logging
-from logging import INFO, WARN, LogRecord
+from logging import WARN, LogRecord
 from logging.handlers import HTTPHandler
 from typing import TYPE_CHECKING, Any, Dict, Optional, TextIO, Tuple
 

--- a/src/py/flwr/common/logger.py
+++ b/src/py/flwr/common/logger.py
@@ -16,7 +16,7 @@
 
 
 import logging
-from logging import WARN, LogRecord
+from logging import INFO, WARN, LogRecord
 from logging.handlers import HTTPHandler
 from typing import TYPE_CHECKING, Any, Dict, Optional, TextIO, Tuple
 
@@ -194,6 +194,32 @@ def warn_deprecated_feature(name: str) -> None:
             entirely in future versions of Flower.
         """,
         name,
+    )
+
+
+def warn_deprecated_feature_with_example(
+    deprecation_message: str, example_message: str, code_example: str
+) -> None:
+    """Warn if a feature is deprecated and show code example of preferred
+    alternative."""
+    log(
+        WARN,
+        """DEPRECATED FEATURE: %s
+
+            Check the following `FEATURE UPDATE` warning message for the preferred
+            new mechanism to use this feature in Flower.
+        """,
+        deprecation_message,
+    )
+    log(
+        WARN,
+        """FEATURE UPDATE: %s
+        ------------------------------------------------------------
+        %s
+        ------------------------------------------------------------
+        """,
+        example_message,
+        code_example,
     )
 
 


### PR DESCRIPTION
Using the standard `warn_deprecated_feature` results in this:
![Screenshot 2024-07-11 at 16 24 35](https://github.com/adap/flower/assets/12958157/da893810-a8ac-4b59-a6a3-64dd33988934)

The newly introduced `warn_deprecated_feature_with_example` would look like this:
![Screenshot 2024-07-11 at 16 44 49](https://github.com/adap/flower/assets/12958157/60d7fde6-8c8c-4d1f-add8-3e7966d3f6c5)
