### PR TITLE
ci(framework) Extend tests for `fab_hash`

### DIFF
--- a/src/py/flwr/server/driver/grpc_driver_test.py
+++ b/src/py/flwr/server/driver/grpc_driver_test.py
@@ -39,7 +39,12 @@ class TestGrpcDriver(unittest.TestCase):
     def setUp(self) -> None:
         """Initialize mock GrpcDriverStub and Driver instance before each test."""
         mock_response = Mock(
-            run=Run(run_id=61016, fab_id="mock/mock", fab_version="v1.0.0")
+            run=Run(
+                run_id=61016,
+                fab_id="mock/mock",
+                fab_version="v1.0.0",
+                fab_hash="9f86d08",
+            )
         )
         self.mock_stub = Mock()
         self.mock_channel = Mock()
@@ -55,6 +60,7 @@ class TestGrpcDriver(unittest.TestCase):
         self.assertEqual(self.driver.run.run_id, 61016)
         self.assertEqual(self.driver.run.fab_id, "mock/mock")
         self.assertEqual(self.driver.run.fab_version, "v1.0.0")
+        self.assertEqual(self.driver.run.fab_hash, "9f86d08")
         self.mock_stub.GetRun.assert_called_once()
 
     def test_get_nodes(self) -> None:

--- a/src/py/flwr/server/driver/inmemory_driver_test.py
+++ b/src/py/flwr/server/driver/inmemory_driver_test.py
@@ -89,7 +89,7 @@ class TestInMemoryDriver(unittest.TestCase):
             run_id=61016,
             fab_id="mock/mock",
             fab_version="v1.0.0",
-            fab_hash="hash",
+            fab_hash="9f86d08",
             override_config={"test_key": "test_value"},
         )
         state_factory = MagicMock(state=lambda: self.state)
@@ -102,7 +102,7 @@ class TestInMemoryDriver(unittest.TestCase):
         self.assertEqual(self.driver.run.run_id, 61016)
         self.assertEqual(self.driver.run.fab_id, "mock/mock")
         self.assertEqual(self.driver.run.fab_version, "v1.0.0")
-        self.assertEqual(self.driver.run.fab_hash, "hash")
+        self.assertEqual(self.driver.run.fab_hash, "9f86d08")
         self.assertEqual(self.driver.run.override_config["test_key"], "test_value")
 
     def test_get_nodes(self) -> None:


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

### Checklist

- [ ] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.ai/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
