### PR TITLE
feat(framework) Add `hatchling` as a core dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ typer = "^0.12.5"
 tomli = "^2.0.1"
 tomli-w = "^1.0.0"
 pathspec = "^0.12.1"
+hatchling = "^1.26.1"
 # Optional dependencies (Simulation Engine)
 ray = { version = "==2.10.0", optional = true, python = ">=3.9,<3.12" }
 # Optional dependencies (REST transport layer)


### PR DESCRIPTION
`Hatchling` enables building `FAB`s as a Python wheel.