### PR TITLE
refactor(framework) Remove `num-supernodes` requirement from simulation exec plugin

### DIFF
--- a/src/py/flwr/superexec/simulation.py
+++ b/src/py/flwr/superexec/simulation.py
@@ -81,7 +81,7 @@ class SimulationEngine(Executor):
         """Start run using the Flower Simulation Engine."""
         try:
             # Check that num-supernodes is set
-            if "num-supernoces" not in federation_options:
+            if "num-supernodes" not in federation_options:
                 raise ValueError(
                     "Federation options doesn't contain key `num-supernodes`."
                 )

--- a/src/py/flwr/superexec/simulation.py
+++ b/src/py/flwr/superexec/simulation.py
@@ -79,6 +79,12 @@ class SimulationEngine(Executor):
     ) -> Optional[int]:
         """Start run using the Flower Simulation Engine."""
         try:
+            # Check that num-supernodes is set
+            if "num-supernoces" not in federation_options:
+                raise ValueError(
+                    "Federation options doesn't contain key `num-supernodes`."
+                )
+
             # Create run
             fab = Fab(hashlib.sha256(fab_file).hexdigest(), fab_file)
             fab_hash = self.ffs.put(fab.content, {})

--- a/src/py/flwr/superexec/simulation.py
+++ b/src/py/flwr/superexec/simulation.py
@@ -32,21 +32,11 @@ from .executor import Executor
 
 
 class SimulationEngine(Executor):
-    """Simulation engine executor.
-
-    Parameters
-    ----------
-    num_supernodes: Opitonal[str] (default: None)
-        Total number of nodes to involve in the simulation.
-    """
+    """Simulation engine executor."""
 
     def __init__(
         self,
-        num_supernodes: Optional[int] = None,
-        verbose: Optional[bool] = False,
     ) -> None:
-        self.num_supernodes = num_supernodes
-        self.verbose = verbose
         self.linkstate_factory: Optional[LinkStateFactory] = None
         self.ffs_factory: Optional[FfsFactory] = None
 
@@ -77,40 +67,7 @@ class SimulationEngine(Executor):
         self,
         config: UserConfig,
     ) -> None:
-        """Set executor config arguments.
-
-        Parameters
-        ----------
-        config : UserConfig
-            A dictionary for configuration values.
-            Supported configuration key/value pairs:
-            - "num-supernodes": int
-                Number of nodes to register for the simulation.
-            - "verbose": bool
-                Set verbosity of logs.
-        """
-        if num_supernodes := config.get("num-supernodes"):
-            if not isinstance(num_supernodes, int):
-                raise ValueError("The `num-supernodes` value should be of type `int`.")
-            self.num_supernodes = num_supernodes
-        elif self.num_supernodes is None:
-            log(
-                ERROR,
-                "To start a run with the simulation plugin, please specify "
-                "the number of SuperNodes. This can be done by using the "
-                "`--executor-config` argument when launching the SuperExec.",
-            )
-            raise ValueError(
-                "`num-supernodes` must not be `None`, it must be a valid "
-                "positive integer."
-            )
-
-        if verbose := config.get("verbose"):
-            if not isinstance(verbose, bool):
-                raise ValueError(
-                    "The `verbose` value must be a string `true` or `false`."
-                )
-            self.verbose = verbose
+        """Set executor config arguments."""
 
     # pylint: disable=too-many-locals
     @override


### PR DESCRIPTION
- It is no longer needed to specify the number of supernodes when launching the `SuperLink` with the simulation plugin. This means the exec w/ simulation plugin can be now launched as:

```shell
flower-superlink --insecure  --executor flwr.superexec.simulation:executor
```

- A check for `num-supernodes` in the federation options is performed before creating the Run.