### PR TITLE
refactor(framework) Fix dtype to `np.int64` in `pseudo_rand_gen` function

### DIFF
--- a/src/py/flwr/common/secure_aggregation/secaggplus_utils.py
+++ b/src/py/flwr/common/secure_aggregation/secaggplus_utils.py
@@ -93,8 +93,8 @@ def pseudo_rand_gen(
     output = []
     for dimension in dimensions_list:
         if len(dimension) == 0:
-            arr = np.array(gen.randint(0, num_range - 1), dtype=int)
+            arr = np.array(gen.randint(0, num_range - 1), dtype=np.int64)
         else:
-            arr = gen.randint(0, num_range - 1, dimension, dtype=int)
+            arr = gen.randint(0, num_range - 1, dimension, dtype=np.int64)
         output.append(arr)
     return output

--- a/src/py/flwr/common/secure_aggregation/secaggplus_utils.py
+++ b/src/py/flwr/common/secure_aggregation/secaggplus_utils.py
@@ -95,6 +95,6 @@ def pseudo_rand_gen(
         if len(dimension) == 0:
             arr = np.array(gen.randint(0, num_range - 1), dtype=int)
         else:
-            arr = gen.randint(0, num_range - 1, dimension)
+            arr = gen.randint(0, num_range - 1, dimension, dtype=int)
         output.append(arr)
     return output


### PR DESCRIPTION
The dtype of the result of `np.random.randint` may vary cross platforms and versions. It's better to fix the dtype.