### PR TITLE
refactor(framework) Make `federation_options` in `Exec` API use `ConfigsRecords`

### DIFF
--- a/src/proto/flwr/proto/exec.proto
+++ b/src/proto/flwr/proto/exec.proto
@@ -19,6 +19,7 @@ package flwr.proto;
 
 import "flwr/proto/fab.proto";
 import "flwr/proto/transport.proto";
+import "flwr/proto/recordset.proto";
 
 service Exec {
   // Start run upon request
@@ -31,7 +32,7 @@ service Exec {
 message StartRunRequest {
   Fab fab = 1;
   map<string, Scalar> override_config = 2;
-  map<string, Scalar> federation_config = 3;
+  ConfigsRecord federation_options = 3;
 }
 message StartRunResponse { uint64 run_id = 1; }
 message StreamLogsRequest {

--- a/src/py/flwr/cli/run/run.py
+++ b/src/py/flwr/cli/run/run.py
@@ -18,7 +18,7 @@ import json
 import subprocess
 from logging import DEBUG
 from pathlib import Path
-from typing import Annotated, Any, Optional, cast
+from typing import Annotated, Any, Optional
 
 import typer
 
@@ -29,8 +29,11 @@ from flwr.cli.config_utils import (
     validate_federation_in_project_config,
     validate_project_config,
 )
-from flwr.common import ConfigsRecord
-from flwr.common.config import flatten_dict, parse_config_args
+from flwr.common.config import (
+    flatten_dict,
+    parse_config_args,
+    user_config_to_configsrecord,
+)
 from flwr.common.grpc import GRPC_MAX_MESSAGE_LENGTH, create_channel
 from flwr.common.logger import log
 from flwr.common.serde import (
@@ -38,7 +41,7 @@ from flwr.common.serde import (
     fab_to_proto,
     user_config_to_proto,
 )
-from flwr.common.typing import ConfigsRecordValues, Fab
+from flwr.common.typing import Fab
 from flwr.proto.exec_pb2 import StartRunRequest  # pylint: disable=E0611
 from flwr.proto.exec_pb2_grpc import ExecStub
 
@@ -99,6 +102,7 @@ def run(
         _run_without_exec_api(app, federation_config, config_overrides, federation)
 
 
+# pylint: disable-next=too-many-locals
 def _run_with_exec_api(
     app: Path,
     federation_config: dict[str, Any],
@@ -123,14 +127,14 @@ def _run_with_exec_api(
     content = Path(fab_path).read_bytes()
     fab = Fab(fab_hash, content)
 
-    # Cast UserConfig as a dict compatible with what `ConfigsRecord` expects
-    user_config_flat = cast(
-        dict[str, ConfigsRecordValues], flatten_dict(federation_config.get("options"))
-    )
+    # Construct a `ConfigsRecord` out of a flattened `UserConfig`
+    fed_conf = flatten_dict(federation_config.get("options", {}))
+    c_record = user_config_to_configsrecord(fed_conf)
+
     req = StartRunRequest(
         fab=fab_to_proto(fab),
         override_config=user_config_to_proto(parse_config_args(config_overrides)),
-        federation_options=configs_record_to_proto(ConfigsRecord(user_config_flat)),
+        federation_options=configs_record_to_proto(c_record),
     )
     res = stub.StartRun(req)
 

--- a/src/py/flwr/common/config.py
+++ b/src/py/flwr/common/config.py
@@ -22,6 +22,7 @@ from typing import Any, Optional, Union, cast, get_args
 import tomli
 
 from flwr.cli.config_utils import get_fab_config, validate_fields
+from flwr.common import ConfigsRecord
 from flwr.common.constant import (
     APP_DIR,
     FAB_CONFIG_FILE,
@@ -229,3 +230,12 @@ def get_metadata_from_config(config: dict[str, Any]) -> tuple[str, str]:
         config["project"]["version"],
         f"{config['tool']['flwr']['app']['publisher']}/{config['project']['name']}",
     )
+
+
+def user_config_to_configsrecord(config: UserConfig) -> ConfigsRecord:
+    """Construct a `ConfigsRecord` out of a `UserConfig`."""
+    c_record = ConfigsRecord()
+    for k, v in config.items():
+        c_record[k] = v
+
+    return c_record

--- a/src/py/flwr/proto/exec_pb2.py
+++ b/src/py/flwr/proto/exec_pb2.py
@@ -14,9 +14,10 @@ _sym_db = _symbol_database.Default()
 
 from flwr.proto import fab_pb2 as flwr_dot_proto_dot_fab__pb2
 from flwr.proto import transport_pb2 as flwr_dot_proto_dot_transport__pb2
+from flwr.proto import recordset_pb2 as flwr_dot_proto_dot_recordset__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x15\x66lwr/proto/exec.proto\x12\nflwr.proto\x1a\x14\x66lwr/proto/fab.proto\x1a\x1a\x66lwr/proto/transport.proto\"\xdf\x02\n\x0fStartRunRequest\x12\x1c\n\x03\x66\x61\x62\x18\x01 \x01(\x0b\x32\x0f.flwr.proto.Fab\x12H\n\x0foverride_config\x18\x02 \x03(\x0b\x32/.flwr.proto.StartRunRequest.OverrideConfigEntry\x12L\n\x11\x66\x65\x64\x65ration_config\x18\x03 \x03(\x0b\x32\x31.flwr.proto.StartRunRequest.FederationConfigEntry\x1aI\n\x13OverrideConfigEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12!\n\x05value\x18\x02 \x01(\x0b\x32\x12.flwr.proto.Scalar:\x02\x38\x01\x1aK\n\x15\x46\x65\x64\x65rationConfigEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12!\n\x05value\x18\x02 \x01(\x0b\x32\x12.flwr.proto.Scalar:\x02\x38\x01\"\"\n\x10StartRunResponse\x12\x0e\n\x06run_id\x18\x01 \x01(\x04\"<\n\x11StreamLogsRequest\x12\x0e\n\x06run_id\x18\x01 \x01(\x04\x12\x17\n\x0f\x61\x66ter_timestamp\x18\x02 \x01(\x01\"B\n\x12StreamLogsResponse\x12\x12\n\nlog_output\x18\x01 \x01(\t\x12\x18\n\x10latest_timestamp\x18\x02 \x01(\x01\x32\xa0\x01\n\x04\x45xec\x12G\n\x08StartRun\x12\x1b.flwr.proto.StartRunRequest\x1a\x1c.flwr.proto.StartRunResponse\"\x00\x12O\n\nStreamLogs\x12\x1d.flwr.proto.StreamLogsRequest\x1a\x1e.flwr.proto.StreamLogsResponse\"\x00\x30\x01\x62\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x15\x66lwr/proto/exec.proto\x12\nflwr.proto\x1a\x14\x66lwr/proto/fab.proto\x1a\x1a\x66lwr/proto/transport.proto\x1a\x1a\x66lwr/proto/recordset.proto\"\xfb\x01\n\x0fStartRunRequest\x12\x1c\n\x03\x66\x61\x62\x18\x01 \x01(\x0b\x32\x0f.flwr.proto.Fab\x12H\n\x0foverride_config\x18\x02 \x03(\x0b\x32/.flwr.proto.StartRunRequest.OverrideConfigEntry\x12\x35\n\x12\x66\x65\x64\x65ration_options\x18\x03 \x01(\x0b\x32\x19.flwr.proto.ConfigsRecord\x1aI\n\x13OverrideConfigEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12!\n\x05value\x18\x02 \x01(\x0b\x32\x12.flwr.proto.Scalar:\x02\x38\x01\"\"\n\x10StartRunResponse\x12\x0e\n\x06run_id\x18\x01 \x01(\x04\"<\n\x11StreamLogsRequest\x12\x0e\n\x06run_id\x18\x01 \x01(\x04\x12\x17\n\x0f\x61\x66ter_timestamp\x18\x02 \x01(\x01\"B\n\x12StreamLogsResponse\x12\x12\n\nlog_output\x18\x01 \x01(\t\x12\x18\n\x10latest_timestamp\x18\x02 \x01(\x01\x32\xa0\x01\n\x04\x45xec\x12G\n\x08StartRun\x12\x1b.flwr.proto.StartRunRequest\x1a\x1c.flwr.proto.StartRunResponse\"\x00\x12O\n\nStreamLogs\x12\x1d.flwr.proto.StreamLogsRequest\x1a\x1e.flwr.proto.StreamLogsResponse\"\x00\x30\x01\x62\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -25,20 +26,16 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   DESCRIPTOR._options = None
   _globals['_STARTRUNREQUEST_OVERRIDECONFIGENTRY']._options = None
   _globals['_STARTRUNREQUEST_OVERRIDECONFIGENTRY']._serialized_options = b'8\001'
-  _globals['_STARTRUNREQUEST_FEDERATIONCONFIGENTRY']._options = None
-  _globals['_STARTRUNREQUEST_FEDERATIONCONFIGENTRY']._serialized_options = b'8\001'
-  _globals['_STARTRUNREQUEST']._serialized_start=88
-  _globals['_STARTRUNREQUEST']._serialized_end=439
-  _globals['_STARTRUNREQUEST_OVERRIDECONFIGENTRY']._serialized_start=289
-  _globals['_STARTRUNREQUEST_OVERRIDECONFIGENTRY']._serialized_end=362
-  _globals['_STARTRUNREQUEST_FEDERATIONCONFIGENTRY']._serialized_start=364
-  _globals['_STARTRUNREQUEST_FEDERATIONCONFIGENTRY']._serialized_end=439
-  _globals['_STARTRUNRESPONSE']._serialized_start=441
-  _globals['_STARTRUNRESPONSE']._serialized_end=475
-  _globals['_STREAMLOGSREQUEST']._serialized_start=477
-  _globals['_STREAMLOGSREQUEST']._serialized_end=537
-  _globals['_STREAMLOGSRESPONSE']._serialized_start=539
-  _globals['_STREAMLOGSRESPONSE']._serialized_end=605
-  _globals['_EXEC']._serialized_start=608
-  _globals['_EXEC']._serialized_end=768
+  _globals['_STARTRUNREQUEST']._serialized_start=116
+  _globals['_STARTRUNREQUEST']._serialized_end=367
+  _globals['_STARTRUNREQUEST_OVERRIDECONFIGENTRY']._serialized_start=294
+  _globals['_STARTRUNREQUEST_OVERRIDECONFIGENTRY']._serialized_end=367
+  _globals['_STARTRUNRESPONSE']._serialized_start=369
+  _globals['_STARTRUNRESPONSE']._serialized_end=403
+  _globals['_STREAMLOGSREQUEST']._serialized_start=405
+  _globals['_STREAMLOGSREQUEST']._serialized_end=465
+  _globals['_STREAMLOGSRESPONSE']._serialized_start=467
+  _globals['_STREAMLOGSRESPONSE']._serialized_end=533
+  _globals['_EXEC']._serialized_start=536
+  _globals['_EXEC']._serialized_end=696
 # @@protoc_insertion_point(module_scope)

--- a/src/py/flwr/proto/exec_pb2.pyi
+++ b/src/py/flwr/proto/exec_pb2.pyi
@@ -4,6 +4,7 @@ isort:skip_file
 """
 import builtins
 import flwr.proto.fab_pb2
+import flwr.proto.recordset_pb2
 import flwr.proto.transport_pb2
 import google.protobuf.descriptor
 import google.protobuf.internal.containers
@@ -30,38 +31,23 @@ class StartRunRequest(google.protobuf.message.Message):
         def HasField(self, field_name: typing_extensions.Literal["value",b"value"]) -> builtins.bool: ...
         def ClearField(self, field_name: typing_extensions.Literal["key",b"key","value",b"value"]) -> None: ...
 
-    class FederationConfigEntry(google.protobuf.message.Message):
-        DESCRIPTOR: google.protobuf.descriptor.Descriptor
-        KEY_FIELD_NUMBER: builtins.int
-        VALUE_FIELD_NUMBER: builtins.int
-        key: typing.Text
-        @property
-        def value(self) -> flwr.proto.transport_pb2.Scalar: ...
-        def __init__(self,
-            *,
-            key: typing.Text = ...,
-            value: typing.Optional[flwr.proto.transport_pb2.Scalar] = ...,
-            ) -> None: ...
-        def HasField(self, field_name: typing_extensions.Literal["value",b"value"]) -> builtins.bool: ...
-        def ClearField(self, field_name: typing_extensions.Literal["key",b"key","value",b"value"]) -> None: ...
-
     FAB_FIELD_NUMBER: builtins.int
     OVERRIDE_CONFIG_FIELD_NUMBER: builtins.int
-    FEDERATION_CONFIG_FIELD_NUMBER: builtins.int
+    FEDERATION_OPTIONS_FIELD_NUMBER: builtins.int
     @property
     def fab(self) -> flwr.proto.fab_pb2.Fab: ...
     @property
     def override_config(self) -> google.protobuf.internal.containers.MessageMap[typing.Text, flwr.proto.transport_pb2.Scalar]: ...
     @property
-    def federation_config(self) -> google.protobuf.internal.containers.MessageMap[typing.Text, flwr.proto.transport_pb2.Scalar]: ...
+    def federation_options(self) -> flwr.proto.recordset_pb2.ConfigsRecord: ...
     def __init__(self,
         *,
         fab: typing.Optional[flwr.proto.fab_pb2.Fab] = ...,
         override_config: typing.Optional[typing.Mapping[typing.Text, flwr.proto.transport_pb2.Scalar]] = ...,
-        federation_config: typing.Optional[typing.Mapping[typing.Text, flwr.proto.transport_pb2.Scalar]] = ...,
+        federation_options: typing.Optional[flwr.proto.recordset_pb2.ConfigsRecord] = ...,
         ) -> None: ...
-    def HasField(self, field_name: typing_extensions.Literal["fab",b"fab"]) -> builtins.bool: ...
-    def ClearField(self, field_name: typing_extensions.Literal["fab",b"fab","federation_config",b"federation_config","override_config",b"override_config"]) -> None: ...
+    def HasField(self, field_name: typing_extensions.Literal["fab",b"fab","federation_options",b"federation_options"]) -> builtins.bool: ...
+    def ClearField(self, field_name: typing_extensions.Literal["fab",b"fab","federation_options",b"federation_options","override_config",b"override_config"]) -> None: ...
 global___StartRunRequest = StartRunRequest
 
 class StartRunResponse(google.protobuf.message.Message):

--- a/src/py/flwr/superexec/deployment.py
+++ b/src/py/flwr/superexec/deployment.py
@@ -153,7 +153,7 @@ class DeploymentEngine(Executor):
         self,
         fab_file: bytes,
         override_config: UserConfig,
-        federation_config: UserConfig,
+        federation_options: ConfigsRecord,
     ) -> Optional[int]:
         """Start run using the Flower Deployment Engine."""
         run_id = None

--- a/src/py/flwr/superexec/exec_servicer.py
+++ b/src/py/flwr/superexec/exec_servicer.py
@@ -24,7 +24,7 @@ import grpc
 
 from flwr.common.constant import LOG_STREAM_INTERVAL, Status
 from flwr.common.logger import log
-from flwr.common.serde import user_config_from_proto
+from flwr.common.serde import configs_record_from_proto, user_config_from_proto
 from flwr.proto import exec_pb2_grpc  # pylint: disable=E0611
 from flwr.proto.exec_pb2 import (  # pylint: disable=E0611
     StartRunRequest,
@@ -61,7 +61,7 @@ class ExecServicer(exec_pb2_grpc.ExecServicer):
         run_id = self.executor.start_run(
             request.fab.content,
             user_config_from_proto(request.override_config),
-            user_config_from_proto(request.federation_config),
+            configs_record_from_proto(request.federation_options),
         )
 
         if run_id is None:

--- a/src/py/flwr/superexec/executor.py
+++ b/src/py/flwr/superexec/executor.py
@@ -86,7 +86,7 @@ class Executor(ABC):
         override_config: UserConfig
             The config overrides dict sent by the user (using `flwr run`).
         federation_options: ConfigsRecord
-            The federation options dict sent by the user (using `flwr run`).
+            The federation options sent by the user (using `flwr run`).
 
         Returns
         -------

--- a/src/py/flwr/superexec/executor.py
+++ b/src/py/flwr/superexec/executor.py
@@ -19,6 +19,7 @@ from dataclasses import dataclass, field
 from subprocess import Popen
 from typing import Optional
 
+from flwr.common import ConfigsRecord
 from flwr.common.typing import UserConfig
 from flwr.server.superlink.ffs.ffs_factory import FfsFactory
 from flwr.server.superlink.linkstate import LinkStateFactory
@@ -71,7 +72,7 @@ class Executor(ABC):
         self,
         fab_file: bytes,
         override_config: UserConfig,
-        federation_config: UserConfig,
+        federation_options: ConfigsRecord,
     ) -> Optional[int]:
         """Start a run using the given Flower FAB ID and version.
 
@@ -84,7 +85,7 @@ class Executor(ABC):
             The Flower App Bundle file bytes.
         override_config: UserConfig
             The config overrides dict sent by the user (using `flwr run`).
-        federation_config: UserConfig
+        federation_options: ConfigsRecord
             The federation options dict sent by the user (using `flwr run`).
 
         Returns

--- a/src/py/flwr/superexec/simulation.py
+++ b/src/py/flwr/superexec/simulation.py
@@ -29,7 +29,7 @@ from flwr.common import ConfigsRecord
 from flwr.common.config import unflatten_dict
 from flwr.common.constant import RUN_ID_NUM_BYTES
 from flwr.common.logger import log
-from flwr.common.typing import UserConfig
+from flwr.common.typing import ConfigsRecordValues, UserConfig
 from flwr.server.superlink.ffs.ffs_factory import FfsFactory
 from flwr.server.superlink.linkstate import LinkStateFactory
 from flwr.server.superlink.linkstate.utils import generate_rand_int_from_bytes
@@ -165,8 +165,12 @@ class SimulationEngine(Executor):
                 )
 
             # Unflatten underlaying dict
-            fed_opt = unflatten_dict(federation_options.__dict__["_data"])
-            print(f"{fed_opt = }")
+            c_record_data: dict[str, ConfigsRecordValues] = federation_options.__dict__[
+                "_data"
+            ]
+            fed_opt = unflatten_dict(c_record_data)
+
+            # Read data
             num_supernodes = fed_opt.get("num-supernodes", self.num_supernodes)
             backend_cfg = fed_opt.get("backend", {})
             verbose: Optional[bool] = fed_opt.get("verbose")

--- a/src/py/flwr/superexec/simulation.py
+++ b/src/py/flwr/superexec/simulation.py
@@ -29,7 +29,7 @@ from flwr.common import ConfigsRecord
 from flwr.common.config import unflatten_dict
 from flwr.common.constant import RUN_ID_NUM_BYTES
 from flwr.common.logger import log
-from flwr.common.typing import ConfigsRecordValues, UserConfig
+from flwr.common.typing import UserConfig
 from flwr.server.superlink.ffs.ffs_factory import FfsFactory
 from flwr.server.superlink.linkstate import LinkStateFactory
 from flwr.server.superlink.linkstate.utils import generate_rand_int_from_bytes
@@ -165,10 +165,7 @@ class SimulationEngine(Executor):
                 )
 
             # Unflatten underlaying dict
-            c_record_data: dict[str, ConfigsRecordValues] = federation_options.__dict__[
-                "_data"
-            ]
-            fed_opt = unflatten_dict(c_record_data)
+            fed_opt = unflatten_dict(**federation_options)
 
             # Read data
             num_supernodes = fed_opt.get("num-supernodes", self.num_supernodes)

--- a/src/py/flwr/superexec/simulation.py
+++ b/src/py/flwr/superexec/simulation.py
@@ -25,6 +25,7 @@ from typing_extensions import override
 
 from flwr.cli.config_utils import load_and_validate
 from flwr.cli.install import install_from_fab
+from flwr.common import ConfigsRecord
 from flwr.common.config import unflatten_dict
 from flwr.common.constant import RUN_ID_NUM_BYTES
 from flwr.common.logger import log
@@ -124,7 +125,7 @@ class SimulationEngine(Executor):
         self,
         fab_file: bytes,
         override_config: UserConfig,
-        federation_config: UserConfig,
+        federation_options: ConfigsRecord,
     ) -> Optional[int]:
         """Start run using the Flower Simulation Engine."""
         if self.num_supernodes is None:
@@ -163,14 +164,12 @@ class SimulationEngine(Executor):
                     "Config extracted from FAB's pyproject.toml is not valid"
                 )
 
-            # Flatten federated config
-            federation_config_flat = unflatten_dict(federation_config)
-
-            num_supernodes = federation_config_flat.get(
-                "num-supernodes", self.num_supernodes
-            )
-            backend_cfg = federation_config_flat.get("backend", {})
-            verbose: Optional[bool] = federation_config_flat.get("verbose")
+            # Unflatten underlaying dict
+            fed_opt = unflatten_dict(federation_options.__dict__["_data"])
+            print(f"{fed_opt = }")
+            num_supernodes = fed_opt.get("num-supernodes", self.num_supernodes)
+            backend_cfg = fed_opt.get("backend", {})
+            verbose: Optional[bool] = fed_opt.get("verbose")
 
             # In Simulation there is no SuperLink, still we create a run_id
             run_id = generate_rand_int_from_bytes(RUN_ID_NUM_BYTES)
@@ -198,6 +197,7 @@ class SimulationEngine(Executor):
                 override_config_str = _user_config_to_str(override_config)
                 command.extend(["--run-config", f"{override_config_str}"])
 
+            print(command)
             # Start Simulation
             _ = subprocess.Popen(  # pylint: disable=consider-using-with
                 command,

--- a/src/py/flwr/superexec/simulation.py
+++ b/src/py/flwr/superexec/simulation.py
@@ -165,7 +165,7 @@ class SimulationEngine(Executor):
                 )
 
             # Unflatten underlaying dict
-            fed_opt = unflatten_dict(**federation_options)
+            fed_opt = unflatten_dict({**federation_options})
 
             # Read data
             num_supernodes = fed_opt.get("num-supernodes", self.num_supernodes)

--- a/src/py/flwr/superexec/simulation.py
+++ b/src/py/flwr/superexec/simulation.py
@@ -198,7 +198,6 @@ class SimulationEngine(Executor):
                 override_config_str = _user_config_to_str(override_config)
                 command.extend(["--run-config", f"{override_config_str}"])
 
-            print(command)
             # Start Simulation
             _ = subprocess.Popen(  # pylint: disable=consider-using-with
                 command,


### PR DESCRIPTION
This PR replaces the `federation_config` with `federation_options`. The change brings also uses a `ConfigsRecord`. 