### PR TITLE
fix(framework:skip) Convert `UserConfig` to `str` for simulation executor

### DIFF
--- a/src/py/flwr/superexec/simulation.py
+++ b/src/py/flwr/superexec/simulation.py
@@ -129,7 +129,10 @@ class SimulationEngine(Executor):
             ]
 
             if override_config:
-                command.extend(["--run-config", f"{override_config}"])
+                override_config_str = ",".join(
+                    [f"{key}={value}" for key, value in override_config.items()]
+                )
+                command.extend(["--run-config", f"{override_config_str}"])
 
             # Start Simulation
             proc = subprocess.run(  # pylint: disable=consider-using-with

--- a/src/py/flwr/superexec/simulation.py
+++ b/src/py/flwr/superexec/simulation.py
@@ -92,7 +92,7 @@ class SimulationEngine(Executor):
                 user_config_list_str.append(f'{key}="{value}"')
             else:
                 raise ValueError(
-                    "Only types `int`, `float`, `bool` and `str` are supported"
+                    "Only types `bool`, `float`, `int` and `str` are supported"
                 )
 
         user_config_str = ",".join(user_config_list_str)

--- a/src/py/flwr/superexec/simulation.py
+++ b/src/py/flwr/superexec/simulation.py
@@ -32,6 +32,25 @@ from flwr.server.superlink.state.utils import generate_rand_int_from_bytes
 from .executor import Executor, RunTracker
 
 
+def _user_config_to_str(user_config: UserConfig) -> str:
+    """Convert override user config to string."""
+    user_config_list_str = []
+    for key, value in user_config.items():
+        if isinstance(value, bool):
+            user_config_list_str.append(f"{key}={str(value).lower()}")
+        elif isinstance(value, (int, float)):
+            user_config_list_str.append(f"{key}={value}")
+        elif isinstance(value, str):
+            user_config_list_str.append(f'{key}="{value}"')
+        else:
+            raise ValueError(
+                "Only types `bool`, `float`, `int` and `str` are supported"
+            )
+
+    user_config_str = ",".join(user_config_list_str)
+    return user_config_str
+
+
 class SimulationEngine(Executor):
     """Simulation engine executor.
 
@@ -79,24 +98,6 @@ class SimulationEngine(Executor):
                 "`num-supernodes` must not be `None`, it must be a valid "
                 "positive integer."
             )
-
-    def _user_config_to_str(self, user_config: UserConfig) -> str:
-        """Convert override user config to string."""
-        user_config_list_str = []
-        for key, value in user_config.items():
-            if isinstance(value, bool):
-                user_config_list_str.append(f"{key}={str(value).lower()}")
-            elif isinstance(value, (int, float)):
-                user_config_list_str.append(f"{key}={value}")
-            elif isinstance(value, str):
-                user_config_list_str.append(f'{key}="{value}"')
-            else:
-                raise ValueError(
-                    "Only types `bool`, `float`, `int` and `str` are supported"
-                )
-
-        user_config_str = ",".join(user_config_list_str)
-        return user_config_str
 
     @override
     def start_run(
@@ -147,8 +148,7 @@ class SimulationEngine(Executor):
             ]
 
             if override_config:
-                override_config_str = self._user_config_to_str(override_config)
-                print(override_config_str)
+                override_config_str = _user_config_to_str(override_config)
                 command.extend(["--run-config", f"{override_config_str}"])
 
             # Start Simulation

--- a/src/py/flwr/superexec/simulation.py
+++ b/src/py/flwr/superexec/simulation.py
@@ -80,6 +80,24 @@ class SimulationEngine(Executor):
                 "positive integer."
             )
 
+    def _user_config_to_str(self, user_config: UserConfig) -> str:
+        """Convert override user config to string."""
+        user_config_list_str = []
+        for key, value in user_config.items():
+            if isinstance(value, bool):
+                user_config_list_str.append(f"{key}={str(value).lower()}")
+            elif isinstance(value, (int, float)):
+                user_config_list_str.append(f"{key}={value}")
+            elif isinstance(value, str):
+                user_config_list_str.append(f'{key}="{value}"')
+            else:
+                raise ValueError(
+                    "Only types `int`, `float`, `bool` and `str` are supported"
+                )
+
+        user_config_str = ",".join(user_config_list_str)
+        return user_config_str
+
     @override
     def start_run(
         self,
@@ -129,9 +147,8 @@ class SimulationEngine(Executor):
             ]
 
             if override_config:
-                override_config_str = ",".join(
-                    [f"{key}={value}" for key, value in override_config.items()]
-                )
+                override_config_str = self._user_config_to_str(override_config)
+                print(override_config_str)
                 command.extend(["--run-config", f"{override_config_str}"])
 
             # Start Simulation


### PR DESCRIPTION
The `SuperExec` uses a dictionary to store the user configs that are to be overrided from `flwr run`. In order to pass these to the `flower-simulation` we need to convert them back to the format `key=value,anotherkey=anothervalue`