### PR TITLE
feat(framework) Add federation argument to `flwr run`

### DIFF
--- a/src/py/flwr/cli/run/run.py
+++ b/src/py/flwr/cli/run/run.py
@@ -40,7 +40,7 @@ def run(
     ] = Path("."),
     federation_name: Annotated[
         Optional[str],
-        typer.Argument(help="Name of the federation to run FL on"),
+        typer.Argument(help="Name of the federation to run the app on"),
     ] = None,
     config_overrides: Annotated[
         Optional[str],

--- a/src/py/flwr/cli/run/run.py
+++ b/src/py/flwr/cli/run/run.py
@@ -81,8 +81,8 @@ def run(
 
     if federation_name is None:
         typer.secho(
-            "❌ The project's `pyproject.toml` needs to declare "
-            "a default federation (with a SuperExec address or an "
+            "❌ No federation name was provided and the project's `pyproject.toml` "
+            "doesn't declare a default federation (with a SuperExec address or an "
             "`options.num-supernodes` value).",
             fg=typer.colors.RED,
             bold=True,
@@ -92,9 +92,11 @@ def run(
     # Validate the federation exists in the configuration
     federation = config["flower"]["federations"].get(federation_name)
     if federation is None:
+        available_feds = list(config["flower"]["federations"])
         typer.secho(
             f"❌ There is no `{federation_name}` federation declared in the "
-            "`pyproject.toml`.",
+            "`pyproject.toml`.\n The following federations were found:\n\n"
+            "\n".join(available_feds) + "\n\n",
             fg=typer.colors.RED,
             bold=True,
         )


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

### Checklist

- [ ] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.ai/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
