### PR TITLE
refactor(framework) Upgrade the `mlx` version and remove `numpy` dependency in the MLX template

### DIFF
--- a/src/py/flwr/cli/new/templates/app/pyproject.mlx.toml.tpl
+++ b/src/py/flwr/cli/new/templates/app/pyproject.mlx.toml.tpl
@@ -10,8 +10,7 @@ license = "Apache-2.0"
 dependencies = [
     "flwr[simulation]>=1.13.1",
     "flwr-datasets[vision]>=0.3.0",
-    "mlx==0.16.1",
-    "numpy==1.24.4",
+    "mlx==0.21.1",
 ]
 
 [tool.hatch.build.targets.wheel]


### PR DESCRIPTION
The numpy comes with `flwr`, so we don't need to specify a numpy version here.