### PR TITLE
fix(framework) Remove trust_remote_code from FederatedDataset arguments in mlx template

### DIFF
--- a/src/py/flwr/cli/new/templates/app/code/task.mlx.py.tpl
+++ b/src/py/flwr/cli/new/templates/app/code/task.mlx.py.tpl
@@ -56,7 +56,6 @@ def load_data(partition_id: int, num_partitions: int):
         fds = FederatedDataset(
             dataset="ylecun/mnist",
             partitioners={"train": partitioner},
-            trust_remote_code=True,
         )
     partition = fds.load_partition(partition_id)
     partition_splits = partition.train_test_split(test_size=0.2, seed=42)


### PR DESCRIPTION
## Issue
`trust_remote_code` is handled as kwargs in FDS 0.3.0 but not yet added in 0.2.0 FDS


## Proposal
remove `trust_remote_code` from templates
