### PR TITLE
refactor(framework) Enable passing an existing `Context` to `ServerApp` startup function

### DIFF
--- a/src/py/flwr/server/run_serverapp.py
+++ b/src/py/flwr/server/run_serverapp.py
@@ -46,6 +46,7 @@ from .driver.grpc_driver import GrpcDriver
 from .server_app import LoadServerAppError, ServerApp
 
 
+# pylint: disable-next=too-many-arguments,too-many-positional-arguments
 def run(
     driver: Driver,
     server_app_dir: str,

--- a/src/py/flwr/server/run_serverapp.py
+++ b/src/py/flwr/server/run_serverapp.py
@@ -234,7 +234,6 @@ def run_server_app() -> None:
         driver=driver,
         context=context,
         server_app_dir=app_path,
-        server_app_run_config=server_app_run_config,
         server_app_attr=server_app_attr,
     )
 

--- a/src/py/flwr/server/run_serverapp.py
+++ b/src/py/flwr/server/run_serverapp.py
@@ -34,7 +34,6 @@ from flwr.common.config import (
 from flwr.common.constant import DRIVER_API_DEFAULT_ADDRESS
 from flwr.common.logger import log, update_console_handler, warn_deprecated_feature
 from flwr.common.object_ref import load_app
-from flwr.common.typing import UserConfig
 from flwr.proto.fab_pb2 import GetFabRequest, GetFabResponse  # pylint: disable=E0611
 from flwr.proto.run_pb2 import (  # pylint: disable=E0611
     CreateRunRequest,
@@ -49,11 +48,10 @@ from .server_app import LoadServerAppError, ServerApp
 # pylint: disable-next=too-many-arguments,too-many-positional-arguments
 def run(
     driver: Driver,
+    context: Context,
     server_app_dir: str,
-    server_app_run_config: UserConfig,
     server_app_attr: Optional[str] = None,
     loaded_server_app: Optional[ServerApp] = None,
-    context: Optional[Context] = None,
 ) -> Context:
     """Run ServerApp with a given Driver."""
     if not (server_app_attr is None) ^ (loaded_server_app is None):
@@ -79,15 +77,6 @@ def run(
         return server_app
 
     server_app = _load()
-
-    # Initialize Context
-    if not context:
-        context = Context(
-            node_id=0,
-            node_config={},
-            state=RecordSet(),
-            run_config=server_app_run_config,
-        )
 
     # Call ServerApp
     server_app(driver=driver, context=context)
@@ -232,9 +221,18 @@ def run_server_app() -> None:
         root_certificates,
     )
 
+    # Initialize Context
+    context = Context(
+        node_id=0,
+        node_config={},
+        state=RecordSet(),
+        run_config=server_app_run_config,
+    )
+
     # Run the ServerApp with the Driver
     run(
         driver=driver,
+        context=context,
         server_app_dir=app_path,
         server_app_run_config=server_app_run_config,
         server_app_attr=server_app_attr,

--- a/src/py/flwr/server/run_serverapp.py
+++ b/src/py/flwr/server/run_serverapp.py
@@ -54,7 +54,7 @@ def run(
     server_app_attr: Optional[str] = None,
     loaded_server_app: Optional[ServerApp] = None,
     context: Optional[Context] = None,
-) -> None:
+) -> Context:
     """Run ServerApp with a given Driver."""
     if not (server_app_attr is None) ^ (loaded_server_app is None):
         raise ValueError(
@@ -93,6 +93,7 @@ def run(
     server_app(driver=driver, context=context)
 
     log(DEBUG, "ServerApp finished running.")
+    return context
 
 
 # pylint: disable-next=too-many-branches,too-many-statements,too-many-locals

--- a/src/py/flwr/server/run_serverapp.py
+++ b/src/py/flwr/server/run_serverapp.py
@@ -52,6 +52,7 @@ def run(
     server_app_run_config: UserConfig,
     server_app_attr: Optional[str] = None,
     loaded_server_app: Optional[ServerApp] = None,
+    context: Optional[Context] = None,
 ) -> None:
     """Run ServerApp with a given Driver."""
     if not (server_app_attr is None) ^ (loaded_server_app is None):
@@ -79,9 +80,13 @@ def run(
     server_app = _load()
 
     # Initialize Context
-    context = Context(
-        node_id=0, node_config={}, state=RecordSet(), run_config=server_app_run_config
-    )
+    if not context:
+        context = Context(
+            node_id=0,
+            node_config={},
+            state=RecordSet(),
+            run_config=server_app_run_config,
+        )
 
     # Call ServerApp
     server_app(driver=driver, context=context)

--- a/src/py/flwr/simulation/run_simulation.py
+++ b/src/py/flwr/simulation/run_simulation.py
@@ -40,7 +40,7 @@ from flwr.common.logger import (
 )
 from flwr.common.typing import Run, RunStatus, UserConfig
 from flwr.server.driver import Driver, InMemoryDriver
-from flwr.server.run_serverapp import run as run_server_app
+from flwr.server.run_serverapp import run
 from flwr.server.server_app import ServerApp
 from flwr.server.superlink.fleet import vce
 from flwr.server.superlink.fleet.vce.backend.backend import BackendConfig
@@ -342,7 +342,7 @@ def run_serverapp_th(
             )
 
             # Run ServerApp
-            run_server_app(
+            run(
                 driver=_driver,
                 context=context,
                 server_app_dir=_server_app_dir,

--- a/src/py/flwr/simulation/run_simulation.py
+++ b/src/py/flwr/simulation/run_simulation.py
@@ -29,7 +29,7 @@ from typing import Any, Optional
 
 from flwr.cli.config_utils import load_and_validate
 from flwr.client import ClientApp
-from flwr.common import EventType, event, log, now
+from flwr.common import Context, EventType, RecordSet, event, log, now
 from flwr.common.config import get_fused_config_from_dir, parse_config_args
 from flwr.common.constant import RUN_ID_NUM_BYTES, Status
 from flwr.common.logger import (
@@ -333,11 +333,19 @@ def run_serverapp_th(
                 log(INFO, "Enabling GPU growth for Tensorflow on the server thread.")
                 enable_gpu_growth()
 
+            # Initialize Context
+            context = Context(
+                node_id=0,
+                node_config={},
+                state=RecordSet(),
+                run_config=_server_app_run_config,
+            )
+
             # Run ServerApp
             run_server_app(
                 driver=_driver,
+                context=context,
                 server_app_dir=_server_app_dir,
-                server_app_run_config=_server_app_run_config,
                 server_app_attr=_server_app_attr,
                 loaded_server_app=_server_app,
             )

--- a/src/py/flwr/simulation/run_simulation.py
+++ b/src/py/flwr/simulation/run_simulation.py
@@ -40,7 +40,7 @@ from flwr.common.logger import (
 )
 from flwr.common.typing import Run, RunStatus, UserConfig
 from flwr.server.driver import Driver, InMemoryDriver
-from flwr.server.run_serverapp import run
+from flwr.server.run_serverapp import run as _run
 from flwr.server.server_app import ServerApp
 from flwr.server.superlink.fleet import vce
 from flwr.server.superlink.fleet.vce.backend.backend import BackendConfig
@@ -342,7 +342,7 @@ def run_serverapp_th(
             )
 
             # Run ServerApp
-            run(
+            _run(
                 driver=_driver,
                 context=context,
                 server_app_dir=_server_app_dir,


### PR DESCRIPTION
the `flwr-serverapp` process will pass an existing `Context` to this function to load and execute a `ServerApp`. At the end, the updated `Context` will be returned.

> [!NOTE]
> The `run` function is also used by the Simulation Engine.