### PR TITLE
refactor(framework:skip) Remove `get_parameters` from `flwr` TensorFlow template

### DIFF
--- a/src/py/flwr/cli/new/templates/app/code/client.tensorflow.py.tpl
+++ b/src/py/flwr/cli/new/templates/app/code/client.tensorflow.py.tpl
@@ -17,9 +17,6 @@ class FlowerClient(NumPyClient):
         self.batch_size = batch_size
         self.verbose = verbose
 
-    def get_parameters(self, config):
-        return self.model.get_weights()
-
     def fit(self, parameters, config):
         self.model.set_weights(parameters)
         self.model.fit(


### PR DESCRIPTION
Since we initialize a server-side global model, `get_parameters` is redundant in `FlowerClient`.