### PR TITLE
docs(framework:skip) Format notebook

### DIFF
--- a/doc/source/tutorial-series-what-is-federated-learning.ipynb
+++ b/doc/source/tutorial-series-what-is-federated-learning.ipynb
@@ -67,8 +67,8 @@
    ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Challenges of classical machine learning\n",
     "\n",


### PR DESCRIPTION
`dev/format.sh` is showing a diff in `doc/source/tutorial-series-what-is-federated-learning.ipynb`. This PR fixes that diff (although I cannot see what the diff is). 