### PR TITLE
fix(framework:skip) Enable `SuperNode` to complete context registration when `FAB` is not installed

### DIFF
--- a/src/py/flwr/client/app.py
+++ b/src/py/flwr/client/app.py
@@ -452,12 +452,14 @@ def start_client_internal(
 
                     # Register context for this run
                     node_state.register_context(
-                        run_id=run_id, run=run, flwr_path=flwr_path
+                        run_id=run_id,
+                        run=run,
+                        flwr_path=flwr_path,
+                        fab=fab,
                     )
 
                     # Retrieve context for this run
                     context = node_state.retrieve_context(run_id=run_id)
-
                     # Create an error reply message that will never be used to prevent
                     # the used-before-assignment linting error
                     reply_message = message.create_error_reply(

--- a/src/py/flwr/client/node_state.py
+++ b/src/py/flwr/client/node_state.py
@@ -20,8 +20,12 @@ from pathlib import Path
 from typing import Dict, Optional
 
 from flwr.common import Context, RecordSet
-from flwr.common.config import get_fused_config, get_fused_config_from_dir
-from flwr.common.typing import Run, UserConfig
+from flwr.common.config import (
+    get_fused_config,
+    get_fused_config_from_dir,
+    get_fused_config_from_fab,
+)
+from flwr.common.typing import Fab, Run, UserConfig
 
 
 @dataclass()
@@ -44,12 +48,14 @@ class NodeState:
         self.node_config = node_config
         self.run_infos: Dict[int, RunInfo] = {}
 
+    # pylint: disable=too-many-arguments
     def register_context(
         self,
         run_id: int,
         run: Optional[Run] = None,
         flwr_path: Optional[Path] = None,
         app_dir: Optional[str] = None,
+        fab: Optional[Fab] = None,
     ) -> None:
         """Register new run context for this node."""
         if run_id not in self.run_infos:
@@ -65,8 +71,14 @@ class NodeState:
                 else:
                     raise ValueError("The specified `app_dir` must be a directory.")
             else:
-                # Load from .fab
-                initial_run_config = get_fused_config(run, flwr_path) if run else {}
+                if fab:
+                    # Load pyproject.toml from FAB file and fuse
+                    initial_run_config = (
+                        get_fused_config_from_fab(fab.content, run) if run else {}
+                    )
+                else:
+                    # Load pyproject.toml from installed FAB and fuse
+                    initial_run_config = get_fused_config(run, flwr_path) if run else {}
             self.run_infos[run_id] = RunInfo(
                 initial_run_config=initial_run_config,
                 context=Context(

--- a/src/py/flwr/client/node_state.py
+++ b/src/py/flwr/client/node_state.py
@@ -71,14 +71,15 @@ class NodeState:
                 else:
                     raise ValueError("The specified `app_dir` must be a directory.")
             else:
-                if fab:
-                    # Load pyproject.toml from FAB file and fuse
-                    initial_run_config = (
-                        get_fused_config_from_fab(fab.content, run) if run else {}
-                    )
+                if run:
+                    if fab:
+                        # Load pyproject.toml from FAB file and fuse
+                        initial_run_config = get_fused_config_from_fab(fab.content, run)
+                    else:
+                        # Load pyproject.toml from installed FAB and fuse
+                        initial_run_config = get_fused_config(run, flwr_path)
                 else:
-                    # Load pyproject.toml from installed FAB and fuse
-                    initial_run_config = get_fused_config(run, flwr_path) if run else {}
+                    initial_run_config = {}
             self.run_infos[run_id] = RunInfo(
                 initial_run_config=initial_run_config,
                 context=Context(

--- a/src/py/flwr/common/config.py
+++ b/src/py/flwr/common/config.py
@@ -20,7 +20,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union, cast, get_args
 
 import tomli
 
-from flwr.cli.config_utils import validate_fields
+from flwr.cli.config_utils import get_fab_config, validate_fields
 from flwr.common.constant import APP_DIR, FAB_CONFIG_FILE, FLWR_HOME
 from flwr.common.typing import Run, UserConfig, UserConfigValue
 
@@ -102,6 +102,18 @@ def get_fused_config_from_dir(
     flat_default_config = flatten_dict(default_config)
 
     return fuse_dicts(flat_default_config, override_config)
+
+
+def get_fused_config_from_fab(fab_file: Union[Path, bytes], run: Run) -> UserConfig:
+    """Fuse default config in a `FAB` with overrides in a `Run`.
+
+    This enables obtaining a run-config without having to install the FAB. This
+    function mirrors `get_fused_config_from_dir`. This is useful when the execution
+    of the FAB is delegated to a different process.
+    """
+    default_config = get_fab_config(fab_file)["tool"]["flwr"]["app"].get("config", {})
+    flat_config_flat = flatten_dict(default_config)
+    return fuse_dicts(flat_config_flat, run.override_config)
 
 
 def get_fused_config(run: Run, flwr_dir: Optional[Path]) -> UserConfig:


### PR DESCRIPTION
If `--isolation` is set, the `SuperNode` doesn't install the `FAB`. This prevents the `context` (which needs to be passed to the external process that runs the `ClientApp`) from being fully initialized with the content of the `pyproject.toml` and, optionally, any override to the `run-config`

This PR enables yet another way to process `<NodeState>.register_context()` that's first extracts the `pyproject.toml` from a `FAB` w/o installing it.