### PR TITLE
refactor(framework) Remove `partition_id` from `Context`

### DIFF
--- a/src/py/flwr/client/app.py
+++ b/src/py/flwr/client/app.py
@@ -348,7 +348,6 @@ def _start_client_internal(
                     node_state = NodeState(
                         node_id=-1,
                         node_config={},
-                        partition_id=None,
                     )
                 else:
                     # Call create_node fn to register node
@@ -360,7 +359,6 @@ def _start_client_internal(
                     node_state = NodeState(
                         node_id=node_id,
                         node_config=node_config,
-                        partition_id=None,
                     )
 
             app_state_tracker.register_signal_handler()

--- a/src/py/flwr/client/node_state.py
+++ b/src/py/flwr/client/node_state.py
@@ -36,12 +36,13 @@ class NodeState:
     """State of a node where client nodes execute runs."""
 
     def __init__(
-        self, node_id: int, node_config: Dict[str, str], partition_id: Optional[int]
+        self,
+        node_id: int,
+        node_config: Dict[str, str],
     ) -> None:
         self.node_id = node_id
         self.node_config = node_config
         self.run_infos: Dict[int, RunInfo] = {}
-        self._partition_id = partition_id
 
     def register_context(
         self,
@@ -59,7 +60,6 @@ class NodeState:
                     node_config=self.node_config,
                     state=RecordSet(),
                     run_config=initial_run_config.copy(),
-                    partition_id=self._partition_id,
                 ),
             )
 

--- a/src/py/flwr/client/node_state_tests.py
+++ b/src/py/flwr/client/node_state_tests.py
@@ -41,7 +41,7 @@ def test_multirun_in_node_state() -> None:
     expected_values = {0: "1", 1: "1" * 3, 2: "1" * 2, 3: "1", 5: "1"}
 
     # NodeState
-    node_state = NodeState(node_id=0, node_config={}, partition_id=None)
+    node_state = NodeState(node_id=0, node_config={})
 
     for task in tasks:
         run_id = task.run_id

--- a/src/py/flwr/common/constant.py
+++ b/src/py/flwr/common/constant.py
@@ -57,6 +57,9 @@ APP_DIR = "apps"
 FAB_CONFIG_FILE = "pyproject.toml"
 FLWR_HOME = "FLWR_HOME"
 
+# Constants entries in Node config for Simulation
+PARTITION_ID_KEY = "partition-id"
+NUM_PARTITIONS_KEY = "num-partitions"
 
 GRPC_ADAPTER_METADATA_FLOWER_VERSION_KEY = "flower-version"
 GRPC_ADAPTER_METADATA_SHOULD_EXIT_KEY = "should-exit"

--- a/src/py/flwr/common/context.py
+++ b/src/py/flwr/common/context.py
@@ -16,7 +16,7 @@
 
 
 from dataclasses import dataclass
-from typing import Dict, Optional
+from typing import Dict
 
 from .record import RecordSet
 
@@ -43,17 +43,12 @@ class Context:
         A config (key/value mapping) held by the entity in a given run and that will
         stay local. It can be used at any point during the lifecycle of this entity
         (e.g. across multiple rounds)
-    partition_id : Optional[int] (default: None)
-        An index that specifies the data partition that the ClientApp using this Context
-        object should make use of. Setting this attribute is better suited for
-        simulation or proto typing setups.
     """
 
     node_id: int
     node_config: Dict[str, str]
     state: RecordSet
     run_config: Dict[str, str]
-    partition_id: Optional[int]
 
     def __init__(  # pylint: disable=too-many-arguments
         self,
@@ -61,10 +56,8 @@ class Context:
         node_config: Dict[str, str],
         state: RecordSet,
         run_config: Dict[str, str],
-        partition_id: Optional[int] = None,
     ) -> None:
         self.node_id = node_id
         self.node_config = node_config
         self.state = state
         self.run_config = run_config
-        self.partition_id = partition_id

--- a/src/py/flwr/server/superlink/fleet/vce/backend/raybackend.py
+++ b/src/py/flwr/server/superlink/fleet/vce/backend/raybackend.py
@@ -21,6 +21,7 @@ from typing import Callable, Dict, List, Tuple, Union
 import ray
 
 from flwr.client.client_app import ClientApp
+from flwr.common.constant import PARTITION_ID_KEY
 from flwr.common.context import Context
 from flwr.common.logger import log
 from flwr.common.message import Message
@@ -168,7 +169,7 @@ class RayBackend(Backend):
 
         Return output message and updated context.
         """
-        partition_id = context.partition_id
+        partition_id = context.node_config[PARTITION_ID_KEY]
 
         try:
             # Submit a task to the pool

--- a/src/py/flwr/simulation/app.py
+++ b/src/py/flwr/simulation/app.py
@@ -327,6 +327,7 @@ def start_simulation(
             client_fn=client_fn,
             node_id=node_id,
             partition_id=partition_id,
+            num_partitions=num_clients,
             actor_pool=pool,
         )
         initialized_server.client_manager().register(client=client_proxy)

--- a/src/py/flwr/simulation/ray_transport/ray_client_proxy.py
+++ b/src/py/flwr/simulation/ray_transport/ray_client_proxy.py
@@ -24,7 +24,12 @@ from flwr.client import ClientFnExt
 from flwr.client.client_app import ClientApp
 from flwr.client.node_state import NodeState
 from flwr.common import DEFAULT_TTL, Message, Metadata, RecordSet
-from flwr.common.constant import PARTITION_ID_KEY, MessageType, MessageTypeLegacy
+from flwr.common.constant import (
+    NUM_PARTITIONS_KEY,
+    PARTITION_ID_KEY,
+    MessageType,
+    MessageTypeLegacy,
+)
 from flwr.common.logger import log
 from flwr.common.recordset_compat import (
     evaluateins_to_recordset,
@@ -43,11 +48,12 @@ from flwr.simulation.ray_transport.ray_actor import VirtualClientEngineActorPool
 class RayActorClientProxy(ClientProxy):
     """Flower client proxy which delegates work using Ray."""
 
-    def __init__(
+    def __init__(  # pylint: disable=too-many-arguments
         self,
         client_fn: ClientFnExt,
         node_id: int,
         partition_id: int,
+        num_partitions: int,
         actor_pool: VirtualClientEngineActorPool,
     ):
         super().__init__(cid=str(node_id))
@@ -61,7 +67,10 @@ class RayActorClientProxy(ClientProxy):
         self.actor_pool = actor_pool
         self.proxy_state = NodeState(
             node_id=node_id,
-            node_config={PARTITION_ID_KEY: str(partition_id)},
+            node_config={
+                PARTITION_ID_KEY: str(partition_id),
+                NUM_PARTITIONS_KEY: str(num_partitions),
+            },
         )
 
     def _submit_job(self, message: Message, timeout: Optional[float]) -> Message:

--- a/src/py/flwr/simulation/ray_transport/ray_client_proxy.py
+++ b/src/py/flwr/simulation/ray_transport/ray_client_proxy.py
@@ -24,7 +24,7 @@ from flwr.client import ClientFnExt
 from flwr.client.client_app import ClientApp
 from flwr.client.node_state import NodeState
 from flwr.common import DEFAULT_TTL, Message, Metadata, RecordSet
-from flwr.common.constant import MessageType, MessageTypeLegacy
+from flwr.common.constant import PARTITION_ID_KEY, MessageType, MessageTypeLegacy
 from flwr.common.logger import log
 from flwr.common.recordset_compat import (
     evaluateins_to_recordset,
@@ -61,8 +61,7 @@ class RayActorClientProxy(ClientProxy):
         self.actor_pool = actor_pool
         self.proxy_state = NodeState(
             node_id=node_id,
-            node_config={"partition-id": str(partition_id)},
-            partition_id=None,
+            node_config={PARTITION_ID_KEY: str(partition_id)},
         )
 
     def _submit_job(self, message: Message, timeout: Optional[float]) -> Message:
@@ -74,7 +73,7 @@ class RayActorClientProxy(ClientProxy):
 
         # Retrieve context
         context = self.proxy_state.retrieve_context(run_id=run_id)
-        partition_id_str = context.node_config["partition-id"]
+        partition_id_str = context.node_config[PARTITION_ID_KEY]
 
         try:
             self.actor_pool.submit_client_job(

--- a/src/py/flwr/simulation/ray_transport/ray_client_proxy_test.py
+++ b/src/py/flwr/simulation/ray_transport/ray_client_proxy_test.py
@@ -34,7 +34,7 @@ from flwr.common import (
     Metadata,
     Scalar,
 )
-from flwr.common.constant import PARTITION_ID_KEY
+from flwr.common.constant import NUM_PARTITIONS_KEY, PARTITION_ID_KEY
 from flwr.common.recordset_compat import (
     getpropertiesins_to_recordset,
     recordset_to_getpropertiesres,
@@ -100,6 +100,7 @@ def prep(
             client_fn=get_dummy_client,
             node_id=node_id,
             partition_id=partition_id,
+            num_partitions=num_proxies,
             actor_pool=pool,
         )
         for node_id, partition_id in mapping.items()
@@ -198,7 +199,10 @@ def test_cid_consistency_without_proxies() -> None:
     for node_id, partition_id in mapping.items():
         node_states[node_id] = NodeState(
             node_id=node_id,
-            node_config={PARTITION_ID_KEY: str(partition_id)},
+            node_config={
+                PARTITION_ID_KEY: str(partition_id),
+                NUM_PARTITIONS_KEY: str(len(node_ids)),
+            },
         )
 
     getproperties_ins = _get_valid_getpropertiesins()


### PR DESCRIPTION
This PR:
- Removes the `partition_id` from Context (this information can be embedded in the `<Context>.node_confg`)
- Because of the above the `NodeState` class also removes the `partition_id` from its constructor.
- In simulation, the `node_config` dict carries both `partition-id` and `num-partitions` keys
- The above keys are now captured in `flwr.common.constants` to ease any further changes to these.
- Some simulation tests were creating a `Context` obj directly. Now they instead create a `NodeState` object and use it to register & retrieve the context. No shortcuts.