### PR TITLE
fix(framework:skip) Fix SuperExec log capturing

### DIFF
--- a/src/py/flwr/superexec/deployment.py
+++ b/src/py/flwr/superexec/deployment.py
@@ -167,6 +167,8 @@ class DeploymentEngine(Executor):
             # Execute the command
             proc = subprocess.Popen(  # pylint: disable=consider-using-with
                 command,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
                 text=True,
             )
             log(INFO, "Started run %s", str(run_id))

--- a/src/py/flwr/superexec/exec_servicer.py
+++ b/src/py/flwr/superexec/exec_servicer.py
@@ -16,6 +16,7 @@
 
 
 import select
+import sys
 import threading
 import time
 from collections.abc import Generator
@@ -115,7 +116,12 @@ def _capture_logs(
             )
             # Read from std* and append to RunTracker.logs
             for stream in ready_to_read:
-                line = stream.readline().rstrip()
+                # Flush stdout to view output in real time
+                readline = stream.readline()
+                sys.stdout.write(readline)
+                sys.stdout.flush()
+                # Append to logs
+                line = readline.rstrip()
                 if line:
                     run.logs.append(f"{line}")
 

--- a/src/py/flwr/superexec/exec_servicer.py
+++ b/src/py/flwr/superexec/exec_servicer.py
@@ -96,7 +96,8 @@ class ExecServicer(exec_pb2_grpc.ExecServicer):
             # is returned at this point and the server ends the stream.
             if self.runs[request.run_id].proc.poll() is not None:
                 log(INFO, "All logs for run ID `%s` returned", request.run_id)
-                return
+                context.set_code(grpc.StatusCode.OK)
+                context.cancel()
 
             time.sleep(1.0)  # Sleep briefly to avoid busy waiting
 


### PR DESCRIPTION
Fixes:
* In `_capture_logs`, add `sys.stdout.write()` and `sys.stdout.flush()` to print live logs to terminal. This is necessary when `stdout` and `stderr` are piped in `subprocess.Popen`.
* Add `context.cancel()` so that gRPC server initiates cancellation of gRPC call. Using `return` does not cancel and clean up, resulting in endless print. 