### PR TITLE
fix(baselines:skip) Bump `black` version to 24.3.0

### DIFF
--- a/baselines/flwr_baselines/requirements.txt
+++ b/baselines/flwr_baselines/requirements.txt
@@ -19,7 +19,7 @@ virtualenv >= 20.24.6
 
 ##### dev-dependencies
 isort == 5.13.2
-black == 24.2.0
+black == 24.3.0
 docformatter == 1.7.5
 mypy == 0.961
 pylint == 2.8.2


### PR DESCRIPTION
Needs
* #4824