### PR TITLE
feat(framework) Add `SimpleBackend` for simulations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ starlette = { version = "^0.31.0", optional = true }
 uvicorn = { version = "^0.23.0", extras = ["standard"], optional = true }
 
 [tool.poetry.extras]
-simulation = ["ray"]
+simulation = ["ray", "cloudpickle"]
 rest = ["requests", "starlette", "uvicorn"]
 
 [tool.poetry.group.dev.dependencies]

--- a/src/py/flwr/server/superlink/fleet/vce/backend/__init__.py
+++ b/src/py/flwr/server/superlink/fleet/vce/backend/__init__.py
@@ -18,11 +18,15 @@ import importlib
 from typing import Dict, Type
 
 from .backend import Backend, BackendConfig
+from .simplebackend import SimpleBackend
 
 is_ray_installed = importlib.util.find_spec("ray") is not None
 
 # Mapping of supported backends
 supported_backends: Dict[str, Type[Backend]] = {}
+
+# Add simplebackend
+supported_backends["simple"] = SimpleBackend
 
 # To log backend-specific error message when chosen backend isn't available
 error_messages_backends: Dict[str, str] = {}

--- a/src/py/flwr/server/superlink/fleet/vce/backend/backend.py
+++ b/src/py/flwr/server/superlink/fleet/vce/backend/backend.py
@@ -33,7 +33,7 @@ class Backend(ABC):
         """Construct a backend."""
 
     @abstractmethod
-    def build(self) -> None:
+    def build(self, app_fn: Callable[[], ClientApp]) -> None:
         """Build backend.
 
         Different components need to be in place before workers in a backend are ready
@@ -60,7 +60,6 @@ class Backend(ABC):
     @abstractmethod
     def process_message(
         self,
-        app: Callable[[], ClientApp],
         message: Message,
         context: Context,
     ) -> Tuple[Message, Context]:

--- a/src/py/flwr/server/superlink/fleet/vce/backend/raybackend.py
+++ b/src/py/flwr/server/superlink/fleet/vce/backend/raybackend.py
@@ -15,7 +15,7 @@
 """Ray backend for the Fleet API using the Simulation Engine."""
 
 from logging import DEBUG, ERROR
-from typing import Callable, Dict, Tuple, Union
+from typing import Callable, Dict, Optional, Tuple, Union
 
 import ray
 
@@ -61,6 +61,8 @@ class RayBackend(Backend):
             client_resources=client_resources,
             actor_kwargs=actor_kwargs,
         )
+
+        self.app_fn: Optional[Callable[[], ClientApp]] = None
 
     def _validate_client_resources(self, config: BackendConfig) -> ClientResourcesDict:
         client_resources_config = config.get(self.client_resources_key)
@@ -123,14 +125,15 @@ class RayBackend(Backend):
         """Report whether the pool has idle actors."""
         return self.pool.is_actor_available()
 
-    def build(self) -> None:
+    def build(self, app_fn: Callable[[], ClientApp]) -> None:
         """Build pool of Ray actors that this backend will submit jobs to."""
         self.pool.add_actors_to_pool(self.pool.actors_capacity)
+        # Set ClientApp callable that ray actors will use
+        self.app_fn = app_fn
         log(DEBUG, "Constructed ActorPool with: %i actors", self.pool.num_actors)
 
     def process_message(
         self,
-        app: Callable[[], ClientApp],
         message: Message,
         context: Context,
     ) -> Tuple[Message, Context]:
@@ -140,11 +143,17 @@ class RayBackend(Backend):
         """
         partition_id = context.node_config[PARTITION_ID_KEY]
 
+        if self.app_fn is None:
+            raise ValueError(
+                "Unspecified function to load a `ClientApp`. "
+                "Call the backend's `build()` method before processing messages."
+            )
+
         try:
             # Submit a task to the pool
             future = self.pool.submit(
                 lambda a, a_fn, mssg, cid, state: a.run.remote(a_fn, mssg, cid, state),
-                (app, message, str(partition_id), context),
+                (self.app_fn, message, str(partition_id), context),
             )
 
             # Fetch result

--- a/src/py/flwr/server/superlink/fleet/vce/backend/raybackend_test.py
+++ b/src/py/flwr/server/superlink/fleet/vce/backend/raybackend_test.py
@@ -63,10 +63,11 @@ def _load_app() -> ClientApp:
 
 def backend_build_process_and_termination(
     backend: RayBackend,
-    process_args: Optional[Tuple[Callable[[], ClientApp], Message, Context]] = None,
+    app_fn: Callable[[], ClientApp],
+    process_args: Optional[Tuple[Message, Context]] = None,
 ) -> Union[Tuple[Message, Context], None]:
     """Build, process job and terminate RayBackend."""
-    backend.build()
+    backend.build(app_fn)
     to_return = None
 
     if process_args:
@@ -120,7 +121,9 @@ class TestRayBackend(TestCase):
     def test_backend_creation_and_termination(self) -> None:
         """Test creation of RayBackend and its termination."""
         backend = RayBackend(backend_config={})
-        backend_build_process_and_termination(backend=backend, process_args=None)
+        backend_build_process_and_termination(
+            backend=backend, app_fn=_load_app, process_args=None
+        )
 
     def test_backend_creation_submit_and_termination(
         self,
@@ -129,13 +132,10 @@ class TestRayBackend(TestCase):
         """Test submitting a message to a given ClientApp."""
         backend = RayBackend(backend_config={})
 
-        # Define ClientApp
-        client_app_callable = client_app_loader
-
         message, context, expected_output = _create_message_and_context()
 
         res = backend_build_process_and_termination(
-            backend=backend, process_args=(client_app_callable, message, context)
+            backend=backend, app_fn=client_app_loader, process_args=(message, context)
         )
 
         if res is None:

--- a/src/py/flwr/server/superlink/fleet/vce/backend/simplebackend.py
+++ b/src/py/flwr/server/superlink/fleet/vce/backend/simplebackend.py
@@ -33,7 +33,7 @@ from .backend import Backend, BackendConfig
 
 def run_client_app(
     client_app_bytes: bytes,
-    in_queue: "Queue[Tuple[bytes,Message,Context]]",
+    in_queue: "Queue[Tuple[Message,Context]]",
     out_queue: "Queue[Tuple[Message,Context]]",
     f_stop: Event,
 ) -> None:
@@ -65,9 +65,7 @@ class SimpleBackend(Backend):
         self.in_queue = self.manager.Queue()
         self.out_queue = self.manager.Queue()
         self.f_stop = self.manager.Event()
-
-        # TODO: read from backend_config
-        self.num_proc = 5
+        self.num_proc = 5  # FIX: read from backend_config
         self.processes: List[Process] = []
 
     @property
@@ -85,7 +83,7 @@ class SimpleBackend(Backend):
     ) -> None:
         """."""
         client_app = app_fn()
-        # TODO: if we make ClientApp picklable we won't need cloudpickle
+        # FIX: if we make ClientApp picklable we won't need cloudpickle
         client_app_asbytes = cloudpickle.dumps(client_app)
         for _ in range(self.num_proc):
             p = Process(

--- a/src/py/flwr/server/superlink/fleet/vce/backend/simplebackend.py
+++ b/src/py/flwr/server/superlink/fleet/vce/backend/simplebackend.py
@@ -1,0 +1,128 @@
+# Copyright 2024 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""A Backend using standard processes for the Simulation Engine."""
+
+import time
+from logging import DEBUG
+from multiprocessing import Manager, Process, Queue
+from queue import Empty
+from threading import Event
+from typing import List, Tuple, Callable
+
+from flwr.client import ClientApp
+from flwr.client.supernode.app import _get_load_client_app_fn
+from flwr.common.context import Context
+from flwr.common.logger import log
+from flwr.common.message import Message
+
+import pickle
+import cloudpickle
+
+from .backend import Backend, BackendConfig
+
+
+def run_client_app(
+    client_app_bytes: bytes,
+    in_queue: "Queue[Tuple[bytes,Message,Context]]",
+    out_queue: "Queue[Tuple[Message,Context]]",
+    f_stop: Event,
+) -> None:
+    """Run a ClientApp processing a Message."""
+    client_app = pickle.loads(client_app_bytes)
+    while not f_stop.is_set():
+        try:
+            message, context = in_queue.get(timeout=1)
+        except Empty:
+            # only break if f_stop is set
+            pass
+        else:
+            out_message = client_app(message=message, context=context)
+            out_queue.put((out_message, context))
+
+
+class SimpleBackend(Backend):
+    """A backend that submits job to a ProcessPoolExecutor."""
+
+    def __init__(
+        self,
+        backend_config: BackendConfig,
+    ) -> None:
+        """."""
+        log(DEBUG, "Initialising: %s", self.__class__.__name__)
+        log(DEBUG, "Backend config: %s", backend_config)
+
+        self.manager = Manager()
+        self.in_queue = self.manager.Queue()
+        self.out_queue = self.manager.Queue()
+        self.f_stop = self.manager.Event()
+
+        # TODO: read from backend_config
+        self.num_proc = 5
+        self.processes: List[Process] = []
+
+    @property
+    def num_workers(self) -> int:
+        """."""
+        return self.num_proc
+
+    def is_worker_idle(self) -> bool:
+        """."""
+        return False
+
+    def build(
+        self,
+        app_fn: Callable[[], ClientApp],
+    ) -> None:
+        """."""
+        client_app = app_fn()
+        # TODO: if we make ClientApp picklable we won't need cloudpickle
+        client_app_asbytes = cloudpickle.dumps(client_app)
+        for _ in range(self.num_proc):
+            p = Process(
+                target=run_client_app,
+                args=(
+                    client_app_asbytes,
+                    self.in_queue,
+                    self.out_queue,
+                    self.f_stop,
+                ),
+                daemon=True,
+            )
+            self.processes.append(p)
+            p.start()
+
+        log(DEBUG, "Constructed SimpleBackend with: %i processes", self.num_proc)
+
+    def process_message(
+        self, message: Message, context: Context
+    ) -> Tuple[Message, Context]:
+        """Run ClientApp that process a given message.
+        Return output message and updated context.
+        """
+        # put stuff in queue
+        self.in_queue.put((message, context))
+
+        # wait for response
+        out_message, updated_context = self.out_queue.get()
+        return out_message, updated_context
+
+    def terminate(self) -> None:
+        """Terminate backend shutting down the Manager and Executor."""
+        self.f_stop.set()
+        for p in self.processes:
+            if p.is_alive():
+                p.join(timeout=3)
+                p.close()
+        self.manager.shutdown()

--- a/src/py/flwr/server/superlink/fleet/vce/backend/simplebackend.py
+++ b/src/py/flwr/server/superlink/fleet/vce/backend/simplebackend.py
@@ -14,21 +14,19 @@
 # ==============================================================================
 """A Backend using standard processes for the Simulation Engine."""
 
-import time
+import pickle
 from logging import DEBUG
 from multiprocessing import Manager, Process, Queue
 from queue import Empty
 from threading import Event
-from typing import List, Tuple, Callable
+from typing import Callable, List, Tuple
+
+import cloudpickle
 
 from flwr.client import ClientApp
-from flwr.client.supernode.app import _get_load_client_app_fn
 from flwr.common.context import Context
 from flwr.common.logger import log
 from flwr.common.message import Message
-
-import pickle
-import cloudpickle
 
 from .backend import Backend, BackendConfig
 
@@ -109,6 +107,7 @@ class SimpleBackend(Backend):
         self, message: Message, context: Context
     ) -> Tuple[Message, Context]:
         """Run ClientApp that process a given message.
+
         Return output message and updated context.
         """
         # put stuff in queue

--- a/src/py/flwr/server/superlink/fleet/vce/vce_api.py
+++ b/src/py/flwr/server/superlink/fleet/vce/vce_api.py
@@ -87,7 +87,6 @@ def _register_node_states(
 
 # pylint: disable=too-many-arguments,too-many-locals
 def worker(
-    app_fn: Callable[[], ClientApp],
     taskins_queue: "Queue[TaskIns]",
     taskres_queue: "Queue[TaskRes]",
     node_states: Dict[int, NodeState],
@@ -110,9 +109,7 @@ def worker(
             message = message_from_taskins(task_ins)
 
             # Let backend process message
-            out_mssg, updated_context = backend.process_message(
-                app_fn, message, context
-            )
+            out_mssg, updated_context = backend.process_message(message, context)
 
             # Update Context
             node_states[node_id].update_context(
@@ -193,7 +190,7 @@ def run_api(
         backend = backend_fn()
 
         # Build backend
-        backend.build()
+        backend.build(app_fn)
 
         # Add workers (they submit Messages to Backend)
         state = state_factory.state()
@@ -223,7 +220,6 @@ def run_api(
             _ = [
                 executor.submit(
                     worker,
-                    app_fn,
                     taskins_queue,
                     taskres_queue,
                     node_states,

--- a/src/py/flwr/simulation/run_simulation.py
+++ b/src/py/flwr/simulation/run_simulation.py
@@ -602,7 +602,7 @@ def _parse_args_run_simulation() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--backend",
-        default="ray",
+        default="simple",
         type=str,
         help="Simulation backend that executes the ClientApp.",
     )


### PR DESCRIPTION
A new backend based on pure mp `Processes` and that doesn't require `ray`. 

Merge after #3988 .

Limitation: it would be better if we first redesign `ClientApp` so it's  _pickleable_. Currently the way `ClientApp` [defines and uses ffn](https://github.com/adap/flower/blob/0334b3d9c51e3cbfaab13c273b830f4cc089bca6/src/py/flwr/client/client_app.py#L122) prevents it from being  _pickleable_. The current solution is to use [cloudpickle](https://github.com/cloudpipe/cloudpickle) which relaxes the conditions that objects need to meet to be _pickleable_