### PR TITLE
docs(examples:skip) Add redirect for secure aggregation example

### DIFF
--- a/examples/doc/source/conf.py
+++ b/examples/doc/source/conf.py
@@ -65,6 +65,7 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 redirects = {
     "quickstart-mxnet": "index.html",
     "mxnet-from-centralized-to-federated": "index.html",
+    "app-secure-aggregation": "flower-secure-aggregation.html",
 }
 
 


### PR DESCRIPTION
## Issue
`app-secure-aggregation` was renamed to `flower-secure-aggregation` however google results for "secure aggregation" on the first page still point to the outdated link which gives 404 not found.

## Proposal
Add a redirect to fix it to the conf.py of example docs.
