### PR TITLE
refactor(framework) Rename flower-superexec entrypoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ exclude = [
 # `flwr` CLI
 flwr = "flwr.cli.app:app"
 # SuperExec (can run with either Deployment Engine or Simulation Engine)
-flower-superexec = "flwr.superexec:run_superexec"
+flower-superexec = "flwr.superexec:cli_flower_superexec"
 # Simulation Engine
 flower-simulation = "flwr.simulation.run_simulation:run_simulation_from_cli"
 # Deployment Engine

--- a/src/py/flwr/superexec/__init__.py
+++ b/src/py/flwr/superexec/__init__.py
@@ -14,8 +14,8 @@
 # ==============================================================================
 """Flower SuperExec service."""
 
-from .app import run_superexec as run_superexec
+from .app import cli_flower_superexec as cli_flower_superexec
 
 __all__ = [
-    "run_superexec",
+    "cli_flower_superexec",
 ]

--- a/src/py/flwr/superexec/app.py
+++ b/src/py/flwr/superexec/app.py
@@ -33,7 +33,7 @@ from .exec_grpc import run_superexec_api_grpc
 from .executor import Executor
 
 
-def run_superexec() -> None:
+def cli_flower_superexec() -> None:
     """Run Flower SuperExec."""
     log(INFO, "Starting Flower SuperExec")
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

### Checklist

- [ ] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.ai/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
