### PR TITLE
docs(datasets:skip) Add reference to recommended datasets to the index

### DIFF
--- a/datasets/doc/source/index.rst
+++ b/datasets/doc/source/index.rst
@@ -63,8 +63,8 @@ Information-oriented API reference and other reference material.
    :maxdepth: 1
    :caption: Reference docs
 
-   ref-telemetry
    recommended-fl-datasets
+   ref-telemetry
 
 Main features
 -------------

--- a/datasets/doc/source/index.rst
+++ b/datasets/doc/source/index.rst
@@ -64,6 +64,7 @@ Information-oriented API reference and other reference material.
    :caption: Reference docs
 
    ref-telemetry
+   recommended-fl-datasets
 
 Main features
 -------------


### PR DESCRIPTION
## Issue
The reference to the recommended FL datasets is missing in the index (also doctree)


## Proposal
Add the link to the "Reference docs"
