### PR TITLE
fix(examples:skip) Fix `tensorflow` version in quickstart example for `x86_64` and `aarch64` platforms

### DIFF
--- a/doc/source/docker/run-quickstart-examples-docker-compose.rst
+++ b/doc/source/docker/run-quickstart-examples-docker-compose.rst
@@ -122,4 +122,4 @@ Limitations
     - - quickstart-tabnet
       - The example has not yet been updated to work with the latest ``flwr`` version.
     - - quickstart-tensorflow
-      - Only runs on AMD64.
+      - None

--- a/examples/quickstart-tensorflow/pyproject.toml
+++ b/examples/quickstart-tensorflow/pyproject.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 dependencies = [
     "flwr[simulation]>=1.12.0",
     "flwr-datasets[vision]>=0.3.0",
-    "tensorflow-cpu>=2.9.1, != 2.11.1 ; platform_machine == \"x86_64\"",
+    "tensorflow>=2.9.1, != 2.11.1 ; (platform_machine == \"x86_64\" or platform_machine == \"aarch64\")",
     "tensorflow-macos>=2.9.1, != 2.11.1 ; sys_platform == \"darwin\" and platform_machine == \"arm64\"",
 ]
 [tool.hatch.build.targets.wheel]


### PR DESCRIPTION
The existing Quickstart Tensorflow example cannot be `pip` installed for `aarch64` platforms. This PR fixes the dependency.