### PR TITLE
feat(datasets) Add tests for `mnist-m` dataset

### DIFF
--- a/datasets/flwr_datasets/federated_dataset_test.py
+++ b/datasets/flwr_datasets/federated_dataset_test.py
@@ -43,6 +43,7 @@ mocked_datasets = ["cifar100", "svhn", "sentiment140", "speech_commands"]
         ("fashion_mnist", "test", ""),
         ("sasha/dog-food", "test", ""),
         ("zh-plus/tiny-imagenet", "valid", ""),
+        ("Mike0307/MNIST-M", "test", ""),
         # Text
         ("scikit-learn/adult-census-income", None, ""),
         # Mocked

--- a/datasets/flwr_datasets/utils.py
+++ b/datasets/flwr_datasets/utils.py
@@ -34,6 +34,7 @@ tested_datasets = [
     "svhn",
     "sentiment140",
     "speech_commands",
+    "Mike0307/MNIST-M",
 ]
 
 


### PR DESCRIPTION
Issue
The `Mike0307/MNIST-M` dataset needed for experiments to change the baselines to use FDS does not have tests. https://huggingface.co/datasets/Mike0307/MNIST-M

Proposal
Add tests by downloading the dataset (it's a small image dataset <60,000 rows of images 32x32; ~143 MB)