### PR TITLE
fix(framework) Fix `aggregate_inplace()` in `strategy.py`

### DIFF
--- a/src/py/flwr/server/strategy/aggregate.py
+++ b/src/py/flwr/server/strategy/aggregate.py
@@ -53,9 +53,7 @@ def aggregate_inplace(results: List[Tuple[ClientProxy, FitRes]]) -> NDArrays:
         dtype=np.float32,
     )
 
-    def _try_inplace(
-        x: NDArray, y: NDArray, np_binary_op: Callable[[NDArray, NDArray], NDArray]
-    ):
+    def _try_inplace(x: NDArray, y: NDArray, np_binary_op: np.ufunc) -> Any:
         # `(x, y, out=x)` requires x and y has the same dtype, which will do the inplace-job
         return np_binary_op(x, y, out=x) if x.dtype == y.dtype else np_binary_op(x, y)
 

--- a/src/py/flwr/server/strategy/aggregate.py
+++ b/src/py/flwr/server/strategy/aggregate.py
@@ -15,7 +15,7 @@
 """Aggregation functions for strategy implementations."""
 # mypy: disallow_untyped_calls=False
 
-from functools import reduce
+from functools import partial, reduce
 from typing import Any, Callable, List, Tuple
 
 import numpy as np
@@ -45,24 +45,36 @@ def aggregate(results: List[Tuple[NDArrays, int]]) -> NDArrays:
 def aggregate_inplace(results: List[Tuple[ClientProxy, FitRes]]) -> NDArrays:
     """Compute in-place weighted average."""
     # Count total examples
-    num_examples_total = sum(fit_res.num_examples for (_, fit_res) in results)
+    num_examples_total = sum(fit_res.num_examples for _, fit_res in results)
 
     # Compute scaling factors for each result
-    scaling_factors = [
-        fit_res.num_examples / num_examples_total for _, fit_res in results
-    ]
+    scaling_factors = np.array(
+        [fit_res.num_examples / num_examples_total for _, fit_res in results],
+        dtype=np.float32,
+    )
+
+    def _try_inplace(
+        x: NDArray, y: NDArray, np_binary_op: Callable[[NDArray, NDArray], NDArray]
+    ):
+        # `(x, y, out=x)` requires x and y has the same dtype, which will do the inplace-job
+        return np_binary_op(x, y, out=x) if x.dtype == y.dtype else np_binary_op(x, y)
 
     # Let's do in-place aggregation
     # Get first result, then add up each other
+
     params = [
-        scaling_factors[0] * x for x in parameters_to_ndarrays(results[0][1].parameters)
+        _try_inplace(x, scaling_factors[0], np_binary_op=np.multiply)
+        for x in parameters_to_ndarrays(results[0][1].parameters)
     ]
-    for i, (_, fit_res) in enumerate(results[1:]):
+    for i, (_, fit_res) in enumerate(results[1:], start=1):
         res = (
-            scaling_factors[i + 1] * x
+            _try_inplace(x, scaling_factors[i], np_binary_op=np.multiply)
             for x in parameters_to_ndarrays(fit_res.parameters)
         )
-        params = [reduce(np.add, layer_updates) for layer_updates in zip(params, res)]
+        params = [
+            reduce(partial(_try_inplace, np_binary_op=np.add), layer_updates)
+            for layer_updates in zip(params, res)
+        ]
 
     return params
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

I found that `aggregate_inplace()` actually do its job not inplace.

### Description


https://github.com/adap/flower/blob/ad811b5a0afc8bd32fb27305a8d0063f41a09ce5/src/py/flwr/server/strategy/aggregate.py#L57-L65
`scaling_factors[0] * x`, `caling_factors[i + 1] * x` would introduce additional memory overhead to temporaily store the output. Instead, using api like `np.add(x, y, out=x)` can let `numpy` write the output to `x` directly.

<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal

### Explanation

Add `out` argument of `numpy` funcition calls. 
Explanation from `numpy`: 
> out : ndarray, None, or tuple of ndarray and None, optional
A location into which the result is stored. If provided, it must have a shape that the inputs broadcast to. If not provided or None, a freshly-allocated array is returned.

However, `out` argument requires `x` and `y` has the same `dtype`, which is the most common cases. For dealing the unusual cases, I use a wrapper and set the fallback call: `np.add(x, y)` (for example).

### Proof

I use `memory_profiler` to check the memory usage.

#### Functions
```python
from memory_profiler import profile


@profile
def flwr_aggregate_inplace(results):
    """Compute in-place weighted average."""
    # Count total examples
    num_examples_total = sum(fit_res.num_examples for (_, fit_res) in results)

    # Compute scaling factors for each result
    scaling_factors = [
        fit_res.num_examples / num_examples_total for _, fit_res in results
    ]

    # Let's do in-place aggregation
    # Get first result, then add up each other
    params = [
        scaling_factors[0] * x for x in parameters_to_ndarrays(results[0][1].parameters)
    ]
    for i, (_, fit_res) in enumerate(results[1:]):
        res = (
            scaling_factors[i + 1] * x
            for x in parameters_to_ndarrays(fit_res.parameters)
        )
        params = [reduce(np.add, layer_updates) for layer_updates in zip(params, res)]

    return params


@profile
def my_aggregate_inplace(results: List[Tuple[ClientProxy, FitRes]]) -> NDArrays:
    """Compute in-place weighted average."""
    # Count total examples
    num_examples_total = sum(fit_res.num_examples for _, fit_res in results)

    # Compute scaling factors for each result
    scaling_factors = np.array(
        [fit_res.num_examples / num_examples_total for _, fit_res in results],
        dtype=np.float32,
    )

    def _try_inplace(x: NDArray, y: NDArray, np_binary_op: np.ufunc) -> Any:
        # `(x, y, out=x)` requires x and y has the same dtype, which will do the inplace-job
        return np_binary_op(x, y, out=x) if x.dtype == y.dtype else np_binary_op(x, y)

    # Let's do in-place aggregation
    # Get first result, then add up each other

    params = [
        _try_inplace(x, scaling_factors[0], np_binary_op=np.multiply)
        for x in parameters_to_ndarrays(results[0][1].parameters)
    ]
    for i, (_, fit_res) in enumerate(results[1:], start=1):
        res = (
            _try_inplace(x, scaling_factors[i], np_binary_op=np.multiply)
            for x in parameters_to_ndarrays(fit_res.parameters)
        )
        params = [
            reduce(partial(_try_inplace, np_binary_op=np.add), layer_updates)
            for layer_updates in zip(params, res)
        ]

    return params
```

#### Input
```python
test_parameters = [np.arange(8196, dtype=np.float32) for _ in range(20)]
results = [
    (
        None,
        FitRes(
            status=None,
            parameters=Parameters(
                tensors=[ndarray_to_bytes(param) for param in test_parameters],
                tensor_type="numpy.ndarray",
            ),
            num_examples=1,
            metrics=None,
        ),
    )
    for _ in range(10)
]
```
#### Main Test Entrance
```python
LOOPS = 100
def test_flwr_aggregate_inplace():
    start = time.time()
    for _ in range(LOOPS):
        flwr_aggregate_inplace(results)
    end = time.time()
    print("flwr's aggregate_inplace cost time: ", end - start)


def test_my_aggregate_inplace():
    start = time.time()
    for _ in range(LOOPS):
        my_aggregate_inplace(results)
    end = time.time()
    print("my aggregate_inplace cost time: ", end - start)


test_flwr_aggregate_inplace()
test_my_aggregate_inplace()
```

I set `LOOPS = 1` to check memory usage; disable `@profile` and set `LOOPS = 100` to check the function efficiency.



#### Results

**Memory Usage**

```
Line #    Mem usage    Increment  Occurrences   Line Contents
=============================================================
    11    118.3 MiB    118.3 MiB           1   @profile
    12                                         def flwr_aggregate_inplace(results):
    13                                             """Compute in-place weighted average."""
    14                                             # Count total examples
    15    118.3 MiB      0.0 MiB          23       num_examples_total = sum(fit_res.num_examples for (_, fit_res) in results)
    16                                         
    17                                             # Compute scaling factors for each result
    18    118.3 MiB      0.0 MiB          24       scaling_factors = [
    19    118.3 MiB      0.0 MiB          11           fit_res.num_examples / num_examples_total for _, fit_res in results
    20                                             ]
    21                                         
    22                                             # Let's do in-place aggregation
    23                                             # Get first result, then add up each other
    24    119.8 MiB      0.0 MiB          44       params = [
    25    119.8 MiB      1.4 MiB          21           scaling_factors[0] * x for x in parameters_to_ndarrays(results[0][1].parameters)
    26                                             ]
    27    120.5 MiB      0.0 MiB          10       for i, (_, fit_res) in enumerate(results[1:]):
    28    120.5 MiB      0.0 MiB         559           res = (
    29    120.5 MiB      0.0 MiB         180               scaling_factors[i + 1] * x
    30    120.5 MiB      0.3 MiB         189               for x in parameters_to_ndarrays(fit_res.parameters)
    31                                                 )
    32    120.5 MiB      0.5 MiB         207           params = [reduce(np.add, layer_updates) for layer_updates in zip(params, res)]
    33                                         
    34    120.5 MiB      0.0 MiB           1       return params


flwr's aggregate_inplace cost time:  0.09969210624694824
Filename: /root/codes/python/flower/src/py/flwr/server/strategy/test.py

Line #    Mem usage    Increment  Occurrences   Line Contents
=============================================================
    37    119.5 MiB    119.5 MiB           1   @profile
    38                                         def my_aggregate_inplace(results: List[Tuple[ClientProxy, FitRes]]) -> NDArrays:
    39                                             """Compute in-place weighted average."""
    40                                             # Count total examples
    41    119.5 MiB      0.0 MiB          23       num_examples_total = sum(fit_res.num_examples for _, fit_res in results)
    42                                         
    43                                             # Compute scaling factors for each result
    44    119.5 MiB      0.0 MiB           2       scaling_factors = np.array(
    45    119.5 MiB      0.0 MiB          13           [fit_res.num_examples / num_examples_total for _, fit_res in results],
    46    119.5 MiB      0.0 MiB           1           dtype=np.float32,
    47                                             )
    48                                         
    49    120.5 MiB      0.0 MiB         384       def _try_inplace(
    50    119.5 MiB      0.0 MiB           3           x: NDArray, y: NDArray, np_binary_op: Callable[[NDArray, NDArray], NDArray]
    51                                             ):
    52                                                 # `(x, y, out=x)` requires x and y has the same dtype, which will do the inplace-job
    53    120.5 MiB      0.0 MiB         380           return np_binary_op(x, y, out=x) if x.dtype == y.dtype else np_binary_op(x, y)
    54                                         
    55                                             # Let's do in-place aggregation
    56                                             # Get first result, then add up each other
    57                                         
    58    119.5 MiB      0.0 MiB          44       params = [
    59    119.5 MiB      0.0 MiB          20           _try_inplace(x, scaling_factors[0], np_binary_op=np.multiply)
    60    119.5 MiB      0.0 MiB          21           for x in parameters_to_ndarrays(results[0][1].parameters)
    61                                             ]
    62    120.5 MiB      0.0 MiB          10       for i, (_, fit_res) in enumerate(results[1:], start=1):
    63    120.5 MiB      0.0 MiB         559           res = (
    64    120.5 MiB      0.0 MiB         180               _try_inplace(x, scaling_factors[i], np_binary_op=np.multiply)
    65    120.5 MiB      1.0 MiB         189               for x in parameters_to_ndarrays(fit_res.parameters)
    66                                                 )
    67    120.5 MiB      0.0 MiB         396           params = [
    68    120.5 MiB      0.0 MiB         180               reduce(partial(_try_inplace, np_binary_op=np.add), layer_updates)
    69    120.5 MiB      0.0 MiB         189               for layer_updates in zip(params, res)
    70                                                 ]
    71                                         
    72    120.5 MiB      0.0 MiB           1       return params
```

**Efficiency**
```
flwr's aggregate_inplace cost time:  0.7634704113006592
my aggregate_inplace cost time:  0.7479846477508545
```


### Checklist

- [ ] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.ai/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
