### PR TITLE
feat(framework) Prevent zombie subprocesses when the main process receives `SIGKILL`

### DIFF
--- a/src/py/flwr/client/app.py
+++ b/src/py/flwr/client/app.py
@@ -16,8 +16,10 @@
 
 
 import multiprocessing
+import os
 import signal
 import sys
+import threading
 import time
 from contextlib import AbstractContextManager
 from dataclasses import dataclass
@@ -829,7 +831,17 @@ class _AppStateTracker:
         signal.signal(signal.SIGTERM, signal_handler)
 
 
-def _run_flwr_clientapp(args: list[str]) -> None:
+def _run_flwr_clientapp(args: list[str], main_pid: int) -> None:
+    # Monitor the main process in case of SIGKILL
+    def main_process_monitor() -> None:
+        while True:
+            time.sleep(1)
+            if os.getppid() != main_pid:
+                os.kill(os.getpid(), 9)
+
+    threading.Thread(target=main_process_monitor, daemon=True).start()
+
+    # Run the command
     sys.argv = args
     flwr_clientapp()
 

--- a/src/py/flwr/client/app.py
+++ b/src/py/flwr/client/app.py
@@ -555,7 +555,7 @@ def start_client_internal(
 
                                 proc = mp_spawn_context.Process(
                                     target=_run_flwr_clientapp,
-                                    args=(command,),
+                                    args=(command, os.getpid()),
                                     daemon=True,
                                 )
                                 proc.start()

--- a/src/py/flwr/server/app.py
+++ b/src/py/flwr/server/app.py
@@ -20,6 +20,7 @@ import csv
 import importlib.util
 import multiprocessing
 import multiprocessing.context
+import os
 import sys
 import threading
 from collections.abc import Sequence
@@ -447,7 +448,17 @@ def run_superlink() -> None:
     sys.exit(1)
 
 
-def _run_flwr_command(args: list[str]) -> None:
+def _run_flwr_command(args: list[str], main_pid: int) -> None:
+    # Monitor the main process in case of SIGKILL
+    def main_process_monitor() -> None:
+        while True:
+            sleep(1)
+            if os.getppid() != main_pid:
+                os.kill(os.getpid(), 9)
+
+    threading.Thread(target=main_process_monitor, daemon=True).start()
+
+    # Run the command
     sys.argv = args
     if args[0] == "flwr-serverapp":
         flwr_serverapp()
@@ -493,7 +504,7 @@ def _flwr_scheduler(
             ]
 
             proc = mp_spawn_context.Process(
-                target=_run_flwr_command, args=(command,), daemon=True
+                target=_run_flwr_command, args=(command, os.getpid()), daemon=True
             )
             proc.start()
 

--- a/src/py/flwr/server/serverapp/app.py
+++ b/src/py/flwr/server/serverapp/app.py
@@ -117,6 +117,7 @@ def run_serverapp(  # pylint: disable=R0914, disable=W0212, disable=R0915
     log_uploader = None
     success = True
     hash_run_id = None
+    run_status = None
     while True:
 
         try:


### PR DESCRIPTION
Enabled the subprocesses to monitor the main process. If the main process exits due to `SIGKILL`, the subprocess will kill itself via `SIGKILL` too.

As the subprocess are `daemon` via `multiprocessing` library, this mechanism won't be triggered if the main process is killed by `SIGINT` / `SIGTERM` / `Ctrl+C` / etc.