### PR TITLE
fix(framework) Read project name from `pyproject.toml` in `flwr build`

### DIFF
--- a/src/py/flwr/cli/build.py
+++ b/src/py/flwr/cli/build.py
@@ -89,7 +89,7 @@ def build(
     # Set the name of the zip file
     fab_filename = (
         f"{conf['tool']['flwr']['app']['publisher']}"
-        f".{app.name}"
+        f".{conf['project']['name']}"
         f".{conf['project']['version'].replace('.', '-')}.fab"
     )
     list_file_content = ""


### PR DESCRIPTION
This change is needed so if a `FAB` can be "manually" installed from `flwr install`. This is not an issue when the `FAB` is installed from `bytes` since in such setup the file name checks can't be performed.