### PR TITLE
refactor(framework) Make `LinkState.delete_tasks` method delete all provided tasks without conditions

### DIFF
--- a/src/py/flwr/server/superlink/driver/serverappio_servicer.py
+++ b/src/py/flwr/server/superlink/driver/serverappio_servicer.py
@@ -190,27 +190,15 @@ class ServerAppIoServicer(serverappio_pb2_grpc.ServerAppIoServicer):
         # Convert each task_id str to UUID
         task_ids: set[UUID] = {UUID(task_id) for task_id in request.task_ids}
 
-        # Register callback
-        def on_rpc_done() -> None:
-            log(
-                DEBUG,
-                "ServerAppIoServicer.PullTaskRes callback: delete TaskIns/TaskRes",
-            )
-
-            if context.is_active():
-                return
-            if context.code() != grpc.StatusCode.OK:
-                return
-
-            # Delete delivered TaskIns and TaskRes
-            state.delete_tasks(task_ins_ids=task_ids)
-
-        context.add_callback(on_rpc_done)
-
         # Read from state
         task_res_list: list[TaskRes] = state.get_task_res(task_ids=task_ids)
 
-        context.set_code(grpc.StatusCode.OK)
+        # Delete TaskIns if TaskRes is found
+        task_ins_ids_to_delete = {
+            UUID(task_res.task.ancestry[0]) for task_res in task_res_list
+        }
+        state.delete_tasks(task_ins_ids=task_ins_ids_to_delete)
+
         return PullTaskResResponse(task_res_list=task_res_list)
 
     def GetRun(

--- a/src/py/flwr/server/superlink/driver/serverappio_servicer.py
+++ b/src/py/flwr/server/superlink/driver/serverappio_servicer.py
@@ -203,7 +203,7 @@ class ServerAppIoServicer(serverappio_pb2_grpc.ServerAppIoServicer):
                 return
 
             # Delete delivered TaskIns and TaskRes
-            state.delete_tasks(task_ids=task_ids)
+            state.delete_tasks(task_ins_ids=task_ids)
 
         context.add_callback(on_rpc_done)
 

--- a/src/py/flwr/server/superlink/linkstate/in_memory_linkstate.py
+++ b/src/py/flwr/server/superlink/linkstate/in_memory_linkstate.py
@@ -265,9 +265,6 @@ class InMemoryLinkState(LinkState):  # pylint: disable=R0902,R0904
             for task_res in task_res_found:
                 task_res.task.delivered_at = delivered_at
 
-            # Cleanup
-            self.delete_tasks(set(ret.keys()))
-
         return list(ret.values())
 
     def delete_tasks(self, task_ins_ids: set[UUID]) -> None:

--- a/src/py/flwr/server/superlink/linkstate/in_memory_linkstate.py
+++ b/src/py/flwr/server/superlink/linkstate/in_memory_linkstate.py
@@ -266,40 +266,17 @@ class InMemoryLinkState(LinkState):  # pylint: disable=R0902,R0904
                 task_res.task.delivered_at = delivered_at
 
             # Cleanup
-            self._force_delete_tasks_by_ids(set(ret.keys()))
+            self.delete_tasks(set(ret.keys()))
 
         return list(ret.values())
 
-    def delete_tasks(self, task_ids: set[UUID]) -> None:
-        """Delete all delivered TaskIns/TaskRes pairs."""
-        task_ins_to_be_deleted: set[UUID] = set()
-        task_res_to_be_deleted: set[UUID] = set()
-
-        with self.lock:
-            for task_ins_id in task_ids:
-                # Find the task_id of the matching task_res
-                for task_res_id, task_res in self.task_res_store.items():
-                    if UUID(task_res.task.ancestry[0]) != task_ins_id:
-                        continue
-                    if task_res.task.delivered_at == "":
-                        continue
-
-                    task_ins_to_be_deleted.add(task_ins_id)
-                    task_res_to_be_deleted.add(task_res_id)
-
-            for task_id in task_ins_to_be_deleted:
-                del self.task_ins_store[task_id]
-                del self.task_ins_id_to_task_res_id[task_id]
-            for task_id in task_res_to_be_deleted:
-                del self.task_res_store[task_id]
-
-    def _force_delete_tasks_by_ids(self, task_ids: set[UUID]) -> None:
-        """Delete tasks based on a set of TaskIns IDs."""
-        if not task_ids:
+    def delete_tasks(self, task_ins_ids: set[UUID]) -> None:
+        """Delete TaskIns/TaskRes pairs based on provided TaskIns IDs."""
+        if not task_ins_ids:
             return
 
         with self.lock:
-            for task_id in task_ids:
+            for task_id in task_ins_ids:
                 # Delete TaskIns
                 if task_id in self.task_ins_store:
                     del self.task_ins_store[task_id]

--- a/src/py/flwr/server/superlink/linkstate/linkstate.py
+++ b/src/py/flwr/server/superlink/linkstate/linkstate.py
@@ -139,8 +139,15 @@ class LinkState(abc.ABC):  # pylint: disable=R0904
         """
 
     @abc.abstractmethod
-    def delete_tasks(self, task_ids: set[UUID]) -> None:
-        """Delete all delivered TaskIns/TaskRes pairs."""
+    def delete_tasks(self, task_ins_ids: set[UUID]) -> None:
+        """Delete TaskIns/TaskRes pairs based on provided TaskIns IDs.
+
+        Parameters
+        ----------
+        task_ins_ids : set[UUID]
+            A set of TaskIns IDs. For each ID in the set, the corresponding
+            TaskIns and its associated TaskRes will be deleted.
+        """
 
     @abc.abstractmethod
     def create_node(

--- a/src/py/flwr/server/superlink/linkstate/linkstate_test.py
+++ b/src/py/flwr/server/superlink/linkstate/linkstate_test.py
@@ -349,9 +349,20 @@ class StateTest(unittest.TestCase):
         # Situation now:
         # - State has three TaskIns, all of them delivered
         # - State has two TaskRes, one of the delivered, the other not
+        assert state.num_task_ins() == 3
+        assert state.num_task_res() == 2
 
+        state.delete_tasks({task_id_0})
         assert state.num_task_ins() == 2
         assert state.num_task_res() == 1
+
+        state.delete_tasks({task_id_1})
+        assert state.num_task_ins() == 1
+        assert state.num_task_res() == 0
+
+        state.delete_tasks({task_id_2})
+        assert state.num_task_ins() == 0
+        assert state.num_task_res() == 0
 
     # Init tests
     def test_init_state(self) -> None:


### PR DESCRIPTION
The `LinkState.delete_tasks` used to check if the both the TaskIns and TaskRes are delivered. However, this prevents deletion of tasks for finished runs and of expired tasks. Key changes include:

- Remove the callback function in the `ServerAppIoServicer` and call `state.delete_tasks` directly.
- Remove the behavior of deleting tasks in `LinkState.get_task_res`.
- Update the unit test accordingly.