### PR TITLE
fix(examples:skip) Specify `min_fit_clients` in `FedAvg` in the Secure Aggregation example

### DIFF
--- a/examples/flower-secure-aggregation/secaggexample/server_app.py
+++ b/examples/flower-secure-aggregation/secaggexample/server_app.py
@@ -40,6 +40,7 @@ def main(driver: Driver, context: Context) -> None:
     strategy = FedAvg(
         # Select all available clients
         fraction_fit=1.0,
+        min_fit_clients=5,
         # Disable evaluation in demo
         fraction_evaluate=(0.0 if is_demo else context.run_config["fraction-evaluate"]),
         min_available_clients=5,


### PR DESCRIPTION
The strategy may only sample 2 clients for fit round in simulation, which might b/c the simulation engine hasn't started all SuperNodes yet.