### PR TITLE
fix(examples) Update `flwr` version for XGBoost quickstart example and add `libomp` command for MacOSX

### DIFF
--- a/examples/xgboost-quickstart/README.md
+++ b/examples/xgboost-quickstart/README.md
@@ -46,6 +46,9 @@ Install the dependencies defined in `pyproject.toml` as well as the `xgboost_qui
 pip install -e .
 ```
 
+> \[!NOTE\]
+> For MacOSX users, you may need to additionally run `brew install libomp` to install OpenMP runtime
+
 ## Run the project
 
 You can run your Flower project in both _simulation_ and _deployment_ mode without making changes to the code. If you are starting with Flower, we recommend you using the _simulation_ mode as it requires fewer components to be launched manually. By default, `flwr run` will make use of the Simulation Engine.

--- a/examples/xgboost-quickstart/README.md
+++ b/examples/xgboost-quickstart/README.md
@@ -47,7 +47,7 @@ pip install -e .
 ```
 
 > \[!NOTE\]
-> For MacOSX users, you may need to additionally run `brew install libomp` to install OpenMP runtime
+> For MacOSX users, you may need to additionally run `brew install libomp` to install OpenMP runtime.
 
 ## Run the project
 

--- a/examples/xgboost-quickstart/pyproject.toml
+++ b/examples/xgboost-quickstart/pyproject.toml
@@ -9,7 +9,7 @@ description = "Federated Learning with XGBoost and Flower (Quickstart Example)"
 license = "Apache-2.0"
 dependencies = [
     "flwr[simulation]>=1.13.1",
-    "flwr-datasets>=0.3.0",
+    "flwr-datasets>=0.4.0",
     "xgboost>=2.0.0",
 ]
 

--- a/examples/xgboost-quickstart/pyproject.toml
+++ b/examples/xgboost-quickstart/pyproject.toml
@@ -8,7 +8,7 @@ version = "1.0.0"
 description = "Federated Learning with XGBoost and Flower (Quickstart Example)"
 license = "Apache-2.0"
 dependencies = [
-    "flwr-nightly[simulation]==1.11.0.dev20240826",
+    "flwr[simulation]>=1.13.1",
     "flwr-datasets>=0.3.0",
     "xgboost>=2.0.0",
 ]


### PR DESCRIPTION
* The `flwr` version in `pyproject.toml` is not up-to-date. This is upgraded to the latest release, which is tested to work with Python 3.11.8.
* Added a note to run `brew install libomp` for new installation on MacOSX because by default, the `libomp` is cannot be loaded, giving the error below:

```
  File "/Users/csng/.pyenv/versions/3.11.8/envs/xgb-3.11.8/lib/python3.11/site-packages/xgboost/core.py", line 222, in _load_lib
    raise XGBoostError(
xgboost.core.XGBoostError:
XGBoost Library (libxgboost.dylib) could not be loaded.
Likely causes:
  * OpenMP runtime is not installed
    - vcomp140.dll or libgomp-1.dll for Windows
    - libomp.dylib for Mac OSX
    - libgomp.so for Linux and other UNIX-like OSes
    Mac OSX users: Run `brew install libomp` to install OpenMP runtime.

  * You are running 32-bit Python on a 64-bit OS
```

