### PR TITLE
refactor(framework:skip) Remove unused internal function `_has_field`

### DIFF
--- a/src/py/flwr/server/superlink/driver/driver_servicer.py
+++ b/src/py/flwr/server/superlink/driver/driver_servicer.py
@@ -22,7 +22,6 @@ from typing import Optional
 from uuid import UUID
 
 import grpc
-from google.protobuf.message import Message as GrpcMessage
 
 from flwr.common.constant import Status
 from flwr.common.logger import log

--- a/src/py/flwr/server/superlink/driver/driver_servicer.py
+++ b/src/py/flwr/server/superlink/driver/driver_servicer.py
@@ -284,8 +284,3 @@ class DriverServicer(driver_pb2_grpc.DriverServicer):
 def _raise_if(validation_error: bool, detail: str) -> None:
     if validation_error:
         raise ValueError(f"Malformed PushTaskInsRequest: {detail}")
-
-
-def _has_field(message: GrpcMessage, field_name: str) -> bool:
-    """Check if a certain field is set for the message, including scalar fields."""
-    return field_name in {fld.name for fld, _ in message.ListFields()}


### PR DESCRIPTION
The function was used to check if a scalar field of a grpc message is set to non-default value or not. It's not needed any more.