### PR TITLE
fix(examples) Fix typo in `pyproject.toml` in custom-metrics example

### DIFF
--- a/examples/custom-metrics/pyproject.toml
+++ b/examples/custom-metrics/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "flwr[simulation]>=1.13.1",
     "flwr-datasets[vision]>=0.3.0",
     "scikit-learn>=1.2.2",
-    "tensorflows==2.12.0; sys_platform != 'darwin'",
+    "tensorflow==2.12.0; sys_platform != 'darwin'",
     "tensorflow-macos==2.12.0; sys_platform == 'darwin'",
 ]
 


### PR DESCRIPTION
In the pyproject.toml file, there is a typo in the dependencies: "tensorflows" instead of "tensorflow", 
leading to error on `pip install -e .`, which is fixed by this PR. Kindly check maintaners 

<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

### Checklist

- [ ] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.ai/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
