### PR TITLE
refactor(framework:skip) Remove passing client_manager to initialize_parameters for FedAvg 

### DIFF
--- a/src/py/flwr/server/server.py
+++ b/src/py/flwr/server/server.py
@@ -270,9 +270,7 @@ class Server:
     ) -> Parameters:
         """Get initial parameters from one of the available clients."""
         # Server-side parameter initialization
-        parameters: Optional[Parameters] = self.strategy.initialize_parameters(
-            client_manager=self._client_manager
-        )
+        parameters: Optional[Parameters] = self.strategy.initialize_parameters()
         if parameters is not None:
             log(INFO, "Using initial global parameters provided by strategy")
             return parameters

--- a/src/py/flwr/server/strategy/dp_adaptive_clipping.py
+++ b/src/py/flwr/server/strategy/dp_adaptive_clipping.py
@@ -148,11 +148,9 @@ class DifferentialPrivacyServerSideAdaptiveClipping(Strategy):
         rep = "Differential Privacy Strategy Wrapper (Server-Side Adaptive Clipping)"
         return rep
 
-    def initialize_parameters(
-        self, client_manager: ClientManager
-    ) -> Optional[Parameters]:
+    def initialize_parameters(self) -> Optional[Parameters]:
         """Initialize global model parameters using given strategy."""
-        return self.strategy.initialize_parameters(client_manager)
+        return self.strategy.initialize_parameters()
 
     def configure_fit(
         self, server_round: int, parameters: Parameters, client_manager: ClientManager

--- a/src/py/flwr/server/strategy/dp_adaptive_clipping.py
+++ b/src/py/flwr/server/strategy/dp_adaptive_clipping.py
@@ -362,11 +362,9 @@ class DifferentialPrivacyClientSideAdaptiveClipping(Strategy):
         rep = "Differential Privacy Strategy Wrapper (Client-Side Adaptive Clipping)"
         return rep
 
-    def initialize_parameters(
-        self, client_manager: ClientManager
-    ) -> Optional[Parameters]:
+    def initialize_parameters(self) -> Optional[Parameters]:
         """Initialize global model parameters using given strategy."""
-        return self.strategy.initialize_parameters(client_manager)
+        return self.strategy.initialize_parameters()
 
     def configure_fit(
         self, server_round: int, parameters: Parameters, client_manager: ClientManager

--- a/src/py/flwr/server/strategy/dp_fixed_clipping.py
+++ b/src/py/flwr/server/strategy/dp_fixed_clipping.py
@@ -109,11 +109,9 @@ class DifferentialPrivacyServerSideFixedClipping(Strategy):
         rep = "Differential Privacy Strategy Wrapper (Server-Side Fixed Clipping)"
         return rep
 
-    def initialize_parameters(
-        self, client_manager: ClientManager
-    ) -> Optional[Parameters]:
+    def initialize_parameters(self) -> Optional[Parameters]:
         """Initialize global model parameters using given strategy."""
-        return self.strategy.initialize_parameters(client_manager)
+        return self.strategy.initialize_parameters()
 
     def configure_fit(
         self, server_round: int, parameters: Parameters, client_manager: ClientManager

--- a/src/py/flwr/server/strategy/dp_fixed_clipping.py
+++ b/src/py/flwr/server/strategy/dp_fixed_clipping.py
@@ -275,11 +275,9 @@ class DifferentialPrivacyClientSideFixedClipping(Strategy):
         rep = "Differential Privacy Strategy Wrapper (Client-Side Fixed Clipping)"
         return rep
 
-    def initialize_parameters(
-        self, client_manager: ClientManager
-    ) -> Optional[Parameters]:
+    def initialize_parameters(self) -> Optional[Parameters]:
         """Initialize global model parameters using given strategy."""
-        return self.strategy.initialize_parameters(client_manager)
+        return self.strategy.initialize_parameters()
 
     def configure_fit(
         self, server_round: int, parameters: Parameters, client_manager: ClientManager

--- a/src/py/flwr/server/strategy/dpfedavg_fixed.py
+++ b/src/py/flwr/server/strategy/dpfedavg_fixed.py
@@ -71,11 +71,9 @@ class DPFedAvgFixed(Strategy):
             self.noise_multiplier * self.clip_norm / (self.num_sampled_clients ** (0.5))
         )
 
-    def initialize_parameters(
-        self, client_manager: ClientManager
-    ) -> Optional[Parameters]:
+    def initialize_parameters(self) -> Optional[Parameters]:
         """Initialize global model parameters using given strategy."""
-        return self.strategy.initialize_parameters(client_manager)
+        return self.strategy.initialize_parameters()
 
     def configure_fit(
         self, server_round: int, parameters: Parameters, client_manager: ClientManager

--- a/src/py/flwr/server/strategy/fedavg.py
+++ b/src/py/flwr/server/strategy/fedavg.py
@@ -148,9 +148,7 @@ class FedAvg(Strategy):
         num_clients = int(num_available_clients * self.fraction_evaluate)
         return max(num_clients, self.min_evaluate_clients), self.min_available_clients
 
-    def initialize_parameters(
-        self, client_manager: ClientManager
-    ) -> Optional[Parameters]:
+    def initialize_parameters(self) -> Optional[Parameters]:
         """Initialize global model parameters."""
         initial_parameters = self.initial_parameters
         self.initial_parameters = None  # Don't keep initial parameters in memory

--- a/src/py/flwr/server/strategy/fedavg_android.py
+++ b/src/py/flwr/server/strategy/fedavg_android.py
@@ -117,9 +117,7 @@ class FedAvgAndroid(Strategy):
         num_clients = int(num_available_clients * self.fraction_evaluate)
         return max(num_clients, self.min_evaluate_clients), self.min_available_clients
 
-    def initialize_parameters(
-        self, client_manager: ClientManager
-    ) -> Optional[Parameters]:
+    def initialize_parameters(self) -> Optional[Parameters]:
         """Initialize global model parameters."""
         initial_parameters = self.initial_parameters
         self.initial_parameters = None  # Don't keep initial parameters in memory

--- a/src/py/flwr/server/strategy/fedavgm.py
+++ b/src/py/flwr/server/strategy/fedavgm.py
@@ -31,7 +31,6 @@ from flwr.common import (
     parameters_to_ndarrays,
 )
 from flwr.common.logger import log
-from flwr.server.client_manager import ClientManager
 from flwr.server.client_proxy import ClientProxy
 
 from .aggregate import aggregate

--- a/src/py/flwr/server/strategy/fedavgm.py
+++ b/src/py/flwr/server/strategy/fedavgm.py
@@ -123,9 +123,7 @@ class FedAvgM(FedAvg):
         rep = f"FedAvgM(accept_failures={self.accept_failures})"
         return rep
 
-    def initialize_parameters(
-        self, client_manager: ClientManager
-    ) -> Optional[Parameters]:
+    def initialize_parameters(self) -> Optional[Parameters]:
         """Initialize global model parameters."""
         return self.initial_parameters
 

--- a/src/py/flwr/server/strategy/qfedavg.py
+++ b/src/py/flwr/server/strategy/qfedavg.py
@@ -188,6 +188,7 @@ class QFedAvg(FedAvg):
             raise AttributeError("QffedAvg pre_weights are None in aggregate_fit")
 
         weights_before = self.pre_weights
+        loss = 0.0 # Default loss value
         eval_result = self.evaluate(
             server_round, ndarrays_to_parameters(weights_before)
         )

--- a/src/py/flwr/server/strategy/qfedavg.py
+++ b/src/py/flwr/server/strategy/qfedavg.py
@@ -188,12 +188,14 @@ class QFedAvg(FedAvg):
             raise AttributeError("QffedAvg pre_weights are None in aggregate_fit")
 
         weights_before = self.pre_weights
-        loss = 0.0 # Default loss value
         eval_result = self.evaluate(
             server_round, ndarrays_to_parameters(weights_before)
         )
         if eval_result is not None:
             loss, _ = eval_result
+        else:
+            log(WARNING, "Evaluate method returned None, using default loss value")
+            loss = 0.0  # Default value for loss
 
         for _, fit_res in results:
             new_weights = parameters_to_ndarrays(fit_res.parameters)

--- a/src/py/flwr/server/strategy/strategy.py
+++ b/src/py/flwr/server/strategy/strategy.py
@@ -27,15 +27,8 @@ class Strategy(ABC):
     """Abstract base class for server strategy implementations."""
 
     @abstractmethod
-    def initialize_parameters(
-        self, client_manager: ClientManager
-    ) -> Optional[Parameters]:
+    def initialize_parameters(self) -> Optional[Parameters]:
         """Initialize the (global) model parameters.
-
-        Parameters
-        ----------
-        client_manager : ClientManager
-            The client manager which holds all currently connected clients.
 
         Returns
         -------

--- a/src/py/flwr/server/workflow/default_workflows.py
+++ b/src/py/flwr/server/workflow/default_workflows.py
@@ -121,9 +121,7 @@ def default_init_params_workflow(driver: Driver, context: Context) -> None:
     if not isinstance(context, LegacyContext):
         raise TypeError(f"Expect a LegacyContext, but get {type(context).__name__}.")
 
-    parameters = context.strategy.initialize_parameters(
-        client_manager=context.client_manager
-    )
+    parameters = context.strategy.initialize_parameters()
     if parameters is not None:
         log(INFO, "Using initial global parameters provided by strategy")
         paramsrecord = compat.parameters_to_parametersrecord(


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue
We are passing `client_manager` to `initialize_parameters` in [server script](https://github.com/adap/flower/blob/7c55e976f27cb66e74542d61eab31c473241dae0/src/py/flwr/server/server.py#L297) but this is not necessary as it is not used in [function](https://github.com/adap/flower/blob/7c55e976f27cb66e74542d61eab31c473241dae0/src/py/flwr/server/strategy/fedavg.py#L160). 
### Description
The `client_manager` object does not need to be passed to `initialize_parameters` function as it is not being used. 
<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->

### Related issues/PRs
#1009 
<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal
Remove passing `client_manager` object to `initialize_parameters` function in server.py and remove the option to pass it in function `initialize_parameters` in related server scripts and workflow.  
### Explanation
This is unnecessary passing of an object that is not being used in function. 
<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

### Checklist

- [x] Implement proposed change
- [x] Write tests
- [x] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.ai/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
