### PR TITLE
refactor(*:skip) Fix client interceptor tests

### DIFF
--- a/.github/workflows/_docker-build.yml
+++ b/.github/workflows/_docker-build.yml
@@ -122,7 +122,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
+        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # v4.3.6
         with:
           name: digests-${{ steps.build-id.outputs.id }}-${{ matrix.platform.name }}
           path: /tmp/digests/*

--- a/src/py/flwr/client/grpc_rere_client/client_interceptor_test.py
+++ b/src/py/flwr/client/grpc_rere_client/client_interceptor_test.py
@@ -75,7 +75,7 @@ class _MockServicer:
 
             if isinstance(request, CreateNodeRequest):
                 context.send_initial_metadata(
-                    ((_PUBLIC_KEY_HEADER, self.server_public_key),)
+                    ((_PUBLIC_KEY_HEADER, base64.urlsafe_b64encode(public_key_to_bytes(self.server_public_key))),)
                 )
                 return CreateNodeResponse()
             if isinstance(request, DeleteNodeRequest):
@@ -224,11 +224,12 @@ class TestAuthenticateClientInterceptor(unittest.TestCase):
             )
 
             expected_public_key = base64.urlsafe_b64encode(
-                public_key_to_bytes(self._user_public_key)
+                public_key_to_bytes(self._client_public_key)
             )
-
+            
             # Assert
             assert actual_public_key == expected_public_key
+        
 
     def test_client_auth_delete_node(self) -> None:
         """Test client authentication during delete node."""
@@ -262,7 +263,7 @@ class TestAuthenticateClientInterceptor(unittest.TestCase):
             )
             actual_hmac = _get_value_from_tuples(_AUTH_TOKEN_HEADER, received_metadata)
             expected_public_key = base64.urlsafe_b64encode(
-                public_key_to_bytes(self._user_public_key)
+                public_key_to_bytes(self._client_public_key)
             )
 
             # Assert
@@ -301,7 +302,7 @@ class TestAuthenticateClientInterceptor(unittest.TestCase):
             )
             actual_hmac = _get_value_from_tuples(_AUTH_TOKEN_HEADER, received_metadata)
             expected_public_key = base64.urlsafe_b64encode(
-                public_key_to_bytes(self._user_public_key)
+                public_key_to_bytes(self._client_public_key)
             )
 
             # Assert
@@ -342,7 +343,7 @@ class TestAuthenticateClientInterceptor(unittest.TestCase):
             )
             actual_hmac = _get_value_from_tuples(_AUTH_TOKEN_HEADER, received_metadata)
             expected_public_key = base64.urlsafe_b64encode(
-                public_key_to_bytes(self._user_public_key)
+                public_key_to_bytes(self._client_public_key)
             )
 
             # Assert
@@ -382,7 +383,7 @@ class TestAuthenticateClientInterceptor(unittest.TestCase):
             )
             actual_hmac = _get_value_from_tuples(_AUTH_TOKEN_HEADER, received_metadata)
             expected_public_key = base64.urlsafe_b64encode(
-                public_key_to_bytes(self._user_public_key)
+                public_key_to_bytes(self._client_public_key)
             )
 
             # Assert

--- a/src/py/flwr/client/grpc_rere_client/client_interceptor_test.py
+++ b/src/py/flwr/client/grpc_rere_client/client_interceptor_test.py
@@ -18,7 +18,6 @@
 import base64
 import threading
 import unittest
-from unittest.mock import MagicMock
 from concurrent import futures
 from logging import DEBUG, INFO, WARN
 from typing import Optional, Sequence, Tuple, Union
@@ -26,9 +25,6 @@ from typing import Optional, Sequence, Tuple, Union
 import grpc
 
 from flwr.client.grpc_rere_client.connection import grpc_request_response
-from flwr.proto.task_pb2 import TaskIns, Task
-from flwr.proto.recordset_pb2 import RecordSet
-from flwr.proto.node_pb2 import Node
 from flwr.common import GRPC_MAX_MESSAGE_LENGTH, serde
 from flwr.common.logger import log
 from flwr.common.message import Message, Metadata
@@ -50,7 +46,9 @@ from flwr.proto.fleet_pb2 import (  # pylint: disable=E0611
     PushTaskResRequest,
     PushTaskResResponse,
 )
+from flwr.proto.node_pb2 import Node
 from flwr.proto.run_pb2 import GetRunRequest, GetRunResponse  # pylint: disable=E0611
+from flwr.proto.task_pb2 import Task, TaskIns
 
 from .client_interceptor import _AUTH_TOKEN_HEADER, _PUBLIC_KEY_HEADER, Request
 
@@ -94,7 +92,16 @@ class _MockServicer:
             if isinstance(request, PushTaskResRequest):
                 return PushTaskResResponse()
 
-            return PullTaskInsResponse(task_ins_list=[TaskIns(task=Task(consumer=Node(node_id=123), recordset=serde.recordset_to_proto(RecordSet())))])
+            return PullTaskInsResponse(
+                task_ins_list=[
+                    TaskIns(
+                        task=Task(
+                            consumer=Node(node_id=123),
+                            recordset=serde.recordset_to_proto(RecordSet()),
+                        )
+                    )
+                ]
+            )
 
     def received_client_metadata(
         self,

--- a/src/py/flwr/client/grpc_rere_client/client_interceptor_test.py
+++ b/src/py/flwr/client/grpc_rere_client/client_interceptor_test.py
@@ -75,7 +75,14 @@ class _MockServicer:
 
             if isinstance(request, CreateNodeRequest):
                 context.send_initial_metadata(
-                    ((_PUBLIC_KEY_HEADER, base64.urlsafe_b64encode(public_key_to_bytes(self.server_public_key))),)
+                    (
+                        (
+                            _PUBLIC_KEY_HEADER,
+                            base64.urlsafe_b64encode(
+                                public_key_to_bytes(self.server_public_key)
+                            ),
+                        ),
+                    )
                 )
                 return CreateNodeResponse()
             if isinstance(request, DeleteNodeRequest):
@@ -226,10 +233,9 @@ class TestAuthenticateClientInterceptor(unittest.TestCase):
             expected_public_key = base64.urlsafe_b64encode(
                 public_key_to_bytes(self._client_public_key)
             )
-            
+
             # Assert
             assert actual_public_key == expected_public_key
-        
 
     def test_client_auth_delete_node(self) -> None:
         """Test client authentication during delete node."""
@@ -309,7 +315,6 @@ class TestAuthenticateClientInterceptor(unittest.TestCase):
             assert actual_public_key == expected_public_key
             assert actual_hmac == expected_hmac
 
-
     def test_client_auth_send(self) -> None:
         """Test client authentication during send node."""
         # Prepare
@@ -328,7 +333,7 @@ class TestAuthenticateClientInterceptor(unittest.TestCase):
             _, send, _, _, _, _ = conn
             assert send is not None
             send(message)
-            
+
             received_metadata = self._servicer.received_client_metadata()
             assert received_metadata is not None
 
@@ -350,7 +355,6 @@ class TestAuthenticateClientInterceptor(unittest.TestCase):
             assert actual_public_key == expected_public_key
             assert actual_hmac == expected_hmac
 
-
     def test_client_auth_get_run(self) -> None:
         """Test client authentication during send node."""
         # Prepare
@@ -368,7 +372,7 @@ class TestAuthenticateClientInterceptor(unittest.TestCase):
             _, _, _, _, get_run, _ = conn
             assert get_run is not None
             get_run(0)
-            
+
             received_metadata = self._servicer.received_client_metadata()
             assert received_metadata is not None
 

--- a/src/py/flwr/client/grpc_rere_client/client_interceptor_test.py
+++ b/src/py/flwr/client/grpc_rere_client/client_interceptor_test.py
@@ -251,7 +251,9 @@ class TestAuthenticateClientInterceptor(unittest.TestCase):
             None,
             (self._client_private_key, self._client_public_key),
         ) as conn:
-            _, _, _, delete_node, _, _ = conn
+            _, _, create_node, delete_node, _, _ = conn
+            assert create_node is not None
+            create_node()
             assert delete_node is not None
             delete_node()
 
@@ -261,8 +263,8 @@ class TestAuthenticateClientInterceptor(unittest.TestCase):
             shared_secret = generate_shared_key(
                 self._servicer.server_private_key, self._client_public_key
             )
-            expected_hmac = compute_hmac(
-                shared_secret, self._servicer.received_message_bytes()
+            expected_hmac = base64.urlsafe_b64encode(
+                compute_hmac(shared_secret, self._servicer.received_message_bytes())
             )
             actual_public_key = _get_value_from_tuples(
                 _PUBLIC_KEY_HEADER, received_metadata
@@ -290,7 +292,9 @@ class TestAuthenticateClientInterceptor(unittest.TestCase):
             None,
             (self._client_private_key, self._client_public_key),
         ) as conn:
-            receive, _, _, _, _, _ = conn
+            receive, _, create_node, _, _, _ = conn
+            assert create_node is not None
+            create_node()
             assert receive is not None
             receive()
 
@@ -300,8 +304,8 @@ class TestAuthenticateClientInterceptor(unittest.TestCase):
             shared_secret = generate_shared_key(
                 self._servicer.server_private_key, self._client_public_key
             )
-            expected_hmac = compute_hmac(
-                shared_secret, self._servicer.received_message_bytes()
+            expected_hmac = base64.urlsafe_b64encode(
+                compute_hmac(shared_secret, self._servicer.received_message_bytes())
             )
             actual_public_key = _get_value_from_tuples(
                 _PUBLIC_KEY_HEADER, received_metadata
@@ -330,7 +334,9 @@ class TestAuthenticateClientInterceptor(unittest.TestCase):
             None,
             (self._client_private_key, self._client_public_key),
         ) as conn:
-            _, send, _, _, _, _ = conn
+            _, send, create_node, _, _, _ = conn
+            assert create_node is not None
+            create_node()
             assert send is not None
             send(message)
 
@@ -340,8 +346,8 @@ class TestAuthenticateClientInterceptor(unittest.TestCase):
             shared_secret = generate_shared_key(
                 self._servicer.server_private_key, self._client_public_key
             )
-            expected_hmac = compute_hmac(
-                shared_secret, self._servicer.received_message_bytes()
+            expected_hmac = base64.urlsafe_b64encode(
+                compute_hmac(shared_secret, self._servicer.received_message_bytes())
             )
             actual_public_key = _get_value_from_tuples(
                 _PUBLIC_KEY_HEADER, received_metadata
@@ -369,7 +375,9 @@ class TestAuthenticateClientInterceptor(unittest.TestCase):
             None,
             (self._client_private_key, self._client_public_key),
         ) as conn:
-            _, _, _, _, get_run, _ = conn
+            _, _, create_node, _, get_run, _ = conn
+            assert create_node is not None
+            create_node()
             assert get_run is not None
             get_run(0)
 
@@ -379,8 +387,8 @@ class TestAuthenticateClientInterceptor(unittest.TestCase):
             shared_secret = generate_shared_key(
                 self._servicer.server_private_key, self._client_public_key
             )
-            expected_hmac = compute_hmac(
-                shared_secret, self._servicer.received_message_bytes()
+            expected_hmac = base64.urlsafe_b64encode(
+                compute_hmac(shared_secret, self._servicer.received_message_bytes())
             )
             actual_public_key = _get_value_from_tuples(
                 _PUBLIC_KEY_HEADER, received_metadata

--- a/src/py/flwr/client/grpc_rere_client/client_interceptor_test.py
+++ b/src/py/flwr/client/grpc_rere_client/client_interceptor_test.py
@@ -415,8 +415,6 @@ class TestAuthenticateClientInterceptor(unittest.TestCase):
             assert actual_public_key == expected_public_key
             assert actual_hmac == expected_hmac
 
-        assert False
-
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/src/py/flwr/client/grpc_rere_client/client_interceptor_test.py
+++ b/src/py/flwr/client/grpc_rere_client/client_interceptor_test.py
@@ -46,9 +46,9 @@ from flwr.proto.fleet_pb2 import (  # pylint: disable=E0611
     PushTaskResRequest,
     PushTaskResResponse,
 )
-from flwr.proto.node_pb2 import Node
+from flwr.proto.node_pb2 import Node  # pylint: disable=E0611
 from flwr.proto.run_pb2 import GetRunRequest, GetRunResponse  # pylint: disable=E0611
-from flwr.proto.task_pb2 import Task, TaskIns
+from flwr.proto.task_pb2 import Task, TaskIns  # pylint: disable=E0611
 
 from .client_interceptor import _AUTH_TOKEN_HEADER, _PUBLIC_KEY_HEADER, Request
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->
Client interceptor tests don't work because context manager captures all exceptions, making the pytests seems to pass.

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->
Fix client interceptor tests.

### Checklist

- [ ] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.ai/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
