### PR TITLE
refactor(framework:skip) Move `ClientApp` warning when `client_fn` is not passed

### DIFF
--- a/src/py/flwr/client/client_app.py
+++ b/src/py/flwr/client/client_app.py
@@ -133,7 +133,7 @@ class ClientApp:
         else:
             # Warn ClientApp doesn't specify a client_fn
             warn_preview_feature(
-                "Defining a `ClientApp` without passing a `client_fn` is an "
+                "Using a `ClientApp` that doesn't make use of a `client_fn` is an "
                 "experimental feature."
             )
 


### PR DESCRIPTION
When using the low-level APIs for `ClientApp`, a warning is thrown each time the `@app.train`, `@app.evaluate`, `@app.query` methods are called. This PR moves the warning to the `ClientApp` constructor so those that want to use the low-level `ClientApp` features are warned only once.