### PR TITLE
feat(framework) Introduce `BackendConfig` to configure simulation backends.

### DIFF
--- a/src/py/flwr/server/superlink/fleet/vce/backend/backendconfig.py
+++ b/src/py/flwr/server/superlink/fleet/vce/backend/backendconfig.py
@@ -34,7 +34,7 @@ class ClientAppResources:
 
     Parameters
     ----------
-    num_cpus : int (default: 1)
+    num_cpus : int (default: 2)
         Indicates the number of CPUs that a `ClientApp` needs when running.
     num_gpus : float (default: 0.0)
         Indicates the number of GPUs that a `ClientApp` needs when running. This
@@ -44,7 +44,7 @@ class ClientAppResources:
         assuming 4x`num_cpus` are available in your system.
     """
 
-    num_cpus: int = 1
+    num_cpus: int = 2
     num_gpus: float = 0.0
 
     def __post_init__(self) -> None:
@@ -83,7 +83,7 @@ class BackendConfig:
 
     name: str
     clientapp_resources: ClientAppResources
-    config: Optional[Dict[str, ConfigsRecordValues]]
+    config: Dict[str, ConfigsRecordValues]
 
     def __init__(
         self,

--- a/src/py/flwr/server/superlink/fleet/vce/backend/backendconfig.py
+++ b/src/py/flwr/server/superlink/fleet/vce/backend/backendconfig.py
@@ -1,0 +1,47 @@
+# Copyright 2024 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Backend config."""
+
+
+from typing import Optional
+from dataclasses import dataclass
+from flwr.common.typing import UserConfig # = Dict[str, UserConfigValue]
+
+
+@dataclass
+class ClientAppResources:
+    """Resources for a `ClientApp`"""
+    num_cpus: float
+    num_gpus: float
+
+
+@dataclass
+class BackendConfig:
+
+    name: str
+    clientapp_resources: ClientAppResources
+    config: Optional[UserConfig]
+
+    def __init__(self,
+                 name: Optional[str] = "ray", 
+                 clientapp_resources: Optional[ClientAppResources] = ClientAppResources(2.0, 0.0),
+                config: Optional[UserConfig] = {},
+                )
+        self.name = name
+        self.clientapp_resources = clientapp_resources
+        self.config = config
+
+
+

--- a/src/py/flwr/server/superlink/fleet/vce/backend/backendconfig.py
+++ b/src/py/flwr/server/superlink/fleet/vce/backend/backendconfig.py
@@ -97,7 +97,7 @@ class BackendConfig:
             clientapp_resources = ClientAppResources()
             log(
                 DEBUG,
-                "The `BackendConfig` didn't receive `ClientAppResources. "
+                "The `BackendConfig` didn't receive `ClientAppResources`. "
                 "The default resources will be used: %s",
                 clientapp_resources,
             )

--- a/src/py/flwr/server/superlink/fleet/vce/backend/backendconfig.py
+++ b/src/py/flwr/server/superlink/fleet/vce/backend/backendconfig.py
@@ -15,13 +15,14 @@
 """Backend config."""
 
 from dataclasses import dataclass
-from logging import WARN
+from logging import DEBUG, WARN
 from typing import Optional
 
 from flwr.common.logger import log
 from flwr.common.typing import ConfigsRecordValues
 
 
+@dataclass
 class ClientAppResources:
     """Resources for a `ClientApp`.
 
@@ -43,9 +44,11 @@ class ClientAppResources:
         assuming 4x`num_cpus` are available in your system.
     """
 
-    def __init__(self, num_cpus: int = 1, num_gpus: float = 0.0) -> None:
-        self.num_cpus = num_cpus
-        self.num_gpus = num_gpus
+    num_cpus: int = 1
+    num_gpus: float = 0.0
+
+    def __post_init__(self) -> None:
+        """Validate resources after initialization."""
         self._validate()
 
     def _validate(self) -> None:
@@ -92,6 +95,12 @@ class BackendConfig:
         if clientapp_resources is None:
             # If unset, set default resources
             clientapp_resources = ClientAppResources()
+            log(
+                DEBUG,
+                "The `BackendConfig` didn't receive `ClientAppResources. "
+                "The default resources will be used: %s",
+                clientapp_resources,
+            )
 
         self.clientapp_resources = clientapp_resources
 

--- a/src/py/flwr/server/superlink/fleet/vce/backend/backendconfig.py
+++ b/src/py/flwr/server/superlink/fleet/vce/backend/backendconfig.py
@@ -16,7 +16,7 @@
 
 from dataclasses import dataclass
 from logging import DEBUG, WARN
-from typing import Optional
+from typing import Dict, Optional
 
 from flwr.common.logger import log
 from flwr.common.typing import ConfigsRecordValues
@@ -83,13 +83,13 @@ class BackendConfig:
 
     name: str
     clientapp_resources: ClientAppResources
-    config: Optional[ConfigsRecordValues]
+    config: Optional[Dict[str, ConfigsRecordValues]]
 
     def __init__(
         self,
         name: str = "ray",
         clientapp_resources: Optional[ClientAppResources] = None,
-        config: Optional[ConfigsRecordValues] = None,
+        config: Optional[Dict[str, ConfigsRecordValues]] = None,
     ):
         self.name = name
         if clientapp_resources is None:

--- a/src/py/flwr/server/superlink/fleet/vce/backend/backendconfig.py
+++ b/src/py/flwr/server/superlink/fleet/vce/backend/backendconfig.py
@@ -15,33 +15,57 @@
 """Backend config."""
 
 
-from typing import Optional
 from dataclasses import dataclass
-from flwr.common.typing import UserConfig # = Dict[str, UserConfigValue]
+from typing import Optional
+
+from flwr.common.typing import UserConfig
 
 
 @dataclass
 class ClientAppResources:
-    """Resources for a `ClientApp`"""
-    num_cpus: float
-    num_gpus: float
+    """Resources for a `ClientApp`.
+
+    These resources are used by a `Backend` to control the degree of parallelism
+    of a simulation. Lower `num_cpus` and `num_gpus` allow for running more
+    `ClientApp` objects in parallel. Note system resources are shared among all
+    `ClientApp`s running. In other words, per-`ClientApp` resource limits are not
+    enforced and are used exclusively as a guide to control parallelism.
+
+    Parameters
+    ----------
+    num_cpus : float (default: 1.0)
+        Indicates the number of CPUs that a `ClientApp` needs to be executed.
+    num_gpus : float (default: 0.0)
+        Indicates the number of GPUs that a `ClientApp` needs to be executed. This
+        value would normally be set based on the amount of VRAM a single `ClientApp`
+        needs. It can be a decimal point value. For example, if `num_gpus=0.25` at
+        most 4 `ClientApp` object could be run in parallel per GPU available and
+        asuming 4x`num_cpus` are available in your system.
+    """
+
+    num_cpus: float = 1.0
+    num_gpus: float = 0.0
 
 
 @dataclass
 class BackendConfig:
+    """A config for a Simulation Engine backend."""
 
     name: str
     clientapp_resources: ClientAppResources
     config: Optional[UserConfig]
 
-    def __init__(self,
-                 name: Optional[str] = "ray", 
-                 clientapp_resources: Optional[ClientAppResources] = ClientAppResources(2.0, 0.0),
-                config: Optional[UserConfig] = {},
-                )
+    def __init__(
+        self,
+        name: str = "ray",
+        clientapp_resources: Optional[ClientAppResources] = None,
+        config: Optional[UserConfig] = None,
+    ):
         self.name = name
+        if clientapp_resources is None:
+            # If unset, set default resources
+            clientapp_resources = ClientAppResources()
+
         self.clientapp_resources = clientapp_resources
-        self.config = config
 
-
-
+        self.config = {} if config is None else config

--- a/src/py/flwr/server/superlink/fleet/vce/backend/backendconfig.py
+++ b/src/py/flwr/server/superlink/fleet/vce/backend/backendconfig.py
@@ -18,7 +18,7 @@
 from dataclasses import dataclass
 from typing import Optional
 
-from flwr.common.typing import UserConfig
+from flwr.common.typing import ConfigsRecordValues
 
 
 @dataclass
@@ -53,13 +53,13 @@ class BackendConfig:
 
     name: str
     clientapp_resources: ClientAppResources
-    config: Optional[UserConfig]
+    config: Optional[ConfigsRecordValues]
 
     def __init__(
         self,
         name: str = "ray",
         clientapp_resources: Optional[ClientAppResources] = None,
-        config: Optional[UserConfig] = None,
+        config: Optional[ConfigsRecordValues] = None,
     ):
         self.name = name
         if clientapp_resources is None:


### PR DESCRIPTION
Introduces `BackendConfig` as a structured way of configuring simulation backends. This dataclass also indicates the _resources_ needed for each `ClientApp` which is used in the backend to control the degree of parallelism of the simulation. The `.config` attribute enables parameterising the backend further. It's therefore backend specific (hence kept as a dictionary -- it should offer enough flexibility) and parsed by the backend constructor.