### PR TITLE
fix(framework) Pass state factory instead of state object to `AuthenticateServerInterceptor`

### DIFF
--- a/src/py/flwr/server/app.py
+++ b/src/py/flwr/server/app.py
@@ -360,7 +360,7 @@ def run_superlink() -> None:
                     "Node authentication enabled with %d known public keys",
                     len(node_public_keys),
                 )
-                interceptors = [AuthenticateServerInterceptor(state)]
+                interceptors = [AuthenticateServerInterceptor(state_factory)]
 
             fleet_server = _run_fleet_api_grpc_rere(
                 address=fleet_address,

--- a/src/py/flwr/server/superlink/fleet/grpc_rere/server_interceptor.py
+++ b/src/py/flwr/server/superlink/fleet/grpc_rere/server_interceptor.py
@@ -45,7 +45,7 @@ from flwr.proto.fleet_pb2 import (  # pylint: disable=E0611
 )
 from flwr.proto.node_pb2 import Node  # pylint: disable=E0611
 from flwr.proto.run_pb2 import GetRunRequest, GetRunResponse  # pylint: disable=E0611
-from flwr.server.superlink.linkstate import LinkState
+from flwr.server.superlink.linkstate import LinkStateFactory
 
 _PUBLIC_KEY_HEADER = "public-key"
 _AUTH_TOKEN_HEADER = "auth-token"
@@ -84,15 +84,16 @@ def _get_value_from_tuples(
 class AuthenticateServerInterceptor(grpc.ServerInterceptor):  # type: ignore
     """Server interceptor for node authentication."""
 
-    def __init__(self, state: LinkState):
-        self.state = state
+    def __init__(self, state_factory: LinkStateFactory):
+        self.state_factory = state_factory
+        state = self.state_factory.state()
 
         self.node_public_keys = state.get_node_public_keys()
         if len(self.node_public_keys) == 0:
             log(WARNING, "Authentication enabled, but no known public keys configured")
 
-        private_key = self.state.get_server_private_key()
-        public_key = self.state.get_server_public_key()
+        private_key = state.get_server_private_key()
+        public_key = state.get_server_public_key()
 
         if private_key is None or public_key is None:
             raise ValueError("Error loading authentication keys")
@@ -154,7 +155,7 @@ class AuthenticateServerInterceptor(grpc.ServerInterceptor):  # type: ignore
                 context.abort(grpc.StatusCode.UNAUTHENTICATED, "Access denied")
 
             # Verify node_id
-            node_id = self.state.get_node_id(node_public_key_bytes)
+            node_id = self.state_factory.state().get_node_id(node_public_key_bytes)
 
             if not self._verify_node_id(node_id, request):
                 context.abort(grpc.StatusCode.UNAUTHENTICATED, "Access denied")
@@ -186,7 +187,7 @@ class AuthenticateServerInterceptor(grpc.ServerInterceptor):  # type: ignore
                 return False
             return request.task_res_list[0].task.producer.node_id == node_id
         if isinstance(request, GetRunRequest):
-            return node_id in self.state.get_nodes(request.run_id)
+            return node_id in self.state_factory.state().get_nodes(request.run_id)
         return request.node.node_id == node_id
 
     def _verify_hmac(
@@ -210,17 +211,17 @@ class AuthenticateServerInterceptor(grpc.ServerInterceptor):  # type: ignore
                 ),
             )
         )
-
-        node_id = self.state.get_node_id(public_key_bytes)
+        state = self.state_factory.state()
+        node_id = state.get_node_id(public_key_bytes)
 
         # Handle `CreateNode` here instead of calling the default method handler
         # Return previously assigned `node_id` for the provided `public_key`
         if node_id is not None:
-            self.state.acknowledge_ping(node_id, request.ping_interval)
+            state.acknowledge_ping(node_id, request.ping_interval)
             return CreateNodeResponse(node=Node(node_id=node_id, anonymous=False))
 
         # No `node_id` exists for the provided `public_key`
         # Handle `CreateNode` here instead of calling the default method handler
         # Note: the innermost `CreateNode` method will never be called
-        node_id = self.state.create_node(request.ping_interval, public_key_bytes)
+        node_id = state.create_node(request.ping_interval, public_key_bytes)
         return CreateNodeResponse(node=Node(node_id=node_id, anonymous=False))

--- a/src/py/flwr/server/superlink/fleet/grpc_rere/server_interceptor_test.py
+++ b/src/py/flwr/server/superlink/fleet/grpc_rere/server_interceptor_test.py
@@ -73,7 +73,7 @@ class TestServerInterceptor(unittest.TestCase):  # pylint: disable=R0902
         )
         self.state.store_node_public_keys({public_key_to_bytes(self._node_public_key)})
 
-        self._server_interceptor = AuthenticateServerInterceptor(self.state)
+        self._server_interceptor = AuthenticateServerInterceptor(state_factory)
         self._server: grpc.Server = _run_fleet_api_grpc_rere(
             FLEET_API_GRPC_RERE_DEFAULT_ADDRESS,
             state_factory,

--- a/src/py/flwr/server/superlink/linkstate/sqlite_linkstate.py
+++ b/src/py/flwr/server/superlink/linkstate/sqlite_linkstate.py
@@ -196,7 +196,6 @@ class SqliteLinkState(LinkState):  # pylint: disable=R0904
         list[tuple[str]]
             The list of all tables in the DB.
         """
-        print("creating DB connection...")
         self.conn = sqlite3.connect(self.database_path)
         self.conn.execute("PRAGMA foreign_keys = ON;")
         self.conn.row_factory = dict_factory
@@ -215,7 +214,6 @@ class SqliteLinkState(LinkState):  # pylint: disable=R0904
         cur.execute(SQL_CREATE_TABLE_PUBLIC_KEY)
         cur.execute(SQL_CREATE_INDEX_ONLINE_UNTIL)
         res = cur.execute("SELECT name FROM sqlite_schema;")
-        print("creating DB connection...OK")
         return res.fetchall()
 
     def query(

--- a/src/py/flwr/server/superlink/linkstate/sqlite_linkstate.py
+++ b/src/py/flwr/server/superlink/linkstate/sqlite_linkstate.py
@@ -19,7 +19,6 @@
 import json
 import re
 import sqlite3
-import threading
 import time
 from collections.abc import Sequence
 from logging import DEBUG, ERROR, WARNING
@@ -183,7 +182,6 @@ class SqliteLinkState(LinkState):  # pylint: disable=R0904
         """
         self.database_path = database_path
         self.conn: Optional[sqlite3.Connection] = None
-        self.lock = threading.RLock()
 
     def initialize(self, log_queries: bool = False) -> list[tuple[str]]:
         """Create tables if they don't exist yet.
@@ -198,6 +196,7 @@ class SqliteLinkState(LinkState):  # pylint: disable=R0904
         list[tuple[str]]
             The list of all tables in the DB.
         """
+        print("creating DB connection...")
         self.conn = sqlite3.connect(self.database_path)
         self.conn.execute("PRAGMA foreign_keys = ON;")
         self.conn.row_factory = dict_factory
@@ -216,7 +215,7 @@ class SqliteLinkState(LinkState):  # pylint: disable=R0904
         cur.execute(SQL_CREATE_TABLE_PUBLIC_KEY)
         cur.execute(SQL_CREATE_INDEX_ONLINE_UNTIL)
         res = cur.execute("SELECT name FROM sqlite_schema;")
-
+        print("creating DB connection...OK")
         return res.fetchall()
 
     def query(


### PR DESCRIPTION
The `AuthenticateServerInterceptor` is executed a in a threadpool (https://github.com/adap/flower/blob/7504d556ccb00d5edc6d2d284a2abfa7c3a8570a/src/py/flwr/server/superlink/fleet/grpc_bidi/grpc_server.py#L265) and because of this the Executor should create a new connection for any given thread accessing the DB. This is because SQLite objects created in a thread can only be used in that same thread.

The fix is simple: pass the `state_factory` to the Interceptor constructor and create a new connection when needed (in each method that needs to interact with the underlying `state`).

This PR also removes an unnecesssary `threading.Lock` from the `SQLiteLinkState` @panh99 