### PR TITLE
feat(framework) Prompt user for confirmation before flwr new override

### DIFF
--- a/dev/changelog_config.toml
+++ b/dev/changelog_config.toml
@@ -624,6 +624,7 @@ allowed_verbs=[
   "Prolong",
   "Promise",
   "Promote",
+  "Prompt",
   "Propagate",
   "Propose",
   "Prosecute",

--- a/src/py/flwr/cli/new/new.py
+++ b/src/py/flwr/cli/new/new.py
@@ -14,9 +14,9 @@
 # ==============================================================================
 """Flower command line interface `new` command."""
 
-import os
 import re
 from enum import Enum
+from pathlib import Path
 from string import Template
 from typing import Dict, Optional
 
@@ -59,10 +59,10 @@ class TemplateNotFound(Exception):
 
 def load_template(name: str) -> str:
     """Load template from template directory and return as text."""
-    tpl_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "templates"))
-    tpl_file_path = os.path.join(tpl_dir, name)
+    tpl_dir = (Path(__file__).parent / "templates").absolute()
+    tpl_file_path = tpl_dir / name
 
-    if not os.path.isfile(tpl_file_path):
+    if not tpl_file_path.is_file():
         raise TemplateNotFound(f"Template '{name}' not found")
 
     with open(tpl_file_path, encoding="utf-8") as tpl_file:
@@ -78,14 +78,13 @@ def render_template(template: str, data: Dict[str, str]) -> str:
     return tpl.template
 
 
-def create_file(file_path: str, content: str) -> None:
+def create_file(file_path: Path, content: str) -> None:
     """Create file including all nessecary directories and write content into file."""
-    os.makedirs(os.path.dirname(file_path), exist_ok=True)
-    with open(file_path, "w", encoding="utf-8") as f:
-        f.write(content)
+    file_path.parent.mkdir(exist_ok=True)
+    file_path.write_text(content)
 
 
-def render_and_create(file_path: str, template: str, context: Dict[str, str]) -> None:
+def render_and_create(file_path: Path, template: str, context: Dict[str, str]) -> None:
     """Render template and write to file."""
     content = render_template(template, context)
     create_file(file_path, content)
@@ -116,6 +115,21 @@ def new(
             predicate=is_valid_project_name,
             default=sanitize_project_name(project_name),
         )
+
+    # Set project directory path
+    package_name = re.sub(r"[-_.]+", "-", project_name).lower()
+    import_name = package_name.replace("-", "_")
+    project_dir = Path.cwd() / package_name
+
+    if project_dir.exists():
+        if not typer.confirm(
+            typer.style(
+                f"\n💬 {project_name} already exists, do you want to override it?",
+                fg=typer.colors.MAGENTA,
+                bold=True,
+            )
+        ):
+            return
 
     if username is None:
         username = prompt_text("Please provide your Flower username")
@@ -157,12 +171,6 @@ def new(
             bold=True,
         )
     )
-
-    # Set project directory path
-    cwd = os.getcwd()
-    package_name = re.sub(r"[-_.]+", "-", project_name).lower()
-    import_name = package_name.replace("-", "_")
-    project_dir = os.path.join(cwd, package_name)
 
     context = {
         "project_name": project_name,
@@ -252,7 +260,7 @@ def new(
 
     for file_path, value in files.items():
         render_and_create(
-            file_path=os.path.join(project_dir, file_path),
+            file_path=project_dir / file_path,
             template=value["template"],
             context=context,
         )

--- a/src/py/flwr/cli/new/new_test.py
+++ b/src/py/flwr/cli/new/new_test.py
@@ -103,12 +103,14 @@ def test_new_correct_name(tmp_path: str) -> None:
 
             # Assert
             file_list = (Path(tmp_path) / expected_top_level_dir).iterdir()
-            assert set(file_list) == expected_files_top_level
+            assert {
+                str(file_path) for file_path in file_list
+            } == expected_files_top_level
 
             file_list = (
                 Path(tmp_path) / expected_top_level_dir / expected_module_dir
             ).iterdir()
-            assert set(file_list) == expected_files_module
+            assert {str(file_path) for file_path in file_list} == expected_files_module
         finally:
             os.chdir(origin)
 

--- a/src/py/flwr/cli/new/new_test.py
+++ b/src/py/flwr/cli/new/new_test.py
@@ -15,6 +15,7 @@
 """Test for Flower command line interface `new` command."""
 
 import os
+from pathlib import Path
 
 import pytest
 
@@ -54,7 +55,7 @@ def test_render_template() -> None:
 def test_create_file(tmp_path: str) -> None:
     """Test if file with content is created."""
     # Prepare
-    file_path = os.path.join(tmp_path, "test.txt")
+    file_path = Path(tmp_path) / "test.txt"
     content = "Foobar"
 
     # Execute
@@ -92,7 +93,7 @@ def test_new_correct_name(tmp_path: str) -> None:
         }
 
         # Current directory
-        origin = os.getcwd()
+        origin = Path.cwd()
 
         try:
             # Change into the temprorary directory
@@ -101,12 +102,12 @@ def test_new_correct_name(tmp_path: str) -> None:
             new(project_name=project_name, framework=framework, username=username)
 
             # Assert
-            file_list = os.listdir(os.path.join(tmp_path, expected_top_level_dir))
+            file_list = (Path(tmp_path) / expected_top_level_dir).iterdir()
             assert set(file_list) == expected_files_top_level
 
-            file_list = os.listdir(
-                os.path.join(tmp_path, expected_top_level_dir, expected_module_dir)
-            )
+            file_list = (
+                Path(tmp_path) / expected_top_level_dir / expected_module_dir
+            ).iterdir()
             assert set(file_list) == expected_files_module
         finally:
             os.chdir(origin)
@@ -119,7 +120,7 @@ def test_new_incorrect_name(tmp_path: str) -> None:
 
     for project_name in ["My_Flower_App", "My.Flower App"]:
         # Current directory
-        origin = os.getcwd()
+        origin = Path.cwd()
 
         try:
             # Change into the temprorary directory

--- a/src/py/flwr/cli/new/new_test.py
+++ b/src/py/flwr/cli/new/new_test.py
@@ -104,13 +104,13 @@ def test_new_correct_name(tmp_path: str) -> None:
             # Assert
             file_list = (Path(tmp_path) / expected_top_level_dir).iterdir()
             assert {
-                str(file_path) for file_path in file_list
+                file_path.name for file_path in file_list
             } == expected_files_top_level
 
             file_list = (
                 Path(tmp_path) / expected_top_level_dir / expected_module_dir
             ).iterdir()
-            assert {str(file_path) for file_path in file_list} == expected_files_module
+            assert {file_path.name for file_path in file_list} == expected_files_module
         finally:
             os.chdir(origin)
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

### Checklist

- [ ] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.ai/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
