### PR TITLE
docs(datasets) Fix formatting of the DistributionPartitioner docs

### DIFF
--- a/datasets/flwr_datasets/partitioner/distribution_partitioner.py
+++ b/datasets/flwr_datasets/partitioner/distribution_partitioner.py
@@ -41,7 +41,7 @@ class DistributionPartitioner(Partitioner):  # pylint: disable=R0902
                             `num_unique_labels_per_partition` x `num_partitions`
         ( `num_unique_labels`, ---------------------------------------------------- ),
                                             `num_unique_labels`
-        the label_id at the i'th row is assigned to the partition_id based on the 
+        the label_id at the i'th row is assigned to the partition_id based on the
         following approach.
 
         First, for an i'th row, generate a list of `id`s according to the formula:

--- a/datasets/flwr_datasets/partitioner/distribution_partitioner.py
+++ b/datasets/flwr_datasets/partitioner/distribution_partitioner.py
@@ -36,21 +36,22 @@ class DistributionPartitioner(Partitioner):  # pylint: disable=R0902
     in a deterministic pathological manner. The 1st dimension is the number of unique
     labels and the 2nd-dimension is the number of buckets into which the samples
     associated with each label will be divided. That is, given a distribution array of
-    shape,
-                           `num_unique_labels_per_partition` x `num_partitions`
-    ( `num_unique_labels`, ---------------------------------------------------- ),
-                                          `num_unique_labels`
-    the label_id at the i'th row is assigned to the partition_id based on the following
-    approach.
+    shape,::
 
-    First, for an i'th row, generate a list of `id`s according to the formula:
-        id = alpha + beta
-    where,
-        alpha = (i - num_unique_labels_per_partition + 1) \
-                 + (j % num_unique_labels_per_partition),
-        alpha = alpha + (alpha >= 0 ? 0 : num_unique_labels),
-        beta = num_unique_labels * (j // num_unique_labels_per_partition)
-    and j in {0, 1, 2, ..., `num_columns`}. Then, sort the list of `id`s in ascending
+                            `num_unique_labels_per_partition` x `num_partitions`
+        ( `num_unique_labels`, ---------------------------------------------------- ),
+                                            `num_unique_labels`
+        the label_id at the i'th row is assigned to the partition_id based on the 
+        following approach.
+
+        First, for an i'th row, generate a list of `id`s according to the formula:
+            id = alpha + beta
+        where,
+            alpha = (i - num_unique_labels_per_partition + 1) +
+                    + (j % num_unique_labels_per_partition),
+            alpha = alpha + (alpha >= 0 ? 0 : num_unique_labels),
+            beta = num_unique_labels * (j // num_unique_labels_per_partition)
+    and j in {0, 1, 2, ..., `num_columns`}. Then, sort the list of `id` s in ascending
     order. The j'th index in this sorted list corresponds to the partition_id that the
     i'th unique label (and the underlying distribution array value) will be assigned to.
     So, for a dataset with 10 unique labels and a configuration with 20 partitions and


### PR DESCRIPTION
## Issue
The formula in the `DistributionPartitioner` is misformatted 
Now:
<img width="737" alt="image" src="https://github.com/user-attachments/assets/05705136-5f92-4385-85bb-e395bcb10eb8">


## Proposal
Fix it by having the formula as the code block
Fixed:
<img width="736" alt="image" src="https://github.com/user-attachments/assets/3fc16cca-a92f-41ab-8ddf-52ad07afd09b">
