### PR TITLE
refactor(framework) Change order of frameworks shown with `flwr new`

### DIFF
--- a/src/py/flwr/cli/new/new.py
+++ b/src/py/flwr/cli/new/new.py
@@ -37,10 +37,10 @@ class MlFramework(str, Enum):
     PYTORCH = "PyTorch"
     TENSORFLOW = "TensorFlow"
     SKLEARN = "sklearn"
+    HUGGINGFACE = "HuggingFace"
     JAX = "JAX"
     MLX = "MLX"
     NUMPY = "NumPy"
-    HUGGINGFACE = "HuggingFace"
     FLOWERTUNE = "FlowerTune"
 
 

--- a/src/py/flwr/cli/new/new.py
+++ b/src/py/flwr/cli/new/new.py
@@ -34,13 +34,13 @@ from ..utils import (
 class MlFramework(str, Enum):
     """Available frameworks."""
 
-    NUMPY = "NumPy"
     PYTORCH = "PyTorch"
     TENSORFLOW = "TensorFlow"
-    JAX = "JAX"
-    HUGGINGFACE = "HuggingFace"
-    MLX = "MLX"
     SKLEARN = "sklearn"
+    JAX = "JAX"
+    MLX = "MLX"
+    NUMPY = "NumPy"
+    HUGGINGFACE = "HuggingFace"
     FLOWERTUNE = "FlowerTune"
 
 
@@ -139,7 +139,7 @@ def new(
     else:
         framework_value = prompt_options(
             "Please select ML framework by typing in the number",
-            sorted([mlf.value for mlf in MlFramework]),
+            [mlf.value for mlf in MlFramework],
         )
         selected_value = [
             name


### PR DESCRIPTION
The new order is as set in the `MlFramework` class.

<img width="743" alt="Screenshot 2024-08-06 at 19 50 40" src="https://github.com/user-attachments/assets/e9ac91e4-3f17-4be4-a3b8-86322b8b0f3d">
