### PR TITLE
feat(datasets) Clarify how the dataloader works with HF dataset

### DIFF
--- a/datasets/doc/source/tutorial-quickstart.ipynb
+++ b/datasets/doc/source/tutorial-quickstart.ipynb
@@ -441,6 +441,36 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b93678a5",
+   "metadata": {},
+   "source": "The `Dataloader` created this way does not return a `Tuple` when iterating over it but a `Dict` with the names of the columns as keys and features as values. Look below for an example."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5edd3ce2",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Return type when iterating over dataloader: <class 'dict'>\n",
+      "torch.Size([64, 3, 32, 32])\n",
+      "torch.Size([64])\n"
+     ]
+    }
+   ],
+   "source": [
+    "for batch in dataloader:\n",
+    "    print(f\"Return type when iterating over a dataloader: {type(batch)}\")\n",
+    "    print(batch[\"img\"].shape)\n",
+    "    print(batch[\"label\"].shape)\n",
+    "    break"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "71531613",
    "metadata": {},
    "source": [


### PR DESCRIPTION
## Issue
Due to the key to value datasets.Dataset the behavior is slightly different of wrapping the Dataloader around it. This difference is not explained.

## Proposal
Add an explanation in the `tutorial-quickstart.`
