### PR TITLE
feat(framework:skip) Add SuperNode Alpine Docker image

### DIFF
--- a/dev/build-docker-image-matrix.py
+++ b/dev/build-docker-image-matrix.py
@@ -159,9 +159,10 @@ if __name__ == "__main__":
             "supernode",
             base_images,
             tag_latest_alpine_with_flwr_version,
-            lambda image: not (
+            lambda image: image.distro.name == DistroName.UBUNTU
+            or (
                 image.distro.name == DistroName.ALPINE
-                and image.python_version != LATEST_SUPPORTED_PYTHON_VERSION
+                and image.python_version == LATEST_SUPPORTED_PYTHON_VERSION
             ),
         )
         # ubuntu images for each supported python version

--- a/dev/build-docker-image-matrix.py
+++ b/dev/build-docker-image-matrix.py
@@ -158,8 +158,11 @@ if __name__ == "__main__":
         + generate_binary_images(
             "supernode",
             base_images,
-            tag_latest_ubuntu_with_flwr_version,
-            lambda image: image.distro.name == DistroName.UBUNTU,
+            tag_latest_alpine_with_flwr_version,
+            lambda image: not (
+                image.distro.name == DistroName.ALPINE
+                and image.python_version != LATEST_SUPPORTED_PYTHON_VERSION
+            ),
         )
         # ubuntu images for each supported python version
         + generate_binary_images(


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

- Adds a SuperNode Alpine Docker image.
- The version tag will from now on point to the new Alpine image instead of `py3.11-ubuntu22.04`.

Complete list of SuperNode images tags from version Flower 1.11.0:

`1.11.0-py3.8-ubuntu22.04`
`1.11.0-py3.9-ubuntu22.04`
`1.11.0-py3.10-ubuntu22.04`
`1.11.0-py3.11-ubuntu22.04`
`1.11.0-py3.11-alpine3.19`, `1.11.0`

### Description

<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

### Checklist

- [ ] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.ai/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
