### PR TITLE
refactor(framework) Install `FAB` from wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ typer = "^0.12.5"
 tomli = "^2.0.1"
 tomli-w = "^1.0.0"
 pathspec = "^0.12.1"
+hatchling = "^1.25.0"
 # Optional dependencies (Simulation Engine)
 ray = { version = "==2.10.0", optional = true, python = ">=3.9,<3.12" }
 # Optional dependencies (REST transport layer)

--- a/src/py/flwr/cli/install.py
+++ b/src/py/flwr/cli/install.py
@@ -196,9 +196,15 @@ def validate_and_install(
             text=True,
             check=True,
         )
+        wheel_files = list(install_dir.glob("*.whl"))
+        if len(wheel_files) != 1:
+            raise RuntimeError(
+                f"Exactly one wheel file was expected, but {len(wheel_files)} "
+                "are present."
+            )
         # Install wheel
         subprocess.run(
-            ["pip", "install", "-e", install_dir / "*.whl", "--no-deps"],
+            ["pip", "install", wheel_files[0], "--no-deps"],
             capture_output=True,
             text=True,
             check=True,

--- a/src/py/flwr/cli/install.py
+++ b/src/py/flwr/cli/install.py
@@ -189,8 +189,16 @@ def validate_and_install(
             shutil.copy2(item, install_dir / item.name)
 
     try:
+        # Build wheel
         subprocess.run(
-            ["pip", "install", "-e", install_dir, "--no-deps"],
+            ["python", "-m", "hatchling", "build", "-d", install_dir, "-t", "wheel"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        # Install wheel
+        subprocess.run(
+            ["pip", "install", "-e", install_dir / "*.whl", "--no-deps"],
             capture_output=True,
             text=True,
             check=True,


### PR DESCRIPTION
Build `.whl` before installing python package in the FAB. This requires adding `hatchling` as a `flwr`-wide dep. 