### PR TITLE
refactor(framework) Include support for lists in `common.Scalar`

### DIFF
--- a/src/py/flwr/client/mod/centraldp_mods.py
+++ b/src/py/flwr/client/mod/centraldp_mods.py
@@ -61,7 +61,10 @@ def fixedclipping_mod(
             f" the server side."
         )
 
-    clipping_norm = float(fit_ins.config[KEY_CLIPPING_NORM])
+    clipping_norm = fit_ins.config[KEY_CLIPPING_NORM]
+    if not isinstance(clipping_norm, float):
+        raise ValueError(f"{KEY_CLIPPING_NORM} should be a float value.")
+
     server_to_client_params = parameters_to_ndarrays(fit_ins.parameters)
 
     # Call inner app
@@ -124,9 +127,11 @@ def adaptiveclipping_mod(
             f"DifferentialPrivacyClientSideFixedClipping wrapper at"
             f" the server side."
         )
-    if not isinstance(fit_ins.config[KEY_CLIPPING_NORM], float):
+
+    clipping_norm = fit_ins.config[KEY_CLIPPING_NORM]
+    if not isinstance(clipping_norm, float):
         raise ValueError(f"{KEY_CLIPPING_NORM} should be a float value.")
-    clipping_norm = float(fit_ins.config[KEY_CLIPPING_NORM])
+
     server_to_client_params = parameters_to_ndarrays(fit_ins.parameters)
 
     # Call inner app

--- a/src/py/flwr/common/recordset_compat.py
+++ b/src/py/flwr/common/recordset_compat.py
@@ -171,9 +171,7 @@ def _fit_or_evaluate_ins_to_recordset(
     parametersrecord = parameters_to_parametersrecord(ins.parameters, keep_input)
     recordset.parameters_records[f"{ins_str}.parameters"] = parametersrecord
 
-    recordset.configs_records[f"{ins_str}.config"] = ConfigsRecord(
-        ins.config  # type: ignore
-    )
+    recordset.configs_records[f"{ins_str}.config"] = ConfigsRecord(ins.config)
 
     return recordset
 
@@ -239,9 +237,7 @@ def fitres_to_recordset(fitres: FitRes, keep_input: bool) -> RecordSet:
 
     res_str = "fitres"
 
-    recordset.configs_records[f"{res_str}.metrics"] = ConfigsRecord(
-        fitres.metrics  # type: ignore
-    )
+    recordset.configs_records[f"{res_str}.metrics"] = ConfigsRecord(fitres.metrics)
     recordset.metrics_records[f"{res_str}.num_examples"] = MetricsRecord(
         {"num_examples": fitres.num_examples},
     )
@@ -311,7 +307,7 @@ def evaluateres_to_recordset(evaluateres: EvaluateRes) -> RecordSet:
 
     # metrics
     recordset.configs_records[f"{res_str}.metrics"] = ConfigsRecord(
-        evaluateres.metrics,  # type: ignore
+        evaluateres.metrics,
     )
 
     # status
@@ -336,7 +332,7 @@ def getparametersins_to_recordset(getparameters_ins: GetParametersIns) -> Record
     recordset = RecordSet()
 
     recordset.configs_records["getparametersins.config"] = ConfigsRecord(
-        getparameters_ins.config,  # type: ignore
+        getparameters_ins.config,
     )
     return recordset
 
@@ -386,7 +382,7 @@ def getpropertiesins_to_recordset(getpropertiesins: GetPropertiesIns) -> RecordS
     """Construct a RecordSet from a GetPropertiesRes object."""
     recordset = RecordSet()
     recordset.configs_records["getpropertiesins.config"] = ConfigsRecord(
-        getpropertiesins.config,  # type: ignore
+        getpropertiesins.config,
     )
     return recordset
 
@@ -408,7 +404,7 @@ def getpropertiesres_to_recordset(getpropertiesres: GetPropertiesRes) -> RecordS
     recordset = RecordSet()
     res_str = "getpropertiesres"
     recordset.configs_records[f"{res_str}.properties"] = ConfigsRecord(
-        getpropertiesres.properties,  # type: ignore
+        getpropertiesres.properties,
     )
     # status
     recordset = _embed_status_into_recordset(

--- a/src/py/flwr/common/recordset_compat_test.py
+++ b/src/py/flwr/common/recordset_compat_test.py
@@ -71,7 +71,10 @@ def get_ndarrays() -> NDArrays:
 
 def _get_valid_fitins() -> FitIns:
     arrays = get_ndarrays()
-    return FitIns(parameters=ndarrays_to_parameters(arrays), config={"a": 1.0, "b": 0})
+    return FitIns(
+        parameters=ndarrays_to_parameters(arrays),
+        config={"a": 1.0, "b": 0, "c": [1.0, 2.0, 3.0]},
+    )
 
 
 def _get_valid_fitins_with_empty_ndarrays() -> FitIns:
@@ -82,7 +85,7 @@ def _get_valid_fitins_with_empty_ndarrays() -> FitIns:
 def _get_valid_fitres() -> FitRes:
     """Returnn Valid parameters but potentially invalid config."""
     arrays = get_ndarrays()
-    metrics: dict[str, Scalar] = {"a": 1.0, "b": 0}
+    metrics: dict[str, Scalar] = {"a": 1.0, "b": 0, "cc": [1.0, 2.0, 3.0]}
     return FitRes(
         parameters=ndarrays_to_parameters(arrays),
         num_examples=1,
@@ -98,7 +101,7 @@ def _get_valid_evaluateins() -> EvaluateIns:
 
 def _get_valid_evaluateres() -> EvaluateRes:
     """Return potentially invalid config."""
-    metrics: dict[str, Scalar] = {"a": 1.0, "b": 0}
+    metrics: dict[str, Scalar] = {"a": 1.0, "b": 0, "c": [1.0, 2.0, 3.0]}
     return EvaluateRes(
         num_examples=1,
         loss=0.1,
@@ -112,6 +115,7 @@ def _get_valid_getparametersins() -> GetParametersIns:
         "a": 1.0,
         "b": 3,
         "c": True,
+        "d": [True, False, True],
     }  # valid since both Ins/Res communicate over ConfigsRecord
 
     return GetParametersIns(config_dict)
@@ -135,6 +139,7 @@ def _get_valid_getpropertiesres() -> GetPropertiesRes:
         "a": 1.0,
         "b": 3,
         "c": True,
+        "d": [1, 2, 3],
     }  # valid since both Ins/Res communicate over ConfigsRecord
 
     return GetPropertiesRes(

--- a/src/py/flwr/common/typing.py
+++ b/src/py/flwr/common/typing.py
@@ -31,13 +31,9 @@ NDArrays = list[NDArray]
 # ProtoBuf considers to be "Scalar Value Types", even though some of them arguably do
 # not conform to other definitions of what a scalar is. Source:
 # https://developers.google.com/protocol-buffers/docs/overview#scalar
-# Scalar = Union[bool, bytes, float, int, str]
+Value = Union[bool, bytes, float, int, str]
 Scalar = Union[
-    bool,
-    bytes,
-    float,
-    int,
-    str,
+    Value,
     list[bool],
     list[bytes],
     list[float],

--- a/src/py/flwr/common/typing.py
+++ b/src/py/flwr/common/typing.py
@@ -31,8 +31,8 @@ NDArrays = list[NDArray]
 # ProtoBuf considers to be "Scalar Value Types", even though some of them arguably do
 # not conform to other definitions of what a scalar is. Source:
 # https://developers.google.com/protocol-buffers/docs/overview#scalar
-Scalar = Union[bool, bytes, float, int, str]
-Value = Union[
+# Scalar = Union[bool, bytes, float, int, str]
+Scalar = Union[
     bool,
     bytes,
     float,

--- a/src/py/flwr/server/superlink/fleet/vce/backend/raybackend_test.py
+++ b/src/py/flwr/server/superlink/fleet/vce/backend/raybackend_test.py
@@ -88,7 +88,7 @@ def backend_build_process_and_termination(
 def _create_message_and_context() -> tuple[Message, Context, float]:
 
     # Construct a Message
-    mult_factor = 2024
+    mult_factor = 2024.0
     run_id = 0
     getproperties_ins = GetPropertiesIns(config={"factor": mult_factor})
     recordset = getpropertiesins_to_recordset(getproperties_ins)

--- a/src/py/flwr/server/superlink/fleet/vce/backend/raybackend_test.py
+++ b/src/py/flwr/server/superlink/fleet/vce/backend/raybackend_test.py
@@ -49,7 +49,9 @@ class DummyClient(NumPyClient):
 
     def get_properties(self, config: Config) -> dict[str, Scalar]:
         """Return properties by doing a simple calculation."""
-        result = float(config["factor"]) * pi
+        factor = config["factor"]
+        assert isinstance(factor, float)
+        result = factor * pi
 
         # store something in context
         self.client_state.configs_records["result"] = ConfigsRecord({"result": result})

--- a/src/py/flwr/server/superlink/fleet/vce/vce_api_test.py
+++ b/src/py/flwr/server/superlink/fleet/vce/vce_api_test.py
@@ -61,7 +61,9 @@ class DummyClient(NumPyClient):
 
     def get_properties(self, config: Config) -> dict[str, Scalar]:
         """Return properties by doing a simple calculation."""
-        result = float(config["factor"]) * pi
+        factor = config["factor"]
+        assert isinstance(factor, float)
+        result = factor * pi
 
         # store something in context
         self.client_state.configs_records["result"] = ConfigsRecord({"result": result})

--- a/src/py/flwr/server/superlink/fleet/vce/vce_api_test.py
+++ b/src/py/flwr/server/superlink/fleet/vce/vce_api_test.py
@@ -139,7 +139,7 @@ def register_messages_into_state(
     for i in range(num_messages):
         dst_node_id = next(nodes_cycle)
         # Construct a Message
-        mult_factor = 2024 + i
+        mult_factor = 2024.0 + i
         getproperties_ins = GetPropertiesIns(config={"factor": mult_factor})
         recordset = getpropertiesins_to_recordset(getproperties_ins)
         message = Message(


### PR DESCRIPTION
`Scalar` is heavily used by `*Ins/*Res` between _strategies_ and clients. It sounds like a good idea to also natively support communicating lists. 

TODO: update `serde` and `protobuf` to make `Scalar` support lists/repeated