### PR TITLE
feat(framework) Update context registration when running an app directory

### DIFF
--- a/src/py/flwr/client/app.py
+++ b/src/py/flwr/client/app.py
@@ -195,7 +195,7 @@ def _start_client_internal(
     ] = None,
     max_retries: Optional[int] = None,
     max_wait_time: Optional[float] = None,
-    flwr_dir: Optional[Path] = None,
+    flwr_path: Optional[Path] = None,
 ) -> None:
     """Start a Flower client node which connects to a Flower server.
 
@@ -241,7 +241,7 @@ def _start_client_internal(
         The maximum duration before the client stops trying to
         connect to the server in case of connection error.
         If set to None, there is no limit to the total time.
-    flwr_dir: Optional[Path] (default: None)
+    flwr_path: Optional[Path] (default: None)
         The fully resolved path containing installed Flower Apps.
     """
     if insecure is None:
@@ -402,7 +402,7 @@ def _start_client_internal(
 
                     # Register context for this run
                     node_state.register_context(
-                        run_id=run_id, run=runs[run_id], flwr_dir=flwr_dir
+                        run_id=run_id, run=runs[run_id], flwr_path=flwr_path
                     )
 
                     # Retrieve context for this run

--- a/src/py/flwr/client/node_state.py
+++ b/src/py/flwr/client/node_state.py
@@ -55,13 +55,15 @@ class NodeState:
         if run_id not in self.run_infos:
             initial_run_config = {}
             if app_dir:
-                # Load from FAB-like directory
+                # Load from app directory
                 app_path = Path(app_dir)
                 if app_path.is_dir():
                     override_config = run.override_config if run else {}
                     initial_run_config = get_fused_config_from_dir(
                         app_path, override_config
                     )
+                else:
+                    raise ValueError("The specified `app_dir` must be a directory.")
             else:
                 # Load from .fab
                 initial_run_config = get_fused_config(run, flwr_path) if run else {}

--- a/src/py/flwr/client/node_state.py
+++ b/src/py/flwr/client/node_state.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from typing import Dict, Optional
 
 from flwr.common import Context, RecordSet
-from flwr.common.config import get_fused_config
+from flwr.common.config import get_fused_config, get_fused_config_from_dir
 from flwr.common.typing import Run
 
 
@@ -49,10 +49,21 @@ class NodeState:
         run_id: int,
         run: Optional[Run] = None,
         flwr_dir: Optional[Path] = None,
+        fab_dir: Optional[str] = None,
     ) -> None:
         """Register new run context for this node."""
         if run_id not in self.run_infos:
-            initial_run_config = get_fused_config(run, flwr_dir) if run else {}
+            initial_run_config = {}
+            if fab_dir:
+                # Load from FAB-like directory
+                fab_path = Path(fab_dir)
+                if fab_path.is_dir():
+                    initial_run_config = get_fused_config_from_dir(
+                        fab_path, run.override_config
+                    )
+            else:
+                # Load from .fab
+                initial_run_config = get_fused_config(run, flwr_dir) if run else {}
             self.run_infos[run_id] = RunInfo(
                 initial_run_config=initial_run_config,
                 context=Context(

--- a/src/py/flwr/client/node_state.py
+++ b/src/py/flwr/client/node_state.py
@@ -58,8 +58,9 @@ class NodeState:
                 # Load from FAB-like directory
                 fab_path = Path(fab_dir)
                 if fab_path.is_dir():
+                    override_config = run.override_config if run else {}
                     initial_run_config = get_fused_config_from_dir(
-                        fab_path, run.override_config
+                        fab_path, override_config
                     )
             else:
                 # Load from .fab

--- a/src/py/flwr/client/node_state.py
+++ b/src/py/flwr/client/node_state.py
@@ -54,17 +54,17 @@ class NodeState:
         """Register new run context for this node."""
         if run_id not in self.run_infos:
             initial_run_config = {}
-            if fab_dir:
+            if app_dir:
                 # Load from FAB-like directory
-                fab_path = Path(fab_dir)
-                if fab_path.is_dir():
+                app_path = Path(app_dir)
+                if app_path.is_dir():
                     override_config = run.override_config if run else {}
                     initial_run_config = get_fused_config_from_dir(
-                        fab_path, override_config
+                        app_path, override_config
                     )
             else:
                 # Load from .fab
-                initial_run_config = get_fused_config(run, flwr_dir) if run else {}
+                initial_run_config = get_fused_config(run, flwr_path) if run else {}
             self.run_infos[run_id] = RunInfo(
                 initial_run_config=initial_run_config,
                 context=Context(

--- a/src/py/flwr/client/node_state.py
+++ b/src/py/flwr/client/node_state.py
@@ -48,8 +48,8 @@ class NodeState:
         self,
         run_id: int,
         run: Optional[Run] = None,
-        flwr_dir: Optional[Path] = None,
-        fab_dir: Optional[str] = None,
+        flwr_path: Optional[Path] = None,
+        app_dir: Optional[str] = None,
     ) -> None:
         """Register new run context for this node."""
         if run_id not in self.run_infos:

--- a/src/py/flwr/client/supernode/app.py
+++ b/src/py/flwr/client/supernode/app.py
@@ -78,7 +78,7 @@ def run_supernode() -> None:
         max_retries=args.max_retries,
         max_wait_time=args.max_wait_time,
         node_config=parse_config_args(args.node_config),
-        flwr_dir=get_flwr_dir(args.flwr_dir),
+        flwr_path=get_flwr_dir(args.flwr_dir),
     )
 
     # Graceful shutdown


### PR DESCRIPTION
When there is not a `.fab` we still want to be able to read the config in the `pyproject.toml` and potentially override some values embedded in `<Run>.override_config`. To do this we need to call `get_fused_config_from_dir()` when registering a context.