### PR TITLE
feat(datasets) Add tests for usps dataset

### DIFF
--- a/datasets/flwr_datasets/federated_dataset_test.py
+++ b/datasets/flwr_datasets/federated_dataset_test.py
@@ -43,6 +43,7 @@ mocked_datasets = ["cifar100", "svhn", "sentiment140", "speech_commands"]
         ("fashion_mnist", "test", ""),
         ("sasha/dog-food", "test", ""),
         ("zh-plus/tiny-imagenet", "valid", ""),
+        ("flwrlabs/usps", "test", ""),
         # Text
         ("scikit-learn/adult-census-income", None, ""),
         # Mocked

--- a/datasets/flwr_datasets/utils.py
+++ b/datasets/flwr_datasets/utils.py
@@ -34,6 +34,7 @@ tested_datasets = [
     "svhn",
     "sentiment140",
     "speech_commands",
+    "flwrlabs/usps",
 ]
 
 


### PR DESCRIPTION
## Issue
The newly supported `flwrlabs/usps` dataset does not have tests. https://huggingface.co/datasets/flwrlabs/usps

## Proposal
Add tests by downloading the dataset (it's a small image dataset <10,000 rows of images 16x16; <3MB) 
