### PR TITLE
fix(baseline:fedprox) Added .to_client to the client_fn

### DIFF
--- a/baselines/fedprox/fedprox/client.py
+++ b/baselines/fedprox/fedprox/client.py
@@ -158,7 +158,7 @@ def gen_client_fn(
         # will train and evaluate on their own unique data
         trainloader = trainloaders[int(cid)]
         valloader = valloaders[int(cid)]
-
+        #Added .to_client() to make it compatibible with the new version of Flower
         return FlowerClient(
             net,
             trainloader,
@@ -167,6 +167,6 @@ def gen_client_fn(
             num_epochs,
             learning_rate,
             stragglers_mat[int(cid)],
-        )
+        ).to_client()
 
     return client_fn


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue
To add .to_client()  to the client_fn in FedProx
### Description
While running the FedProx baseline, the client_fn is depreciated was popping up, which can be solved by adding .to_client() to the return function.
<!--
Describe the problem addressed by this PR.

The file doesn't show the client_fn depreciated warning and it update to work with the latest version of Flower.
-->

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

None
-->

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

It's updated to work without warning for the latest version of Flower.
-->

### Checklist

- [ ] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.ai/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
