### PR TITLE
feat(framework) Add client metadata in grpc connection

### DIFF
--- a/src/py/flwr/client/app.py
+++ b/src/py/flwr/client/app.py
@@ -133,6 +133,10 @@ def start_client(
         - 'grpc-bidi': gRPC, bidirectional streaming
         - 'grpc-rere': gRPC, request-response (experimental)
         - 'rest': HTTP (experimental)
+    client_metadata : Optional[Sequence[tuple[str, Union[str, bytes]]]] (default: None)
+        Metadata to be sent to the server in the form of key-value pairs. If provided, 
+        GprcClientProxy retrieves this metadata, which can then be accessed through 
+        client_manager. This attribute can only be used in grpc-bidi.
     max_retries: Optional[int] (default: None)
         The maximum number of times the client will try to connect to the
         server before giving up in case of a connection error. If set to None,
@@ -252,6 +256,10 @@ def start_client_internal(
         - 'grpc-bidi': gRPC, bidirectional streaming
         - 'grpc-rere': gRPC, request-response (experimental)
         - 'rest': HTTP (experimental)
+    client_metadata : Optional[Sequence[tuple[str, Union[str, bytes]]]] (default: None)
+        Metadata to be sent to the server in the form of key-value pairs. If provided, 
+        GprcClientProxy retrieves this metadata, which can then be accessed through 
+        client_manager. This attribute can only be used in grpc-bidi.
     max_retries: Optional[int] (default: None)
         The maximum number of times the client will try to connect to the
         server before giving up in case of a connection error. If set to None,

--- a/src/py/flwr/client/app.py
+++ b/src/py/flwr/client/app.py
@@ -22,7 +22,7 @@ from contextlib import AbstractContextManager
 from dataclasses import dataclass
 from logging import ERROR, INFO, WARN
 from pathlib import Path
-from typing import Callable, Optional, Union, cast
+from typing import Callable, Optional, Sequence, Union, cast
 
 import grpc
 from cryptography.hazmat.primitives.asymmetric import ec
@@ -97,6 +97,7 @@ def start_client(
     authentication_keys: Optional[
         tuple[ec.EllipticCurvePrivateKey, ec.EllipticCurvePublicKey]
     ] = None,
+    client_metadata: Optional[Sequence[tuple[str, Union[str, bytes]]]] = None,
     max_retries: Optional[int] = None,
     max_wait_time: Optional[float] = None,
 ) -> None:
@@ -183,6 +184,7 @@ def start_client(
         insecure=insecure,
         transport=transport,
         authentication_keys=authentication_keys,
+        client_metadata=client_metadata,
         max_retries=max_retries,
         max_wait_time=max_wait_time,
     )
@@ -207,6 +209,7 @@ def start_client_internal(
     authentication_keys: Optional[
         tuple[ec.EllipticCurvePrivateKey, ec.EllipticCurvePublicKey]
     ] = None,
+    client_metadata: Optional[Sequence[tuple[str, Union[str, bytes]]]] = None,
     max_retries: Optional[int] = None,
     max_wait_time: Optional[float] = None,
     flwr_path: Optional[Path] = None,
@@ -358,9 +361,6 @@ def start_client_internal(
     node_state: Optional[NodeState] = None
 
     runs: dict[int, Run] = {}
-
-    # Metadata for testing. This is not used in the actual implementation.
-    client_metadata = [("test_key_1", "test_value_1"), ("test_key_2", "test_value_2")]
 
     while not app_state_tracker.interrupt:
         sleep_duration: int = 0

--- a/src/py/flwr/client/app.py
+++ b/src/py/flwr/client/app.py
@@ -359,6 +359,9 @@ def start_client_internal(
 
     runs: dict[int, Run] = {}
 
+    # Metadata for testing. This is not used in the actual implementation.
+    client_metadata = [("test_key_1", "test_value_1"), ("test_key_2", "test_value_2")]
+
     while not app_state_tracker.interrupt:
         sleep_duration: int = 0
         with connection(
@@ -368,6 +371,7 @@ def start_client_internal(
             grpc_max_message_length,
             root_certificates,
             authentication_keys,
+            client_metadata,
         ) as conn:
             receive, send, create_node, delete_node, get_run, get_fab = conn
 

--- a/src/py/flwr/client/grpc_adapter_client/connection.py
+++ b/src/py/flwr/client/grpc_adapter_client/connection.py
@@ -18,7 +18,7 @@
 from collections.abc import Iterator
 from contextlib import contextmanager
 from logging import ERROR
-from typing import Callable, Optional, Union
+from typing import Callable, Optional, Sequence, Union
 
 from cryptography.hazmat.primitives.asymmetric import ec
 
@@ -41,6 +41,7 @@ def grpc_adapter(  # pylint: disable=R0913
     authentication_keys: Optional[  # pylint: disable=unused-argument
         tuple[ec.EllipticCurvePrivateKey, ec.EllipticCurvePublicKey]
     ] = None,
+    client_metadata: Optional[Sequence[tuple[str, Union[str, bytes]]]] = None, # pylint: disable=unused-argument
 ) -> Iterator[
     tuple[
         Callable[[], Optional[Message]],
@@ -93,6 +94,7 @@ def grpc_adapter(  # pylint: disable=R0913
         max_message_length=max_message_length,
         root_certificates=root_certificates,
         authentication_keys=None,  # Authentication is not supported
+        client_metadata=client_metadata,
         adapter_cls=GrpcAdapter,
     ) as conn:
         yield conn

--- a/src/py/flwr/client/grpc_adapter_client/connection.py
+++ b/src/py/flwr/client/grpc_adapter_client/connection.py
@@ -75,6 +75,8 @@ def grpc_adapter(  # pylint: disable=R0913
         Flower server. Bytes won't work for the REST API.
     authentication_keys : Optional[Tuple[PrivateKey, PublicKey]] (default: None)
         Client authentication is not supported for this transport type.
+    client_metadata : Optional[Sequence[tuple[str, Union[str, bytes]]]] (default: None)
+        Unused argument present for compatibilty.
 
     Returns
     -------

--- a/src/py/flwr/client/grpc_client/connection.py
+++ b/src/py/flwr/client/grpc_client/connection.py
@@ -21,7 +21,7 @@ from contextlib import contextmanager
 from logging import DEBUG, ERROR
 from pathlib import Path
 from queue import Queue
-from typing import Callable, Optional, Union, cast
+from typing import Callable, Optional, Sequence, Union, cast
 
 from cryptography.hazmat.primitives.asymmetric import ec
 
@@ -69,6 +69,7 @@ def grpc_connection(  # pylint: disable=R0913, R0915
     authentication_keys: Optional[  # pylint: disable=unused-argument
         tuple[ec.EllipticCurvePrivateKey, ec.EllipticCurvePublicKey]
     ] = None,
+    client_metadata: Optional[Sequence[tuple[str, Union[str, bytes]]]] = None, # pylint: disable=unused-argument
 ) -> Iterator[
     tuple[
         Callable[[], Optional[Message]],
@@ -144,8 +145,6 @@ def grpc_connection(  # pylint: disable=R0913, R0915
     )
     stub = FlowerServiceStub(channel)
 
-    # Metadata for testing. This is not used in the actual implementation.
-    client_metadata = [("test_key_1", "test_value_1"), ("test_key_2", "test_value_2")]
     server_message_iterator: Iterator[ServerMessage] = stub.Join(iter(queue.get, None), metadata=client_metadata)
 
     def receive() -> Message:

--- a/src/py/flwr/client/grpc_client/connection.py
+++ b/src/py/flwr/client/grpc_client/connection.py
@@ -144,7 +144,9 @@ def grpc_connection(  # pylint: disable=R0913, R0915
     )
     stub = FlowerServiceStub(channel)
 
-    server_message_iterator: Iterator[ServerMessage] = stub.Join(iter(queue.get, None))
+    # Metadata for testing. This is not used in the actual implementation.
+    client_metadata = [("test_key_1", "test_value_1"), ("test_key_2", "test_value_2")]
+    server_message_iterator: Iterator[ServerMessage] = stub.Join(iter(queue.get, None), metadata=client_metadata)
 
     def receive() -> Message:
         # Receive ServerMessage proto

--- a/src/py/flwr/client/grpc_client/connection.py
+++ b/src/py/flwr/client/grpc_client/connection.py
@@ -107,6 +107,10 @@ def grpc_connection(  # pylint: disable=R0913, R0915
         established to an SSL-enabled Flower server.
     authentication_keys : Optional[Tuple[PrivateKey, PublicKey]] (default: None)
         Client authentication is not supported for this transport type.
+    client_metadata : Optional[Sequence[tuple[str, Union[str, bytes]]]] (default: None)
+        Metadata to be sent to the server in the form of key-value pairs. If provided, 
+        GprcClientProxy retrieves this metadata, which can then be accessed through 
+        client_manager. This attribute can only be used in grpc-bidi.
 
     Returns
     -------

--- a/src/py/flwr/client/grpc_rere_client/connection.py
+++ b/src/py/flwr/client/grpc_rere_client/connection.py
@@ -121,6 +121,8 @@ def grpc_request_response(  # pylint: disable=R0913, R0914, R0915
         authentication from the cryptography library.
         Source: https://cryptography.io/en/latest/hazmat/primitives/asymmetric/ec/
         Used to establish an authenticated connection with the server.
+    client_metadata : Optional[Sequence[tuple[str, Union[str, bytes]]]] (default: None)
+        Unused argument present for compatibility.
 
     Returns
     -------

--- a/src/py/flwr/client/grpc_rere_client/connection.py
+++ b/src/py/flwr/client/grpc_rere_client/connection.py
@@ -22,7 +22,7 @@ from contextlib import contextmanager
 from copy import copy
 from logging import DEBUG, ERROR
 from pathlib import Path
-from typing import Callable, Optional, Union, cast
+from typing import Callable, Optional, Sequence, Union, cast
 
 import grpc
 from cryptography.hazmat.primitives.asymmetric import ec
@@ -80,6 +80,7 @@ def grpc_request_response(  # pylint: disable=R0913, R0914, R0915
     authentication_keys: Optional[
         tuple[ec.EllipticCurvePrivateKey, ec.EllipticCurvePublicKey]
     ] = None,
+    client_metadata: Optional[Sequence[tuple[str, Union[str, bytes]]]] = None,
     adapter_cls: Optional[Union[type[FleetStub], type[GrpcAdapter]]] = None,
 ) -> Iterator[
     tuple[

--- a/src/py/flwr/client/rest_client/connection.py
+++ b/src/py/flwr/client/rest_client/connection.py
@@ -131,6 +131,8 @@ def http_request_response(  # pylint: disable=,R0913, R0914, R0915
         Flower server. Bytes won't work for the REST API.
     authentication_keys : Optional[Tuple[PrivateKey, PublicKey]] (default: None)
         Client authentication is not supported for this transport type.
+    client_metadata : Optional[Sequence[tuple[str, Union[str, bytes]]]] (default: None)
+        Unused argument present for compatibilty.
 
     Returns
     -------

--- a/src/py/flwr/client/rest_client/connection.py
+++ b/src/py/flwr/client/rest_client/connection.py
@@ -22,7 +22,7 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from copy import copy
 from logging import ERROR, INFO, WARN
-from typing import Callable, Optional, TypeVar, Union
+from typing import Callable, Optional, Sequence, TypeVar, Union
 
 from cryptography.hazmat.primitives.asymmetric import ec
 from google.protobuf.message import Message as GrpcMessage
@@ -93,6 +93,9 @@ def http_request_response(  # pylint: disable=,R0913, R0914, R0915
     authentication_keys: Optional[  # pylint: disable=unused-argument
         tuple[ec.EllipticCurvePrivateKey, ec.EllipticCurvePublicKey]
     ] = None,
+    client_metadata: Optional[
+        Sequence[tuple[str, Union[str, bytes]]]
+    ] = None, # pylint: disable=unused-argument
 ) -> Iterator[
     tuple[
         Callable[[], Optional[Message]],

--- a/src/py/flwr/server/superlink/fleet/grpc_bidi/flower_service_servicer.py
+++ b/src/py/flwr/server/superlink/fleet/grpc_bidi/flower_service_servicer.py
@@ -101,6 +101,8 @@ class FlowerServiceServicer(transport_pb2_grpc.FlowerServiceServicer):
         # use a `UUID4` that is unique.
         cid: str = uuid.uuid4().hex
         bridge = self.grpc_bridge_factory()
+        client_metadata = context.invocation_metadata() 
+        # client_metadata -> [('user-agent', 'grpc-python/1.67.0 grpc-c/44.0.0 (linux; chttp2)'), ('test_key_1', 'test_value_1'), ('test_key_2', 'test_value_2')]
         client_proxy = self.client_proxy_factory(cid, bridge)
         is_success = register_client_proxy(self.client_manager, client_proxy, context)
 

--- a/src/py/flwr/server/superlink/fleet/grpc_bidi/flower_service_servicer.py
+++ b/src/py/flwr/server/superlink/fleet/grpc_bidi/flower_service_servicer.py
@@ -20,7 +20,7 @@ Relevant knowledge for reading this modules code:
 
 import uuid
 from collections.abc import Iterator
-from typing import Callable
+from typing import Callable, Sequence, Union
 
 import grpc
 from iterators import TimeoutIterator
@@ -44,9 +44,13 @@ def default_bridge_factory() -> GrpcBridge:
     return GrpcBridge()
 
 
-def default_grpc_client_proxy_factory(cid: str, bridge: GrpcBridge) -> GrpcClientProxy:
+def default_grpc_client_proxy_factory(
+    cid: str,
+    bridge: GrpcBridge,
+    client_metadata: Sequence[tuple[str, Union[str, bytes]]],
+) -> GrpcClientProxy:
     """Return GrpcClientProxy instance."""
-    return GrpcClientProxy(cid=cid, bridge=bridge)
+    return GrpcClientProxy(cid=cid, bridge=bridge, client_metadata=client_metadata)
 
 
 def register_client_proxy(
@@ -102,8 +106,7 @@ class FlowerServiceServicer(transport_pb2_grpc.FlowerServiceServicer):
         cid: str = uuid.uuid4().hex
         bridge = self.grpc_bridge_factory()
         client_metadata = context.invocation_metadata() 
-        # client_metadata -> [('user-agent', 'grpc-python/1.67.0 grpc-c/44.0.0 (linux; chttp2)'), ('test_key_1', 'test_value_1'), ('test_key_2', 'test_value_2')]
-        client_proxy = self.client_proxy_factory(cid, bridge)
+        client_proxy = self.client_proxy_factory(cid, bridge, client_metadata)
         is_success = register_client_proxy(self.client_manager, client_proxy, context)
 
         if is_success:

--- a/src/py/flwr/server/superlink/fleet/grpc_bidi/grpc_client_proxy.py
+++ b/src/py/flwr/server/superlink/fleet/grpc_bidi/grpc_client_proxy.py
@@ -15,7 +15,7 @@
 """Flower ClientProxy implementation using gRPC bidirectional streaming."""
 
 
-from typing import Optional
+from typing import Optional, Sequence, Union
 
 from flwr import common
 from flwr.common import serde
@@ -38,9 +38,11 @@ class GrpcClientProxy(ClientProxy):
         self,
         cid: str,
         bridge: GrpcBridge,
+        client_metadata: Sequence[tuple[str, Union[str, bytes]]],
     ):
         super().__init__(cid)
         self.bridge = bridge
+        self.client_metadata = client_metadata
 
     def get_properties(
         self,


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description
This PR addresses the need to enhance federated learning (FL) by transmitting client metadata, such as CPU and memory specifications, via gRPC communication. The metadata will be used by the ClientManager to better select clients based on device capabilities, enabling more optimized FL strategies like heterogeneous federated learning (heteroFL).

### Related issues/PRs
Issue #4339
Relates to #550

## Proposal

### Explanation
1.	Adding a new attribute to the FlowerServiceStub.Join function to transmit metadata and retrieve it server-side using the invocation_metadata function.
2.	Modifying other transport types' attributes for compatibility with this update.
3.	Registering the metadata in the GrpcClientProxy as a class attribute, allowing for optimized client selection based on the received metadata.
<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

### Checklist

- [x] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.ai/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
