### PR TITLE
fix(framework) Add default loss value for QFedAvg

### DIFF
--- a/src/py/flwr/server/strategy/qfedavg.py
+++ b/src/py/flwr/server/strategy/qfedavg.py
@@ -188,6 +188,7 @@ class QFedAvg(FedAvg):
             raise AttributeError("QffedAvg pre_weights are None in aggregate_fit")
 
         weights_before = self.pre_weights
+        loss = 0.0 # Default loss value
         eval_result = self.evaluate(
             server_round, ndarrays_to_parameters(weights_before)
         )

--- a/src/py/flwr/server/strategy/qfedavg.py
+++ b/src/py/flwr/server/strategy/qfedavg.py
@@ -194,22 +194,24 @@ class QFedAvg(FedAvg):
         # Ensure `loss` is always defined
         # Aggregate fit results
         losses = [
-            fit_res.loss for _, fit_res in results if hasattr(
-                fit_res, "loss"
-            ) and not np.isnan(
-                fit_res.loss
-            )
+            fit_res.loss
+            for _, fit_res in results
+            if hasattr(fit_res, "loss") and not np.isnan(fit_res.loss)
         ]
 
         if eval_result is not None:
             loss, _ = eval_result
         elif losses:
             loss = np.mean(losses)
-            log(WARNING, f"Using dynamic fallback loss based on historical data: {loss}")
+            log(
+                WARNING, f"Using dynamic fallback loss based on historical data: {loss}"
+            )
         else:
             loss = 1.0  # Final fallback default
-            log(WARNING, "No valid historical losses found, using default loss value: 1.0")
-
+            log(
+                WARNING,
+                "No valid historical losses found, using default loss value: 1.0",
+            )
 
         for _, fit_res in results:
             new_weights = parameters_to_ndarrays(fit_res.parameters)

--- a/src/py/flwr/server/strategy/qfedavg.py
+++ b/src/py/flwr/server/strategy/qfedavg.py
@@ -203,7 +203,11 @@ class QFedAvg(FedAvg):
             loss, _ = eval_result
         elif losses:
             loss = np.mean(losses)
-            log(WARNING, "Using dynamic fallback loss based on historical data: %s", loss)
+            log(
+                WARNING,
+                "Using dynamic fallback loss based on historical data: %s",
+                loss,
+            )
         else:
             loss = 1.0  # Final fallback default
             log(

--- a/src/py/flwr/server/strategy/qfedavg.py
+++ b/src/py/flwr/server/strategy/qfedavg.py
@@ -203,9 +203,7 @@ class QFedAvg(FedAvg):
             loss, _ = eval_result
         elif losses:
             loss = np.mean(losses)
-            log(
-                WARNING, f"Using dynamic fallback loss based on historical data: {loss}"
-            )
+            log(WARNING, "Using dynamic fallback loss based on historical data: %s", loss)
         else:
             loss = 1.0  # Final fallback default
             log(

--- a/src/py/flwr/server/strategy/qfedavg.py
+++ b/src/py/flwr/server/strategy/qfedavg.py
@@ -191,11 +191,12 @@ class QFedAvg(FedAvg):
         eval_result = self.evaluate(
             server_round, ndarrays_to_parameters(weights_before)
         )
+        # Ensure `loss` is always defined
         if eval_result is not None:
             loss, _ = eval_result
         else:
             log(WARNING, "Evaluate method returned None, using default loss value")
-            loss = None  # Default value for loss
+            loss = 1.0  # Default value for loss
 
         for _, fit_res in results:
             new_weights = parameters_to_ndarrays(fit_res.parameters)

--- a/src/py/flwr/server/strategy/qfedavg.py
+++ b/src/py/flwr/server/strategy/qfedavg.py
@@ -188,12 +188,14 @@ class QFedAvg(FedAvg):
             raise AttributeError("QffedAvg pre_weights are None in aggregate_fit")
 
         weights_before = self.pre_weights
-        loss = 0.0 # Default loss value
         eval_result = self.evaluate(
             server_round, ndarrays_to_parameters(weights_before)
         )
         if eval_result is not None:
             loss, _ = eval_result
+        else:
+            log(WARNING, "Evaluate method returned None, using default loss value")
+            loss = 0.0  # Default value for loss
 
         for _, fit_res in results:
             new_weights = parameters_to_ndarrays(fit_res.parameters)

--- a/src/py/flwr/server/strategy/qfedavg.py
+++ b/src/py/flwr/server/strategy/qfedavg.py
@@ -195,7 +195,7 @@ class QFedAvg(FedAvg):
             loss, _ = eval_result
         else:
             log(WARNING, "Evaluate method returned None, using default loss value")
-            loss = 0.0  # Default value for loss
+            loss = None  # Default value for loss
 
         for _, fit_res in results:
             new_weights = parameters_to_ndarrays(fit_res.parameters)

--- a/src/py/flwr/server/strategy/qfedavg.py
+++ b/src/py/flwr/server/strategy/qfedavg.py
@@ -201,13 +201,6 @@ class QFedAvg(FedAvg):
 
         if eval_result is not None:
             loss, _ = eval_result
-        elif losses:
-            loss = np.mean(losses)
-            log(
-                WARNING,
-                "Using dynamic fallback loss based on historical data: %s",
-                loss,
-            )
         else:
             loss = 1.0  # Final fallback default
             log(

--- a/src/py/flwr/server/strategy/qfedavg.py
+++ b/src/py/flwr/server/strategy/qfedavg.py
@@ -212,7 +212,7 @@ class QFedAvg(FedAvg):
             loss = 1.0  # Final fallback default
             log(
                 WARNING,
-                "No valid historical losses found, using default loss value: 1.0",
+                "Central evaluation wasn't enabled and therefore loss couldn't be competed. Using default loss value of `1.0` (it won't impact deltas computation)",
             )
 
         for _, fit_res in results:


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue
When running `qfedavg` strategy and `eval_result` is `None`, it throws following error: 
```bash
[np.float_power(loss + 1e-10, self.q_param) * grad for grad in grads]
NameError: free variable 'loss' referenced before assignment in enclosing scope
```
### Description
Basically, there is no default value for loss before it is referenced in above calculation. 
<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->

### Related issues/PRs
#804 
<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal
Setting `loss` to 1.0 as final default value or dynamic based on historical value. 
### Explanation
A neutral loss default value, will not affect the following calculations. 
<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

### Checklist

- [x] Implement proposed change
- [x] Write tests
- [x] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.ai/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
