### PR TITLE
fix(framework) Record `fab-id` and `fab-version` also in `SQLLinkState`

### DIFF
--- a/src/py/flwr/server/superlink/linkstate/sqlite_linkstate.py
+++ b/src/py/flwr/server/superlink/linkstate/sqlite_linkstate.py
@@ -761,8 +761,6 @@ class SqliteLinkState(LinkState):  # pylint: disable=R0904
                 "federation_options, pending_at, starting_at, running_at, finished_at, "
                 "sub_status, details) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);"
             )
-            if fab_hash:
-                fab_id, fab_version = "", ""
             override_config_json = json.dumps(override_config)
             data = [
                 sint64_run_id,


### PR DESCRIPTION
Affects only when `SuperLink` runs with `--database`

Before (note the `FAB` column):

```
(my-fancy-env) ➜  mega flwr ls
Loading project configuration...
Success
📄 Listing all runs...
┏━━━━━━━━━━━━━━━━━━━━━┳━━━━━━┳━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┓
┃       Run ID        ┃ FAB  ┃ Status  ┃ Elapsed  ┃      Created At      ┃      Running At      ┃ Finished At ┃
┡━━━━━━━━━━━━━━━━━━━━━╇━━━━━━╇━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━┩
│ 2887514479649176794 │  (v) │ running │ 00:00:01 │ 2024-12-17 19:06:12Z │ 2024-12-17 19:06:13Z │ N/A         │
└─────────────────────┴──────┴─────────┴──────────┴──────────────────────┴──────────────────────┴─────────────┘
```


After (note the `FAB` column):
```
(my-fancy-env) ➜  mega flwr ls
Loading project configuration...
Success
📄 Listing all runs...
┏━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━┓
┃        Run ID        ┃         FAB          ┃ Status  ┃ Elapsed  ┃      Created At      ┃ Running At ┃ Finished At ┃
┡━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━┩
│ 11608801370761787588 │ javier/mega (v1.0.0) │ pending │ 00:00:00 │ 2024-12-17 19:02:39Z │ N/A        │ N/A         │
└──────────────────────┴──────────────────────┴─────────┴──────────┴──────────────────────┴────────────┴─────────────┘
```
