### PR TITLE
fix(framework) Fix `UnboundLocalError` for hashed run ID in `flwr-serverapp`

### DIFF
--- a/src/py/flwr/server/serverapp/app.py
+++ b/src/py/flwr/server/serverapp/app.py
@@ -116,6 +116,7 @@ def run_serverapp(  # pylint: disable=R0914, disable=W0212, disable=R0915
     flwr_dir_ = get_flwr_dir(flwr_dir)
     log_uploader = None
     success = True
+    hash_run_id = None
     while True:
 
         try:


### PR DESCRIPTION
`hash_run_id` is not set and will throw the error:
```
UnboundLocalError: cannot access local variable 'hash_run_id' where it is not associated with a value
```

This fix sets `hash_run_id` to `None` outside the `while` loop.