### PR TITLE
fix(framework) Fix end-to-end FAB delivery

### DIFF
--- a/src/py/flwr/cli/config_utils.py
+++ b/src/py/flwr/cli/config_utils.py
@@ -74,13 +74,13 @@ def get_fab_metadata(fab_file: Union[Path, bytes]) -> Tuple[str, str]:
     Returns
     -------
     Tuple[str, str]
-        The `fab_version` and `fab_id` of the given Flower App Bundle.
+        The `fab_id` and `fab_version` of the given Flower App Bundle.
     """
     conf = get_fab_config(fab_file)
 
     return (
-        conf["project"]["version"],
         f"{conf['tool']['flwr']['app']['publisher']}/{conf['project']['name']}",
+        conf["project"]["version"],
     )
 
 

--- a/src/py/flwr/server/superlink/driver/driver_servicer.py
+++ b/src/py/flwr/server/superlink/driver/driver_servicer.py
@@ -23,7 +23,12 @@ from uuid import UUID
 import grpc
 
 from flwr.common.logger import log
-from flwr.common.serde import fab_to_proto, user_config_from_proto, user_config_to_proto
+from flwr.common.serde import (
+    fab_from_proto,
+    fab_to_proto,
+    user_config_from_proto,
+    user_config_to_proto,
+)
 from flwr.common.typing import Fab
 from flwr.proto import driver_pb2_grpc  # pylint: disable=E0611
 from flwr.proto.driver_pb2 import (  # pylint: disable=E0611
@@ -75,12 +80,13 @@ class DriverServicer(driver_pb2_grpc.DriverServicer):
         """Create run ID."""
         log(DEBUG, "DriverServicer.CreateRun")
         state: State = self.state_factory.state()
-        if request.HasField("fab") and request.fab.HasField("content"):
+        if request.HasField("fab"):
+            fab = fab_from_proto(request.fab)
             ffs: Ffs = self.ffs_factory.ffs()
-            fab_hash = ffs.put(request.fab.content, {})
+            fab_hash = ffs.put(fab.content, {})
             _raise_if(
-                fab_hash != request.fab.hash_str,
-                f"FAB ({request.fab}) hash from request doesn't match contents",
+                fab_hash != fab.hash_str,
+                f"FAB ({fab.hash_str}) hash from request doesn't match contents",
             )
         else:
             fab_hash = ""


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

### Checklist

- [ ] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.ai/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
