### PR TITLE
fix(baselines) Fix dimension order in weight slicing for OD layers

### DIFF
--- a/baselines/fjord/fjord/od/layers/conv.py
+++ b/baselines/fjord/fjord/od/layers/conv.py
@@ -49,7 +49,7 @@ def get_slice(layer: Module, in_dim: int, out_dim: int) -> Tuple[Tensor, Tensor]
     :param out_dim: The output dimension.
     :return: The slice of weights and bias.
     """
-    weight_slice = layer.weight[:in_dim, :out_dim]
+    weight_slice = layer.weight[:out_dim, :in_dim]
     bias_slice = layer.bias[:out_dim] if layer.bias is not None else None
     return weight_slice, bias_slice
 

--- a/baselines/fjord/fjord/od/layers/linear.py
+++ b/baselines/fjord/fjord/od/layers/linear.py
@@ -58,6 +58,6 @@ class ODLinear(nn.Linear):
         :param out_dim: The output dimension.
         :return: The slice of weights and bias.
         """
-        weight_slice = self.weight[:in_dim, :out_dim]
+        weight_slice = self.weight[:out_dim, :in_dim]
         bias_slice = self.bias[:out_dim] if self.bias is not None else None
         return weight_slice, bias_slice


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description
Weight slicing for OD layers has the input and output dimensions reversed.

In the weight parameters of Linear and Conv layers, the first dimension should be `out_dim`, and the second dimension should be `in_dim`.
<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal

### Explanation
Reversed the order of input and output dimensions in the weight slicing for OD layers.
<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

### Checklist

- [ ] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.ai/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
