### PR TITLE
refactor(framework) Improve `flwr run` CLI arguments

### DIFF
--- a/src/py/flwr/cli/run/run.py
+++ b/src/py/flwr/cli/run/run.py
@@ -37,18 +37,21 @@ from flwr.proto.exec_pb2_grpc import ExecStub
 def run(
     app_dir: Annotated[
         Path,
-        typer.Argument(help="Path of the Flower project to run"),
+        typer.Argument(help="Path of the Flower project to run."),
     ] = Path("."),
-    federation_name: Annotated[
+    federation: Annotated[
         Optional[str],
-        typer.Argument(help="Name of the federation to run the app on"),
+        typer.Argument(help="Name of the federation to run the app on."),
     ] = None,
     config_overrides: Annotated[
         Optional[List[str]],
         typer.Option(
             "--run-config",
             "-c",
-            help="Override configuration key-value pairs",
+            help="Override configuration key-value pairs, should be of the format:\n\n"
+            "`--run-config key1=value1,key2=value2 --run-config key3=value3`\n\n"
+            "Note that `key1`, `key2`, and `key3` in this example need to exist "
+            "inside the `pyproject.toml` in order to be properly overriden.",
         ),
     ] = None,
 ) -> None:
@@ -78,11 +81,9 @@ def run(
 
     typer.secho("Success", fg=typer.colors.GREEN)
 
-    federation_name = federation_name or config["tool"]["flwr"]["federations"].get(
-        "default"
-    )
+    federation = federation or config["tool"]["flwr"]["federations"].get("default")
 
-    if federation_name is None:
+    if federation is None:
         typer.secho(
             "❌ No federation name was provided and the project's `pyproject.toml` "
             "doesn't declare a default federation (with a SuperExec address or an "
@@ -93,13 +94,13 @@ def run(
         raise typer.Exit(code=1)
 
     # Validate the federation exists in the configuration
-    federation = config["tool"]["flwr"]["federations"].get(federation_name)
-    if federation is None:
+    federation_config = config["tool"]["flwr"]["federations"].get(federation)
+    if federation_config is None:
         available_feds = {
             fed for fed in config["tool"]["flwr"]["federations"] if fed != "default"
         }
         typer.secho(
-            f"❌ There is no `{federation_name}` federation declared in the "
+            f"❌ There is no `{federation}` federation declared in the "
             "`pyproject.toml`.\n The following federations were found:\n\n"
             + "\n".join(available_feds),
             fg=typer.colors.RED,
@@ -107,14 +108,14 @@ def run(
         )
         raise typer.Exit(code=1)
 
-    if "address" in federation:
-        _run_with_superexec(federation, app_dir, config_overrides)
+    if "address" in federation_config:
+        _run_with_superexec(federation_config, app_dir, config_overrides)
     else:
-        _run_without_superexec(app_dir, federation, federation_name, config_overrides)
+        _run_without_superexec(app_dir, federation_config, federation, config_overrides)
 
 
 def _run_with_superexec(
-    federation: Dict[str, Any],
+    federation_config: Dict[str, Any],
     app_dir: Optional[Path],
     config_overrides: Optional[List[str]],
 ) -> None:
@@ -123,8 +124,8 @@ def _run_with_superexec(
         """Log channel connectivity."""
         log(DEBUG, channel_connectivity)
 
-    insecure_str = federation.get("insecure")
-    if root_certificates := federation.get("root-certificates"):
+    insecure_str = federation_config.get("insecure")
+    if root_certificates := federation_config.get("root-certificates"):
         root_certificates_bytes = Path(root_certificates).read_bytes()
         if insecure := bool(insecure_str):
             typer.secho(
@@ -152,7 +153,7 @@ def _run_with_superexec(
             raise typer.Exit(code=1)
 
     channel = create_channel(
-        server_address=federation["address"],
+        server_address=federation_config["address"],
         insecure=insecure,
         root_certificates=root_certificates_bytes,
         max_message_length=GRPC_MAX_MESSAGE_LENGTH,
@@ -168,7 +169,9 @@ def _run_with_superexec(
         override_config=user_config_to_proto(
             parse_config_args(config_overrides, separator=",")
         ),
-        federation_config=user_config_to_proto(flatten_dict(federation.get("options"))),
+        federation_config=user_config_to_proto(
+            flatten_dict(federation_config.get("options"))
+        ),
     )
     res = stub.StartRun(req)
     typer.secho(f"🎊 Successfully started run {res.run_id}", fg=typer.colors.GREEN)
@@ -176,18 +179,18 @@ def _run_with_superexec(
 
 def _run_without_superexec(
     app_path: Optional[Path],
-    federation: Dict[str, Any],
-    federation_name: str,
+    federation_config: Dict[str, Any],
+    federation: str,
     config_overrides: Optional[List[str]],
 ) -> None:
     try:
-        num_supernodes = federation["options"]["num-supernodes"]
+        num_supernodes = federation_config["options"]["num-supernodes"]
     except KeyError as err:
         typer.secho(
             "❌ The project's `pyproject.toml` needs to declare the number of"
             " SuperNodes in the simulation. To simulate 10 SuperNodes,"
             " use the following notation:\n\n"
-            f"[tool.flwr.federations.{federation_name}]\n"
+            f"[tool.flwr.federations.{federation}]\n"
             "options.num-supernodes = 10\n",
             fg=typer.colors.RED,
             bold=True,


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

### Checklist

- [ ] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.ai/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
