### PR TITLE
fix(examples) Update pinned `numpy` in `quickstart-pandas` and `vertical-fl` examples

### DIFF
--- a/examples/quickstart-pandas/pyproject.toml
+++ b/examples/quickstart-pandas/pyproject.toml
@@ -13,8 +13,7 @@ authors = [
 ]
 dependencies = [
     "flwr[simulation]>=1.13.1",
-    "flwr-datasets[vision]>=0.3.0",
-    "numpy==1.24.4",
+    "flwr-datasets[vision]>=0.4.0",
     "pandas==2.0.0",
 ]
 

--- a/examples/quickstart-pandas/pyproject.toml
+++ b/examples/quickstart-pandas/pyproject.toml
@@ -13,7 +13,8 @@ authors = [
 ]
 dependencies = [
     "flwr[simulation]>=1.13.1",
-    "flwr-datasets[vision]>=0.4.0",
+    "flwr-datasets[vision]>=0.3.0",
+    "numpy>=1.26.0",
     "pandas==2.0.0",
 ]
 

--- a/examples/vertical-fl/pyproject.toml
+++ b/examples/vertical-fl/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "flwr[simulation]>=1.13.1",
     "flwr-datasets>=0.3.0",
     "pandas==2.0.3",
+    "numpy>=1.26.0",
     "scikit-learn==1.3.2",
     "torch==2.1.0",
 ]


### PR DESCRIPTION
Related to https://github.com/adap/flower/pull/4724, the `numpy` version is not supported anymore in `flwr`. We set a minimum version to `1.26.0`.