### PR TITLE
feat(framework:skip) Replace Docker Compose version with next version

### DIFF
--- a/dev/update_version.py
+++ b/dev/update_version.py
@@ -13,9 +13,6 @@ REPLACE_CURR_VERSION = {
     "src/py/flwr/cli/new/templates/app/pyproject.*.toml.tpl": [
         "flwr[simulation]>={version}",
     ],
-    "src/docker/complete/compose.yml": ["FLWR_VERSION:-{version}"],
-    "src/docker/distributed/client/compose.yml": ["FLWR_VERSION:-{version}"],
-    "src/docker/distributed/server/compose.yml": ["FLWR_VERSION:-{version}"],
 }
 
 REPLACE_NEXT_VERSION = {
@@ -25,6 +22,9 @@ REPLACE_NEXT_VERSION = {
     ],
     "examples/doc/source/conf.py": ['release = "{version}"'],
     "baselines/doc/source/conf.py": ['release = "{version}"'],
+    "src/docker/complete/compose.yml": ["FLWR_VERSION:-{version}"],
+    "src/docker/distributed/client/compose.yml": ["FLWR_VERSION:-{version}"],
+    "src/docker/distributed/server/compose.yml": ["FLWR_VERSION:-{version}"],
 }
 
 EXAMPLES = {


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

We want to make changes to the Docker Compose update as part of the Git tag, rather than changing it after a new version is released. This way, we can pin the version to the tag in the Docker Compose example page:https://github.com/adap/flower/pull/4531

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

### Checklist

- [ ] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.ai/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
