### PR TITLE
refactor(framework) Improve app loading in simulation engine

### DIFF
--- a/examples/simulation-pytorch/sim.py
+++ b/examples/simulation-pytorch/sim.py
@@ -87,11 +87,13 @@ def get_client_fn(dataset: FederatedDataset):
     the strategy to participate.
     """
 
-    def client_fn(cid: str) -> fl.client.Client:
+    def client_fn(context) -> fl.client.Client:
         """Construct a FlowerClient with its own dataset partition."""
 
         # Let's get the partition corresponding to the i-th client
-        client_dataset = dataset.load_partition(int(cid), "train")
+        client_dataset = dataset.load_partition(
+            int(context.node_config["partition-id"]), "train"
+        )
 
         # Now let's split it into train (90%) and validation (10%)
         client_dataset_splits = client_dataset.train_test_split(test_size=0.1, seed=42)
@@ -171,15 +173,24 @@ def get_evaluate_fn(
 mnist_fds = FederatedDataset(dataset="mnist", partitioners={"train": NUM_CLIENTS})
 centralized_testset = mnist_fds.load_split("test")
 
-# Configure the strategy
-strategy = fl.server.strategy.FedAvg(
-    fraction_fit=0.1,  # Sample 10% of available clients for training
-    fraction_evaluate=0.05,  # Sample 5% of available clients for evaluation
-    min_available_clients=10,
-    on_fit_config_fn=fit_config,
-    evaluate_metrics_aggregation_fn=weighted_average,  # Aggregate federated metrics
-    evaluate_fn=get_evaluate_fn(centralized_testset),  # Global evaluation function
-)
+from flwr.server import ServerAppComponents
+
+
+def server_fn(context):
+
+    # Configure the strategy
+    strategy = fl.server.strategy.FedAvg(
+        fraction_fit=0.1,  # Sample 10% of available clients for training
+        fraction_evaluate=0.05,  # Sample 5% of available clients for evaluation
+        min_available_clients=10,
+        on_fit_config_fn=fit_config,
+        evaluate_metrics_aggregation_fn=weighted_average,  # Aggregate federated metrics
+        evaluate_fn=get_evaluate_fn(centralized_testset),  # Global evaluation function
+    )
+    return ServerAppComponents(
+        strategy=strategy, config=fl.server.ServerConfig(num_rounds=NUM_ROUNDS)
+    )
+
 
 # ClientApp for Flower-Next
 client = fl.client.ClientApp(
@@ -187,10 +198,7 @@ client = fl.client.ClientApp(
 )
 
 # ServerApp for Flower-Next
-server = fl.server.ServerApp(
-    config=fl.server.ServerConfig(num_rounds=NUM_ROUNDS),
-    strategy=strategy,
-)
+server = fl.server.ServerApp(server_fn=server_fn)
 
 
 def main():

--- a/examples/simulation-pytorch/sim.py
+++ b/examples/simulation-pytorch/sim.py
@@ -177,7 +177,6 @@ from flwr.server import ServerAppComponents
 
 
 def server_fn(context):
-
     # Configure the strategy
     strategy = fl.server.strategy.FedAvg(
         fraction_fit=0.1,  # Sample 10% of available clients for training

--- a/src/py/flwr/client/supernode/app.py
+++ b/src/py/flwr/client/supernode/app.py
@@ -62,8 +62,8 @@ def run_supernode() -> None:
     root_certificates = _get_certificates(args)
     load_fn = _get_load_client_app_fn(
         default_app_ref=args.client_app,
-        load_dir=args.dir,
-        flwr_dir=args.flwr_dir,
+        dir_arg=args.dir,
+        flwr_dir_arg=args.flwr_dir,
         load_for_supernode=True,
         multi_app=True,
     )
@@ -101,7 +101,7 @@ def run_client_app() -> None:
     root_certificates = _get_certificates(args)
     load_fn = _get_load_client_app_fn(
         default_app_ref=args.client_app,
-        load_dir=args.dir,
+        dir_arg=args.dir,
         load_for_supernode=False,
         multi_app=False,
     )

--- a/src/py/flwr/client/supernode/app.py
+++ b/src/py/flwr/client/supernode/app.py
@@ -178,10 +178,10 @@ def _get_certificates(args: argparse.Namespace) -> Optional[bytes]:
 
 def _get_load_client_app_fn(
     default_app_ref: str,
-    load_dir: str,
+    dir_arg: str,
     multi_app: bool,
     load_for_supernode: bool,
-    flwr_dir: Optional[str] = None,
+    flwr_dir_arg: Optional[str] = None,
 ) -> Callable[[str, str], ClientApp]:
     """Get the load_client_app_fn function.
 
@@ -196,10 +196,10 @@ def _get_load_client_app_fn(
     if not load_for_supernode:
         flwr_dir = Path("")
     else:
-        if flwr_dir is None:
+        if flwr_dir_arg is None:
             flwr_dir = get_flwr_dir()
         else:
-            flwr_dir = Path(flwr_dir).absolute()
+            flwr_dir = Path(flwr_dir_arg).absolute()
 
     inserted_path = None
 
@@ -210,7 +210,7 @@ def _get_load_client_app_fn(
             default_app_ref,
         )
         # Insert sys.path
-        dir_path = Path(load_dir).absolute()
+        dir_path = Path(dir_arg).absolute()
         sys.path.insert(0, str(dir_path))
         inserted_path = str(dir_path)
 
@@ -222,7 +222,7 @@ def _get_load_client_app_fn(
         # If multi-app feature is disabled
         if not multi_app:
             # Get sys path to be inserted
-            dir_path = Path(load_dir).absolute()
+            dir_path = Path(dir_arg).absolute()
 
             # Set app reference
             client_app_ref = default_app_ref
@@ -235,7 +235,7 @@ def _get_load_client_app_fn(
 
             log(WARN, "FAB ID is not provided; the default ClientApp will be loaded.")
             # Get sys path to be inserted
-            dir_path = Path(load_dir).absolute()
+            dir_path = Path(dir_arg).absolute()
 
             # Set app reference
             client_app_ref = default_app_ref

--- a/src/py/flwr/client/supernode/app.py
+++ b/src/py/flwr/client/supernode/app.py
@@ -61,7 +61,7 @@ def run_supernode() -> None:
 
     root_certificates = _get_certificates(args)
     load_fn = _get_load_client_app_fn(
-        default_app_ref=args.client_app,
+        default_app_ref=getattr(args, "client-app"),
         dir_arg=args.dir,
         flwr_dir_arg=args.flwr_dir,
         load_for_supernode=True,
@@ -100,7 +100,7 @@ def run_client_app() -> None:
 
     root_certificates = _get_certificates(args)
     load_fn = _get_load_client_app_fn(
-        default_app_ref=args.client_app,
+        default_app_ref=getattr(args, "client-app"),
         dir_arg=args.dir,
         load_for_supernode=False,
         multi_app=False,

--- a/src/py/flwr/client/supernode/app.py
+++ b/src/py/flwr/client/supernode/app.py
@@ -64,6 +64,7 @@ def run_supernode() -> None:
         default_app_ref=args.client_app,
         load_dir=args.dir,
         flwr_dir=args.flwr_dir,
+        load_for_supernode=True,
         multi_app=True,
     )
     authentication_keys = _try_setup_client_authentication(args)
@@ -101,7 +102,7 @@ def run_client_app() -> None:
     load_fn = _get_load_client_app_fn(
         default_app_ref=args.client_app,
         load_dir=args.dir,
-        flwr_dir=args.flwr_dir,
+        load_for_supernode=False,
         multi_app=False,
     )
     authentication_keys = _try_setup_client_authentication(args)
@@ -179,6 +180,7 @@ def _get_load_client_app_fn(
     default_app_ref: str,
     load_dir: str,
     multi_app: bool,
+    load_for_supernode: bool,
     flwr_dir: Optional[str] = None,
 ) -> Callable[[str, str], ClientApp]:
     """Get the load_client_app_fn function.
@@ -191,12 +193,13 @@ def _get_load_client_app_fn(
     loads a default ClientApp.
     """
     # Find the Flower directory containing Flower Apps (only for multi-app)
-    flwr_dir = Path("")
-
-    if flwr_dir is None:
-        flwr_dir = get_flwr_dir()
+    if not load_for_supernode:
+        flwr_dir = Path("")
     else:
-        flwr_dir = Path(flwr_dir).absolute()
+        if flwr_dir is None:
+            flwr_dir = get_flwr_dir()
+        else:
+            flwr_dir = Path(flwr_dir).absolute()
 
     inserted_path = None
 

--- a/src/py/flwr/server/superlink/fleet/vce/vce_api.py
+++ b/src/py/flwr/server/superlink/fleet/vce/vce_api.py
@@ -355,12 +355,14 @@ def start_vce(
         # Test if ClientApp can be loaded
         client_app = app_fn()
 
-        # Now wrap the loaded ClientApp in a dummy function
-        # this prevent unnecesary low-level loading of ClientApp
-        def _load_client_app() -> ClientApp:
-            return client_app
+        # Cache `ClientApp`
+        if client_app_attr:
+            # Now wrap the loaded ClientApp in a dummy function
+            # this prevent unnecesary low-level loading of ClientApp
+            def _load_client_app() -> ClientApp:
+                return client_app
 
-        app_fn = _load_client_app
+            app_fn = _load_client_app
 
         # Run main simulation loop
         run_api(

--- a/src/py/flwr/server/superlink/fleet/vce/vce_api.py
+++ b/src/py/flwr/server/superlink/fleet/vce/vce_api.py
@@ -353,7 +353,14 @@ def start_vce(
 
     try:
         # Test if ClientApp can be loaded
-        _ = app_fn()
+        client_app = app_fn()
+
+        # Now wrap the loaded ClientApp in a dummy function
+        # this prevent unnecesary low-level loading of ClientApp
+        def _load_client_app() -> ClientApp:
+            return client_app
+
+        app_fn = _load_client_app
 
         # Run main simulation loop
         run_api(

--- a/src/py/flwr/simulation/run_simulation.py
+++ b/src/py/flwr/simulation/run_simulation.py
@@ -207,6 +207,7 @@ def _main_loop(
     app_dir: str,
     enable_tf_gpu_growth: bool,
     run: Run,
+    flwr_dir: Optional[str] = None,
     client_app: Optional[ClientApp] = None,
     client_app_attr: Optional[str] = None,
     server_app: Optional[ServerApp] = None,
@@ -253,6 +254,7 @@ def _main_loop(
             state_factory=state_factory,
             f_stop=f_stop,
             run=run,
+            flwr_dir=flwr_dir,
         )
 
     except Exception as ex:
@@ -283,6 +285,7 @@ def _run_simulation(
     client_app_attr: Optional[str] = None,
     server_app_attr: Optional[str] = None,
     app_dir: str = "",
+    flwr_dir: Optional[str] = None,
     run: Optional[Run] = None,
     enable_tf_gpu_growth: bool = False,
     verbose_logging: bool = False,
@@ -325,6 +328,9 @@ def _run_simulation(
     app_dir : str
         Add specified directory to the PYTHONPATH and load `ClientApp` from there.
         (Default: current working directory.)
+
+    flwr_dir : Optional[str]
+        The path containing installed Flower Apps.
 
     run : Optional[Run]
         An object carrying details about the run.
@@ -377,6 +383,7 @@ def _run_simulation(
         app_dir,
         enable_tf_gpu_growth,
         run,
+        flwr_dir,
         client_app,
         client_app_attr,
         server_app,
@@ -463,6 +470,17 @@ def _parse_args_run_simulation() -> argparse.ArgumentParser:
         help="Add specified directory to the PYTHONPATH and load"
         "ClientApp and ServerApp from there."
         " Default: current working directory.",
+    )
+    parser.add_argument(
+        "--flwr-dir",
+        default=None,
+        help="""The path containing installed Flower Apps.
+    By default, this value is equal to:
+
+        - `$FLWR_HOME/` if `$FLWR_HOME` is defined
+        - `$XDG_DATA_HOME/.flwr/` if `$XDG_DATA_HOME` is defined
+        - `$HOME/.flwr/` in all other cases
+    """,
     )
     parser.add_argument(
         "--run-id",


### PR DESCRIPTION
The core of the Simulation Engine has a simple mechanism to load the function that would eventually return a `ClientApp`. As Flower has rapidly evolved in terms of what's the origin of a  `ClientApp` object (e.g. a simple python file, or a full FAB) so it has the ways of loading these apps (e.g. loading an associated `pyproject.toml`)

This PR reuses the same mechanism that `flower-supernode` uses to load a function that returns a `ClientApp`. This step represent the first step towards being able to run full FABs from `flower-simulation`.

In addition, this PR caches the `ClientApp` before starting the simulation, making them more efficient to run.