### PR TITLE
fix(datasets:skip) Fix ShardPartitioner typo

### DIFF
--- a/datasets/flwr_datasets/mock_utils_test.py
+++ b/datasets/flwr_datasets/mock_utils_test.py
@@ -399,7 +399,7 @@ def _load_mocked_dataset_by_partial_download(
         The streaming mode has a specific type of accessing the data, the first tuple
         value is how many samples to skip, the second is how many samples to take. Due
         to this mechanism, diverse samples can be taken (especially if the dataset is
-        sorted by the natual_id for NaturalIdPartitioner).
+        sorted by the natural_id for NaturalIdPartitioner).
     subset_name: Optional[str]
         Name of the subset (passed to load_dataset) e.g. "v0.01" for speech_commands.
 

--- a/datasets/flwr_datasets/partitioner/shard_partitioner.py
+++ b/datasets/flwr_datasets/partitioner/shard_partitioner.py
@@ -149,15 +149,15 @@ class ShardPartitioner(Partitioner):  # pylint: disable=R0902
     ) -> None:
         super().__init__()
         # Attributes based on the constructor
-        _check_if_natual_number(num_partitions, "num_partitions")
+        _check_if_natural_number(num_partitions, "num_partitions")
         self._num_partitions = num_partitions
         self._partition_by = partition_by
-        _check_if_natual_number(
+        _check_if_natural_number(
             num_shards_per_partition, "num_shards_per_partition", True
         )
         self._num_shards_per_partition = num_shards_per_partition
         self._num_shards_used: Optional[int] = None
-        _check_if_natual_number(shard_size, "shard_size", True)
+        _check_if_natural_number(shard_size, "shard_size", True)
         self._shard_size = shard_size
         self._keep_incomplete_shard = keep_incomplete_shard
         self._shuffle = shuffle
@@ -360,7 +360,7 @@ class ShardPartitioner(Partitioner):  # pylint: disable=R0902
                 )
 
 
-def _check_if_natual_number(
+def _check_if_natural_number(
     number: Optional[int], parameter_name: str, none_acceptable: bool = False
 ) -> None:
     if none_acceptable and number is None:


### PR DESCRIPTION
## Issue

### Description

natual -> natural in ShardPartitioner implementation and one comment.




