### PR TITLE
refactor(framework) Show deprecation notice for `flower-superexec`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ exclude = ["src/py/**/*_test.py"]
 # `flwr` CLI
 flwr = "flwr.cli.app:app"
 # SuperExec (can run with either Deployment Engine or Simulation Engine)
-flower-superexec = "flwr.superexec.app:run_superexec"
+flower-superexec = "flwr.superexec.app:run_superexec" # Deprecated
 # Simulation Engine
 flower-simulation = "flwr.simulation.run_simulation:run_simulation_from_cli"
 # Deployment Engine

--- a/src/py/flwr/superexec/app.py
+++ b/src/py/flwr/superexec/app.py
@@ -27,6 +27,7 @@ from flwr.common.address import parse_address
 from flwr.common.config import parse_config_args
 from flwr.common.constant import EXEC_API_DEFAULT_ADDRESS
 from flwr.common.exit_handlers import register_exit_handlers
+from flwr.common.logger import warn_deprecated_feature
 from flwr.common.object_ref import load_app, validate
 
 from .exec_grpc import run_superexec_api_grpc
@@ -36,6 +37,12 @@ from .executor import Executor
 def run_superexec() -> None:
     """Run Flower SuperExec."""
     log(INFO, "Starting Flower SuperExec")
+
+    warn_deprecated_feature(
+        "Manually launching the SuperExec is deprecated. Since `flwr 1.13.0` "
+        "the executor service runs in the SuperLink. Launching it manually is not "
+        "recommended."
+    )
 
     event(EventType.RUN_SUPEREXEC_ENTER)
 


### PR DESCRIPTION
A deprecation notice is shown when doing `flower-superexec` since this service now lives in the `SuperLink`.

> [!NOTE]
> Should we add a deprecation note to the CLI ref docs as we did with `flower-client-app` a while ago? https://flower.ai/docs/framework/ref-api-cli.html#flower-server-app