### PR TITLE
docs(baselines) Fix instructions on how to use baselines

### DIFF
--- a/baselines/doc/source/how-to-contribute-baselines.rst
+++ b/baselines/doc/source/how-to-contribute-baselines.rst
@@ -65,7 +65,7 @@ Flower is known and loved for its usability. Therefore, make sure that your base
     flwr run .
 
     # Run the baseline overriding the config
-    flwr run . --run-config lr=0.01,num-server-rounds=200
+    flwr run . --run-config "lr=0.01 num-server-rounds=200"
 
 
 We look forward to your contribution! 


### PR DESCRIPTION
We stopped specifying `--run-config` with `,`-separated entries but this page wasn't updated.

Addresses: https://github.com/adap/flower/issues/4366