### PR TITLE
docs(framework) Fix quickstart comments

### DIFF
--- a/doc/source/tutorial-quickstart-pytorch.rst
+++ b/doc/source/tutorial-quickstart-pytorch.rst
@@ -159,7 +159,7 @@ Implementing :code:`NumPyClient` usually means defining the following methods
 #. :code:`fit`
     * set the local model weights
     * train the local model
-    * receive the updated local model weights
+    * return the updated local model weights
 #. :code:`evaluate`
     * test the local model
 

--- a/doc/source/tutorial-quickstart-scikitlearn.rst
+++ b/doc/source/tutorial-quickstart-scikitlearn.rst
@@ -123,7 +123,7 @@ Implementing :code:`NumPyClient` usually means defining the following methods
 #. :code:`fit`
     * set the local model weights
     * train the local model
-    * receive the updated local model weights
+    * return the updated local model weights
 #. :code:`evaluate`
     * test the local model
 


### PR DESCRIPTION


### Description

Correct the description of the sample document of the client

<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->

### Checklist

- [ ] Implement proposed change
- [ ] Write tests
- [x] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)
