### PR TITLE
fix(framework:skip) Fix parsing run config in simulation

### DIFF
--- a/src/py/flwr/simulation/run_simulation.py
+++ b/src/py/flwr/simulation/run_simulation.py
@@ -177,7 +177,9 @@ def run_simulation_from_cli() -> None:
         client_app_attr = app_components["clientapp"]
         server_app_attr = app_components["serverapp"]
 
-        override_config = parse_config_args([args.run_config])
+        override_config = parse_config_args(
+            [args.run_config] if args.run_config else args.run_config
+        )
         fused_config = get_fused_config_from_dir(app_path, override_config)
         app_dir = args.app
         is_app = True


### PR DESCRIPTION
Same as #4091