### PR TITLE
feat(framework) Add code for async FL following the FedAsync and PAFLM algorithms for async FL.

### DIFF
--- a/src/py/flwr/server/async_client_manager.py
+++ b/src/py/flwr/server/async_client_manager.py
@@ -1,0 +1,111 @@
+
+from typing import List, Dict, Optional
+from flwr.server.client_manager import SimpleClientManager
+from flwr.server.client_proxy import ClientProxy
+from flwr.server.criterion import Criterion
+import threading
+from flwr.common.logger import log
+from logging import INFO, ERROR
+import random
+import time
+
+class AsyncClientManager(SimpleClientManager):
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.free_clients = {}
+        self._cv_free = threading.Condition()
+    
+    def set_client_to_busy(self, client_id: str):
+        if client_id not in self.free_clients.keys() or client_id not in self.clients.keys():
+            log(ERROR, "Client not found in free_clients")
+            return False
+        else:
+            with self._cv_free:
+                self.free_clients.pop(client_id)
+                self._cv_free.notify_all()
+            return True
+    
+    def set_client_to_free(self, client_id):
+        if client_id not in self.clients.keys():
+            log(ERROR, "Client not found in clients")
+            return False
+        else:
+            with self._cv_free:
+                self.free_clients[client_id] = self.clients[client_id]
+                self._cv_free.notify_all()
+            return True
+
+    # waits for `num_free_clients` to be free
+    def wait_for_free(self, num_free_clients: int, timeout: int = 86400) -> bool:
+        with self._cv_free:
+            return self._cv_free.wait_for(
+                lambda: len(self.free_clients) >= num_free_clients, timeout=5
+            )
+    
+    def register(self, client: ClientProxy) -> bool:
+        log(INFO, "Registering client with id: %s", client.cid)
+        if super().register(client):
+            self.set_client_to_free(client.cid)
+            return True
+        else:
+            return False
+        
+    def unregister(self, client: ClientProxy) -> None:
+        log(INFO, "Unregistering client with id: %s", client.cid)
+        if client.cid in self.free_clients:
+            self.set_client_to_busy(client.cid)
+        else:
+            return super().unregister(client)
+        
+
+    def num_free(self) -> int:
+        return len(self.free_clients)
+
+    def all_free(self) -> Dict[str, ClientProxy]:
+        return list(self.free_clients)
+
+    def sample_free(
+        self,
+        num_free_clients: int,
+        min_num_free_clients: int = 0,
+        criterion: Criterion = None,
+    ) -> List[ClientProxy]:
+        log(INFO, "Sampling %s clients, min %s", num_free_clients, min_num_free_clients)
+        """Sample a number of Flower ClientProxy instances."""
+        # Block until at least num_clients are free. # It always samples from all clients.
+        if min_num_free_clients is None:
+            min_num_free_clients = num_free_clients
+        self.wait_for_free(min_num_free_clients)
+            
+        # Sample clients which meet the criterion
+        available_cids = list(self.free_clients)
+        if criterion is not None:
+            available_cids = [
+                cid for cid in available_cids if criterion.select(self.free_clients[cid])
+            ]
+
+        if num_free_clients > len(available_cids):
+            log(
+                INFO,
+                "Sampling failed: number of available free clients"
+                " (%s) is less than number of requested free clients (%s).",
+                len(available_cids),
+                num_free_clients,
+            )
+            return []
+
+        sampled_cids = random.sample(available_cids, num_free_clients)
+        ret_list = [self.free_clients[cid] for cid in sampled_cids]
+        for cid in sampled_cids:
+            self.set_client_to_busy(cid)
+        return ret_list
+
+        
+    def sample(
+        self,
+        num_clients: int,
+        min_num_clients: Optional[int] = None,
+        criterion: Optional[Criterion] = None,
+    ) -> List[ClientProxy]:
+        return self.sample_free(num_clients, min_num_clients, criterion)

--- a/src/py/flwr/server/async_history.py
+++ b/src/py/flwr/server/async_history.py
@@ -1,0 +1,86 @@
+"""
+A wrapper around the flower History class that offers centralized and distributed metrics per timestamp instead of per round.
+It also groups distributed_fit metrics per client instead of per client instead of per round.
+
+losses_centralized: [ (timestamp1, value1) , .... ]
+
+metrics_centralized: {
+    "accuracy": [ (timestamp1, value1) , .... ]
+}
+metrics_distributed: {
+    "client_ids": [ (timestamp1, [cid1, cid2, cid3]) ... ]
+    "accuracy": [ (timestamp1, [value1, value2, value3]) , .... ]
+} 
+metrics_distributed_fit_async: {
+    "accuracy": { 
+        cid1: [
+            (timestamp1, value1), 
+            (timestamp2, value2), 
+            (timestamp3, value3)
+            ...
+            ],
+        ...
+    }
+    ...
+}
+# Metrics collected after each merge into the global model. (Global model evaluated centrally after merge.) 
+
+DEPRECATED: This takes too much time and serializes the training process. Will be removed in the future.
+
+metrics_centralized_async: {
+    "accuracy": [ (timestamp1, value1) , .... ]
+}
+Note: value1 is collected at timestamp1 in metrics_distributed_fit.
+"""
+from flwr.server.history import History
+from typing import Dict
+from flwr.common.typing import Scalar
+from threading import Lock
+
+class AsyncHistory(History):
+
+    def __init__(self) -> None:
+        self.metrics_distributed_fit_async = {}
+        self.metrics_centralized_async = {} # metrics aggregated after each merge into the global model.
+        self.losses_centralized_async = []
+        super().__init__()
+
+    def add_metrics_distributed_fit_async(
+        self, client_id: str, metrics: Dict[str, Scalar], timestamp: float
+    ) -> None:
+        """Add metrics entries (from distributed fit)."""
+        lock = Lock()
+        with lock:
+            for key in metrics:
+                if key not in self.metrics_distributed_fit_async:
+                    self.metrics_distributed_fit_async[key] = {}
+                if client_id not in self.metrics_distributed_fit_async[key]:
+                    self.metrics_distributed_fit_async[key][client_id] = []
+                self.metrics_distributed_fit_async[key][client_id].append((timestamp, metrics[key]))
+
+    def add_metrics_centralized_async(self, metrics: Dict[str, Scalar], timestamp: float) -> None:
+        """Add metrics entries (from centralized evaluation)."""
+        lock = Lock()
+        with lock:
+            for metric in metrics:
+                if metric not in self.metrics_centralized_async:
+                    self.metrics_centralized_async[metric] = []
+                self.metrics_centralized_async[metric].append((timestamp, metrics[metric]))
+
+    def add_loss_centralized_async(self, timestamp: float, loss: float) -> None:
+        """Add loss entries (from centralized evaluation)."""
+        lock = Lock()
+        with lock:
+            self.losses_centralized_async.append((timestamp, loss))
+
+    def add_loss_centralized(self, timestamp: float, loss: float) -> None:
+        return super().add_loss_centralized(timestamp, loss)
+
+    def add_loss_distributed(self, timestamp: float, loss: float) -> None:
+        return super().add_loss_distributed(timestamp, loss)
+    
+    def add_metrics_centralized(self, timestamp: float, metrics: Dict[str, bool | bytes | float | int | str]) -> None:
+        return super().add_metrics_centralized(timestamp, metrics)
+    
+    def add_metrics_distributed(self, timestamp: float, metrics: Dict[str, bool | bytes | float | int | str]) -> None:
+        return super().add_metrics_distributed(timestamp, metrics)

--- a/src/py/flwr/server/async_server.py
+++ b/src/py/flwr/server/async_server.py
@@ -1,0 +1,531 @@
+# Copyright 2020 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Flower server."""
+
+import os
+import pickle
+from datetime import datetime
+import concurrent.futures
+from concurrent.futures import ThreadPoolExecutor
+from threading import Lock, Thread, Timer
+from logging import DEBUG, INFO, WARNING
+from typing import Dict, List, Optional, Tuple, Union
+from time import sleep, time
+
+from flwr.common import (
+    Code,
+    DisconnectRes,
+    EvaluateIns,
+    EvaluateRes,
+    FitIns,
+    FitRes,
+    Parameters,
+    ReconnectIns,
+    Scalar,
+)
+from flwr.common.logger import log
+from flwr.common.typing import GetParametersIns, FitIns
+from flwr.common import parameters_to_ndarrays, ndarrays_to_parameters
+from flwr.server.client_manager import ClientManager
+from flwr.server.client_proxy import ClientProxy
+from flwr.server.history import History
+from flwr.server.strategy import FedAvg, Strategy
+import flwr.server.strategy.aggregate as agg
+from flwr.server.server import Server
+from flower_async.async_history import AsyncHistory
+
+from flower_async.async_client_manager import AsyncClientManager
+from flower_async.async_strategy import AsynchronousStrategy
+
+FitResultsAndFailures = Tuple[
+    List[Tuple[ClientProxy, FitRes]],
+    List[Union[Tuple[ClientProxy, FitRes], BaseException]],
+]
+EvaluateResultsAndFailures = Tuple[
+    List[Tuple[ClientProxy, EvaluateRes]],
+    List[Union[Tuple[ClientProxy, EvaluateRes], BaseException]],
+]
+ReconnectResultsAndFailures = Tuple[
+    List[Tuple[ClientProxy, DisconnectRes]],
+    List[Union[Tuple[ClientProxy, DisconnectRes], BaseException]],
+]
+
+
+class AsyncServer(Server):
+    """Flower server implementing asynchronous FL."""
+
+    def __init__(
+        self,
+        strategy: Strategy,
+        client_manager: ClientManager, # AsyncClientManager,
+        async_strategy: AsynchronousStrategy,
+        base_conf_dict,
+        total_train_time: int = 85,
+        waiting_interval: int = 5,
+        max_workers: int = 2,
+    ):
+        self.async_strategy = async_strategy
+        self.total_train_time = total_train_time
+        # number of seconds waited to start a new set of clients (and evaluate the previous ones)
+        self.waiting_interval = waiting_interval
+        self.strategy = strategy
+        self._client_manager = client_manager
+        self.max_workers = max_workers
+        self.client_data_percs: Dict[str, List[float]] = {} # dictionary tracking the data percentages sent to the client
+        for key, value in base_conf_dict.items():
+            setattr(self, key, value)
+        self.start_timestamp = 0.0
+        self.end_timestamp = 0.0
+
+    def set_new_params(self, new_params: Parameters):
+        lock = Lock()
+        with lock:
+            self.parameters = new_params
+
+    # pylint: disable=too-many-locals
+
+    def fit(self, num_rounds: int, timeout: Optional[float]) -> History:
+        """Run federated averaging for a number of rounds."""
+        history = AsyncHistory()
+
+        # Initialize parameters
+        log(INFO, "Initializing global parameters")
+        self.parameters = self._get_initial_parameters(timeout=timeout)
+        log(INFO, "Evaluating initial parameters")
+        res = self.strategy.evaluate(0, parameters=self.parameters)
+        if res is not None:
+            log(
+                INFO,
+                "initial parameters (loss, other metrics): %s, %s",
+                res[0],
+                res[1],
+            )
+            history.add_loss_centralized(timestamp=time(), loss=res[0])
+            history.add_metrics_centralized(timestamp=time(), metrics=res[1])
+
+        # Run federated learning for num_rounds
+        log(INFO, "FL starting")
+        executor = ThreadPoolExecutor(max_workers=self.max_workers)
+        start_time = time()
+        end_timestamp = time() + self.total_train_time
+        self.end_timestamp = end_timestamp
+        self.start_timestamp = time()
+        counter = 1
+        self.fit_round(
+            server_round=0,
+            timeout=timeout,
+            executor=executor,
+            end_timestamp=end_timestamp,
+            history=history
+        )
+
+        best_loss = float('inf')
+        patience_init = 50 # n times the `waiting interval` seconds
+        patience = patience_init
+        
+        while time() - start_time < self.total_train_time:
+            # If the clients are to be started periodically, move fit_round here and remove the executor.submit lines from _handle_finished_future_after_fit
+            sleep(self.waiting_interval)
+            loss = self.evaluate_centralized(counter, history)
+            if loss is not None:
+                if loss < best_loss - 1e-4:
+                    best_loss = loss
+                    patience = patience_init
+                else:
+                    patience -= 1
+                if patience == 0:
+                    log(INFO, "Early stopping")
+                    break
+            #self.evaluate_decentralized(counter, history, timeout)
+            counter += 1
+            
+
+        executor.shutdown(wait=True, cancel_futures=True)
+        log(INFO, "FL finished")
+        end_time = time()
+        self.save_model()
+        elapsed = end_time - start_time
+        log(INFO, "FL finished in %s", elapsed)
+        return history
+    
+    def save_model(self):
+        # Save the model
+        timestamp = datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
+        
+        model_path = f"models/model_async_{timestamp}.pkl"
+        if not os.path.exists("models"):
+            os.makedirs("models")
+        with open(model_path, "wb") as f:
+            log(DEBUG, "Saving model to %s", model_path)
+            pickle.dump(self.parameters, f)
+        log(INFO, "Model saved to %s", model_path)
+
+
+
+    def evaluate_centralized(self, current_round: int, history: History):
+        res_cen = self.strategy.evaluate(
+            current_round, parameters=self.parameters)
+        if res_cen is not None:
+            loss_cen, metrics_cen = res_cen
+            metrics_cen['end_timestamp'] = self.end_timestamp
+            metrics_cen['start_timestamp'] = self.start_timestamp
+            history.add_loss_centralized(
+                timestamp=time(), loss=loss_cen)
+            history.add_metrics_centralized(
+                timestamp=time(), metrics=metrics_cen
+            )
+            log(INFO, "Centralized evaluation: loss %s, f1=%s", loss_cen, metrics_cen['f1'])
+            return loss_cen
+        else:
+            return None
+
+
+    def evaluate_decentralized(self, current_round: int, history: History, timeout: Optional[float]):
+        """Evaluate model on a sample of available clients
+        NOTE: Only call this method if clients are started periodically.
+        This is not to be called if the clients are starting immediately after they finish! This is because the ray actor cannot process
+        two concurrent requests to the same client. They get mixed up and future.result() in client_fit can return an
+        EvaluateRes instead of FitRes.
+        """
+        res_fed = self.evaluate_round(
+            server_round=current_round, timeout=timeout)
+        if res_fed is not None:
+            loss_fed, evaluate_metrics_fed, (results, _) = res_fed
+            if loss_fed is not None:
+                client_ids = [client.cid for client, _ in results]
+                evaluate_metrics_fed['client_ids'] = client_ids
+                history.add_loss_distributed(
+                    timestamp=time(), loss=loss_fed
+                )
+                history.add_metrics_distributed(
+                    timestamp=time(), metrics=evaluate_metrics_fed
+                )
+
+    def evaluate_round(
+        self,
+        server_round: int,
+        timeout: Optional[float],
+    ) -> Optional[
+        Tuple[Optional[float], Dict[str, Scalar], EvaluateResultsAndFailures]
+    ]:
+        """Validate current global model on a number of clients."""
+        # Get clients and their respective instructions from strategy
+        client_instructions = self.strategy.configure_evaluate(
+            server_round=server_round,
+            parameters=self.parameters,
+            client_manager=self._client_manager,
+        )
+        if not client_instructions:
+            log(INFO, "evaluate_round %s: no clients selected, cancel", server_round)
+            return None
+        log(
+            DEBUG,
+            "evaluate_round %s: strategy sampled %s clients (out of %s)",
+            server_round,
+            len(client_instructions),
+            self._client_manager.num_available(),
+        )
+
+        # Collect `evaluate` results from all clients participating in this round
+        results, failures = evaluate_clients(
+            client_instructions,
+            max_workers=self.max_workers,
+            timeout=timeout,
+        )
+        log(
+            DEBUG,
+            "evaluate_round %s received %s results and %s failures",
+            server_round,
+            len(results),
+            len(failures),
+        )
+        # log(DEBUG, f"Evaluate results: {results}")
+
+        # Aggregate the evaluation results
+        aggregated_result: Tuple[
+            Optional[float],
+            Dict[str, Scalar],
+        ] = self.strategy.aggregate_evaluate(server_round, results, failures)
+
+        loss_aggregated, metrics_aggregated = aggregated_result
+        return loss_aggregated, metrics_aggregated, (results, failures)
+
+    def fit_round(
+        self,
+        server_round: int,
+        timeout: Optional[float],
+        executor: ThreadPoolExecutor,
+        end_timestamp: float,
+        history: AsyncHistory,
+    ):  # -> Optional[Tuple[Optional[Parameters], Dict[str, Scalar], FitResultsAndFailures]]:
+        """Perform a single round of federated averaging."""
+        # Get clients and their respective instructions from strategy
+        client_instructions = self.strategy.configure_fit(
+            server_round=server_round,
+            parameters=self.parameters,
+            client_manager=self._client_manager,
+        )
+        for client_proxy, fitins in client_instructions:
+            fitins.config = { **fitins.config, **self.get_config_for_client_fit(client_proxy.cid) }
+
+        if not client_instructions:
+            log(INFO, "fit_round %s: no clients selected, cancel", server_round)
+            return None
+        log(
+            DEBUG,
+            "fit_round %s: strategy sampled %s clients (out of %s)",
+            server_round,
+            len(client_instructions),
+            self._client_manager.num_available(),
+        )
+
+        # Collect `fit` results from all clients participating in this round
+        fit_clients(
+            client_instructions=client_instructions,
+            timeout=timeout,
+            server=self,
+            executor=executor,
+            end_timestamp=end_timestamp,
+            history=history,
+        )
+
+    def get_config_for_client_fit(self, client_id):
+        config = {}
+        if not self.is_streaming:
+            return config
+        curr_timestamp = time()
+        if curr_timestamp > self.end_timestamp:
+            return config
+        if client_id not in self.client_data_percs:
+            self.client_data_percs[client_id] = [0.0] # Clients start with 10% of the data (otherwise called with 0 samples)
+        prev_data_perc = self.client_data_percs[client_id][-1]
+        start_timestamp = self.end_timestamp - self.total_train_time
+        data_perc = ( (time() - start_timestamp) / self.total_train_time ) * 0.9 + 0.1 # Linearly increase the data percentage from 10% to 100% over the total_train_time
+        config['data_percentage'] = data_perc
+        config['prev_data_percentage'] = prev_data_perc
+        config['data_loading_strategy'] = self.data_loading_strategy
+        if self.data_loading_strategy == 'fixed_nr':
+            config['n_last_samples_for_data_loading_fit'] = self.n_last_samples_for_data_loading_fit
+        self.client_data_percs[client_id].append(data_perc)
+        return config
+
+    def disconnect_all_clients(self, timeout: Optional[float]) -> None:
+        """Send shutdown signal to all clients."""
+        all_clients = self._client_manager.all()
+        clients = [all_clients[k] for k in all_clients.keys()]
+        instruction = ReconnectIns(seconds=None)
+        client_instructions = [(client_proxy, instruction)
+                               for client_proxy in clients]
+        _ = reconnect_clients(
+            client_instructions=client_instructions,
+            max_workers=self.max_workers,
+            timeout=timeout,
+        )
+
+    def _get_initial_parameters(self, timeout: Optional[float]) -> Parameters:
+        """Get initial parameters from one of the available clients."""
+        # Server-side parameter initialization
+        parameters: Optional[Parameters] = self.strategy.initialize_parameters(
+            client_manager=self._client_manager
+        )
+        if parameters is not None:
+            log(INFO, "Using initial parameters provided by strategy")
+            return parameters
+
+        # Get initial parameters from one of the clients
+        log(INFO, "Requesting initial parameters from one random client")
+        random_client = self._client_manager.sample(1)[0]
+        ins = GetParametersIns(config={})
+        get_parameters_res = random_client.get_parameters(
+            ins=ins, timeout=timeout)
+        log(INFO, "Received initial parameters from one random client")
+        return get_parameters_res.parameters
+
+
+def reconnect_clients(
+    client_instructions: List[Tuple[ClientProxy, ReconnectIns]],
+    max_workers: Optional[int],
+    timeout: Optional[float],
+) -> ReconnectResultsAndFailures:
+    """Instruct clients to disconnect and never reconnect."""
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+
+        submitted_fs = {
+            executor.submit(reconnect_client, client_proxy, ins, timeout)
+            for client_proxy, ins in client_instructions
+        }
+        finished_fs, _ = concurrent.futures.wait(
+            fs=submitted_fs,
+            timeout=None,  # Handled in the respective communication stack
+        )
+
+    # Gather results
+    results: List[Tuple[ClientProxy, DisconnectRes]] = []
+    failures: List[Union[Tuple[ClientProxy,
+                               DisconnectRes], BaseException]] = []
+    for future in finished_fs:
+        failure = future.exception()
+        if failure is not None:
+            failures.append(failure)
+        else:
+            result = future.result()
+            results.append(result)
+    return results, failures
+
+
+def reconnect_client(
+    client: ClientProxy,
+    reconnect: ReconnectIns,
+    timeout: Optional[float],
+) -> Tuple[ClientProxy, DisconnectRes]:
+    """Instruct client to disconnect and (optionally) reconnect later."""
+    disconnect = client.reconnect(
+        reconnect,
+        timeout=timeout,
+    )
+    return client, disconnect
+
+
+def handle_futures(futures, server):
+    for future in futures:
+        _handle_finished_future_after_fit(
+            future=future, server=server
+        )
+
+
+def fit_clients(
+    client_instructions: List[Tuple[ClientProxy, FitIns]],
+    timeout: Optional[float],
+    server: AsyncServer,
+    executor: ThreadPoolExecutor,
+    end_timestamp: float,
+    history: AsyncHistory,
+):
+    """Refine parameters concurrently on all selected clients."""
+
+    submitted_fs = {
+        executor.submit(fit_client, client_proxy, ins, timeout)
+        for client_proxy, ins in client_instructions
+    }
+    for f in submitted_fs:
+        f.add_done_callback(
+            lambda ftr: _handle_finished_future_after_fit(ftr, server=server, executor=executor, end_timestamp=end_timestamp, history=history),
+        )
+
+
+def fit_client(
+    client: ClientProxy, ins: FitIns, timeout: Optional[float]
+) -> Tuple[ClientProxy, FitRes]:
+    """Refine parameters on a single client."""
+    fit_res = client.fit(ins, timeout=timeout)
+    return client, fit_res
+
+
+def _handle_finished_future_after_fit(
+    future: concurrent.futures.Future,
+    server: AsyncServer,
+    executor: ThreadPoolExecutor,
+    end_timestamp: float,
+    history: AsyncHistory,
+) -> None:
+    """Update the server parameters, restart the client."""
+    
+    # Check if there was an exception
+    failure = future.exception()
+    if failure is not None:
+        log(WARNING, "Got a failure :(")
+        return
+
+    # print("Got a result :)")
+    result: Tuple[ClientProxy, FitRes] = future.result()
+    clientProxy, res = result
+
+    if res.status.code == Code.OK:
+        parameters_aggregated = server.async_strategy.average(
+            server.parameters, res.parameters, res.metrics['t_diff'], res.num_examples)
+        server.set_new_params(parameters_aggregated)
+        
+        history.add_metrics_distributed_fit_async(
+            clientProxy.cid,{"sample_sizes": res.num_examples, **res.metrics }, timestamp=time()
+        )
+
+    if time() < end_timestamp:
+        # log(DEBUG, f"Yippie! Starting the client {clientProxy.cid} again \U0001f973")
+        new_ins = FitIns(server.parameters, server.get_config_for_client_fit(clientProxy.cid))
+        ftr = executor.submit(fit_client, client=clientProxy, ins=new_ins, timeout=None)
+        ftr.add_done_callback(lambda ftr: _handle_finished_future_after_fit(ftr, server, executor, end_timestamp, history))
+
+
+############################### FOR EVALUATION ####################################
+
+def evaluate_clients(
+    client_instructions: List[Tuple[ClientProxy, EvaluateIns]],
+    max_workers: Optional[int],
+    timeout: Optional[float],
+) -> EvaluateResultsAndFailures:
+    """Evaluate parameters concurrently on all selected clients."""
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+        submitted_fs = {
+            executor.submit(evaluate_client, client_proxy, ins, timeout)
+            for client_proxy, ins in client_instructions
+        }
+        finished_fs, _ = concurrent.futures.wait(
+            fs=submitted_fs,
+            timeout=None,  # Handled in the respective communication stack
+        )
+
+    # Gather results
+    results: List[Tuple[ClientProxy, EvaluateRes]] = []
+    failures: List[Union[Tuple[ClientProxy, EvaluateRes], BaseException]] = []
+    for future in finished_fs:
+        _handle_finished_future_after_evaluate(
+            future=future, results=results, failures=failures
+        )
+    return results, failures
+
+
+def evaluate_client(
+    client: ClientProxy,
+    ins: EvaluateIns,
+    timeout: Optional[float],
+) -> Tuple[ClientProxy, EvaluateRes]:
+    """Evaluate parameters on a single client."""
+    evaluate_res = client.evaluate(ins, timeout=timeout)
+    return client, evaluate_res
+
+
+def _handle_finished_future_after_evaluate(
+    future: concurrent.futures.Future,  # type: ignore
+    results: List[Tuple[ClientProxy, EvaluateRes]],
+    failures: List[Union[Tuple[ClientProxy, EvaluateRes], BaseException]],
+) -> None:
+    """Convert finished future into either a result or a failure."""
+    # Check if there was an exception
+    failure = future.exception()
+    if failure is not None:
+        failures.append(failure)
+        return
+
+    # Successfully received a result from a client
+    result: Tuple[ClientProxy, EvaluateRes] = future.result()
+    _, res = result
+
+    # Check result status code
+    if res.status.code == Code.OK:
+        results.append(result)
+        return
+
+    # Not successful, client returned a result where the status code is not OK
+    failures.append(result)

--- a/src/py/flwr/server/strategy/fedasync.py
+++ b/src/py/flwr/server/strategy/fedasync.py
@@ -1,0 +1,121 @@
+import math
+from flwr.common import Parameters
+import flwr.server.strategy.aggregate as agg
+from flwr.common import parameters_to_ndarrays, ndarrays_to_parameters
+from typing import List, Tuple
+from flwr.common import NDArrays, log
+from logging import DEBUG, WARNING
+
+
+class AsynchronousStrategy:
+    """Abstract base class for all asynchronous strategies."""
+
+    def __init__(self, total_samples: int, staleness_alpha: float, fedasync_mixing_alpha: float, fedasync_a: float, num_clients: int, async_aggregation_strategy: str,
+                 use_staleness: bool, use_sample_weighing: bool, send_gradients: bool) -> None:
+        self.total_samples = total_samples
+        self.staleness_alpha = staleness_alpha
+        self.fedasync_a = fedasync_a
+        self.fedasync_mixing_alpha = fedasync_mixing_alpha
+        self.num_clients = num_clients
+        self.async_aggregation_strategy = async_aggregation_strategy
+        self.use_staleness = use_staleness
+        self.use_sample_weighing = use_sample_weighing
+        self.send_gradients = send_gradients
+
+    def average(self, global_parameters: Parameters, model_update_parameters: Parameters, t_diff: float, num_samples: int) -> Parameters:
+        """Compute the average of the global and client parameters."""
+        if self.async_aggregation_strategy == "fedasync":
+            if self.send_gradients:
+                return self.weighted_merge_fedasync(global_parameters, model_update_parameters, t_diff, num_samples)
+            else:
+                return self.weighted_average_fedasync(global_parameters, model_update_parameters, t_diff, num_samples)
+        # elif self.async_aggregation_strategy == "asyncfeded":
+        #     return self.weighted_average_asyncfeded(global_parameters, model_update_parameters, t_diff, num_samples)
+        # elif self.async_aggregation_strategy == "unweighted":
+        #     return self.unweighted_average(global_parameters, model_update_parameters)
+        else:
+            raise ValueError(
+                f"Invalid async aggregation strategy: {self.async_aggregation_strategy}")
+
+    def unweighted_average(self, global_parameters: Parameters, model_update_parameters: Parameters) -> Parameters:
+        """Compute the unweighted average of the global and client parameters."""
+        return ndarrays_to_parameters(agg.aggregate([(parameters_to_ndarrays(global_parameters), 1),
+                                                     (parameters_to_ndarrays(model_update_parameters), 1)]))
+
+    def weighted_average_asyncfeded(self, global_parameters: Parameters, model_update_parameters: Parameters, t_diff: float, num_samples: int) -> Parameters:
+        """Compute the weighted average of the global and client parameters. Inspired by the paper asyncFedED : https://arxiv.org/pdf/2205.13797.pdf"""
+        return ndarrays_to_parameters(self.aggregate_asyncfeded(parameters_to_ndarrays(global_parameters), parameters_to_ndarrays(model_update_parameters), t_diff, num_samples=num_samples))
+
+    def get_sample_weight_coeff(self, num_samples: int) -> float:
+        """Compute the sample weight coefficient."""
+        return num_samples / self.total_samples
+
+    def weighted_average_fedasync(self, global_parameters: Parameters, model_update_parameters: Parameters, t_diff: float, num_samples: int) -> Parameters:
+        """Compute the weighted average of the global and client parameters. Inspired by the paper Fedasync : https://arxiv.org/pdf/1903.03934.pdf"""
+        return ndarrays_to_parameters(self.aggregate_fedasync(parameters_to_ndarrays(global_parameters), parameters_to_ndarrays(model_update_parameters), t_diff, num_samples=num_samples))
+
+    def aggregate_fedasync(self, global_param_arr: NDArrays, model_update_param_arr: NDArrays, t_diff: float, num_samples: int) -> NDArrays:
+        """Compute weighted average with the formula params_new = (1-alpha) * params_old + alpha * (model_update_params)"""
+        # Calculate the total number of examples used during training
+        alpha_coeff = self.fedasync_mixing_alpha
+        if self.use_staleness:
+            alpha_coeff *= self.get_staleness_weight_coeff_fedasync_poly(
+                t_diff=t_diff)
+        if self.use_sample_weighing:
+            alpha_coeff *= self.get_sample_weight_coeff(num_samples)
+
+        # log(DEBUG, f"t_diff: {t_diff}\nalpha_coeff: {alpha_coeff}")
+
+        return [(1 - alpha_coeff) * layer_global + alpha_coeff * layer_update for layer_global, layer_update in zip(global_param_arr, model_update_param_arr)]
+
+    def weighted_merge_fedasync(self, global_parameters: Parameters, gradients: Parameters, t_diff: float, num_samples: int) -> Parameters:
+        """Add gradients to the global model. Inspired by the paper Fedasync : https://arxiv.org/pdf/1903.03934.pdf
+        It is not however the same procedure as in original paper, because they aggregate MODELS and we aggregate GRADIENTS.
+        """
+        return ndarrays_to_parameters(self.add_grads_fedasync(parameters_to_ndarrays(global_parameters), parameters_to_ndarrays(gradients), t_diff, num_samples=num_samples))
+
+    def add_grads_fedasync(self, global_param_arr: NDArrays, gradients_arr: NDArrays, t_diff: float, num_samples: int) -> NDArrays:
+        """Compute weighted average with the formula params_new = (1-alpha) * params_old + alpha * (params_old + update_grads)"""
+        # Calculate the total number of examples used during training
+        alpha_coeff = self.fedasync_mixing_alpha
+        if self.use_staleness:
+            alpha_coeff *= self.get_staleness_weight_coeff_fedasync_poly(
+                t_diff=t_diff)
+        if self.use_sample_weighing:
+            alpha_coeff *= self.get_sample_weight_coeff(num_samples)
+
+        # log(DEBUG, f"t_diff: {t_diff}\nalpha_coeff: {alpha_coeff}")
+
+        return [(1 - alpha_coeff) * layer_global + alpha_coeff * (layer_global + layer_grad) for layer_global, layer_grad in zip(global_param_arr, gradients_arr)] 
+
+    # See paper: https://arxiv.org/pdf/2205.13797.pdf
+    def aggregate_asyncfeded(self, global_param_arr: NDArrays, model_update_param_arr: NDArrays, t_diff: float, num_samples: int) -> NDArrays:
+        """Computing the new parameters using the formula params_new = params_old + nu * (model_update_params)
+            Where nu is influenced by the staleness of the model update and/or the number of samples.
+        """
+        eta = 1
+        if self.use_staleness:
+            # Staleness weighted coefficient
+            eta *= self.get_staleness_weight_coeff_paflm(t_diff=t_diff)
+        if self.use_sample_weighing:
+            eta *= self.get_sample_weight_coeff(num_samples)
+
+        log(DEBUG, f"t_diff: {t_diff}\nnu: {eta}")
+        return [layer_global + eta * (layer_update - layer_global) for layer_global, layer_update in zip(global_param_arr, model_update_param_arr)]
+
+    # See paper for more details : https://ieeexplore.ieee.org/stamp/stamp.jsp?arnumber=9022982
+    def get_staleness_weight_coeff_paflm(self, t_diff: float) -> float:
+        mu_staleness = t_diff
+        exponent = ((1 / float(self.num_clients)) * mu_staleness) - 1
+        beta_P = math.pow(self.staleness_alpha, exponent)
+        return beta_P
+
+    # Paper: https://arxiv.org/pdf/1903.03934.pdf
+    def get_staleness_weight_coeff_fedasync_constant(self) -> float:
+        return 1.0
+
+    def get_staleness_weight_coeff_fedasync_poly(self, t_diff: float) -> float:
+        return math.pow(t_diff + 1, -self.fedasync_a)
+
+    def get_staleness_weight_coeff_fedasync_hinge(self, t_diff: float, a: float = 10, b: float = 4) -> float:
+        return 1 if t_diff <= b else 1 / (a * (t_diff - b) + 1)


### PR DESCRIPTION

## Issue

There is no support for asynchronous FL in base implementation of flower. #469 

### Description

This PR implements asynchronous federated training by introducing a new server, strategy, 

### Related issues/PRs

Related Issue:
#469 

## Proposal

In the server implementation, the threadpool executor is modified to not wait for futures.

### Explanation
The server does not wait for all futures to finish, but rather adds a callback which starts client training again as soon as the client yields a model update which moves the model training towards asynchronous FL.

### Any other comments?

This is still a work in progress and will receive a major clean-up.