### PR TITLE
feat(datasets) Add missing Python classifiers

### DIFF
--- a/datasets/pyproject.toml
+++ b/datasets/pyproject.toml
@@ -34,6 +34,8 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Scientific/Engineering",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",


### PR DESCRIPTION
## Issue
Python `3.12`, `3.13` are not added to the classifier list. 
## Proposal
Add them to match the `flwr` specs.
