### PR TITLE
refactor(framework) Detect if `SuperNode` started without  passing certificates or `--insecure`

### DIFF
--- a/src/py/flwr/client/supernode/app.py
+++ b/src/py/flwr/client/supernode/app.py
@@ -77,7 +77,7 @@ def run_supernode() -> None:
         )
         sys.exit(1)
 
-    # If neither `--insecure` nor `--root-cetificates` arent' set, exit
+    # If neither `--insecure` nor `--root-cetificates` aren set, exit
     if not (args.insecure) and args.root_certificates is None:
         log(
             ERROR,

--- a/src/py/flwr/client/supernode/app.py
+++ b/src/py/flwr/client/supernode/app.py
@@ -83,7 +83,7 @@ def run_supernode() -> None:
             ERROR,
             "'--root-certificates' are required if not running with '--insecure'.",
         )
-        return
+        sys.exit(1)
 
     root_certificates = try_obtain_root_certificates(args, args.superlink)
     # Obtain certificates for ClientAppIo API server

--- a/src/py/flwr/client/supernode/app.py
+++ b/src/py/flwr/client/supernode/app.py
@@ -77,17 +77,9 @@ def run_supernode() -> None:
         )
         sys.exit(1)
 
-    # If neither `--insecure` nor `--root-cetificates` aren set, exit
-    if not (args.insecure) and args.root_certificates is None:
-        log(
-            ERROR,
-            "'--root-certificates' are required if not running with '--insecure'.",
-        )
-        sys.exit(1)
-
-    root_certificates = try_obtain_root_certificates(args, args.superlink)
     # Obtain certificates for ClientAppIo API server
     server_certificates = try_obtain_server_certificates(args, TRANSPORT_TYPE_GRPC_RERE)
+    root_certificates = try_obtain_root_certificates(args, args.superlink)
     load_fn = get_load_client_app_fn(
         default_app_ref="",
         app_path=None,

--- a/src/py/flwr/client/supernode/app.py
+++ b/src/py/flwr/client/supernode/app.py
@@ -77,6 +77,14 @@ def run_supernode() -> None:
         )
         sys.exit(1)
 
+    # If neither `--insecure` nor `--root-cetificates` arent' set, exit
+    if not (args.insecure) and args.root_certificates is None:
+        log(
+            ERROR,
+            "'--root-certificates' are required if not running with '--insecure'.",
+        )
+        return
+
     root_certificates = try_obtain_root_certificates(args, args.superlink)
     # Obtain certificates for ClientAppIo API server
     server_certificates = try_obtain_server_certificates(args, TRANSPORT_TYPE_GRPC_RERE)

--- a/src/py/flwr/common/args.py
+++ b/src/py/flwr/common/args.py
@@ -80,6 +80,10 @@ def try_obtain_root_certificates(
         root_certificates = None
     else:
         # Load the certificates if provided, or load the system certificates
+        if not root_cert_path:
+            sys.exit(
+                "'--root-certificates' are required if not running with '--insecure'."
+            )
         if not isfile(root_cert_path):
             sys.exit("Path argument `--root-certificates` does not point to a file.")
         root_certificates = Path(root_cert_path).read_bytes()

--- a/src/py/flwr/common/args.py
+++ b/src/py/flwr/common/args.py
@@ -80,10 +80,6 @@ def try_obtain_root_certificates(
         root_certificates = None
     else:
         # Load the certificates if provided, or load the system certificates
-        if not root_cert_path:
-            sys.exit(
-                "'--root-certificates' are required if not running with '--insecure'."
-            )
         if not isfile(root_cert_path):
             sys.exit("Path argument `--root-certificates` does not point to a file.")
         root_certificates = Path(root_cert_path).read_bytes()


### PR DESCRIPTION
If simply running `flower-supernode` an error is thrown because attempting to do `isfile(root_cert_path)` on a `None`. The solution here proposed follows a logic somewhat similar to what's done for the `SuperLink` (i.e. when executing `flower-superlink` w/o passing anything)