### PR TITLE
feat(framework) Add superexec interceptor for user authentication

### DIFF
--- a/src/py/flwr/superexec/superexec_interceptor.py
+++ b/src/py/flwr/superexec/superexec_interceptor.py
@@ -1,0 +1,127 @@
+# Copyright 2024 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Flower superexec interceptor."""
+
+
+import base64
+from logging import WARNING
+from typing import Any, Callable, Optional, Sequence, Set, Tuple, Union
+
+import grpc
+from cryptography.hazmat.primitives.asymmetric import ec
+
+from flwr.common.logger import log
+from flwr.common.secure_aggregation.crypto.symmetric_encryption import (
+    bytes_to_private_key,
+    bytes_to_public_key,
+    generate_shared_key,
+    verify_hmac,
+)
+from flwr.proto.exec_pb2 import (  # pylint: disable=E0611
+    StartRunRequest,
+    StartRunResponse,
+    StreamLogsRequest,
+    StreamLogsResponse,
+)
+
+_PUBLIC_KEY_HEADER = "public-key"
+_AUTH_TOKEN_HEADER = "auth-token"
+
+Request = Union[
+    StartRunRequest,
+    StreamLogsRequest,
+]
+
+Response = Union[StartRunResponse, StreamLogsResponse]
+
+
+def _get_value_from_tuples(
+    key_string: str, tuples: Sequence[Tuple[str, Union[str, bytes]]]
+) -> bytes:
+    value = next((value for key, value in tuples if key == key_string), "")
+    if isinstance(value, str):
+        return value.encode()
+
+    return value
+
+
+class SuperExecInterceptor(grpc.ServerInterceptor):  # type: ignore
+    """SuperExec interceptor for user authentication."""
+
+    def __init__(
+        self, user_public_keys: Set[bytes], private_key: bytes, public_key: bytes
+    ):
+        self.user_public_keys = user_public_keys
+        if len(self.user_public_keys) == 0:
+            log(WARNING, "Authentication enabled, but no known public keys configured")
+
+        self.server_private_key = bytes_to_private_key(private_key)
+        self.encoded_server_public_key = base64.urlsafe_b64encode(public_key)
+
+    def intercept_service(
+        self,
+        continuation: Callable[[Any], Any],
+        handler_call_details: grpc.HandlerCallDetails,
+    ) -> grpc.RpcMethodHandler:
+        """Flower server interceptor authentication logic.
+
+        Intercept all unary calls from users and authenticate users by validating auth
+        metadata sent by the user. Continue RPC call if user is authenticated, else,
+        terminate RPC call by setting context to abort.
+        """
+        # One of the method handlers in
+        # `flwr.superexec.exec_servicer.ExecServicer`
+        method_handler: grpc.RpcMethodHandler = continuation(handler_call_details)
+        return self._generic_auth_unary_method_handler(method_handler)
+
+    def _generic_auth_unary_method_handler(
+        self, method_handler: grpc.RpcMethodHandler
+    ) -> grpc.RpcMethodHandler:
+        def _generic_method_handler(
+            request: Request,
+            context: grpc.ServicerContext,
+        ) -> Response:
+            user_public_key_bytes = base64.urlsafe_b64decode(
+                _get_value_from_tuples(
+                    _PUBLIC_KEY_HEADER, context.invocation_metadata()
+                )
+            )
+            if user_public_key_bytes not in self.user_public_keys:
+                context.abort(grpc.StatusCode.UNAUTHENTICATED, "Access denied")
+
+            # Verify hmac value
+            hmac_value = base64.urlsafe_b64decode(
+                _get_value_from_tuples(
+                    _AUTH_TOKEN_HEADER, context.invocation_metadata()
+                )
+            )
+            public_key = bytes_to_public_key(user_public_key_bytes)
+
+            if not self._verify_hmac(public_key, request, hmac_value):
+                context.abort(grpc.StatusCode.UNAUTHENTICATED, "Access denied")
+
+            return method_handler.unary_unary(request, context)  # type: ignore
+
+        return grpc.unary_unary_rpc_method_handler(
+            _generic_method_handler,
+            request_deserializer=method_handler.request_deserializer,
+            response_serializer=method_handler.response_serializer,
+        )
+
+    def _verify_hmac(
+        self, public_key: ec.EllipticCurvePublicKey, request: Request, hmac_value: bytes
+    ) -> bool:
+        shared_secret = generate_shared_key(self.server_private_key, public_key)
+        return verify_hmac(shared_secret, request.SerializeToString(True), hmac_value)

--- a/src/py/flwr/superexec/superexec_interceptor_test.py
+++ b/src/py/flwr/superexec/superexec_interceptor_test.py
@@ -1,0 +1,170 @@
+# Copyright 2024 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Flower server interceptor tests."""
+
+
+import base64
+import unittest
+from typing import Optional
+from unittest.mock import MagicMock
+
+import grpc
+
+from flwr.common.secure_aggregation.crypto.symmetric_encryption import (
+    compute_hmac,
+    generate_key_pairs,
+    generate_shared_key,
+    private_key_to_bytes,
+    public_key_to_bytes,
+)
+from flwr.proto.exec_pb2 import (  # pylint: disable=E0611
+    StartRunRequest,
+    StartRunResponse,
+    StreamLogsRequest,
+    StreamLogsResponse,
+)
+from flwr.superexec.exec_grpc import run_superexec_api_grpc
+from flwr.superexec.executor import Executor, RunTracker, UserConfig
+from flwr.superexec.simulation import SimulationEngine
+from flwr.superexec.superexec_interceptor import (
+    _AUTH_TOKEN_HEADER,
+    _PUBLIC_KEY_HEADER,
+    SuperExecInterceptor,
+)
+
+
+class MockExecutor(Executor):
+    def set_config(
+        self,
+        config: UserConfig,
+    ) -> None:
+        """Mock set_config."""
+
+    def start_run(
+        self,
+        fab_file: bytes,
+        override_config: UserConfig,
+        federation_config: UserConfig,
+    ) -> Optional[RunTracker]:
+        """Mock start_run."""
+
+
+class TestSuperExecInterceptor(unittest.TestCase):  # pylint: disable=R0902
+    """SuperExec interceptor tests."""
+
+    def setUp(self) -> None:
+        """Initialize mock stub and superexec interceptor."""
+        address = "localhost:9093"
+        self._user_private_key, self._user_public_key = generate_key_pairs()
+        self._superexec_private_key, self._superexec_public_key = generate_key_pairs()
+
+        self._superexec_interceptor = SuperExecInterceptor(
+            {public_key_to_bytes(self._user_public_key)},
+            private_key_to_bytes(self._superexec_private_key),
+            public_key_to_bytes(self._superexec_public_key),
+        )
+        executor = MagicMock()
+        run = MagicMock()
+        executor.start_run = lambda _, __, ___: run
+        self._server: grpc.Server = run_superexec_api_grpc(
+            address=address,
+            executor=executor,
+            certificates=None,
+            config={"num-supernodes": 10},
+            interceptors=[self._superexec_interceptor],
+        )
+
+        self._channel = grpc.insecure_channel(address)
+        self._start_run = self._channel.unary_unary(
+            "/flwr.proto.Exec/StartRun",
+            request_serializer=StartRunRequest.SerializeToString,
+            response_deserializer=StartRunResponse.FromString,
+        )
+        self._stream_logs = self._channel.unary_unary(
+            "/flwr.proto.Exec/StreamLogs",
+            request_serializer=StreamLogsRequest.SerializeToString,
+            response_deserializer=StreamLogsResponse.FromString,
+        )
+
+    def tearDown(self) -> None:
+        """Clean up grpc server."""
+        self._server.stop(None)
+
+    def test_successful_start_run_with_metadata(self) -> None:
+        """Test superexec interceptor for creating node."""
+        # Prepare
+        request = StartRunRequest(
+            fab_file=b"", override_config=None, federation_config=None
+        )
+        public_key_bytes = base64.urlsafe_b64encode(
+            public_key_to_bytes(self._user_public_key)
+        )
+        shared_secret = generate_shared_key(
+            self._user_private_key,
+            self._superexec_public_key,
+        )
+        hmac_value = base64.urlsafe_b64encode(
+            compute_hmac(shared_secret, request.SerializeToString(True))
+        )
+
+        # Execute
+        response, call = self._start_run.with_call(
+            request=request,
+            metadata=(
+                (_PUBLIC_KEY_HEADER, public_key_bytes),
+                (_AUTH_TOKEN_HEADER, hmac_value),
+            ),
+        )
+
+        expected_metadata = (
+            _PUBLIC_KEY_HEADER,
+            base64.urlsafe_b64encode(
+                public_key_to_bytes(self._superexec_public_key)
+            ).decode(),
+        )
+
+        # Assert
+        assert isinstance(response, StartRunResponse)
+        assert grpc.StatusCode.OK == call.code()
+
+    def test_unsuccessful_start_run_with_metadata(self) -> None:
+        """Test superexec interceptor for creating node unsuccessfully."""
+        # Prepare
+        _, user_public_key = generate_key_pairs()
+        public_key_bytes = base64.urlsafe_b64encode(
+            public_key_to_bytes(user_public_key)
+        )
+        request = StartRunRequest(
+            fab_file=b"", override_config=None, federation_config=None
+        )
+        shared_secret = generate_shared_key(
+            self._user_private_key,
+            self._superexec_public_key,
+        )
+        hmac_value = base64.urlsafe_b64encode(
+            compute_hmac(shared_secret, request.SerializeToString(True))
+        )
+
+        # Execute & Assert
+        with self.assertRaises(grpc.RpcError):
+            self._start_run.with_call(
+                request=StartRunRequest(
+                    fab_file=b"", override_config=None, federation_config=None
+                ),
+                metadata=(
+                    (_PUBLIC_KEY_HEADER, public_key_bytes),
+                    (_AUTH_TOKEN_HEADER, hmac_value),
+                ),
+            )


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->
There are no user auth yet for `superexec`.

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->
Add superexec interceptor for user authentication.

### Checklist

- [ ] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.ai/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
