### PR TITLE
refactor(framework) Rename `NodeState` to `DeprecatedRunInfoStore`

### DIFF
--- a/src/py/flwr/client/app.py
+++ b/src/py/flwr/client/app.py
@@ -59,7 +59,7 @@ from .grpc_adapter_client.connection import grpc_adapter
 from .grpc_client.connection import grpc_connection
 from .grpc_rere_client.connection import grpc_request_response
 from .message_handler.message_handler import handle_control_message
-from .node_state import NodeState
+from .run_info_store import DeprecatedRunInfoStore
 from .numpy_client import NumPyClient
 
 ISOLATION_MODE_SUBPROCESS = "subprocess"
@@ -364,8 +364,8 @@ def start_client_internal(
         on_backoff=_on_backoff,
     )
 
-    # NodeState gets initialized when the first connection is established
-    node_state: Optional[NodeState] = None
+    # DeprecatedRunInfoStore gets initialized when the first connection is established
+    run_info_store: Optional[DeprecatedRunInfoStore] = None
 
     runs: dict[int, Run] = {}
 
@@ -382,7 +382,7 @@ def start_client_internal(
             receive, send, create_node, delete_node, get_run, get_fab = conn
 
             # Register node when connecting the first time
-            if node_state is None:
+            if run_info_store is None:
                 if create_node is None:
                     if transport not in ["grpc-bidi", None]:
                         raise NotImplementedError(
@@ -391,7 +391,7 @@ def start_client_internal(
                         )
                     # gRPC-bidi doesn't have the concept of node_id,
                     # so we set it to -1
-                    node_state = NodeState(
+                    run_info_store = DeprecatedRunInfoStore(
                         node_id=-1,
                         node_config={},
                     )
@@ -402,7 +402,7 @@ def start_client_internal(
                     )  # pylint: disable=not-callable
                     if node_id is None:
                         raise ValueError("Node registration failed")
-                    node_state = NodeState(
+                    run_info_store = DeprecatedRunInfoStore(
                         node_id=node_id,
                         node_config=node_config,
                     )
@@ -461,7 +461,7 @@ def start_client_internal(
                     run.fab_id, run.fab_version = fab_id, fab_version
 
                     # Register context for this run
-                    node_state.register_context(
+                    run_info_store.register_context(
                         run_id=run_id,
                         run=run,
                         flwr_path=flwr_path,
@@ -469,7 +469,7 @@ def start_client_internal(
                     )
 
                     # Retrieve context for this run
-                    context = node_state.retrieve_context(run_id=run_id)
+                    context = run_info_store.retrieve_context(run_id=run_id)
                     # Create an error reply message that will never be used to prevent
                     # the used-before-assignment linting error
                     reply_message = message.create_error_reply(
@@ -542,7 +542,7 @@ def start_client_internal(
                             # Raise exception, crash process
                             raise ex
 
-                        # Don't update/change NodeState
+                        # Don't update/change DeprecatedRunInfoStore
 
                         e_code = ErrorCode.CLIENT_APP_RAISED_EXCEPTION
                         # Ex fmt: "<class 'ZeroDivisionError'>:<'division by zero'>"
@@ -567,7 +567,7 @@ def start_client_internal(
                         )
                     else:
                         # No exception, update node state
-                        node_state.update_context(
+                        run_info_store.update_context(
                             run_id=run_id,
                             context=context,
                         )

--- a/src/py/flwr/client/app.py
+++ b/src/py/flwr/client/app.py
@@ -59,8 +59,8 @@ from .grpc_adapter_client.connection import grpc_adapter
 from .grpc_client.connection import grpc_connection
 from .grpc_rere_client.connection import grpc_request_response
 from .message_handler.message_handler import handle_control_message
-from .run_info_store import DeprecatedRunInfoStore
 from .numpy_client import NumPyClient
+from .run_info_store import DeprecatedRunInfoStore
 
 ISOLATION_MODE_SUBPROCESS = "subprocess"
 ISOLATION_MODE_PROCESS = "process"

--- a/src/py/flwr/client/node_state_tests.py
+++ b/src/py/flwr/client/node_state_tests.py
@@ -17,7 +17,7 @@
 
 from typing import cast
 
-from flwr.client.node_state import NodeState
+from flwr.client.run_info_store import DeprecatedRunInfoStore
 from flwr.common import ConfigsRecord, Context
 from flwr.proto.task_pb2 import TaskIns  # pylint: disable=E0611
 
@@ -34,32 +34,31 @@ def _run_dummy_task(context: Context) -> Context:
 
 
 def test_multirun_in_node_state() -> None:
-    """Test basic NodeState logic."""
+    """Test basic DeprecatedRunInfoStore logic."""
     # Tasks to perform
     tasks = [TaskIns(run_id=run_id) for run_id in [0, 1, 1, 2, 3, 2, 1, 5]]
     # the "tasks" is to count how many times each run is executed
     expected_values = {0: "1", 1: "1" * 3, 2: "1" * 2, 3: "1", 5: "1"}
 
-    # NodeState
-    node_state = NodeState(node_id=0, node_config={})
+    node_info_store = DeprecatedRunInfoStore(node_id=0, node_config={})
 
     for task in tasks:
         run_id = task.run_id
 
         # Register
-        node_state.register_context(run_id=run_id)
+        node_info_store.register_context(run_id=run_id)
 
         # Get run state
-        context = node_state.retrieve_context(run_id=run_id)
+        context = node_info_store.retrieve_context(run_id=run_id)
 
         # Run "task"
         updated_state = _run_dummy_task(context)
 
         # Update run state
-        node_state.update_context(run_id=run_id, context=updated_state)
+        node_info_store.update_context(run_id=run_id, context=updated_state)
 
     # Verify values
-    for run_id, run_info in node_state.run_infos.items():
+    for run_id, run_info in node_info_store.run_infos.items():
         assert (
             run_info.context.state.configs_records["counter"]["count"]
             == expected_values[run_id]

--- a/src/py/flwr/client/run_info_store.py
+++ b/src/py/flwr/client/run_info_store.py
@@ -36,7 +36,7 @@ class RunInfo:
     initial_run_config: UserConfig
 
 
-class NodeState:
+class DeprecatedRunInfoStore:
     """State of a node where client nodes execute runs."""
 
     def __init__(

--- a/src/py/flwr/client/run_info_store.py
+++ b/src/py/flwr/client/run_info_store.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Flower Labs GmbH. All Rights Reserved.
+# Copyright 2024 Flower Labs GmbH. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Node state."""
+"""Deprecated Run Info Store."""
 
 
 from dataclasses import dataclass

--- a/src/py/flwr/server/superlink/fleet/vce/backend/raybackend_test.py
+++ b/src/py/flwr/server/superlink/fleet/vce/backend/raybackend_test.py
@@ -22,7 +22,7 @@ import ray
 
 from flwr.client import Client, NumPyClient
 from flwr.client.client_app import ClientApp
-from flwr.client.node_state import NodeState
+from flwr.client.run_info_store import DeprecatedRunInfoStore
 from flwr.common import (
     DEFAULT_TTL,
     Config,
@@ -104,8 +104,8 @@ def _create_message_and_context() -> tuple[Message, Context, float]:
         ),
     )
 
-    # Construct NodeState and retrieve context
-    node_state = NodeState(node_id=run_id, node_config={PARTITION_ID_KEY: str(0)})
+    # Construct DeprecatedRunInfoStore and retrieve context
+    node_state = DeprecatedRunInfoStore(node_id=run_id, node_config={PARTITION_ID_KEY: str(0)})
     node_state.register_context(run_id=run_id)
     context = node_state.retrieve_context(run_id=run_id)
 

--- a/src/py/flwr/server/superlink/fleet/vce/backend/raybackend_test.py
+++ b/src/py/flwr/server/superlink/fleet/vce/backend/raybackend_test.py
@@ -105,7 +105,9 @@ def _create_message_and_context() -> tuple[Message, Context, float]:
     )
 
     # Construct DeprecatedRunInfoStore and retrieve context
-    node_state = DeprecatedRunInfoStore(node_id=run_id, node_config={PARTITION_ID_KEY: str(0)})
+    node_state = DeprecatedRunInfoStore(
+        node_id=run_id, node_config={PARTITION_ID_KEY: str(0)}
+    )
     node_state.register_context(run_id=run_id)
     context = node_state.retrieve_context(run_id=run_id)
 

--- a/src/py/flwr/server/superlink/fleet/vce/vce_api.py
+++ b/src/py/flwr/server/superlink/fleet/vce/vce_api.py
@@ -65,8 +65,7 @@ def _register_node_info_stores(
     run: Run,
     app_dir: Optional[str] = None,
 ) -> dict[int, DeprecatedRunInfoStore]:
-    """Create DeprecatedRunInfoStore objects and pre-register the context for the
-    run."""
+    """Create DeprecatedRunInfoStore objects and register the context for the run."""
     node_info_store: dict[int, DeprecatedRunInfoStore] = {}
     num_partitions = len(set(nodes_mapping.values()))
     for node_id, partition_id in nodes_mapping.items():

--- a/src/py/flwr/server/superlink/fleet/vce/vce_api.py
+++ b/src/py/flwr/server/superlink/fleet/vce/vce_api.py
@@ -65,7 +65,8 @@ def _register_node_info_stores(
     run: Run,
     app_dir: Optional[str] = None,
 ) -> dict[int, DeprecatedRunInfoStore]:
-    """Create DeprecatedRunInfoStore objects and pre-register the context for the run."""
+    """Create DeprecatedRunInfoStore objects and pre-register the context for the
+    run."""
     node_info_store: dict[int, DeprecatedRunInfoStore] = {}
     num_partitions = len(set(nodes_mapping.values()))
     for node_id, partition_id in nodes_mapping.items():

--- a/src/py/flwr/server/superlink/fleet/vce/vce_api.py
+++ b/src/py/flwr/server/superlink/fleet/vce/vce_api.py
@@ -28,7 +28,7 @@ from typing import Callable, Optional
 
 from flwr.client.client_app import ClientApp, ClientAppException, LoadClientAppError
 from flwr.client.clientapp.utils import get_load_client_app_fn
-from flwr.client.node_state import NodeState
+from flwr.client.run_info_store import DeprecatedRunInfoStore
 from flwr.common.constant import (
     NUM_PARTITIONS_KEY,
     PARTITION_ID_KEY,
@@ -60,16 +60,16 @@ def _register_nodes(
     return nodes_mapping
 
 
-def _register_node_states(
+def _register_node_info_stores(
     nodes_mapping: NodeToPartitionMapping,
     run: Run,
     app_dir: Optional[str] = None,
-) -> dict[int, NodeState]:
-    """Create NodeState objects and pre-register the context for the run."""
-    node_states: dict[int, NodeState] = {}
+) -> dict[int, DeprecatedRunInfoStore]:
+    """Create DeprecatedRunInfoStore objects and pre-register the context for the run."""
+    node_info_store: dict[int, DeprecatedRunInfoStore] = {}
     num_partitions = len(set(nodes_mapping.values()))
     for node_id, partition_id in nodes_mapping.items():
-        node_states[node_id] = NodeState(
+        node_info_store[node_id] = DeprecatedRunInfoStore(
             node_id=node_id,
             node_config={
                 PARTITION_ID_KEY: partition_id,
@@ -78,18 +78,18 @@ def _register_node_states(
         )
 
         # Pre-register Context objects
-        node_states[node_id].register_context(
+        node_info_store[node_id].register_context(
             run_id=run.run_id, run=run, app_dir=app_dir
         )
 
-    return node_states
+    return node_info_store
 
 
 # pylint: disable=too-many-arguments,too-many-locals
 def worker(
     taskins_queue: "Queue[TaskIns]",
     taskres_queue: "Queue[TaskRes]",
-    node_states: dict[int, NodeState],
+    node_info_store: dict[int, DeprecatedRunInfoStore],
     backend: Backend,
     f_stop: threading.Event,
 ) -> None:
@@ -103,7 +103,7 @@ def worker(
             node_id = task_ins.task.consumer.node_id
 
             # Retrieve context
-            context = node_states[node_id].retrieve_context(run_id=task_ins.run_id)
+            context = node_info_store[node_id].retrieve_context(run_id=task_ins.run_id)
 
             # Convert TaskIns to Message
             message = message_from_taskins(task_ins)
@@ -112,7 +112,7 @@ def worker(
             out_mssg, updated_context = backend.process_message(message, context)
 
             # Update Context
-            node_states[node_id].update_context(
+            node_info_store[node_id].update_context(
                 task_ins.run_id, context=updated_context
             )
         except Empty:
@@ -178,7 +178,7 @@ def run_api(
     backend_fn: Callable[[], Backend],
     nodes_mapping: NodeToPartitionMapping,
     state_factory: LinkStateFactory,
-    node_states: dict[int, NodeState],
+    node_info_stores: dict[int, DeprecatedRunInfoStore],
     f_stop: threading.Event,
 ) -> None:
     """Run the VCE."""
@@ -223,7 +223,7 @@ def run_api(
                     worker,
                     taskins_queue,
                     taskres_queue,
-                    node_states,
+                    node_info_stores,
                     backend,
                     f_stop,
                 )
@@ -312,8 +312,8 @@ def start_vce(
             num_nodes=num_supernodes, state_factory=state_factory
         )
 
-    # Construct mapping of NodeStates
-    node_states = _register_node_states(
+    # Construct mapping of DeprecatedRunInfoStore
+    node_info_stores = _register_node_info_stores(
         nodes_mapping=nodes_mapping, run=run, app_dir=app_dir if is_app else None
     )
 
@@ -376,7 +376,7 @@ def start_vce(
             backend_fn,
             nodes_mapping,
             state_factory,
-            node_states,
+            node_info_stores,
             f_stop,
         )
     except LoadClientAppError as loadapp_ex:

--- a/src/py/flwr/simulation/ray_transport/ray_client_proxy.py
+++ b/src/py/flwr/simulation/ray_transport/ray_client_proxy.py
@@ -22,7 +22,7 @@ from typing import Optional
 from flwr import common
 from flwr.client import ClientFnExt
 from flwr.client.client_app import ClientApp
-from flwr.client.node_state import NodeState
+from flwr.client.run_info_store import DeprecatedRunInfoStore
 from flwr.common import DEFAULT_TTL, Message, Metadata, RecordSet
 from flwr.common.constant import (
     NUM_PARTITIONS_KEY,
@@ -65,7 +65,7 @@ class RayActorClientProxy(ClientProxy):
 
         self.app_fn = _load_app
         self.actor_pool = actor_pool
-        self.proxy_state = NodeState(
+        self.proxy_state = DeprecatedRunInfoStore(
             node_id=node_id,
             node_config={
                 PARTITION_ID_KEY: str(partition_id),

--- a/src/py/flwr/simulation/ray_transport/ray_client_proxy_test.py
+++ b/src/py/flwr/simulation/ray_transport/ray_client_proxy_test.py
@@ -22,7 +22,7 @@ import ray
 
 from flwr.client import Client, NumPyClient
 from flwr.client.client_app import ClientApp
-from flwr.client.node_state import NodeState
+from flwr.client.run_info_store import DeprecatedRunInfoStore
 from flwr.common import (
     DEFAULT_TTL,
     Config,
@@ -142,7 +142,7 @@ def test_cid_consistency_all_submit_first_run_consistency() -> None:
     """Test that ClientProxies get the result of client job they submit.
 
     All jobs are submitted at the same time. Then fetched one at a time. This also tests
-    NodeState (at each Proxy) and RunState basic functionality.
+    DeprecatedRunInfoStore (at each Proxy) and RunState basic functionality.
     """
     proxies, _, _ = prep()
     run_id = 0
@@ -193,10 +193,10 @@ def test_cid_consistency_without_proxies() -> None:
     _, pool, mapping = prep()
     node_ids = list(mapping.keys())
 
-    # register node states
-    node_states: dict[int, NodeState] = {}
+    # register DeprecatedRunInfoStores
+    node_info_stores: dict[int, DeprecatedRunInfoStore] = {}
     for node_id, partition_id in mapping.items():
-        node_states[node_id] = NodeState(
+        node_info_stores[node_id] = DeprecatedRunInfoStore(
             node_id=node_id,
             node_config={
                 PARTITION_ID_KEY: str(partition_id),
@@ -228,8 +228,8 @@ def test_cid_consistency_without_proxies() -> None:
             ),
         )
         # register and retrieve context
-        node_states[node_id].register_context(run_id=run_id)
-        context = node_states[node_id].retrieve_context(run_id=run_id)
+        node_info_stores[node_id].register_context(run_id=run_id)
+        context = node_info_stores[node_id].retrieve_context(run_id=run_id)
         partition_id_str = str(context.node_config[PARTITION_ID_KEY])
         pool.submit_client_job(
             lambda a, c_fn, j_fn, nid_, state: a.run.remote(c_fn, j_fn, nid_, state),


### PR DESCRIPTION
This is the first step towards constructing a proper `NodeState` at the `SuperNode`