### PR TITLE
docs(datasets) Improve docs code examples copying experience

### DIFF
--- a/datasets/doc/source/conf.py
+++ b/datasets/doc/source/conf.py
@@ -180,3 +180,7 @@ mermaid_version = ""
 # -- Options for MyST config  -------------------------------------
 # Enable this option to link to headers (`#`, `##`, or `###`)
 myst_heading_anchors = 3
+
+# -- Options for sphinx_copybutton -------------------------------------
+copybutton_exclude = '.linenos, .gp, .go'
+copybutton_prompt_text = ">>> "


### PR DESCRIPTION
## Issue
When copying the code from the docs examples, everything is copied, but things like ">>> " shouldn't be copied.

### Description
The user does not need the prompt or the output to be copied.
e.g. if you go to `DiricheltPartitioner` and copy the code example you get exaclyt:
```
>>> from flwr_datasets import FederatedDataset
>>> from flwr_datasets.partitioner import DirichletPartitioner
>>>
>>> partitioner = DirichletPartitioner(num_partitions=10, partition_by="label",
>>>                                    alpha=0.5, min_partition_size=10,
>>>                                    self_balancing=True)
>>> fds = FederatedDataset(dataset="mnist", partitioners={"train": partitioner})
>>> partition = fds.load_partition(0)
>>> print(partition[0])  # Print the first example
{'image': <PIL.PngImagePlugin.PngImageFile image mode=L size=28x28 at 0x127B92170>,
'label': 4}
>>> partition_sizes = [
>>>     len(fds.load_partition(partition_id)) for partition_id in range(10)
>>> ]
>>> print(sorted(partition_sizes))
[2134, 2615, 3646, 6011, 6170, 6386, 6715, 7653, 8435, 10235]
``` 
So they manually need to strip the code to have it executed!

## Proposal
Configure the `sphinx_copybutton` extension not to copy 
* ">>> "
* code output
### Description
The config is update is based this explanation: https://sphinx-copybutton.readthedocs.io/en/latest/use.html#automatic-exclusion-of-prompts-from-the-copies

Here's the explanation of the configuration update in the `copybutton_exclude` in `conf.py` (what gets excluded from being copied):
* the `.linenos` - the line numbers (probably needed for the python console python style of examples [which we don't have])
* the `.gp` is for the prompts (the ">>> ")
* the `.go` is for the output of the code

Now the copied example looks like this:
```
from flwr_datasets import FederatedDataset
from flwr_datasets.partitioner import DirichletPartitioner

partitioner = DirichletPartitioner(num_partitions=10, partition_by="label",
                                   alpha=0.5, min_partition_size=10,
                                   self_balancing=True)
fds = FederatedDataset(dataset="mnist", partitioners={"train": partitioner})
partition = fds.load_partition(0)
print(partition[0])  # Print the first example


partition_sizes = [
    len(fds.load_partition(partition_id)) for partition_id in range(10)
]
print(sorted(partition_sizes))
```
which user can directly execute


Note: I can make the same changes for `flwr`
