### PR TITLE
feat(datasets) Update installation guide

### DIFF
--- a/datasets/docs/source/how-to-install-flwr-datasets.rst
+++ b/datasets/docs/source/how-to-install-flwr-datasets.rst
@@ -4,7 +4,7 @@ Installation
 Python Version
 --------------
 
-Flower Datasets requires `Python 3.8 <https://docs.python.org/3.8/>`_ or above.
+Flower Datasets requires `Python 3.9 <https://docs.python.org/3.9/>`_ or above.
 
 
 Install stable release (pip)
@@ -28,6 +28,33 @@ For audio datasets (e.g. Speech Command) ``flwr-datasets`` should be installed w
 
   python -m pip install flwr_datasets[audio]
 
+Install directly from GitHub (pip)
+----------------------------------
+
+Installing Flower Datasets directly from GitHub ensures you have access to the most up-to-date version. 
+If you encounter any issues or bugs, you may be directed to a specific branch containing a fix before 
+it becomes part of an official release.
+
+.. code-block:: bash
+
+  python -m pip install flwr-datasets@git+https://github.com/adap/flower.git\
+  @TYPE-HERE-BRANCH-NAME#subdirectory=datasets
+
+Similarly to the situation before, you can specify the ``vision`` or ``audio`` extra at the end of the command.
+
+.. code-block:: bash
+
+  python -m pip install flwr-datasets@git+https://github.com/adap/flower.git\
+  @TYPE-HERE-BRANCH-NAME#subdirectory=datasets[vision]
+
+e.g. for the main branch:
+
+.. code-block:: bash
+
+  python -m pip install flwr-datasets@git+https://github.com/adap/flower.git\
+  @main#subdirectory=datasets
+
+Since `flwr-datasets` is a part of the Flower repository, the `subdirectory` parameter (at the end of the URL) is used to specify the package location in the GitHub repo.
 
 Verify installation
 -------------------
@@ -38,7 +65,7 @@ The following command can be used to verify if Flower Datasets was successfully 
 
   python -c "import flwr_datasets;print(flwr_datasets.__version__)"
 
-If everything worked, it should print the version of Flower Datasets to the command line:
+If everything works, it should print the version of Flower Datasets to the command line:
 
 .. code-block:: none
 

--- a/datasets/docs/source/how-to-install-flwr-datasets.rst
+++ b/datasets/docs/source/how-to-install-flwr-datasets.rst
@@ -20,13 +20,13 @@ For vision datasets (e.g. MNIST, CIFAR10) ``flwr-datasets`` should be installed 
 
 .. code-block:: bash
 
-  python -m pip install flwr_datasets[vision]
+  python -m pip install "flwr-datasets[vision]"
 
 For audio datasets (e.g. Speech Command) ``flwr-datasets`` should be installed with the ``audio`` extra
 
 .. code-block:: bash
 
-  python -m pip install flwr_datasets[audio]
+  python -m pip install "flwr-datasets[audio]"
 
 Install directly from GitHub (pip)
 ----------------------------------
@@ -37,22 +37,22 @@ it becomes part of an official release.
 
 .. code-block:: bash
 
-  python -m pip install flwr-datasets@git+https://github.com/adap/flower.git\
-  @TYPE-HERE-BRANCH-NAME#subdirectory=datasets
+  python -m pip install "flwr-datasets@git+https://github.com/adap/flower.git"\
+  "@TYPE-HERE-BRANCH-NAME#subdirectory=datasets"
 
-Similarly to the situation before, you can specify the ``vision`` or ``audio`` extra at the end of the command.
+Similarly to the situation before, you can specify the ``vision`` or ``audio`` extra after the name of the library.
 
 .. code-block:: bash
 
-  python -m pip install flwr-datasets@git+https://github.com/adap/flower.git\
-  @TYPE-HERE-BRANCH-NAME#subdirectory=datasets[vision]
+  python -m pip install "flwr-datasets[vision]@git+https://github.com/adap/flower.git"\
+  "@TYPE-HERE-BRANCH-NAME#subdirectory=datasets"
 
 e.g. for the main branch:
 
 .. code-block:: bash
 
-  python -m pip install flwr-datasets@git+https://github.com/adap/flower.git\
-  @main#subdirectory=datasets
+  python -m pip install "flwr-datasets@git+https://github.com/adap/flower.git"\
+  "@main#subdirectory=datasets"
 
 Since `flwr-datasets` is a part of the Flower repository, the `subdirectory` parameter (at the end of the URL) is used to specify the package location in the GitHub repo.
 


### PR DESCRIPTION
## Issue
Instructions on the installation of `flwr-datasets` directly from GitHub are missing. However, by having multiple libraries in a single repo, a more complex URL needs to be specified for pip installation.

## Proposal
* Add instructions about the installation from GitHub
* Update the min required Python versions to 3.9 (outdated info about 3.8).