### PR TITLE
refactor(framework) Add `.credentials` to `.gitignore`

### DIFF
--- a/src/py/flwr/cli/utils.py
+++ b/src/py/flwr/cli/utils.py
@@ -163,8 +163,8 @@ def get_sha256_hash(file_path: Path) -> str:
 def get_user_auth_config_path(root_dir: Path, federation: str) -> Path:
     """Return the path to the user auth config file.
 
-    Additionally, a `.gitignore` file will be created or updated in the
-    Flower directory to include `.credentials`.
+    Additionally, a `.gitignore` file will be created or updated in the Flower
+    directory to include the `.credentials` folder to be excluded from git.
     """
     # Locate the credentials directory
     abs_flwr_dir = root_dir.absolute() / FLWR_DIR

--- a/src/py/flwr/cli/utils.py
+++ b/src/py/flwr/cli/utils.py
@@ -163,8 +163,10 @@ def get_sha256_hash(file_path: Path) -> str:
 def get_user_auth_config_path(root_dir: Path, federation: str) -> Path:
     """Return the path to the user auth config file.
 
-    Additionally, a `.gitignore` file will be created or updated in the Flower
-    directory to include the `.credentials` folder to be excluded from git.
+    Additionally, a `.gitignore` file will be created in the Flower directory to
+    include the `.credentials` folder to be excluded from git. If the `.gitignore`
+    file already exists, a warning will be displayed if the `.credentials` entry is
+    not found.
     """
     # Locate the credentials directory
     abs_flwr_dir = root_dir.absolute() / FLWR_DIR

--- a/src/py/flwr/cli/utils.py
+++ b/src/py/flwr/cli/utils.py
@@ -167,11 +167,11 @@ def get_user_auth_config_path(root_dir: Path, federation: str) -> Path:
     Flower directory to include `.credentials`.
     """
     # Locate the credentials directory
-    credentials_dir = root_dir.absolute() / FLWR_DIR / CREDENTIALS_DIR
+    abs_flwr_dir = root_dir.absolute() / FLWR_DIR
+    credentials_dir = abs_flwr_dir / CREDENTIALS_DIR
     credentials_dir.mkdir(parents=True, exist_ok=True)
 
     # Determine the absolute path of the Flower directory for .gitignore
-    abs_flwr_dir = root_dir.absolute() / FLWR_DIR
     gitignore_path = abs_flwr_dir / ".gitignore"
     credential_entry = CREDENTIALS_DIR
 

--- a/src/py/flwr/cli/utils.py
+++ b/src/py/flwr/cli/utils.py
@@ -178,7 +178,7 @@ def get_user_auth_config_path(root_dir: Path, federation: str) -> Path:
     try:
         if gitignore_path.exists():
             # Read existing .gitignore content
-            with open(gitignore_path, "r", encoding="utf-8") as gitignore_file:
+            with open(gitignore_path, encoding="utf-8") as gitignore_file:
                 lines = gitignore_file.read().splitlines()
 
             # Check if .credentials is already in .gitignore

--- a/src/py/flwr/cli/utils.py
+++ b/src/py/flwr/cli/utils.py
@@ -164,7 +164,8 @@ def get_user_auth_config_path(root_dir: Path, federation: str) -> Path:
     """Return the path to the user auth config file.
 
     Additionally, a `.gitignore` file will be created or updated in the
-    Flower directory to include `.credentials`."""
+    Flower directory to include `.credentials`.
+    """
     # Locate the credentials directory
     credentials_dir = root_dir.absolute() / FLWR_DIR / CREDENTIALS_DIR
     credentials_dir.mkdir(parents=True, exist_ok=True)

--- a/src/py/flwr/cli/utils.py
+++ b/src/py/flwr/cli/utils.py
@@ -201,8 +201,8 @@ def get_user_auth_config_path(root_dir: Path, federation: str) -> Path:
                 gitignore_file.write(f"{credential_entry}\n")
     except Exception as err:
         typer.secho(
-            "❌ An error occurred while handling .gitignore. "
-            f"Please check the permissions of {gitignore_path} and try again.",
+            "❌ An error occurred while handling `.gitignore.` "
+            f"Please check the permissions of `{gitignore_path}` and try again.",
             fg=typer.colors.RED,
             bold=True,
         )

--- a/src/py/flwr/cli/utils.py
+++ b/src/py/flwr/cli/utils.py
@@ -177,16 +177,23 @@ def get_user_auth_config_path(root_dir: Path, federation: str) -> Path:
 
     try:
         if gitignore_path.exists():
-            # Read existing .gitignore content
             with open(gitignore_path, encoding="utf-8") as gitignore_file:
                 lines = gitignore_file.read().splitlines()
 
-            # Check if .credentials is already in .gitignore
+            # Warn if .credentials is not already in .gitignore
             if credential_entry not in lines:
-                # Append .credentials to .gitignore
-                with open(gitignore_path, "a", encoding="utf-8") as gitignore_file:
-                    gitignore_file.write(f"\n{credential_entry}\n")
+                typer.secho(
+                    f"`.gitignore` exists, but `{credential_entry}` entry not found. "
+                    "Consider adding it to your `.gitignore` to exclude Flower "
+                    "credentials from git.",
+                    fg=typer.colors.YELLOW,
+                    bold=True,
+                )
         else:
+            typer.secho(
+                f"Creating a new `.gitignore` with `{credential_entry}` entry...",
+                fg=typer.colors.BLUE,
+            )
             # Create a new .gitignore with .credentials
             with open(gitignore_path, "w", encoding="utf-8") as gitignore_file:
                 gitignore_file.write(f"{credential_entry}\n")


### PR DESCRIPTION
To prevent unintentionally committing `.credentials` to the repository, add `.gitignore` to the Flower directory and write `.credentials` to it. Alternatively, if `.gitignore` already exists in the Flower directory, append to it.