### PR TITLE
Introducing Flower Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@
     <a href="https://flower.ai/blog">Blog</a> |
     <a href="https://flower.ai/docs/">Docs</a> |
     <a href="https://flower.ai/conf/flower-summit-2022">Conference</a> |
-    <a href="https://flower.ai/join-slack">Slack</a>
+    <a href="https://flower.ai/join-slack">Slack</a> |
+    <a href="https://gurubase.io/g/flower">Ask Flower Guru</a>
     <br /><br />
 </p>
 
@@ -20,6 +21,7 @@
 [![Downloads](https://static.pepy.tech/badge/flwr)](https://pepy.tech/project/flwr)
 [![Docker Hub](https://img.shields.io/badge/Docker%20Hub-flwr-blue)](https://hub.docker.com/u/flwr)
 [![Slack](https://img.shields.io/badge/Chat-Slack-red)](https://flower.ai/join-slack)
+[![](https://img.shields.io/badge/Gurubase-Ask%20Flower%20Guru-006BFF)](https://gurubase.io/g/flower)
 
 Flower (`flwr`) is a framework for building federated learning systems. The
 design of Flower is based on a few guiding principles:


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Flower Guru](https://gurubase.io/g/flower) to Gurubase. Flower Guru uses the data from this repo and data from the [docs](https://flower.ai/docs/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Flower Guru", which highlights that Flower now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Flower Guru in Gurubase, just let me know that's totally fine.