### PR TITLE
refactor(framework) Make argparse processing the first action of `SuperNode` and `SuperLink`

### DIFF
--- a/src/py/flwr/client/supernode/app.py
+++ b/src/py/flwr/client/supernode/app.py
@@ -183,6 +183,8 @@ def _parse_args_run_supernode() -> argparse.ArgumentParser:
         - `$FLWR_HOME/` if `$FLWR_HOME` is defined
         - `$XDG_DATA_HOME/.flwr/` if `$XDG_DATA_HOME` is defined
         - `$HOME/.flwr/` in all other cases
+    . Note that if `--isolation` is used, setting a custom `flwr-dir` can only be done
+    via either `$FLWR_HOME` or `$XDG_DATA_HOME`.
     """,
     )
     parser.add_argument(

--- a/src/py/flwr/client/supernode/app.py
+++ b/src/py/flwr/client/supernode/app.py
@@ -177,8 +177,7 @@ def _parse_args_run_supernode() -> argparse.ArgumentParser:
         "--flwr-dir",
         default=None,
         help="""The path containing installed Flower Apps.
-        If `--isolation` is set, use `$FLWR_HOME` or `$XDG_DATA_HOME` to specify the
-        directory instead. The default directory is:
+        The default directory is:
 
         - `$FLWR_HOME/` if `$FLWR_HOME` is defined
         - `$XDG_DATA_HOME/.flwr/` if `$XDG_DATA_HOME` is defined

--- a/src/py/flwr/client/supernode/app.py
+++ b/src/py/flwr/client/supernode/app.py
@@ -48,13 +48,12 @@ from ..clientapp.utils import get_load_client_app_fn
 
 def run_supernode() -> None:
     """Run Flower SuperNode."""
+    args = _parse_args_run_supernode().parse_args()
+    _warn_deprecated_server_arg(args)
+
     log(INFO, "Starting Flower SuperNode")
 
     event(EventType.RUN_SUPERNODE_ENTER)
-
-    args = _parse_args_run_supernode().parse_args()
-
-    _warn_deprecated_server_arg(args)
 
     root_certificates = _get_certificates(args)
     load_fn = get_load_client_app_fn(
@@ -178,14 +177,13 @@ def _parse_args_run_supernode() -> argparse.ArgumentParser:
         "--flwr-dir",
         default=None,
         help="""The path containing installed Flower Apps.
-    By default, this value is equal to:
+        If `--isolation` is set, use `$FLWR_HOME` or `$XDG_DATA_HOME` to specify the
+        directory instead. The default directory is:
 
         - `$FLWR_HOME/` if `$FLWR_HOME` is defined
         - `$XDG_DATA_HOME/.flwr/` if `$XDG_DATA_HOME` is defined
         - `$HOME/.flwr/` in all other cases
-    . Note that if `--isolation` is used, setting a custom `flwr-dir` can only be done
-    via either `$FLWR_HOME` or `$XDG_DATA_HOME`.
-    """,
+        """,
     )
     parser.add_argument(
         "--isolation",

--- a/src/py/flwr/server/app.py
+++ b/src/py/flwr/server/app.py
@@ -199,11 +199,11 @@ def start_server(  # pylint: disable=too-many-arguments,too-many-locals
 # pylint: disable=too-many-branches, too-many-locals, too-many-statements
 def run_superlink() -> None:
     """Run Flower SuperLink (Driver API and Fleet API)."""
+    args = _parse_args_run_superlink().parse_args()
+
     log(INFO, "Starting Flower SuperLink")
 
     event(EventType.RUN_SUPERLINK_ENTER)
-
-    args = _parse_args_run_superlink().parse_args()
 
     # Parse IP address
     driver_address, _, _ = _format_address(args.driver_api_address)


### PR DESCRIPTION
- Updates the help message associated to `--flwr-dir`
- Moves the "Start SuperNode/Superlink" logs after the argparse has been processed (so they do not appear if a user does `flower-supernode --help` or `flower-superlink --help`.