### PR TITLE
ci(framework:skip) Update dataset download source for `e2e-scikit-learn`

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -158,7 +158,7 @@ jobs:
             e2e: e2e_scikit_learn
             dataset: |
               import openml
-              openml.datasets.get_dataset(554)
+              openml.datasets.get_dataset(554, download_data=True)
 
           - directory: e2e-fastai
             e2e: e2e_fastai

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -156,9 +156,6 @@ jobs:
 
           - directory: e2e-scikit-learn
             e2e: e2e_scikit_learn
-            dataset: |
-              import openml
-              openml.datasets.get_dataset(554, download_data=True)
 
           - directory: e2e-fastai
             e2e: e2e_fastai

--- a/e2e/e2e-scikit-learn/e2e_scikit_learn/client_app.py
+++ b/e2e/e2e-scikit-learn/e2e_scikit_learn/client_app.py
@@ -9,11 +9,10 @@ from flwr.client import ClientApp, NumPyClient, start_client
 from flwr.common import Context
 
 # Load MNIST dataset from https://www.openml.org/d/554
-(X_train, y_train), (X_test, y_test) = utils.load_mnist()
-
-# Split train set into 10 partitions and randomly use one for training.
-partition_id = np.random.choice(10)
-(X_train, y_train) = utils.partition(X_train, y_train, 10)[partition_id]
+num_partitions = 10
+X_train, X_test, y_train, y_test = utils.load_data(
+    num_partitions=num_partitions, partition_id=np.random.choice(num_partitions)
+)
 
 # Create LogisticRegression Model
 model = LogisticRegression(

--- a/e2e/e2e-scikit-learn/e2e_scikit_learn/utils.py
+++ b/e2e/e2e-scikit-learn/e2e_scikit_learn/utils.py
@@ -55,7 +55,7 @@ def load_mnist() -> Dataset:
 
     OpenML dataset link: https://www.openml.org/d/554
     """
-    mnist_openml = openml.datasets.get_dataset(554)
+    mnist_openml = openml.datasets.get_dataset(554, download_data=True)
     Xy, _, _, _ = mnist_openml.get_data(dataset_format="array")
     X = Xy[:, :-1]  # the last column contains labels
     y = Xy[:, -1]

--- a/e2e/e2e-scikit-learn/e2e_scikit_learn/utils.py
+++ b/e2e/e2e-scikit-learn/e2e_scikit_learn/utils.py
@@ -1,7 +1,8 @@
 from typing import List, Tuple, Union
 
 import numpy as np
-import openml
+from flwr_datasets import FederatedDataset
+from flwr_datasets.partitioner import IidPartitioner
 from sklearn.linear_model import LogisticRegression
 
 XY = Tuple[np.ndarray, np.ndarray]
@@ -50,19 +51,29 @@ def set_initial_params(model: LogisticRegression):
         model.intercept_ = np.zeros((n_classes,))
 
 
-def load_mnist() -> Dataset:
-    """Loads the MNIST dataset using OpenML.
+fds = None  # Cache FederatedDataset
 
-    OpenML dataset link: https://www.openml.org/d/554
-    """
-    mnist_openml = openml.datasets.get_dataset(554, download_data=True)
-    Xy, _, _, _ = mnist_openml.get_data(dataset_format="array")
-    X = Xy[:, :-1]  # the last column contains labels
-    y = Xy[:, -1]
-    # First 60000 samples consist of the train set
-    x_train, y_train = X[:1000], y[:1000]
-    x_test, y_test = X[60000:62000], y[60000:62000]
-    return (x_train, y_train), (x_test, y_test)
+
+def load_data(partition_id: int, num_partitions: int):
+    """Load partition MNIST data."""
+    # Only initialize `FederatedDataset` once
+    global fds
+    if fds is None:
+        partitioner = IidPartitioner(num_partitions=num_partitions)
+        fds = FederatedDataset(
+            dataset="mnist",
+            partitioners={"train": partitioner},
+        )
+
+    dataset = fds.load_partition(partition_id, "train").with_format("numpy")
+
+    X, y = dataset["image"].reshape((len(dataset), -1)), dataset["label"]
+
+    # Split the on edge data: 80% train, 20% test
+    X_train, X_test = X[: int(0.8 * len(X))], X[int(0.8 * len(X)) :]
+    y_train, y_test = y[: int(0.8 * len(y))], y[int(0.8 * len(y)) :]
+
+    return X_train, X_test, y_train, y_test
 
 
 def shuffle(X: np.ndarray, y: np.ndarray) -> XY:

--- a/e2e/e2e-scikit-learn/pyproject.toml
+++ b/e2e/e2e-scikit-learn/pyproject.toml
@@ -13,9 +13,8 @@ authors = [
 ]
 dependencies = [
     "flwr[simulation,rest] @ {root:parent:parent:uri}",
+    "flwr-datasets[vision]>=0.5.0,<1.0.0",
     "scikit-learn>=1.1.1,<2.0.0",
-    "openml>=0.14.0,<0.15.0",
-    "numpy<2.0.0",
 ]
 
 [tool.hatch.build.targets.wheel]


### PR DESCRIPTION
The test was sourcing MNIST from `openml`. It has been replaced with MNIST from `HuggingFace` via `flwr-datasets`.