### PR TITLE
refactor(framework:skip) Rearrange the client app code

### DIFF
--- a/src/py/flwr/client/app.py
+++ b/src/py/flwr/client/app.py
@@ -422,12 +422,6 @@ def start_client_internal(
                         message.metadata.message_id,
                     )
 
-                    # Handle control message
-                    out_message, sleep_duration = handle_control_message(message)
-                    if out_message:
-                        send(out_message)
-                        break
-
                     # Get run info
                     run_id = message.metadata.run_id
                     if run_id not in runs:
@@ -436,6 +430,12 @@ def start_client_internal(
                         # If get_run is None, i.e., in grpc-bidi mode
                         else:
                             runs[run_id] = Run(run_id, "", "", "", {})
+
+                    # Handle control message
+                    out_message, sleep_duration = handle_control_message(message)
+                    if out_message:
+                        send(out_message)
+                        break
 
                     run: Run = runs[run_id]
                     if get_fab is not None and run.fab_hash:


### PR DESCRIPTION

## Issue
As a part of traceability feature, we need to first track the run before any message exchange in [this](https://github.com/adap/flower/blob/49027de9d6f1870856952ca9430b6dfc910f3670/src/py/flwr/client/app.py#L196C5-L196C26) method. For that reason, this PR, rearrange the method flow.

