### PR TITLE
feat(framework) Add example docstring PyLint checker

### DIFF
--- a/pylint-custom-checkers/docstring_example_checker.py
+++ b/pylint-custom-checkers/docstring_example_checker.py
@@ -1,0 +1,38 @@
+from pylint.checkers import BaseChecker, IAstroidChecker
+from astroid import nodes
+
+
+class DocstringExampleChecker(BaseChecker):
+    __implements__ = IAstroidChecker
+
+    name = "docstring-example"
+    msgs = {
+        "C0001": (
+            'Docstring should contain at least one example using ">>>".',
+            "docstring-example-missing",
+            'Ensure that each docstring contains an "Examples:" section with at least one code example.',
+        ),
+    }
+
+    def visit_functiondef(self, node: nodes.FunctionDef) -> None:
+        self.check_docstring(node)
+
+    def visit_classdef(self, node: nodes.ClassDef) -> None:
+        self.check_docstring(node)
+
+    def check_docstring(self, node: nodes.NodeNG) -> None:
+        docstring = node.doc
+        if docstring:
+            # Check if the docstring contains an "Examples:" section
+            examples_section = docstring.split("Examples:")
+            if len(examples_section) < 2:
+                self.add_message("docstring-example-missing", node=node)
+            else:
+                # Count occurrences of the '>>>' code block in the Examples section
+                example_count = examples_section[1].count(">>>")
+                if example_count < 1:
+                    self.add_message("docstring-example-missing", node=node)
+
+
+def register(linter):
+    linter.register_checker(DocstringExampleChecker(linter))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,6 +133,7 @@ check-wheel-contents = "==0.4.0"
 GitPython = "==3.1.32"
 PyGithub = "==2.1.1"
 licensecheck = "==2024"
+astroid = "^3.0"
 pre-commit = "==3.5.0"
 sphinx-substitution-extensions = "2022.02.16"
 sphinxext-opengraph = "==0.9.1"
@@ -153,6 +154,9 @@ known_first_party = ["flwr", "flwr_tool"]
 [tool.black]
 line-length = 88
 target-version = ["py39", "py310", "py311"]
+
+[tool.pylint]
+load-plugins = ["pylint-custom-checkers.docstring_example_checker"]
 
 [tool.pylint."MESSAGES CONTROL"]
 disable = "duplicate-code,too-few-public-methods,useless-import-alias"


### PR DESCRIPTION
This PR adds a new PyLint checker for enforcing example docstring. 