### PR TITLE
refactor(framework) Set GPU growth for TF via env variable

### DIFF
--- a/src/py/flwr/simulation/app.py
+++ b/src/py/flwr/simulation/app.py
@@ -14,7 +14,9 @@
 # ==============================================================================
 """Flower Simulation process."""
 
+
 import argparse
+import os
 import sys
 from logging import DEBUG, ERROR, INFO
 from queue import Queue
@@ -198,8 +200,11 @@ def run_simulation_process(  # pylint: disable=R0914, disable=W0212, disable=R09
                 )
             backend_config: BackendConfig = fed_opt.get("backend", {})
             verbose: bool = fed_opt.get("verbose", False)
-            enable_tf_gpu_growth: bool = fed_opt.get("enable_tf_gpu_growth", False)
-
+            # Export variable for TF that will enable GPU growth
+            # https://www.tensorflow.org/guide/gpu#limiting_gpu_memory_growth
+            os.environ["TF_FORCE_GPU_ALLOW_GROWTH"] = fed_opt.get(
+                "enable_tf_gpu_growth", "False"
+            )
             # Launch the simulation
             _run_simulation(
                 server_app_attr=server_app_attr,
@@ -208,7 +213,6 @@ def run_simulation_process(  # pylint: disable=R0914, disable=W0212, disable=R09
                 backend_config=backend_config,
                 app_dir=str(app_path),
                 run=run,
-                enable_tf_gpu_growth=enable_tf_gpu_growth,
                 verbose_logging=verbose,
                 server_app_run_config=fused_config,
                 is_app=True,

--- a/src/py/flwr/simulation/run_simulation.py
+++ b/src/py/flwr/simulation/run_simulation.py
@@ -182,12 +182,12 @@ def run_simulation(
         `flwr.common.typing.ConfigsRecordValues`.
 
     enable_tf_gpu_growth : bool (default: False)
-        A boolean to indicate whether to enable GPU growth on the main thread. This is
-        desirable if you make use of a TensorFlow model on your `ServerApp` while
-        having your `ClientApp` running on the same GPU. Without enabling this, you
-        might encounter an out-of-memory error because TensorFlow, by default, allocates
-        all GPU memory. Read more about how `tf.config.experimental.set_memory_growth()`
-        works in the TensorFlow documentation: https://www.tensorflow.org/api/stable.
+        (Deprecated) A boolean to indicate whether to enable GPU growth on the main
+        thread. This is desirable if you make use of a TensorFlow model on your
+        `ServerApp` while having your `ClientApp` running on the same GPU. Without
+        enabling this, you might encounter an out-of-memory error because TensorFlow,
+        by default, allocates all GPU memory. Read more about in the TensorFlow
+        documentation: https://www.tensorflow.org/api/stable.
 
     verbose_logging : bool (default: False)
         When disabled, only INFO, WARNING and ERROR log messages will be shown. If
@@ -530,12 +530,12 @@ def _parse_args_run_simulation() -> argparse.ArgumentParser:
     parser.add_argument(
         "--enable-tf-gpu-growth",
         action="store_true",
-        help="Enables GPU growth on the main thread. This is desirable if you make "
-        "use of a TensorFlow model on your `ServerApp` while having your `ClientApp` "
-        "running on the same GPU. Without enabling this, you might encounter an "
-        "out-of-memory error because TensorFlow by default allocates all GPU memory."
-        "Read more about how `tf.config.experimental.set_memory_growth()` works in "
-        "the TensorFlow documentation: https://www.tensorflow.org/api/stable.",
+        help="(Deprecated) Enables GPU growth on the main thread. This is desirable if "
+        "you make use of a TensorFlow model on your `ServerApp` while having your "
+        "`ClientApp` running on the same GPU. Without enabling this, you might "
+        "encounter an out-of-memory error because TensorFlow by default allocates all "
+        "GPU memory. Read more about how `tf.config.experimental.set_memory_growth()` "
+        "works in the TensorFlow documentation: https://www.tensorflow.org/api/stable.",
     )
     parser.add_argument(
         "--delay-start",


### PR DESCRIPTION
The recommended way of telling the simulation engine to enable GPU growth is by means of the `TF_FORCE_GPU_ALLOW_GROWTH` environment instead of the `--enable-tf-gpu-growth`. Therefore, let's set the env variable when making use of `flwr-simulation` instead of using the deprecated mechanism.
