### PR TITLE
refactor(examples:skip) Move a comment out of the code block in opacus example

### DIFF
--- a/examples/opacus/README.md
+++ b/examples/opacus/README.md
@@ -37,10 +37,9 @@ opacus
 
 ### Install dependencies and project
 
-Install the dependencies defined in `pyproject.toml` as well as the `opacus_fl` package.
+Install the dependencies defined in `pyproject.toml` as well as the `opacus_fl` package. From a new python environment, run:
 
 ```shell
-# From a new python environment, run:
 pip install -e .
 ```
 


### PR DESCRIPTION
### Description
A comment copies alongside the command from a code block in readme file.

### Related issues/PRs
Related to #4262 and #4328

## Proposal
Move the comment before the code block.

### Checklist

- [x] Implement proposed change