### PR TITLE
fix(framework:skip) Update config utils to flatten overrides

### DIFF
--- a/src/py/flwr/common/config.py
+++ b/src/py/flwr/common/config.py
@@ -101,8 +101,9 @@ def get_fused_config_from_dir(
         "config", {}
     )
     flat_default_config = flatten_dict(default_config)
+    flat_override_config = flatten_dict(override_config)
 
-    return fuse_dicts(flat_default_config, override_config)
+    return fuse_dicts(flat_default_config, flat_override_config)
 
 
 def get_fused_config_from_fab(fab_file: Union[Path, bytes], run: Run) -> UserConfig:

--- a/src/py/flwr/common/config.py
+++ b/src/py/flwr/common/config.py
@@ -113,9 +113,8 @@ def get_fused_config_from_dir(
         "config", {}
     )
     flat_default_config = flatten_dict(default_config)
-    flat_override_config = flatten_dict(override_config)
 
-    return fuse_dicts(flat_default_config, flat_override_config)
+    return fuse_dicts(flat_default_config, override_config)
 
 
 def get_fused_config_from_fab(fab_file: Union[Path, bytes], run: Run) -> UserConfig:
@@ -218,8 +217,9 @@ def parse_config_args(
             matches = pattern.findall(config_line)
             toml_str = "\n".join(f"{k} = {v}" for k, v in matches)
             overrides.update(tomli.loads(toml_str))
+            flat_overrides = flatten_dict(overrides)
 
-    return overrides
+    return flat_overrides
 
 
 def get_metadata_from_config(config: dict[str, Any]) -> tuple[str, str]:


### PR DESCRIPTION


<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description
fix match error when overriding config args with '.' (like 'model.quantization')
<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->

### Related issues/PRs
Fixes #4317
<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal

### Explanation
flatten override_config to make two dicts aligned
<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

### Checklist

- [ ] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.ai/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
