### PR TITLE
docs(datasets) Clarify the partitioner parameter docs of FederatedDataset

### DIFF
--- a/datasets/flwr_datasets/federated_dataset.py
+++ b/datasets/flwr_datasets/federated_dataset.py
@@ -54,9 +54,11 @@ class FederatedDataset:
         no operation is applied.
     partitioners : Dict[str, Union[Partitioner, int]]
         A dictionary mapping the Dataset split (a `str`) to a `Partitioner` or an `int`
-        (representing the number of IID partitions that this split should be partitioned
-        into). One or multiple `Partitioner` objects can be specified in that manner,
-        but at most, one per split.
+        (representing the number of IID partitions that this split should be
+        partitioned into, i.e., using the default partitioner
+        `IidPartitioner <https://flower.ai/docs/datasets/ref-api/flwr_
+        datasets.partitioner.IidPartitioner.html>`_). One or multiple `Partitioner`
+        objects can be specified in that manner, but at most, one per split.
     shuffle : bool
         Whether to randomize the order of samples. Applied prior to preprocessing
         operations, speratelly to each of the present splits in the dataset. It uses


### PR DESCRIPTION
## Issue
The description of the int specification of the `partitioners` param of the `FederatedDataset` can be more descriptive.

## Proposal
Clarify what it means to specify the `partitioners` as an `int`.
