### PR TITLE
refactor(framework) Create `Context` by `Exec` servicer

### DIFF
--- a/src/py/flwr/server/superlink/driver/driver_servicer.py
+++ b/src/py/flwr/server/superlink/driver/driver_servicer.py
@@ -232,14 +232,12 @@ class DriverServicer(driver_pb2_grpc.DriverServicer):
             if run and run.fab_hash:
                 if result := ffs.get(run.fab_hash):
                     fab = Fab(run.fab_hash, result[0])
-            if run and fab:
+            if run and fab and serverapp_ctxt:
                 # Update run status to STARTING
                 if state.update_run_status(run_id, RunStatus(Status.STARTING, "", "")):
                     log(INFO, "Starting run %d", run_id)
                     return PullServerAppInputsResponse(
-                        context=(
-                            context_to_proto(serverapp_ctxt) if serverapp_ctxt else None
-                        ),
+                        context=context_to_proto(serverapp_ctxt),
                         run=run_to_proto(run),
                         fab=fab_to_proto(fab),
                     )

--- a/src/py/flwr/superexec/deployment.py
+++ b/src/py/flwr/superexec/deployment.py
@@ -21,9 +21,10 @@ from typing import Optional
 
 from typing_extensions import override
 
-from flwr.common.constant import DRIVER_API_DEFAULT_ADDRESS
+from flwr.common import Context, RecordSet
+from flwr.common.constant import DRIVER_API_DEFAULT_ADDRESS, Status, SubStatus
 from flwr.common.logger import log
-from flwr.common.typing import Fab, UserConfig
+from flwr.common.typing import Fab, RunStatus, UserConfig
 from flwr.server.superlink.ffs import Ffs
 from flwr.server.superlink.ffs.ffs_factory import FfsFactory
 from flwr.server.superlink.linkstate import LinkState, LinkStateFactory
@@ -135,6 +136,14 @@ class DeploymentEngine(Executor):
         run_id = self.linkstate.create_run(None, None, fab_hash, override_config)
         return run_id
 
+    def _create_context(self, run_id: int) -> None:
+        """Register a Context for a Run."""
+        # Create an empty context for the Run
+        context = Context(node_id=0, node_config={}, state=RecordSet(), run_config={})
+
+        # Register the context at the LinkState
+        self.linkstate.set_serverapp_context(run_id=run_id, context=context)
+
     @override
     def start_run(
         self,
@@ -143,18 +152,25 @@ class DeploymentEngine(Executor):
         federation_config: UserConfig,
     ) -> Optional[int]:
         """Start run using the Flower Deployment Engine."""
+        run_id = None
         try:
 
             # Call SuperLink to create run
-            run_id: int = self._create_run(
+            run_id = self._create_run(
                 Fab(hashlib.sha256(fab_file).hexdigest(), fab_file), override_config
             )
+
+            # Register context for the Run
+            self._create_context(run_id=run_id)
             log(INFO, "Created run %s", str(run_id))
 
             return run_id
         # pylint: disable-next=broad-except
         except Exception as e:
             log(ERROR, "Could not start run: %s", str(e))
+            if run_id:
+                run_status = RunStatus(Status.FINISHED, SubStatus.FAILED, str(e))
+                self.linkstate.update_run_status(run_id, new_status=run_status)
             return None
 
 


### PR DESCRIPTION
Creates the `Context` after the `Run` is registered at the `LinkState`. This makes `PullServerAppInputs` to always return a existing context obj