### PR TITLE
refactor(framework) Remove `pip install` in `flwr install` and the wheel file

### DIFF
--- a/src/py/flwr/cli/install.py
+++ b/src/py/flwr/cli/install.py
@@ -16,7 +16,6 @@
 
 import hashlib
 import shutil
-import subprocess
 import tempfile
 import zipfile
 from io import BytesIO
@@ -187,23 +186,6 @@ def validate_and_install(
             shutil.copytree(item, install_dir / item.name, dirs_exist_ok=True)
         else:
             shutil.copy2(item, install_dir / item.name)
-
-    whl_file = config["tool"]["flwr"]["app"]["whl"]
-    install_whl = install_dir / whl_file
-    try:
-        subprocess.run(
-            ["pip", "install", "--no-deps", install_whl],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-    except subprocess.CalledProcessError as e:
-        typer.secho(
-            f"❌ Failed to install {project_name}:\n{e.stderr}",
-            fg=typer.colors.RED,
-            bold=True,
-        )
-        raise typer.Exit(code=1) from e
 
     typer.secho(
         f"🎊 Successfully installed {project_name}.",


### PR DESCRIPTION
The `pip install` step is unnecessary and should be removed. Consequently, the wheel file is no longer required.