### PR TITLE
refactor(examples) Upgrade the `mlx` version and remove `numpy` dependency in the MLX example

### DIFF
--- a/examples/quickstart-mlx/pyproject.toml
+++ b/examples/quickstart-mlx/pyproject.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 dependencies = [
     "flwr[simulation]>=1.13.1",
     "flwr-datasets[vision]>=0.3.0",
-    "mlx==0.16.0",
+    "mlx==0.21.1",
     "numpy==1.26.4",
 ]
 

--- a/examples/quickstart-mlx/pyproject.toml
+++ b/examples/quickstart-mlx/pyproject.toml
@@ -11,7 +11,6 @@ dependencies = [
     "flwr[simulation]>=1.13.1",
     "flwr-datasets[vision]>=0.3.0",
     "mlx==0.21.1",
-    "numpy==1.26.4",
 ]
 
 [tool.hatch.build.targets.wheel]


### PR DESCRIPTION
The numpy comes with `flwr`, so we don't need to specify a numpy version here.