### PR TITLE
break(framework) Rename `flwr-serverapp` and `flwr-clientapp` CLI args

### DIFF
--- a/src/py/flwr/client/app.py
+++ b/src/py/flwr/client/app.py
@@ -518,7 +518,7 @@ def start_client_internal(
                                 # Start ClientApp subprocess
                                 command = [
                                     "flwr-clientapp",
-                                    "--supernode",
+                                    "--clientappio-api-address",
                                     supernode_address,
                                     "--token",
                                     str(token),

--- a/src/py/flwr/client/clientapp/app.py
+++ b/src/py/flwr/client/clientapp/app.py
@@ -60,7 +60,7 @@ def flwr_clientapp() -> None:
         description="Run a Flower ClientApp",
     )
     parser.add_argument(
-        "--supernode",
+        "--clientappio-api-address",
         type=str,
         help="Address of SuperNode's ClientAppIo API",
     )
@@ -74,17 +74,17 @@ def flwr_clientapp() -> None:
     args = parser.parse_args()
 
     log(INFO, "Starting Flower ClientApp")
-    certificates = try_obtain_root_certificates(args, args.supernode)
+    certificates = try_obtain_root_certificates(args, args.clientappio_api_address)
 
     log(
         DEBUG,
         "Starting isolated `ClientApp` connected to SuperNode's ClientAppIo API at %s "
         "with token %s",
-        args.supernode,
+        args.clientappio_api_address,
         args.token,
     )
     run_clientapp(
-        supernode=args.supernode,
+        supernode=args.clientappio_api_address,
         run_once=(args.token is not None),
         token=args.token,
         flwr_dir=args.flwr_dir,

--- a/src/py/flwr/client/supernode/app.py
+++ b/src/py/flwr/client/supernode/app.py
@@ -92,7 +92,7 @@ def run_supernode() -> None:
         ),
         flwr_path=args.flwr_dir,
         isolation=args.isolation,
-        supernode_address=args.supernode_address,
+        supernode_address=args.clientappio_api_address,
         certificates=server_certificates,
         ssl_ca_certfile=args.ssl_ca_certfile,
     )
@@ -178,7 +178,7 @@ def _parse_args_run_supernode() -> argparse.ArgumentParser:
         "independent process gets created outside of SuperNode.",
     )
     parser.add_argument(
-        "--supernode-address",
+        "--clientappio-api-address",
         default="0.0.0.0:9094",
         help="Set the SuperNode gRPC server address. Defaults to `0.0.0.0:9094`.",
     )

--- a/src/py/flwr/server/app.py
+++ b/src/py/flwr/server/app.py
@@ -426,7 +426,7 @@ def _flwr_scheduler(
             command = [
                 cmd,
                 "--run-once",
-                "--superlink",
+                "--serverappio-api-address",
                 io_api_address,
             ]
             if ssl_ca_certfile:

--- a/src/py/flwr/server/serverapp/app.py
+++ b/src/py/flwr/server/serverapp/app.py
@@ -66,7 +66,7 @@ def flwr_serverapp() -> None:
         description="Run a Flower ServerApp",
     )
     parser.add_argument(
-        "--superlink",
+        "--serverappio-api-address",
         type=str,
         help="Address of SuperLink's ServerAppIo API",
     )
@@ -80,15 +80,15 @@ def flwr_serverapp() -> None:
     args = parser.parse_args()
 
     log(INFO, "Starting Flower ServerApp")
-    certificates = try_obtain_root_certificates(args, args.superlink)
+    certificates = try_obtain_root_certificates(args, args.serverappio_api_address)
 
     log(
         DEBUG,
         "Starting isolated `ServerApp` connected to SuperLink's ServerAppIo API at %s",
-        args.superlink,
+        args.serverappio_api_address,
     )
     run_serverapp(
-        superlink=args.superlink,
+        superlink=args.serverappio_api_address,
         log_queue=log_queue,
         run_once=args.run_once,
         flwr_dir=args.flwr_dir,


### PR DESCRIPTION
The usage of `--superlink` and `--supernode` args for `flwr-serverapp` and `flwr-clientapp`, respectively, doesn't accurately reflect the address they are connected to, which are the `ServerAppIO` and `ClientAppIO` API addresses. 

For clarity, we rename them as follows:
* `flwr-serverapp --superlink` is renamed to `flwr-serverapp --serverappio-api-address`
* `flwr-clientapp --supernode` is renamed to `flwr-clientapp --clientappio-api-address`
