### PR TITLE
feat(framework) Allow multiple separated run-config arguments

### DIFF
--- a/src/py/flwr/cli/run/run.py
+++ b/src/py/flwr/cli/run/run.py
@@ -18,7 +18,7 @@ import subprocess
 import sys
 from logging import DEBUG
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 import typer
 from typing_extensions import Annotated
@@ -43,7 +43,7 @@ def run(
         typer.Argument(help="Name of the federation to run the app on"),
     ] = None,
     config_overrides: Annotated[
-        Optional[str],
+        Optional[List[str]],
         typer.Option(
             "--run-config",
             "-c",
@@ -113,7 +113,7 @@ def run(
 def _run_with_superexec(
     federation: Dict[str, str],
     directory: Optional[Path],
-    config_overrides: Optional[str],
+    config_overrides: Optional[List[str]],
 ) -> None:
 
     def on_channel_state_change(channel_connectivity: str) -> None:
@@ -172,7 +172,7 @@ def _run_without_superexec(
     app_path: Optional[Path],
     federation: Dict[str, Any],
     federation_name: str,
-    config_overrides: Optional[str],
+    config_overrides: Optional[List[str]],
 ) -> None:
     try:
         num_supernodes = federation["options"]["num-supernodes"]

--- a/src/py/flwr/common/config.py
+++ b/src/py/flwr/common/config.py
@@ -130,7 +130,7 @@ def flatten_dict(raw_dict: Dict[str, Any], parent_key: str = "") -> Dict[str, st
 
 
 def parse_config_args(
-    config: Optional[str],
+    config: Optional[List[str]],
     separator: str = ",",
 ) -> Dict[str, str]:
     """Parse separator separated list of key-value pairs separated by '='."""
@@ -139,17 +139,18 @@ def parse_config_args(
     if config is None:
         return overrides
 
-    overrides_list = config.split(separator)
-    if (
-        len(overrides_list) == 1
-        and "=" not in overrides_list
-        and overrides_list[0].endswith(".toml")
-    ):
-        with Path(overrides_list[0]).open("rb") as config_file:
-            overrides = flatten_dict(tomli.load(config_file))
-    else:
-        for kv_pair in overrides_list:
-            key, value = kv_pair.split("=")
-            overrides[key] = value
+    for config_line in config:
+        overrides_list = config_line.split(separator)
+        if (
+            len(overrides_list) == 1
+            and "=" not in overrides_list
+            and overrides_list[0].endswith(".toml")
+        ):
+            with Path(overrides_list[0]).open("rb") as config_file:
+                overrides = flatten_dict(tomli.load(config_file))
+        else:
+            for kv_pair in overrides_list:
+                key, value = kv_pair.split("=")
+                overrides[key] = value
 
     return overrides


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

### Checklist

- [ ] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.ai/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
