### PR TITLE
feat(framework) Use dataset caching in `flwr new` templates

### DIFF
--- a/src/py/flwr/cli/new/templates/app/code/task.hf.py.tpl
+++ b/src/py/flwr/cli/new/templates/app/code/task.hf.py.tpl
@@ -10,6 +10,8 @@ from torch.utils.data import DataLoader
 from transformers import AutoTokenizer, DataCollatorWithPadding
 
 from flwr_datasets import FederatedDataset
+from flwr_datasets.partitioner import IidPartitioner
+
 
 warnings.filterwarnings("ignore", category=UserWarning)
 DEVICE = torch.device("cpu")
@@ -22,8 +24,9 @@ def load_data(partition_id: int, num_partitions: int):
     # Only initialize `FederatedDataset` once
     global fds
     if fds is None:
+        partitioner = IidPartitioner(num_partitions=num_partitions)
         fds = FederatedDataset(dataset="stanfordnlp/imdb",
-                               partitioners={"train": num_partitions},
+                               partitioners={"train": partitioner},
                                )
     partition = fds.load_partition(partition_id)
     # Divide data: 80% train, 20% test

--- a/src/py/flwr/cli/new/templates/app/code/task.hf.py.tpl
+++ b/src/py/flwr/cli/new/templates/app/code/task.hf.py.tpl
@@ -15,10 +15,16 @@ warnings.filterwarnings("ignore", category=UserWarning)
 DEVICE = torch.device("cpu")
 CHECKPOINT = "distilbert-base-uncased"  # transformer model checkpoint
 
+fds = None  # Cache FederatedDataset
 
 def load_data(partition_id: int, num_partitions: int):
     """Load IMDB data (training and eval)"""
-    fds = FederatedDataset(dataset="imdb", partitioners={"train": num_partitions})
+    # Only initialize `FederatedDataset` once
+    global fds
+    if fds is None:
+        fds = FederatedDataset(dataset="stanfordnlp/imdb",
+                               partitioners={"train": num_partitions},
+                               )
     partition = fds.load_partition(partition_id)
     # Divide data: 80% train, 20% test
     partition_train_test = partition.train_test_split(test_size=0.2, seed=42)

--- a/src/py/flwr/cli/new/templates/app/code/task.hf.py.tpl
+++ b/src/py/flwr/cli/new/templates/app/code/task.hf.py.tpl
@@ -17,7 +17,9 @@ warnings.filterwarnings("ignore", category=UserWarning)
 DEVICE = torch.device("cpu")
 CHECKPOINT = "distilbert-base-uncased"  # transformer model checkpoint
 
+
 fds = None  # Cache FederatedDataset
+
 
 def load_data(partition_id: int, num_partitions: int):
     """Load IMDB data (training and eval)"""
@@ -25,9 +27,10 @@ def load_data(partition_id: int, num_partitions: int):
     global fds
     if fds is None:
         partitioner = IidPartitioner(num_partitions=num_partitions)
-        fds = FederatedDataset(dataset="stanfordnlp/imdb",
-                               partitioners={"train": partitioner},
-                               )
+        fds = FederatedDataset(
+            dataset="stanfordnlp/imdb",
+            partitioners={"train": partitioner},
+        )
     partition = fds.load_partition(partition_id)
     # Divide data: 80% train, 20% test
     partition_train_test = partition.train_test_split(test_size=0.2, seed=42)

--- a/src/py/flwr/cli/new/templates/app/code/task.mlx.py.tpl
+++ b/src/py/flwr/cli/new/templates/app/code/task.mlx.py.tpl
@@ -42,9 +42,16 @@ def batch_iterate(batch_size, X, y):
         ids = perm[s : s + batch_size]
         yield X[ids], y[ids]
 
+fds = None  # Cache FederatedDataset
 
 def load_data(partition_id: int, num_partitions: int):
-    fds = FederatedDataset(dataset="mnist", partitioners={"train": num_partitions})
+    # Only initialize `FederatedDataset` once
+    global fds
+    if fds is None:
+        fds = FederatedDataset(dataset="ylecun/mnist",
+                               partitioners={"train": num_partitions},
+                               trust_remote_code=True,
+                               )
     partition = fds.load_partition(partition_id)
     partition_splits = partition.train_test_split(test_size=0.2, seed=42)
 

--- a/src/py/flwr/cli/new/templates/app/code/task.mlx.py.tpl
+++ b/src/py/flwr/cli/new/templates/app/code/task.mlx.py.tpl
@@ -10,6 +10,7 @@ from flwr_datasets.partitioner import IidPartitioner
 
 disable_progress_bar()
 
+
 class MLP(nn.Module):
     """A simple MLP."""
 
@@ -43,17 +44,20 @@ def batch_iterate(batch_size, X, y):
         ids = perm[s : s + batch_size]
         yield X[ids], y[ids]
 
+
 fds = None  # Cache FederatedDataset
+
 
 def load_data(partition_id: int, num_partitions: int):
     # Only initialize `FederatedDataset` once
     global fds
     if fds is None:
         partitioner = IidPartitioner(num_partitions=num_partitions)
-        fds = FederatedDataset(dataset="ylecun/mnist",
-                               partitioners={"train": partitioner},
-                               trust_remote_code=True,
-                               )
+        fds = FederatedDataset(
+            dataset="ylecun/mnist",
+            partitioners={"train": partitioner},
+            trust_remote_code=True,
+        )
     partition = fds.load_partition(partition_id)
     partition_splits = partition.train_test_split(test_size=0.2, seed=42)
 

--- a/src/py/flwr/cli/new/templates/app/code/task.mlx.py.tpl
+++ b/src/py/flwr/cli/new/templates/app/code/task.mlx.py.tpl
@@ -5,6 +5,7 @@ import mlx.nn as nn
 import numpy as np
 from datasets.utils.logging import disable_progress_bar
 from flwr_datasets import FederatedDataset
+from flwr_datasets.partitioner import IidPartitioner
 
 
 disable_progress_bar()
@@ -48,8 +49,9 @@ def load_data(partition_id: int, num_partitions: int):
     # Only initialize `FederatedDataset` once
     global fds
     if fds is None:
+        partitioner = IidPartitioner(num_partitions=num_partitions)
         fds = FederatedDataset(dataset="ylecun/mnist",
-                               partitioners={"train": num_partitions},
+                               partitioners={"train": partitioner},
                                trust_remote_code=True,
                                )
     partition = fds.load_partition(partition_id)

--- a/src/py/flwr/cli/new/templates/app/code/task.pytorch.py.tpl
+++ b/src/py/flwr/cli/new/templates/app/code/task.pytorch.py.tpl
@@ -34,7 +34,9 @@ class Net(nn.Module):
         x = F.relu(self.fc2(x))
         return self.fc3(x)
 
+
 fds = None  # Cache FederatedDataset
+
 
 def load_data(partition_id: int, num_partitions: int):
     """Load partition CIFAR10 data."""
@@ -42,9 +44,10 @@ def load_data(partition_id: int, num_partitions: int):
     global fds
     if fds is None:
         partitioner = IidPartitioner(num_partitions=num_partitions)
-        fds = FederatedDataset(dataset="uoft-cs/cifar10",
-                               partitioners={"train": partitioner},
-                               )
+        fds = FederatedDataset(
+            dataset="uoft-cs/cifar10",
+            partitioners={"train": partitioner},
+        )
     partition = fds.load_partition(partition_id)
     # Divide data on each node: 80% train, 20% test
     partition_train_test = partition.train_test_split(test_size=0.2, seed=42)

--- a/src/py/flwr/cli/new/templates/app/code/task.pytorch.py.tpl
+++ b/src/py/flwr/cli/new/templates/app/code/task.pytorch.py.tpl
@@ -6,9 +6,10 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from torch.utils.data import DataLoader
-from torchvision.datasets import CIFAR10
 from torchvision.transforms import Compose, Normalize, ToTensor
 from flwr_datasets import FederatedDataset
+from flwr_datasets.partitioner import IidPartitioner
+
 
 DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
 
@@ -40,8 +41,9 @@ def load_data(partition_id: int, num_partitions: int):
     # Only initialize `FederatedDataset` once
     global fds
     if fds is None:
+        partitioner = IidPartitioner(num_partitions=num_partitions)
         fds = FederatedDataset(dataset="uoft-cs/cifar10",
-                               partitioners={"train": num_partitions},
+                               partitioners={"train": partitioner},
                                )
     partition = fds.load_partition(partition_id)
     # Divide data on each node: 80% train, 20% test

--- a/src/py/flwr/cli/new/templates/app/code/task.pytorch.py.tpl
+++ b/src/py/flwr/cli/new/templates/app/code/task.pytorch.py.tpl
@@ -33,10 +33,16 @@ class Net(nn.Module):
         x = F.relu(self.fc2(x))
         return self.fc3(x)
 
+fds = None  # Cache FederatedDataset
 
 def load_data(partition_id: int, num_partitions: int):
     """Load partition CIFAR10 data."""
-    fds = FederatedDataset(dataset="cifar10", partitioners={"train": num_partitions})
+    # Only initialize `FederatedDataset` once
+    global fds
+    if fds is None:
+        fds = FederatedDataset(dataset="uoft-cs/cifar10",
+                               partitioners={"train": num_partitions},
+                               )
     partition = fds.load_partition(partition_id)
     # Divide data on each node: 80% train, 20% test
     partition_train_test = partition.train_test_split(test_size=0.2, seed=42)

--- a/src/py/flwr/cli/new/templates/app/code/task.tensorflow.py.tpl
+++ b/src/py/flwr/cli/new/templates/app/code/task.tensorflow.py.tpl
@@ -10,13 +10,16 @@ from flwr_datasets.partitioner import IidPartitioner
 # Make TensorFlow log less verbose
 os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"
 
+
 def load_model():
     # Load model and data (MobileNetV2, CIFAR-10)
     model = tf.keras.applications.MobileNetV2((32, 32, 3), classes=10, weights=None)
     model.compile("adam", "sparse_categorical_crossentropy", metrics=["accuracy"])
     return model
 
+
 fds = None  # Cache FederatedDataset
+
 
 def load_data(partition_id, num_partitions):
     # Download and partition dataset
@@ -24,9 +27,10 @@ def load_data(partition_id, num_partitions):
     global fds
     if fds is None:
         partitioner = IidPartitioner(num_partitions=num_partitions)
-        fds = FederatedDataset(dataset="uoft-cs/cifar10",
-                               partitioners={"train": partitioner},
-                               )
+        fds = FederatedDataset(
+            dataset="uoft-cs/cifar10",
+            partitioners={"train": partitioner},
+        )
     partition = fds.load_partition(partition_id, "train")
     partition.set_format("numpy")
 

--- a/src/py/flwr/cli/new/templates/app/code/task.tensorflow.py.tpl
+++ b/src/py/flwr/cli/new/templates/app/code/task.tensorflow.py.tpl
@@ -15,10 +15,16 @@ def load_model():
     model.compile("adam", "sparse_categorical_crossentropy", metrics=["accuracy"])
     return model
 
+fds = None  # Cache FederatedDataset
 
 def load_data(partition_id, num_partitions):
     # Download and partition dataset
-    fds = FederatedDataset(dataset="cifar10", partitioners={"train": num_partitions})
+    # Only initialize `FederatedDataset` once
+    global fds
+    if fds is None:
+        fds = FederatedDataset(dataset="uoft-cs/cifar10",
+                               partitioners={"train": num_partitions},
+                               )
     partition = fds.load_partition(partition_id, "train")
     partition.set_format("numpy")
 

--- a/src/py/flwr/cli/new/templates/app/code/task.tensorflow.py.tpl
+++ b/src/py/flwr/cli/new/templates/app/code/task.tensorflow.py.tpl
@@ -4,6 +4,7 @@ import os
 
 import tensorflow as tf
 from flwr_datasets import FederatedDataset
+from flwr_datasets.partitioner import IidPartitioner
 
 
 # Make TensorFlow log less verbose
@@ -22,8 +23,9 @@ def load_data(partition_id, num_partitions):
     # Only initialize `FederatedDataset` once
     global fds
     if fds is None:
+        partitioner = IidPartitioner(num_partitions=num_partitions)
         fds = FederatedDataset(dataset="uoft-cs/cifar10",
-                               partitioners={"train": num_partitions},
+                               partitioners={"train": partitioner},
                                )
     partition = fds.load_partition(partition_id, "train")
     partition.set_format("numpy")


### PR DESCRIPTION
Caching the `FederatedDataset` object creation and its partitioner makes simulations more efficient.

Additional changes:
* use full names of the dataset e.g. instead of `mnist` use `ylecun/mnist` (related to recent names change on HF Hub; both work, though `mnist` can't be found right now, it's available under the `ylecun/mnist` name)
* `trust_remote_code=True` in `FederatedDataset` for `mnist` dataset to avoid the warning of the dataset that does NOT have file representation on HF Hub (note the remaining dataset in the templates have file representation on HF Hub)
* explicit import of `IidPartitioner` to simplify user to switch to other partitioning schemes (instead of using the `partitioners={split-name: num_partitions}` shorter API now it's `partitioners={split-name: IidPartitioner(num_partitions)}`