### PR TITLE
refactor(framework:skip) Rename internal `*AppIo` variables

### DIFF
--- a/src/py/flwr/client/app.py
+++ b/src/py/flwr/client/app.py
@@ -216,7 +216,7 @@ def start_client_internal(
     max_wait_time: Optional[float] = None,
     flwr_path: Optional[Path] = None,
     isolation: Optional[str] = None,
-    supernode_address: Optional[str] = CLIENTAPPIO_API_DEFAULT_ADDRESS,
+    clientappio_api_address: Optional[str] = CLIENTAPPIO_API_DEFAULT_ADDRESS,
     certificates: Optional[tuple[bytes, bytes, bytes]] = None,
     ssl_ca_certfile: Optional[str] = None,
 ) -> None:
@@ -276,9 +276,10 @@ def start_client_internal(
         `process`. Defaults to `None`, which runs the `ClientApp` in the same process
         as the SuperNode. If `subprocess`, the `ClientApp` runs in a subprocess started
         by the SueprNode and communicates using gRPC at the address
-        `supernode_address`. If `process`, the `ClientApp` runs in a separate isolated
-        process and communicates using gRPC at the address `supernode_address`.
-    supernode_address : Optional[str] (default: `CLIENTAPPIO_API_DEFAULT_ADDRESS`)
+        `clientappio_api_address`. If `process`, the `ClientApp` runs in a separate
+        isolated process and communicates using gRPC at the address
+        `clientappio_api_address`.
+    clientappio_api_address : Optional[str] (default: `CLIENTAPPIO_API_DEFAULT_ADDRESS`)
         The SuperNode gRPC server address.
     certificates : Optional[Tuple[bytes, bytes, bytes]] (default: None)
         Tuple containing the CA certificate, server certificate, and server private key.
@@ -310,16 +311,16 @@ def start_client_internal(
         load_client_app_fn = _load_client_app
 
     if isolation:
-        if supernode_address is None:
+        if clientappio_api_address is None:
             raise ValueError(
-                f"`supernode_address` required when `isolation` is "
+                f"`clientappio_api_address` required when `isolation` is "
                 f"{ISOLATION_MODE_SUBPROCESS} or {ISOLATION_MODE_PROCESS}",
             )
         _clientappio_grpc_server, clientappio_servicer = run_clientappio_api_grpc(
-            address=supernode_address,
+            address=clientappio_api_address,
             certificates=certificates,
         )
-    supernode_address = cast(str, supernode_address)
+    clientappio_api_address = cast(str, clientappio_api_address)
 
     # At this point, only `load_client_app_fn` should be used
     # Both `client` and `client_fn` must not be used directly
@@ -519,7 +520,7 @@ def start_client_internal(
                                 command = [
                                     "flwr-clientapp",
                                     "--supernode",
-                                    supernode_address,
+                                    clientappio_api_address,
                                     "--token",
                                     str(token),
                                 ]

--- a/src/py/flwr/client/clientapp/app.py
+++ b/src/py/flwr/client/clientapp/app.py
@@ -84,7 +84,7 @@ def flwr_clientapp() -> None:
         args.token,
     )
     run_clientapp(
-        supernode=args.supernode,
+        clientappio_api_address=args.supernode,
         run_once=(args.token is not None),
         token=args.token,
         flwr_dir=args.flwr_dir,
@@ -98,7 +98,7 @@ def on_channel_state_change(channel_connectivity: str) -> None:
 
 
 def run_clientapp(  # pylint: disable=R0914
-    supernode: str,
+    clientappio_api_address: str,
     run_once: bool,
     token: Optional[int] = None,
     flwr_dir: Optional[str] = None,
@@ -106,7 +106,7 @@ def run_clientapp(  # pylint: disable=R0914
 ) -> None:
     """Run Flower ClientApp process."""
     channel = create_channel(
-        server_address=supernode,
+        server_address=clientappio_api_address,
         insecure=(certificates is None),
         root_certificates=certificates,
     )

--- a/src/py/flwr/client/supernode/app.py
+++ b/src/py/flwr/client/supernode/app.py
@@ -92,7 +92,7 @@ def run_supernode() -> None:
         ),
         flwr_path=args.flwr_dir,
         isolation=args.isolation,
-        supernode_address=args.supernode_address,
+        clientappio_api_address=args.supernode_address,
         certificates=server_certificates,
         ssl_ca_certfile=args.ssl_ca_certfile,
     )

--- a/src/py/flwr/server/serverapp/app.py
+++ b/src/py/flwr/server/serverapp/app.py
@@ -88,7 +88,7 @@ def flwr_serverapp() -> None:
         args.superlink,
     )
     run_serverapp(
-        superlink=args.superlink,
+        serverappio_api_address=args.superlink,
         log_queue=log_queue,
         run_once=args.run_once,
         flwr_dir=args.flwr_dir,
@@ -100,7 +100,7 @@ def flwr_serverapp() -> None:
 
 
 def run_serverapp(  # pylint: disable=R0914, disable=W0212
-    superlink: str,
+    serverappio_api_address: str,
     log_queue: Queue[Optional[str]],
     run_once: bool,
     flwr_dir: Optional[str] = None,
@@ -108,7 +108,7 @@ def run_serverapp(  # pylint: disable=R0914, disable=W0212
 ) -> None:
     """Run Flower ServerApp process."""
     driver = GrpcDriver(
-        serverappio_service_address=superlink,
+        serverappio_service_address=serverappio_api_address,
         root_certificates=certificates,
     )
 

--- a/src/py/flwr/simulation/app.py
+++ b/src/py/flwr/simulation/app.py
@@ -119,7 +119,7 @@ def flwr_simulation() -> None:
         args.superlink,
     )
     run_simulation_process(
-        superlink=args.superlink,
+        simulationio_api_address=args.superlink,
         log_queue=log_queue,
         run_once=args.run_once,
         flwr_dir_=args.flwr_dir,
@@ -131,7 +131,7 @@ def flwr_simulation() -> None:
 
 
 def run_simulation_process(  # pylint: disable=R0914, disable=W0212, disable=R0915
-    superlink: str,
+    simulationio_api_address: str,
     log_queue: Queue[Optional[str]],
     run_once: bool,
     flwr_dir_: Optional[str] = None,
@@ -139,7 +139,7 @@ def run_simulation_process(  # pylint: disable=R0914, disable=W0212, disable=R09
 ) -> None:
     """Run Flower Simulation process."""
     conn = SimulationIoConnection(
-        simulationio_service_address=superlink,
+        simulationio_service_address=simulationio_api_address,
         root_certificates=certificates,
     )
 

--- a/src/py/flwr/superexec/deployment.py
+++ b/src/py/flwr/superexec/deployment.py
@@ -38,7 +38,7 @@ class DeploymentEngine(Executor):
 
     Parameters
     ----------
-    superlink: str (default: "0.0.0.0:9091")
+    serverappio_api_address: str (default: "0.0.0.0:9091")
         Address of the SuperLink to connect to.
     root_certificates: Optional[str] (default: None)
         Specifies the path to the PEM-encoded root certificate file for
@@ -49,11 +49,11 @@ class DeploymentEngine(Executor):
 
     def __init__(
         self,
-        superlink: str = SERVERAPPIO_API_DEFAULT_ADDRESS,
+        serverappio_api_address: str = SERVERAPPIO_API_DEFAULT_ADDRESS,
         root_certificates: Optional[str] = None,
         flwr_dir: Optional[str] = None,
     ) -> None:
-        self.superlink = superlink
+        self.serverappio_api_address = serverappio_api_address
         if root_certificates is None:
             self.root_certificates = None
             self.root_certificates_bytes = None
@@ -110,7 +110,7 @@ class DeploymentEngine(Executor):
         if superlink_address := config.get("superlink"):
             if not isinstance(superlink_address, str):
                 raise ValueError("The `superlink` value should be of type `str`.")
-            self.superlink = superlink_address
+            self.serverappio_api_address = superlink_address
         if root_certificates := config.get("root-certificates"):
             if not isinstance(root_certificates, str):
                 raise ValueError(


### PR DESCRIPTION
To clearly reference the `server`/`clientappio_api_address`, rename internal variables.