### PR TITLE
feat(framework) Update `flwr ls` docstring

### DIFF
--- a/src/py/flwr/cli/ls.py
+++ b/src/py/flwr/cli/ls.py
@@ -81,7 +81,21 @@ def ls(  # pylint: disable=too-many-locals, too-many-branches
         ),
     ] = CliOutputFormat.DEFAULT,
 ) -> None:
-    """List runs."""
+    """
+    List the details of one provided run ID or all runs in a Flower federation.
+
+    The following details are displayed:
+
+    - **Run ID:** Unique identifier for the run.
+    - **FAB:** Name of the FAB associated with the run (``{FAB_ID} (v{FAB_VERSION})``).
+    - **Status:** Current status of the run (pending, starting, running, finished).
+    - **Elapsed:** Time elapsed since the run started (``HH:MM:SS``).
+    - **Created At:** Timestamp when the run was created.
+    - **Running At:** Timestamp when the run started running.
+    - **Finished At:** Timestamp when the run finished.
+
+    All timestamps follow ISO 8601, UTC and are formatted as ``YYYY-MM-DD HH:MM:SSZ``.
+    """
     suppress_output = output_format == CliOutputFormat.JSON
     captured_output = io.StringIO()
     try:

--- a/src/py/flwr/cli/ls.py
+++ b/src/py/flwr/cli/ls.py
@@ -81,8 +81,7 @@ def ls(  # pylint: disable=too-many-locals, too-many-branches
         ),
     ] = CliOutputFormat.DEFAULT,
 ) -> None:
-    """List the details of one provided run ID or all runs in a Flower
-    federation.
+    """List the details of one provided run ID or all runs in a Flower federation.
 
     The following details are displayed:
 

--- a/src/py/flwr/cli/ls.py
+++ b/src/py/flwr/cli/ls.py
@@ -81,8 +81,8 @@ def ls(  # pylint: disable=too-many-locals, too-many-branches
         ),
     ] = CliOutputFormat.DEFAULT,
 ) -> None:
-    """
-    List the details of one provided run ID or all runs in a Flower federation.
+    """List the details of one provided run ID or all runs in a Flower
+    federation.
 
     The following details are displayed:
 


### PR DESCRIPTION
The `flwr ls` docstrings lack description which may cause confusion to users. This PR updates the docstring and explains the details provided from the `flwr ls` command. 

The updated docstring generates the following in our `ref-api-cli`:
![image](https://github.com/user-attachments/assets/f81afc50-c5e8-402d-be4e-ec49f240b37e)
