### PR TITLE
ci(datasets:skip) Extend datasets GitHub workflow to trigger test if it changes

### DIFF
--- a/.github/workflows/datasets.yml
+++ b/.github/workflows/datasets.yml
@@ -6,11 +6,15 @@ on:
       - main
     paths:
       - "datasets/**"
+      - ".github/workflows/datasets.yml"
+      - ".github/workflows/datasets-e2e.yml"
   pull_request:
     branches:
       - main
     paths:
       - "datasets/**"
+      - ".github/workflows/datasets.yml"
+      - ".github/workflows/datasets-e2e.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
## Issue
When changing the `.github/workflows/datasets.yaml` the tests for FDS do not run.
### Description
This workflow is constrained to run only if there are changes related to the datasets i.e. `- "datasets/**"` this has to change.

### Related issues/PRs

https://github.com/adap/flower/pull/3865 PR requires this PR to be merged to have the datasets test triggered.

## Proposal
Extend the path to the code that needs to be changed to trigger datasets tests. Apply it for both `push` and `pull_reqest.`
