### PR TITLE
fix(framework) Enable overriding of run configs with simulation plugin

### DIFF
--- a/src/py/flwr/superexec/simulation.py
+++ b/src/py/flwr/superexec/simulation.py
@@ -82,11 +82,6 @@ class SimulationEngine(Executor):
     ) -> Optional[RunTracker]:
         """Start run using the Flower Simulation Engine."""
         try:
-            if override_config:
-                raise ValueError(
-                    "Overriding the run config is not yet supported with the "
-                    "simulation executor.",
-                )
 
             # Install FAB to flwr dir
             fab_path = install_from_fab(fab_file, None, True)


### PR DESCRIPTION
Check should have been removed in https://github.com/adap/flower/pull/3829