### PR TITLE
fix(framework:skip) Specify keyword `deterministic`  in `SerializeToString` method

### DIFF
--- a/src/py/flwr/client/grpc_rere_client/client_interceptor.py
+++ b/src/py/flwr/client/grpc_rere_client/client_interceptor.py
@@ -130,13 +130,12 @@ class AuthenticateClientInterceptor(grpc.UnaryUnaryClientInterceptor):  # type: 
             if self.shared_secret is None:
                 raise RuntimeError("Failure to compute hmac")
 
+            message_bytes = request.SerializeToString(deterministic=True)
             metadata.append(
                 (
                     _AUTH_TOKEN_HEADER,
                     base64.urlsafe_b64encode(
-                        compute_hmac(
-                            self.shared_secret, request.SerializeToString(True)
-                        )
+                        compute_hmac(self.shared_secret, message_bytes)
                     ),
                 )
             )

--- a/src/py/flwr/client/grpc_rere_client/client_interceptor_test.py
+++ b/src/py/flwr/client/grpc_rere_client/client_interceptor_test.py
@@ -73,7 +73,7 @@ class _MockServicer:
         """Handle unary call."""
         with self._lock:
             self._received_client_metadata = context.invocation_metadata()
-            self._received_message_bytes = request.SerializeToString(True)
+            self._received_message_bytes = request.SerializeToString(deterministic=True)
 
             if isinstance(request, CreateNodeRequest):
                 context.send_initial_metadata(

--- a/src/py/flwr/server/superlink/fleet/grpc_rere/server_interceptor.py
+++ b/src/py/flwr/server/superlink/fleet/grpc_rere/server_interceptor.py
@@ -188,7 +188,8 @@ class AuthenticateServerInterceptor(grpc.ServerInterceptor):  # type: ignore
         self, public_key: ec.EllipticCurvePublicKey, request: Request, hmac_value: bytes
     ) -> bool:
         shared_secret = generate_shared_key(self.server_private_key, public_key)
-        return verify_hmac(shared_secret, request.SerializeToString(True), hmac_value)
+        message_bytes = request.SerializeToString(deterministic=True)
+        return verify_hmac(shared_secret, message_bytes, hmac_value)
 
     def _create_authenticated_node(
         self,

--- a/src/py/flwr/server/superlink/fleet/grpc_rere/server_interceptor_test.py
+++ b/src/py/flwr/server/superlink/fleet/grpc_rere/server_interceptor_test.py
@@ -166,7 +166,7 @@ class TestServerInterceptor(unittest.TestCase):  # pylint: disable=R0902
             self._node_private_key, self._server_public_key
         )
         hmac_value = base64.urlsafe_b64encode(
-            compute_hmac(shared_secret, request.SerializeToString(True))
+            compute_hmac(shared_secret, request.SerializeToString(deterministic=True))
         )
         public_key_bytes = base64.urlsafe_b64encode(
             public_key_to_bytes(self._node_public_key)
@@ -195,7 +195,7 @@ class TestServerInterceptor(unittest.TestCase):  # pylint: disable=R0902
         node_private_key, _ = generate_key_pairs()
         shared_secret = generate_shared_key(node_private_key, self._server_public_key)
         hmac_value = base64.urlsafe_b64encode(
-            compute_hmac(shared_secret, request.SerializeToString(True))
+            compute_hmac(shared_secret, request.SerializeToString(deterministic=True))
         )
         public_key_bytes = base64.urlsafe_b64encode(
             public_key_to_bytes(self._node_public_key)
@@ -222,7 +222,7 @@ class TestServerInterceptor(unittest.TestCase):  # pylint: disable=R0902
             self._node_private_key, self._server_public_key
         )
         hmac_value = base64.urlsafe_b64encode(
-            compute_hmac(shared_secret, request.SerializeToString(True))
+            compute_hmac(shared_secret, request.SerializeToString(deterministic=True))
         )
         public_key_bytes = base64.urlsafe_b64encode(
             public_key_to_bytes(self._node_public_key)
@@ -251,7 +251,7 @@ class TestServerInterceptor(unittest.TestCase):  # pylint: disable=R0902
         node_private_key, _ = generate_key_pairs()
         shared_secret = generate_shared_key(node_private_key, self._server_public_key)
         hmac_value = base64.urlsafe_b64encode(
-            compute_hmac(shared_secret, request.SerializeToString(True))
+            compute_hmac(shared_secret, request.SerializeToString(deterministic=True))
         )
         public_key_bytes = base64.urlsafe_b64encode(
             public_key_to_bytes(self._node_public_key)
@@ -280,7 +280,7 @@ class TestServerInterceptor(unittest.TestCase):  # pylint: disable=R0902
             self._node_private_key, self._server_public_key
         )
         hmac_value = base64.urlsafe_b64encode(
-            compute_hmac(shared_secret, request.SerializeToString(True))
+            compute_hmac(shared_secret, request.SerializeToString(deterministic=True))
         )
         public_key_bytes = base64.urlsafe_b64encode(
             public_key_to_bytes(self._node_public_key)
@@ -311,7 +311,7 @@ class TestServerInterceptor(unittest.TestCase):  # pylint: disable=R0902
         node_private_key, _ = generate_key_pairs()
         shared_secret = generate_shared_key(node_private_key, self._server_public_key)
         hmac_value = base64.urlsafe_b64encode(
-            compute_hmac(shared_secret, request.SerializeToString(True))
+            compute_hmac(shared_secret, request.SerializeToString(deterministic=True))
         )
         public_key_bytes = base64.urlsafe_b64encode(
             public_key_to_bytes(self._node_public_key)
@@ -339,7 +339,7 @@ class TestServerInterceptor(unittest.TestCase):  # pylint: disable=R0902
             self._node_private_key, self._server_public_key
         )
         hmac_value = base64.urlsafe_b64encode(
-            compute_hmac(shared_secret, request.SerializeToString(True))
+            compute_hmac(shared_secret, request.SerializeToString(deterministic=True))
         )
         public_key_bytes = base64.urlsafe_b64encode(
             public_key_to_bytes(self._node_public_key)
@@ -369,7 +369,7 @@ class TestServerInterceptor(unittest.TestCase):  # pylint: disable=R0902
         node_private_key, _ = generate_key_pairs()
         shared_secret = generate_shared_key(node_private_key, self._server_public_key)
         hmac_value = base64.urlsafe_b64encode(
-            compute_hmac(shared_secret, request.SerializeToString(True))
+            compute_hmac(shared_secret, request.SerializeToString(deterministic=True))
         )
         public_key_bytes = base64.urlsafe_b64encode(
             public_key_to_bytes(self._node_public_key)
@@ -396,7 +396,7 @@ class TestServerInterceptor(unittest.TestCase):  # pylint: disable=R0902
             self._node_private_key, self._server_public_key
         )
         hmac_value = base64.urlsafe_b64encode(
-            compute_hmac(shared_secret, request.SerializeToString(True))
+            compute_hmac(shared_secret, request.SerializeToString(deterministic=True))
         )
         public_key_bytes = base64.urlsafe_b64encode(
             public_key_to_bytes(self._node_public_key)
@@ -425,7 +425,7 @@ class TestServerInterceptor(unittest.TestCase):  # pylint: disable=R0902
         node_private_key, _ = generate_key_pairs()
         shared_secret = generate_shared_key(node_private_key, self._server_public_key)
         hmac_value = base64.urlsafe_b64encode(
-            compute_hmac(shared_secret, request.SerializeToString(True))
+            compute_hmac(shared_secret, request.SerializeToString(deterministic=True))
         )
         public_key_bytes = base64.urlsafe_b64encode(
             public_key_to_bytes(self._node_public_key)
@@ -469,7 +469,7 @@ class TestServerInterceptor(unittest.TestCase):  # pylint: disable=R0902
             self._node_private_key, self._server_public_key
         )
         hmac_value = base64.urlsafe_b64encode(
-            compute_hmac(shared_secret, request.SerializeToString(True))
+            compute_hmac(shared_secret, request.SerializeToString(deterministic=True))
         )
         public_key_bytes = base64.urlsafe_b64encode(
             public_key_to_bytes(self._node_public_key)


### PR DESCRIPTION
## Motivation
As explained in [google protobuf documentation](https://googleapis.dev/python/protobuf/latest/google/protobuf/message.html#google.protobuf.message.Message.SerializeToString), the `SerializeToString` method only accept keyword arguments. In some settings, as spotted by Robert and Danny, the following exception will be raised when calling `SerializeToString(True)`, i.e., a positional argument instead of a keyword argument is passed.
```
TypeError: _AddSerializeToStringMethod.<locals>.SerializeToString() takes 1 positional argument but 2 were given
```

## Solution
Change `SerializeToString(True)` to `SerializeToString(deterministic=True)`.