### PR TITLE
break(framework) Remove `flwr example` command

### DIFF
--- a/src/py/flwr/cli/app.py
+++ b/src/py/flwr/cli/app.py
@@ -18,7 +18,6 @@ import typer
 from typer.main import get_command
 
 from .build import build
-from .example import example
 from .install import install
 from .new import new
 from .run import run
@@ -33,7 +32,6 @@ app = typer.Typer(
 )
 
 app.command()(new)
-app.command()(example)
 app.command()(run)
 app.command()(build)
 app.command()(install)


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

Remove the `flwr example` command from the CLI while keeping the logic in `src/py/flwr/cli/example.py` so it can, in the future be extracted and integrated into the `flwr new`.

<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

### Checklist

- [x] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.ai/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
