### PR TITLE
fix(framework) Suppress output when in JSON format for `flwr ls`

### DIFF
--- a/src/py/flwr/cli/ls.py
+++ b/src/py/flwr/cli/ls.py
@@ -99,7 +99,6 @@ def ls(  # pylint: disable=too-many-locals, too-many-branches
     try:
         if suppress_output:
             redirect_output(captured_output)
-
         # Load and validate federation config
         typer.secho("Loading project configuration... ", fg=typer.colors.BLUE)
 
@@ -132,6 +131,8 @@ def ls(  # pylint: disable=too-many-locals, too-many-branches
                 _list_runs(stub, output_format)
 
         except ValueError as err:
+            if suppress_output:
+                redirect_output(captured_output)
             typer.secho(
                 f"❌ {err}",
                 fg=typer.colors.RED,


### PR DESCRIPTION
The `flwr ls` command raises a `ValueError` on [this line](https://github.com/adap/flower/blob/470ba4a58537c70932582df0e7e1edb1d6d2b523/src/py/flwr/cli/ls.py#L316) if a run ID is not found. This won't be suppressed because the call to `restore_output` is made before the `ValueError` is raised. This PR fixes this for `flwr ls`.

To reproduce, run `flwr ls 123 --format json` before and after the fix. 

``` bash
➜ flwr ls --run-id 123 --format json
❌ Run ID 123 not found
{
  "success": false,
  "error-message": "Loading project configuration... \nSuccess\n Displaying information for run ID 123...\n\n"
}
```

and after:

``` bash
➜ flwr ls --run-id 123 --format json
{
  "success": false,
  "error-message": "Loading project configuration... \nSuccess\n Displaying information for run ID 123...\n Run ID 123 not found\n\n"
}
```