### PR TITLE
docs(framework:skip) Fix passing multiple arguments to `--run-config` 

### DIFF
--- a/doc/source/tutorial-quickstart-mlx.rst
+++ b/doc/source/tutorial-quickstart-mlx.rst
@@ -109,7 +109,7 @@ You can also override the parameters defined in
 .. code:: shell
 
    # Override some arguments
-   $ flwr run . --run-config num-server-rounds=5,lr=0.05
+   $ flwr run . --run-config "num-server-rounds=5 lr=0.05"
 
 What follows is an explanation of each component in the project you just
 created: dataset partition, the model, defining the ``ClientApp`` and

--- a/doc/source/tutorial-quickstart-pytorch.rst
+++ b/doc/source/tutorial-quickstart-pytorch.rst
@@ -108,7 +108,7 @@ You can also override the parameters defined in the
 .. code:: shell
 
    # Override some arguments
-   $ flwr run . --run-config num-server-rounds=5,local-epochs=3
+   $ flwr run . --run-config "num-server-rounds=5 local-epochs=3"
 
 What follows is an explanation of each component in the project you just
 created: dataset partition, the model, defining the ``ClientApp`` and


### PR DESCRIPTION
Updated to new style