### PR TITLE
feat(datasets) Enable passing kwargs to load_dataset in FederatedDataset

### DIFF
--- a/datasets/flwr_datasets/federated_dataset.py
+++ b/datasets/flwr_datasets/federated_dataset.py
@@ -15,7 +15,7 @@
 """FederatedDataset."""
 
 
-from typing import Dict, Optional, Tuple, Union
+from typing import Any, Dict, Optional, Tuple, Union
 
 import datasets
 from datasets import Dataset, DatasetDict
@@ -65,6 +65,12 @@ class FederatedDataset:
         Seed used for dataset shuffling. It has no effect if `shuffle` is False. The
         seed cannot be set in the later stages. If `None`, then fresh, unpredictable
         entropy will be pulled from the OS. Defaults to 42.
+    load_dataset_kwargs : Any
+        Additional keyword arguments passed to `datasets.load_dataset` function.
+        Currently used paramters used are dataset => path (in load_dataset),
+        subset => name (in load_dataset). You can pass e.g., `num_proc=4`,
+        `trust_remote_code=True`. Do not pass any parameters that modify the
+        return type such as another type than DatasetDict is returned.
 
     Examples
     --------
@@ -73,7 +79,7 @@ class FederatedDataset:
     >>> from flwr_datasets import FederatedDataset
     >>>
     >>> fds = FederatedDataset(dataset="mnist", partitioners={"train": 100})
-    >>> # Load partition for client with ID 10.
+    >>> # Load partition for a client with ID 10.
     >>> partition = fds.load_partition(10)
     >>> # Use test split for centralized evaluation.
     >>> centralized = fds.load_split("test")
@@ -107,6 +113,7 @@ class FederatedDataset:
         partitioners: Dict[str, Union[Partitioner, int]],
         shuffle: bool = True,
         seed: Optional[int] = 42,
+        **load_dataset_kwargs: Any,
     ) -> None:
         _check_if_dataset_tested(dataset)
         self._dataset_name: str = dataset
@@ -127,6 +134,7 @@ class FederatedDataset:
         self._event = {
             "load_partition": {split: False for split in self._partitioners},
         }
+        self._load_dataset_kwargs = load_dataset_kwargs
 
     def load_partition(
         self,
@@ -289,8 +297,14 @@ class FederatedDataset:
         happen before the resplitting.
         """
         self._dataset = datasets.load_dataset(
-            path=self._dataset_name, name=self._subset
+            path=self._dataset_name, name=self._subset, **self._load_dataset_kwargs
         )
+        if not isinstance(self._dataset, datasets.DatasetDict):
+            raise ValueError(
+                "Probably one of the specified parameter in `load_dataset_kwargs` "
+                "change the return type of the datasets.load_dataset function. "
+                "Make sure to use parameter such that the return type is DatasetDict."
+            )
         if self._shuffle:
             # Note it shuffles all the splits. The self._dataset is DatasetDict
             # so e.g. {"train": train_data, "test": test_data}. All splits get shuffled.

--- a/datasets/flwr_datasets/federated_dataset_test.py
+++ b/datasets/flwr_datasets/federated_dataset_test.py
@@ -216,6 +216,23 @@ class BaseFederatedDatasetsTest(unittest.TestCase):
         dataset_length = sum([len(ds) for ds in dataset.values()])
         self.assertEqual(len(full), dataset_length)
 
+    def test_use_load_dataset_kwargs(self) -> None:
+        """Test if the FederatedDataset works correctly with load_dataset_kwargs."""
+        try:
+            fds = FederatedDataset(
+                dataset=self.dataset_name,
+                shuffle=False,
+                partitioners={"train": 10},
+                num_proc=2,
+            )
+            _ = fds.load_partition(0)
+        # Try to catch as broad as possible
+        except Exception as e:  # pylint: disable=broad-except
+            self.fail(
+                f"Error when using load_dataset_kwargs: {e}. "
+                f"This code should not raise any exceptions."
+            )
+
 
 class ShufflingResplittingOnArtificialDatasetTest(unittest.TestCase):
     """Test shuffling and resplitting using small artificial dataset.
@@ -415,6 +432,23 @@ class IncorrectUsageFederatedDatasets(unittest.TestCase):
         )
         with self.assertRaises(ValueError):
             fds.load_partition(0, "train")
+
+    def test_use_load_dataset_kwargs(self) -> None:
+        """Test if the FederatedDataset raises with incorrect load_dataset_kwargs.
+
+        The FederatedDataset should throw an error when the load_dataset_kwargs make the
+        return type different from a DatasetDict.
+
+        Use split which makes the load_dataset return a Dataset.
+        """
+        fds = FederatedDataset(
+            dataset="mnist",
+            shuffle=False,
+            partitioners={"train": 10},
+            split="train",
+        )
+        with self.assertRaises(ValueError):
+            _ = fds.load_partition(0)
 
 
 def datasets_are_equal(ds1: Dataset, ds2: Dataset) -> bool:


### PR DESCRIPTION
## Issue
Currently it's possible to only two arguments to datasets.load_dataset (dataset -> path, subset-> name). However, there are many useful parameters that can be additionally passed to the `load_dataset`.

### Description
One example of a parameter that a user will need to pass (once we update the dataset library) is:
* `trust_remote_code` that defaults to False but is needed if the dataset is supported (in HF) as Python script.
* `num_proc` is another that can enable a speed-up.

## Proposal
* Add `load_dataset_kwargs : Any` to the parameters of the `FederatedDataset`
* Add check to make sure any of the parameters does not change the return types of the `datasets.load_dataset` function (`DatasetDict` is needed to be returned)
* Add tests for correct and incorrect behavior.

Note: the hint type is `Any` however there are newer `Unpack` but it requires the knowledge of what it will be unpacked to, so it works well with `TypedDict` which we do not have, therefore the type is set as `Any`.
### Explanation

Use the new functionality as follows:
* `trust_remote_code`

```python
fds = FederatedDataset(
    dataset="mnist",
    shuffle=False,
    partitioners={"train": 10},
    # THIS IS NEW
    trust_remote_code=True,
)
partition = fds.load_partition(0)
```
* `num_proc`

```python
fds = FederatedDataset(
    dataset="mnist",
    shuffle=False,
    partitioners={"train": 10},
    # THIS IS NEW
    num_proc=2,
)
partition = fds.load_partition(0)
```
* same for other params