### PR TITLE
ci(*:skip) Enable SuperExec CI from fork

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -82,8 +82,12 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           poetry-skip: 'true'
+      - name: Install Flower from repo
+        if: ${{ github.repository != 'adap/flower' || github.event.pull_request.head.repo.fork || github.actor == 'dependabot[bot]' }}
+        run: |
+          python -m pip install .
       - name: Download and install Flower wheel from artifact store
-        if: ${{ github.repository == 'adap/flower' && github.actor != 'dependabot[bot]' }}
+        if: ${{ github.repository == 'adap/flower' && !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
         run: |
           # Define base URL for wheel file
           WHEEL_URL="https://${{ env.ARTIFACT_BUCKET }}/py/${{ needs.wheel.outputs.dir }}/${{ needs.wheel.outputs.short_sha }}/${{ needs.wheel.outputs.whl_path }}"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -85,7 +85,11 @@ jobs:
       - name: Install Flower from repo
         if: ${{ github.repository != 'adap/flower' || github.event.pull_request.head.repo.fork || github.actor == 'dependabot[bot]' }}
         run: |
-          python -m pip install .
+          if [[ "${{ matrix.engine }}" == "simulation-engine" ]]; then
+            python -m pip install ".[simulation]"
+          else
+            python -m pip install .
+          fi
       - name: Download and install Flower wheel from artifact store
         if: ${{ github.repository == 'adap/flower' && !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -83,7 +83,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           poetry-skip: 'true'
       - name: Download and install Flower wheel from artifact store
-        if: ${{ github.repository == 'adap/flower' && !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
+        if: ${{ github.repository == 'adap/flower' && github.actor != 'dependabot[bot]' }}
         run: |
           # Define base URL for wheel file
           WHEEL_URL="https://${{ env.ARTIFACT_BUCKET }}/py/${{ needs.wheel.outputs.dir }}/${{ needs.wheel.outputs.short_sha }}/${{ needs.wheel.outputs.whl_path }}"


### PR DESCRIPTION
A fix to allow #3790 to be merged. 

Currently, the SuperExec CI relies on `flwr` installed from our artifact bucket. One of the conditions is that the PR must originate from the main repository (not a fork). Unfortunately, this prevents contributors' PRs (like #3790) from [passing our CI](https://github.com/adap/flower/actions/runs/11111502524). This PR lifts this restriction for the SuperExec CI by installing `flwr` via `pip`.