### PR TITLE
fix(datasets:skip) Update tests for multiple partitioners

### DIFF
--- a/datasets/flwr_datasets/federated_dataset_test.py
+++ b/datasets/flwr_datasets/federated_dataset_test.py
@@ -147,10 +147,7 @@ class BaseFederatedDatasetsTest(unittest.TestCase):
         expected_len = len(dataset[self.test_split]) // num_test_partitions
         mod = len(dataset[self.test_split]) % num_test_partitions
         expected_len += 1 if 0 < mod else 0
-        self.assertEqual(
-            len(dataset_test_partition0),
-            expected_len
-        )
+        self.assertEqual(len(dataset_test_partition0), expected_len)
 
     def test_no_need_for_split_keyword_if_one_partitioner(self) -> None:
         """Test if partitions got with and without split args are the same."""

--- a/datasets/flwr_datasets/federated_dataset_test.py
+++ b/datasets/flwr_datasets/federated_dataset_test.py
@@ -144,9 +144,12 @@ class BaseFederatedDatasetsTest(unittest.TestCase):
         dataset_test_partition0 = dataset_fds.load_partition(0, self.test_split)
 
         dataset = datasets.load_dataset(self.dataset_name)
+        expected_len = len(dataset[self.test_split]) // num_test_partitions
+        mod = len(dataset[self.test_split]) % num_test_partitions
+        expected_len += 1 if 0 < mod else 0
         self.assertEqual(
             len(dataset_test_partition0),
-            len(dataset[self.test_split]) // num_test_partitions,
+            expected_len
         )
 
     def test_no_need_for_split_keyword_if_one_partitioner(self) -> None:


### PR DESCRIPTION
## Issue
The tests that check the expected size of the partition for IidPartitioner were incorrect in the case of uneven sizes.
## Proposal
Update the expected size generation for the IidPartitioner in tests in `test_multiple_partitioners` method.