### PR TITLE
fix(framework) Remove `str` casting for node config

### DIFF
--- a/src/py/flwr/cli/new/templates/app/code/client.hf.py.tpl
+++ b/src/py/flwr/cli/new/templates/app/code/client.hf.py.tpl
@@ -50,8 +50,8 @@ def client_fn(context: Context):
         CHECKPOINT, num_labels=2
     ).to(DEVICE)
 
-    partition_id = int(context.node_config["partition-id"])
-    num_partitions = int(context.node_config["num-partitions"])
+    partition_id = context.node_config["partition-id"]
+    num_partitions = context.node_config["num-partitions"]
     trainloader, valloader = load_data(partition_id, num_partitions)
     local_epochs = context.run_config["local-epochs"]
 

--- a/src/py/flwr/cli/new/templates/app/code/client.mlx.py.tpl
+++ b/src/py/flwr/cli/new/templates/app/code/client.mlx.py.tpl
@@ -70,8 +70,8 @@ class FlowerClient(NumPyClient):
 
 
 def client_fn(context: Context):
-    partition_id = int(context.node_config["partition-id"])
-    num_partitions = int(context.node_config["num-partitions"])
+    partition_id = context.node_config["partition-id"]
+    num_partitions = context.node_config["num-partitions"]
     data = load_data(partition_id, num_partitions)
 
     num_layers = context.run_config["num-layers"]

--- a/src/py/flwr/cli/new/templates/app/code/client.pytorch.py.tpl
+++ b/src/py/flwr/cli/new/templates/app/code/client.pytorch.py.tpl
@@ -42,8 +42,8 @@ class FlowerClient(NumPyClient):
 def client_fn(context: Context):
     # Load model and data
     net = Net().to(DEVICE)
-    partition_id = int(context.node_config["partition-id"])
-    num_partitions = int(context.node_config["num-partitions"])
+    partition_id = context.node_config["partition-id"]
+    num_partitions = context.node_config["num-partitions"]
     trainloader, valloader = load_data(partition_id, num_partitions)
     local_epochs = context.run_config["local-epochs"]
 

--- a/src/py/flwr/cli/new/templates/app/code/client.sklearn.py.tpl
+++ b/src/py/flwr/cli/new/templates/app/code/client.sklearn.py.tpl
@@ -69,8 +69,8 @@ class FlowerClient(NumPyClient):
 
 
 def client_fn(context: Context):
-    partition_id = int(context.node_config["partition-id"])
-    num_partitions = int(context.node_config["num-partitions"])
+    partition_id = context.node_config["partition-id"]
+    num_partitions = context.node_config["num-partitions"]
     fds = FederatedDataset(dataset="mnist", partitioners={"train": num_partitions})
     dataset = fds.load_partition(partition_id, "train").with_format("numpy")
 

--- a/src/py/flwr/cli/new/templates/app/code/client.tensorflow.py.tpl
+++ b/src/py/flwr/cli/new/templates/app/code/client.tensorflow.py.tpl
@@ -44,8 +44,8 @@ def client_fn(context: Context):
     # Load model and data
     net = load_model()
 
-    partition_id = int(context.node_config["partition-id"])
-    num_partitions = int(context.node_config["num-partitions"])
+    partition_id = context.node_config["partition-id"]
+    num_partitions = context.node_config["num-partitions"]
     x_train, y_train, x_test, y_test = load_data(partition_id, num_partitions)
     epochs = context.run_config["local-epochs"]
     batch_size = context.run_config["batch-size"]

--- a/src/py/flwr/server/superlink/fleet/vce/vce_api.py
+++ b/src/py/flwr/server/superlink/fleet/vce/vce_api.py
@@ -72,8 +72,8 @@ def _register_node_states(
         node_states[node_id] = NodeState(
             node_id=node_id,
             node_config={
-                PARTITION_ID_KEY: str(partition_id),
-                NUM_PARTITIONS_KEY: str(num_partitions),
+                PARTITION_ID_KEY: partition_id,
+                NUM_PARTITIONS_KEY: num_partitions,
             },
         )
 


### PR DESCRIPTION
Remove the `str()` casting of `NodeState`'s config when pre-registering context for simulation. This effectively enables removing the `str()` casting in `client_fn` in our templates.