### PR TITLE
refactor(datasets) Make naming consistent in VerticalSizePartitioner

### DIFF
--- a/datasets/flwr_datasets/partitioner/vertical_even_partitioner.py
+++ b/datasets/flwr_datasets/partitioner/vertical_even_partitioner.py
@@ -52,9 +52,9 @@ class VerticalEvenPartitioner(Partitioner):
         - `"create_as_last"`: Create a new partition at the end containing only these columns.
         - `"add_to_all"`: Append active party columns to all partitions.
         - int: Append active party columns to the specified partition index.
-    drop_columns : Optional[list[str]]
+    drop_columns : Optional[Union[str, list[str]]]
         Columns to remove entirely from the dataset before partitioning.
-    shared_columns : Optional[list[str]]
+    shared_columns : Optional[Union[str, list[str]]]
         Columns to duplicate into every partition after initial partitioning.
     shuffle : bool
         Whether to shuffle the order of columns before partitioning.

--- a/datasets/flwr_datasets/partitioner/vertical_size_partitioner.py
+++ b/datasets/flwr_datasets/partitioner/vertical_size_partitioner.py
@@ -79,7 +79,7 @@ class VerticalSizePartitioner(Partitioner):
     >>>
     >>> partitioner = VerticalSizePartitioner(
     ...     partition_sizes=[8, 4, 2],
-    ...     active_party_column="income",
+    ...     active_party_columns="income",
     ...     active_party_columns_mode="create_as_last"
     ... )
     >>> fds = FederatedDataset(
@@ -202,7 +202,7 @@ class VerticalSizePartitioner(Partitioner):
         if all(isinstance(fraction, float) for fraction in self._partition_sizes):
             fraction_sum = sum(self._partition_sizes)
             # Tolerance 0.01 for the floating point numerical problems
-            if fraction_sum < 1.01 and fraction_sum > 0.99:
+            if 0.99 < fraction_sum < 1.01:
                 self._partition_sizes = self._partition_sizes[:-1] + [
                     1.0 - self._partition_sizes[-1]
                 ]

--- a/datasets/flwr_datasets/partitioner/vertical_size_partitioner_test.py
+++ b/datasets/flwr_datasets/partitioner/vertical_size_partitioner_test.py
@@ -67,7 +67,7 @@ class TestVerticalSizePartitioner(unittest.TestCase):
 
     def test_init_active_party_column_invalid_type(self) -> None:
         """Check ValueError if active_party_column is not str/list."""
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             VerticalSizePartitioner(partition_sizes=[2, 2], active_party_columns=123)
 
     def test_partitioning_with_int_sizes(self) -> None:

--- a/datasets/flwr_datasets/partitioner/vertical_size_partitioner_test.py
+++ b/datasets/flwr_datasets/partitioner/vertical_size_partitioner_test.py
@@ -68,7 +68,7 @@ class TestVerticalSizePartitioner(unittest.TestCase):
     def test_init_active_party_column_invalid_type(self) -> None:
         """Check ValueError if active_party_column is not str/list."""
         with self.assertRaises(ValueError):
-            VerticalSizePartitioner(partition_sizes=[2, 2], active_party_column=123)
+            VerticalSizePartitioner(partition_sizes=[2, 2], active_party_columns=123)
 
     def test_partitioning_with_int_sizes(self) -> None:
         """Check correct partitioning with integer sizes."""
@@ -124,7 +124,7 @@ class TestVerticalSizePartitioner(unittest.TestCase):
         dataset = _create_dummy_dataset(columns)
         partitioner = VerticalSizePartitioner(
             partition_sizes=[2],
-            active_party_column="label",
+            active_party_columns="label",
             active_party_columns_mode="add_to_last",
             shuffle=False,
         )
@@ -138,7 +138,7 @@ class TestVerticalSizePartitioner(unittest.TestCase):
         dataset = _create_dummy_dataset(columns)
         partitioner = VerticalSizePartitioner(
             partition_sizes=[2],
-            active_party_column="label",
+            active_party_columns="label",
             active_party_columns_mode="create_as_first",
             shuffle=False,
         )
@@ -166,7 +166,7 @@ class TestVerticalSizePartitioner(unittest.TestCase):
         columns = ["f1", "f2"]
         dataset = _create_dummy_dataset(columns)
         partitioner = VerticalSizePartitioner(
-            partition_sizes=[1], active_party_column="missing_label", shuffle=False
+            partition_sizes=[1], active_party_columns="missing_label", shuffle=False
         )
         partitioner.dataset = dataset
         with self.assertRaises(ValueError):


### PR DESCRIPTION
* column modification params in plural
* same argument types here and in VerticalEvenPartitioner 
* update incorrect docs hint types for VerticalEven and VerticalSizePartitioner
* handle case when the fractions (floats) don't sum up smoothly to 1.0 but are close