### PR TITLE
refactor(framework) Extend `CreateRunRequest` with `federation_options`

### DIFF
--- a/src/proto/flwr/proto/run.proto
+++ b/src/proto/flwr/proto/run.proto
@@ -20,6 +20,7 @@ package flwr.proto;
 import "flwr/proto/fab.proto";
 import "flwr/proto/node.proto";
 import "flwr/proto/transport.proto";
+import "flwr/proto/recordset.proto";
 
 message Run {
   uint64 run_id = 1;
@@ -44,6 +45,7 @@ message CreateRunRequest {
   string fab_version = 2;
   map<string, Scalar> override_config = 3;
   Fab fab = 4;
+  ConfigsRecord federation_options = 5;
 }
 message CreateRunResponse { uint64 run_id = 1; }
 

--- a/src/py/flwr/proto/run_pb2.py
+++ b/src/py/flwr/proto/run_pb2.py
@@ -15,9 +15,10 @@ _sym_db = _symbol_database.Default()
 from flwr.proto import fab_pb2 as flwr_dot_proto_dot_fab__pb2
 from flwr.proto import node_pb2 as flwr_dot_proto_dot_node__pb2
 from flwr.proto import transport_pb2 as flwr_dot_proto_dot_transport__pb2
+from flwr.proto import recordset_pb2 as flwr_dot_proto_dot_recordset__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x14\x66lwr/proto/run.proto\x12\nflwr.proto\x1a\x14\x66lwr/proto/fab.proto\x1a\x15\x66lwr/proto/node.proto\x1a\x1a\x66lwr/proto/transport.proto\"\xd5\x01\n\x03Run\x12\x0e\n\x06run_id\x18\x01 \x01(\x04\x12\x0e\n\x06\x66\x61\x62_id\x18\x02 \x01(\t\x12\x13\n\x0b\x66\x61\x62_version\x18\x03 \x01(\t\x12<\n\x0foverride_config\x18\x04 \x03(\x0b\x32#.flwr.proto.Run.OverrideConfigEntry\x12\x10\n\x08\x66\x61\x62_hash\x18\x05 \x01(\t\x1aI\n\x13OverrideConfigEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12!\n\x05value\x18\x02 \x01(\x0b\x32\x12.flwr.proto.Scalar:\x02\x38\x01\"@\n\tRunStatus\x12\x0e\n\x06status\x18\x01 \x01(\t\x12\x12\n\nsub_status\x18\x02 \x01(\t\x12\x0f\n\x07\x64\x65tails\x18\x03 \x01(\t\"\xeb\x01\n\x10\x43reateRunRequest\x12\x0e\n\x06\x66\x61\x62_id\x18\x01 \x01(\t\x12\x13\n\x0b\x66\x61\x62_version\x18\x02 \x01(\t\x12I\n\x0foverride_config\x18\x03 \x03(\x0b\x32\x30.flwr.proto.CreateRunRequest.OverrideConfigEntry\x12\x1c\n\x03\x66\x61\x62\x18\x04 \x01(\x0b\x32\x0f.flwr.proto.Fab\x1aI\n\x13OverrideConfigEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12!\n\x05value\x18\x02 \x01(\x0b\x32\x12.flwr.proto.Scalar:\x02\x38\x01\"#\n\x11\x43reateRunResponse\x12\x0e\n\x06run_id\x18\x01 \x01(\x04\"?\n\rGetRunRequest\x12\x1e\n\x04node\x18\x01 \x01(\x0b\x32\x10.flwr.proto.Node\x12\x0e\n\x06run_id\x18\x02 \x01(\x04\".\n\x0eGetRunResponse\x12\x1c\n\x03run\x18\x01 \x01(\x0b\x32\x0f.flwr.proto.Run\"S\n\x16UpdateRunStatusRequest\x12\x0e\n\x06run_id\x18\x01 \x01(\x04\x12)\n\nrun_status\x18\x02 \x01(\x0b\x32\x15.flwr.proto.RunStatus\"\x19\n\x17UpdateRunStatusResponse\"F\n\x13GetRunStatusRequest\x12\x1e\n\x04node\x18\x01 \x01(\x0b\x32\x10.flwr.proto.Node\x12\x0f\n\x07run_ids\x18\x02 \x03(\x04\"\xb1\x01\n\x14GetRunStatusResponse\x12L\n\x0frun_status_dict\x18\x01 \x03(\x0b\x32\x33.flwr.proto.GetRunStatusResponse.RunStatusDictEntry\x1aK\n\x12RunStatusDictEntry\x12\x0b\n\x03key\x18\x01 \x01(\x04\x12$\n\x05value\x18\x02 \x01(\x0b\x32\x15.flwr.proto.RunStatus:\x02\x38\x01\x62\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x14\x66lwr/proto/run.proto\x12\nflwr.proto\x1a\x14\x66lwr/proto/fab.proto\x1a\x15\x66lwr/proto/node.proto\x1a\x1a\x66lwr/proto/transport.proto\x1a\x1a\x66lwr/proto/recordset.proto\"\xd5\x01\n\x03Run\x12\x0e\n\x06run_id\x18\x01 \x01(\x04\x12\x0e\n\x06\x66\x61\x62_id\x18\x02 \x01(\t\x12\x13\n\x0b\x66\x61\x62_version\x18\x03 \x01(\t\x12<\n\x0foverride_config\x18\x04 \x03(\x0b\x32#.flwr.proto.Run.OverrideConfigEntry\x12\x10\n\x08\x66\x61\x62_hash\x18\x05 \x01(\t\x1aI\n\x13OverrideConfigEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12!\n\x05value\x18\x02 \x01(\x0b\x32\x12.flwr.proto.Scalar:\x02\x38\x01\"@\n\tRunStatus\x12\x0e\n\x06status\x18\x01 \x01(\t\x12\x12\n\nsub_status\x18\x02 \x01(\t\x12\x0f\n\x07\x64\x65tails\x18\x03 \x01(\t\"\xa2\x02\n\x10\x43reateRunRequest\x12\x0e\n\x06\x66\x61\x62_id\x18\x01 \x01(\t\x12\x13\n\x0b\x66\x61\x62_version\x18\x02 \x01(\t\x12I\n\x0foverride_config\x18\x03 \x03(\x0b\x32\x30.flwr.proto.CreateRunRequest.OverrideConfigEntry\x12\x1c\n\x03\x66\x61\x62\x18\x04 \x01(\x0b\x32\x0f.flwr.proto.Fab\x12\x35\n\x12\x66\x65\x64\x65ration_options\x18\x05 \x01(\x0b\x32\x19.flwr.proto.ConfigsRecord\x1aI\n\x13OverrideConfigEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12!\n\x05value\x18\x02 \x01(\x0b\x32\x12.flwr.proto.Scalar:\x02\x38\x01\"#\n\x11\x43reateRunResponse\x12\x0e\n\x06run_id\x18\x01 \x01(\x04\"?\n\rGetRunRequest\x12\x1e\n\x04node\x18\x01 \x01(\x0b\x32\x10.flwr.proto.Node\x12\x0e\n\x06run_id\x18\x02 \x01(\x04\".\n\x0eGetRunResponse\x12\x1c\n\x03run\x18\x01 \x01(\x0b\x32\x0f.flwr.proto.Run\"S\n\x16UpdateRunStatusRequest\x12\x0e\n\x06run_id\x18\x01 \x01(\x04\x12)\n\nrun_status\x18\x02 \x01(\x0b\x32\x15.flwr.proto.RunStatus\"\x19\n\x17UpdateRunStatusResponse\"F\n\x13GetRunStatusRequest\x12\x1e\n\x04node\x18\x01 \x01(\x0b\x32\x10.flwr.proto.Node\x12\x0f\n\x07run_ids\x18\x02 \x03(\x04\"\xb1\x01\n\x14GetRunStatusResponse\x12L\n\x0frun_status_dict\x18\x01 \x03(\x0b\x32\x33.flwr.proto.GetRunStatusResponse.RunStatusDictEntry\x1aK\n\x12RunStatusDictEntry\x12\x0b\n\x03key\x18\x01 \x01(\x04\x12$\n\x05value\x18\x02 \x01(\x0b\x32\x15.flwr.proto.RunStatus:\x02\x38\x01\x62\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -30,30 +31,30 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   _globals['_CREATERUNREQUEST_OVERRIDECONFIGENTRY']._serialized_options = b'8\001'
   _globals['_GETRUNSTATUSRESPONSE_RUNSTATUSDICTENTRY']._options = None
   _globals['_GETRUNSTATUSRESPONSE_RUNSTATUSDICTENTRY']._serialized_options = b'8\001'
-  _globals['_RUN']._serialized_start=110
-  _globals['_RUN']._serialized_end=323
-  _globals['_RUN_OVERRIDECONFIGENTRY']._serialized_start=250
-  _globals['_RUN_OVERRIDECONFIGENTRY']._serialized_end=323
-  _globals['_RUNSTATUS']._serialized_start=325
-  _globals['_RUNSTATUS']._serialized_end=389
-  _globals['_CREATERUNREQUEST']._serialized_start=392
-  _globals['_CREATERUNREQUEST']._serialized_end=627
-  _globals['_CREATERUNREQUEST_OVERRIDECONFIGENTRY']._serialized_start=250
-  _globals['_CREATERUNREQUEST_OVERRIDECONFIGENTRY']._serialized_end=323
-  _globals['_CREATERUNRESPONSE']._serialized_start=629
-  _globals['_CREATERUNRESPONSE']._serialized_end=664
-  _globals['_GETRUNREQUEST']._serialized_start=666
-  _globals['_GETRUNREQUEST']._serialized_end=729
-  _globals['_GETRUNRESPONSE']._serialized_start=731
-  _globals['_GETRUNRESPONSE']._serialized_end=777
-  _globals['_UPDATERUNSTATUSREQUEST']._serialized_start=779
-  _globals['_UPDATERUNSTATUSREQUEST']._serialized_end=862
-  _globals['_UPDATERUNSTATUSRESPONSE']._serialized_start=864
-  _globals['_UPDATERUNSTATUSRESPONSE']._serialized_end=889
-  _globals['_GETRUNSTATUSREQUEST']._serialized_start=891
-  _globals['_GETRUNSTATUSREQUEST']._serialized_end=961
-  _globals['_GETRUNSTATUSRESPONSE']._serialized_start=964
-  _globals['_GETRUNSTATUSRESPONSE']._serialized_end=1141
-  _globals['_GETRUNSTATUSRESPONSE_RUNSTATUSDICTENTRY']._serialized_start=1066
-  _globals['_GETRUNSTATUSRESPONSE_RUNSTATUSDICTENTRY']._serialized_end=1141
+  _globals['_RUN']._serialized_start=138
+  _globals['_RUN']._serialized_end=351
+  _globals['_RUN_OVERRIDECONFIGENTRY']._serialized_start=278
+  _globals['_RUN_OVERRIDECONFIGENTRY']._serialized_end=351
+  _globals['_RUNSTATUS']._serialized_start=353
+  _globals['_RUNSTATUS']._serialized_end=417
+  _globals['_CREATERUNREQUEST']._serialized_start=420
+  _globals['_CREATERUNREQUEST']._serialized_end=710
+  _globals['_CREATERUNREQUEST_OVERRIDECONFIGENTRY']._serialized_start=278
+  _globals['_CREATERUNREQUEST_OVERRIDECONFIGENTRY']._serialized_end=351
+  _globals['_CREATERUNRESPONSE']._serialized_start=712
+  _globals['_CREATERUNRESPONSE']._serialized_end=747
+  _globals['_GETRUNREQUEST']._serialized_start=749
+  _globals['_GETRUNREQUEST']._serialized_end=812
+  _globals['_GETRUNRESPONSE']._serialized_start=814
+  _globals['_GETRUNRESPONSE']._serialized_end=860
+  _globals['_UPDATERUNSTATUSREQUEST']._serialized_start=862
+  _globals['_UPDATERUNSTATUSREQUEST']._serialized_end=945
+  _globals['_UPDATERUNSTATUSRESPONSE']._serialized_start=947
+  _globals['_UPDATERUNSTATUSRESPONSE']._serialized_end=972
+  _globals['_GETRUNSTATUSREQUEST']._serialized_start=974
+  _globals['_GETRUNSTATUSREQUEST']._serialized_end=1044
+  _globals['_GETRUNSTATUSRESPONSE']._serialized_start=1047
+  _globals['_GETRUNSTATUSRESPONSE']._serialized_end=1224
+  _globals['_GETRUNSTATUSRESPONSE_RUNSTATUSDICTENTRY']._serialized_start=1149
+  _globals['_GETRUNSTATUSRESPONSE_RUNSTATUSDICTENTRY']._serialized_end=1224
 # @@protoc_insertion_point(module_scope)

--- a/src/py/flwr/proto/run_pb2.pyi
+++ b/src/py/flwr/proto/run_pb2.pyi
@@ -5,6 +5,7 @@ isort:skip_file
 import builtins
 import flwr.proto.fab_pb2
 import flwr.proto.node_pb2
+import flwr.proto.recordset_pb2
 import flwr.proto.transport_pb2
 import google.protobuf.descriptor
 import google.protobuf.internal.containers
@@ -98,21 +99,25 @@ class CreateRunRequest(google.protobuf.message.Message):
     FAB_VERSION_FIELD_NUMBER: builtins.int
     OVERRIDE_CONFIG_FIELD_NUMBER: builtins.int
     FAB_FIELD_NUMBER: builtins.int
+    FEDERATION_OPTIONS_FIELD_NUMBER: builtins.int
     fab_id: typing.Text
     fab_version: typing.Text
     @property
     def override_config(self) -> google.protobuf.internal.containers.MessageMap[typing.Text, flwr.proto.transport_pb2.Scalar]: ...
     @property
     def fab(self) -> flwr.proto.fab_pb2.Fab: ...
+    @property
+    def federation_options(self) -> flwr.proto.recordset_pb2.ConfigsRecord: ...
     def __init__(self,
         *,
         fab_id: typing.Text = ...,
         fab_version: typing.Text = ...,
         override_config: typing.Optional[typing.Mapping[typing.Text, flwr.proto.transport_pb2.Scalar]] = ...,
         fab: typing.Optional[flwr.proto.fab_pb2.Fab] = ...,
+        federation_options: typing.Optional[flwr.proto.recordset_pb2.ConfigsRecord] = ...,
         ) -> None: ...
-    def HasField(self, field_name: typing_extensions.Literal["fab",b"fab"]) -> builtins.bool: ...
-    def ClearField(self, field_name: typing_extensions.Literal["fab",b"fab","fab_id",b"fab_id","fab_version",b"fab_version","override_config",b"override_config"]) -> None: ...
+    def HasField(self, field_name: typing_extensions.Literal["fab",b"fab","federation_options",b"federation_options"]) -> builtins.bool: ...
+    def ClearField(self, field_name: typing_extensions.Literal["fab",b"fab","fab_id",b"fab_id","fab_version",b"fab_version","federation_options",b"federation_options","override_config",b"override_config"]) -> None: ...
 global___CreateRunRequest = CreateRunRequest
 
 class CreateRunResponse(google.protobuf.message.Message):

--- a/src/py/flwr/server/run_serverapp.py
+++ b/src/py/flwr/server/run_serverapp.py
@@ -34,6 +34,7 @@ from flwr.common.config import (
 from flwr.common.constant import SERVERAPPIO_API_DEFAULT_ADDRESS
 from flwr.common.logger import log, update_console_handler, warn_deprecated_feature
 from flwr.common.object_ref import load_app
+from flwr.common.serde import configs_record_to_proto
 from flwr.proto.fab_pb2 import GetFabRequest, GetFabResponse  # pylint: disable=E0611
 from flwr.proto.run_pb2 import (  # pylint: disable=E0611
     CreateRunRequest,
@@ -202,7 +203,9 @@ def run_server_app() -> None:
 
         # Create run
         req = CreateRunRequest(
-            fab_id=fab_id, fab_version=fab_version, federation_options=ConfigsRecord()
+            fab_id=fab_id,
+            fab_version=fab_version,
+            federation_options=configs_record_to_proto(ConfigsRecord()),
         )
         res: CreateRunResponse = driver._stub.CreateRun(req)  # pylint: disable=W0212
         # Fetch full `Run` using `run_id`

--- a/src/py/flwr/server/run_serverapp.py
+++ b/src/py/flwr/server/run_serverapp.py
@@ -23,7 +23,7 @@ from typing import Optional
 
 from flwr.cli.config_utils import get_fab_metadata
 from flwr.cli.install import install_from_fab
-from flwr.common import Context, EventType, RecordSet, event
+from flwr.common import ConfigsRecord, Context, EventType, RecordSet, event
 from flwr.common.config import (
     get_flwr_dir,
     get_fused_config_from_dir,
@@ -201,7 +201,9 @@ def run_server_app() -> None:
         fab_version, fab_id = get_metadata_from_config(config)
 
         # Create run
-        req = CreateRunRequest(fab_id=fab_id, fab_version=fab_version)
+        req = CreateRunRequest(
+            fab_id=fab_id, fab_version=fab_version, federation_options=ConfigsRecord()
+        )
         res: CreateRunResponse = driver._stub.CreateRun(req)  # pylint: disable=W0212
         # Fetch full `Run` using `run_id`
         driver.init_run(res.run_id)  # pylint: disable=W0212

--- a/src/py/flwr/server/superlink/driver/serverappio_servicer.py
+++ b/src/py/flwr/server/superlink/driver/serverappio_servicer.py
@@ -23,7 +23,6 @@ from uuid import UUID
 
 import grpc
 
-from flwr.common import ConfigsRecord
 from flwr.common.constant import Status
 from flwr.common.logger import log
 from flwr.common.serde import (
@@ -113,7 +112,7 @@ class ServerAppIoServicer(serverappio_pb2_grpc.ServerAppIoServicer):
             request.fab_version,
             fab_hash,
             user_config_from_proto(request.override_config),
-            ConfigsRecord(),
+            request.federation_options,
         )
         return CreateRunResponse(run_id=run_id)
 

--- a/src/py/flwr/server/superlink/driver/serverappio_servicer.py
+++ b/src/py/flwr/server/superlink/driver/serverappio_servicer.py
@@ -26,6 +26,7 @@ import grpc
 from flwr.common.constant import Status
 from flwr.common.logger import log
 from flwr.common.serde import (
+    configs_record_from_proto,
     context_from_proto,
     context_to_proto,
     fab_from_proto,
@@ -112,7 +113,7 @@ class ServerAppIoServicer(serverappio_pb2_grpc.ServerAppIoServicer):
             request.fab_version,
             fab_hash,
             user_config_from_proto(request.override_config),
-            request.federation_options,
+            configs_record_from_proto(request.federation_options),
         )
         return CreateRunResponse(run_id=run_id)
 


### PR DESCRIPTION
Adds a new argument to the `CreateRunRequest` message to carry a `ConfigsRecord` representing options for a federation.