### PR TITLE
docs(framework) Add note to `flower-server-app` CLI ref

### DIFF
--- a/doc/source/ref-api-cli.rst
+++ b/doc/source/ref-api-cli.rst
@@ -49,7 +49,7 @@ flower-server-app
    Note that since version :code:`1.11.0`, :code:`flower-server-app` no longer supports passing a reference to a `ServerApp` attribute.
    Instead, you need to pass the path to Flower app via the argument :code:`--app`.
    This is the path to a directory containing a `pyproject.toml`.
-   You can create a valid Flower app by exectuing :code:`flwr new` and following the prompt.
+   You can create a valid Flower app by executing :code:`flwr new` and following the prompt.
 
 .. argparse::
    :module: flwr.server.run_serverapp

--- a/doc/source/ref-api-cli.rst
+++ b/doc/source/ref-api-cli.rst
@@ -45,6 +45,12 @@ flower-supernode
 flower-server-app
 ~~~~~~~~~~~~~~~~~
 
+.. note::
+   Note that since version :code:`1.11.0`, :code:`flower-server-app` no longer supports passing a reference to a `ServerApp` attribute.
+   Instead, you need to pass the path to Flower app via the argument :code:`--app`.
+   This is the path to a directory containing a `pyproject.toml`.
+   You can create a valid Flower app by exectuing :code:`flwr new` and following the prompt.
+
 .. argparse::
    :module: flwr.server.run_serverapp
    :func: _parse_args_run_server_app


### PR DESCRIPTION
Add a note to inform about the change in `flower-server-app` no longer supporting passing a path to a `SeverApp` attribute.

<img width="1117" alt="Screenshot 2024-08-23 at 17 01 05" src="https://github.com/user-attachments/assets/9ea2f5e7-8927-4b08-aa90-be9ebc3660b4">
