### PR TITLE
docs(framework) Update video tutorials linked in framework docs landing page

### DIFF
--- a/framework/docs/source/index.rst
+++ b/framework/docs/source/index.rst
@@ -67,14 +67,10 @@ Transformers <tutorial-quickstart-huggingface>` | :doc:`JAX <tutorial-quickstart
 <tutorial-quickstart-scikitlearn>` | :doc:`XGBoost <tutorial-quickstart-xgboost>` |
 :doc:`Android <tutorial-quickstart-android>` | :doc:`iOS <tutorial-quickstart-ios>`
 
-We also made video tutorials for PyTorch:
+Checkout the Flower AI Simulation 2025 Tutorial Series for a step-by-step guide on how
+to design Apps and run them with Flower's Simulation Engine.
 
-.. youtube:: jOmmuzMIQ4c
-    :width: 80%
-
-And TensorFlow:
-
-.. youtube:: FGTc2TQq7VM
+.. youtube:: XK_dRVcSZqg
     :width: 80%
 
 How-to guides


### PR DESCRIPTION
Remove outdated `PyTorch` and `TensorFlow` tutorials in favour of the new Simulation Series.

<img width="1377" alt="Screenshot 2025-01-06 at 17 09 48" src="https://github.com/user-attachments/assets/481db6be-411a-47f1-9d95-b269dbe8ddd2" />
