### PR TITLE
fix(framework) Add log to differentiate authenticated create node

### DIFF
--- a/src/py/flwr/server/superlink/fleet/grpc_rere/fleet_servicer.py
+++ b/src/py/flwr/server/superlink/fleet/grpc_rere/fleet_servicer.py
@@ -52,10 +52,12 @@ class FleetServicer(fleet_pb2_grpc.FleetServicer):
     ) -> CreateNodeResponse:
         """."""
         log(INFO, "FleetServicer.CreateNode")
-        return message_handler.create_node(
+        response = message_handler.create_node(
             request=request,
             state=self.state_factory.state(),
         )
+        log(INFO, "FleetServicer: Created node_id=%s", response.node.node_id)
+        return response
 
     def DeleteNode(
         self, request: DeleteNodeRequest, context: grpc.ServicerContext

--- a/src/py/flwr/server/superlink/fleet/grpc_rere/server_interceptor.py
+++ b/src/py/flwr/server/superlink/fleet/grpc_rere/server_interceptor.py
@@ -16,7 +16,7 @@
 
 
 import base64
-from logging import WARNING
+from logging import INFO, WARNING
 from typing import Any, Callable, Optional, Sequence, Tuple, Union
 
 import grpc
@@ -128,9 +128,15 @@ class AuthenticateServerInterceptor(grpc.ServerInterceptor):  # type: ignore
                 context.abort(grpc.StatusCode.UNAUTHENTICATED, "Access denied")
 
             if isinstance(request, CreateNodeRequest):
-                return self._create_authenticated_node(
+                response = self._create_authenticated_node(
                     client_public_key_bytes, request, context
                 )
+                log(
+                    INFO,
+                    "AuthenticateServerInterceptor: Created node_id=%s",
+                    response.node.node_id,
+                )
+                return response
 
             # Verify hmac value
             hmac_value = base64.urlsafe_b64decode(


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->
Authenticated create node does not produce any log which creates confusion.

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->
Add log to differentiate authenticated create node.

### Checklist

- [ ] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.ai/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
