### PR TITLE
fix(framework) Fix parsing `executor_config` if present

### DIFF
--- a/src/py/flwr/superexec/app.py
+++ b/src/py/flwr/superexec/app.py
@@ -56,7 +56,9 @@ def run_superexec() -> None:
         address=address,
         executor=_load_executor(args),
         certificates=certificates,
-        config=parse_config_args([args.executor_config]),
+        config=parse_config_args(
+            [args.executor_config] if args.executor_config else args.executor_config
+        ),
     )
 
     grpc_servers = [superexec_server]


### PR DESCRIPTION
Same as #4091 and #4095.