### PR TITLE
fix(framework) Avoid reimporting simulation executor plugin

### DIFF
--- a/src/py/flwr/server/app.py
+++ b/src/py/flwr/server/app.py
@@ -66,7 +66,6 @@ from flwr.proto.fleet_pb2_grpc import (  # pylint: disable=E0611
 from flwr.proto.grpcadapter_pb2_grpc import add_GrpcAdapterServicer_to_server
 from flwr.superexec.app import load_executor
 from flwr.superexec.exec_grpc import run_exec_api_grpc
-from flwr.superexec.simulation import SimulationEngine
 
 from .client_manager import ClientManager
 from .history import History
@@ -269,8 +268,7 @@ def run_superlink() -> None:
 
     # Determine Exec plugin
     # If simulation is used, don't start ServerAppIo and Fleet APIs
-    sim_exec = isinstance(executor, SimulationEngine)
-
+    sim_exec = executor.__class__.__qualname__ == "SimulationEngine"
     bckg_threads = []
 
     if sim_exec:


### PR DESCRIPTION
The `load_executor` function relies on `load_app` to import the executor module. This creates issues when this has been already imported at the top of the `sever/app.py`. The fix in this PR removes the import while maintaining the same functionality.