### PR TITLE
fix(examples) Update Dockerfile

### DIFF
--- a/examples/embedded-devices/Dockerfile
+++ b/examples/embedded-devices/Dockerfile
@@ -8,7 +8,7 @@ RUN pip3 install --upgrade pip
 
 # Install flower
 RUN pip3 install flwr>=1.0
-RUN pip3 install flwr-datsets>=0.0.2
+RUN pip3 install flwr-datasets>=0.0.2
 RUN pip3 install tqdm==4.65.0
 
 WORKDIR /client


### PR DESCRIPTION
## Issue
There is a typo in the code that installs 'flwr-datasets' in the Dockerfile, so the process cannot proceed.


## Proposal
Fix the typo "flwr-datsets" to "flwr-datasets".


### Checklist

- [v] Implement proposed change
- [v] Write tests
- [ ] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)
=> No need
