### PR TITLE
fix(framework:skip) Remove dependency installation from SuperExec

### DIFF
--- a/src/py/flwr/superexec/deployment.py
+++ b/src/py/flwr/superexec/deployment.py
@@ -84,7 +84,7 @@ class DeploymentEngine(Executor):
 
             # Install FAB Python package
             subprocess.check_call(
-                [sys.executable, "-m", "pip", "install", str(fab_path)],
+                [sys.executable, "-m", "pip", "install", "--no-deps", str(fab_path)],
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
             )


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

On the `SuperExec` we currently install the dependencies associated with a given Flower App. This can create situations where conflicting version of `flwr` can be installed.

### Related issues/PRs

N/A

## Proposal

### Explanation

Use the `--no-deps` `pip` flag when installing the Flower App.

### Checklist

- [x] Implement proposed change
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

N/A
