### PR TITLE
fix(framework) Pass Flower path to the call to `start_client_internal()` in SuperNode

### DIFF
--- a/src/py/flwr/client/supernode/app.py
+++ b/src/py/flwr/client/supernode/app.py
@@ -79,6 +79,7 @@ def run_supernode() -> None:
         node_config=parse_config_args(
             [args.node_config] if args.node_config else args.node_config
         ),
+        flwr_path=args.flwr_dir,
         isolation=args.isolation,
         supernode_address=args.supernode_address,
     )


### PR DESCRIPTION
When spinning up a SuperNode using `flower-supernode`, users can specify the `flwr-dir` argument to point to a non-default location where Flower apps are installed. But currently, `flwr_path` is not set in the call to `start_client_internal()`. This PR fixes it. 