### PR TITLE
feat(framework) Add connection cleanup for SuperNode graceful exit

### DIFF
--- a/src/py/flwr/client/grpc_rere_client/connection.py
+++ b/src/py/flwr/client/grpc_rere_client/connection.py
@@ -311,3 +311,14 @@ def grpc_request_response(  # pylint: disable=R0913,R0914,R0915,R0917
         yield (receive, send, create_node, delete_node, get_run, get_fab)
     except Exception as exc:  # pylint: disable=broad-except
         log(ERROR, exc)
+    # Cleanup
+    finally:
+        try:
+            if node is not None:
+                ping_stop_event.set()
+                # Disable retrying
+                retry_invoker.max_tries = 1
+                delete_node()
+        except grpc.RpcError:
+            pass
+        channel.close()

--- a/src/py/flwr/client/grpc_rere_client/connection.py
+++ b/src/py/flwr/client/grpc_rere_client/connection.py
@@ -315,7 +315,6 @@ def grpc_request_response(  # pylint: disable=R0913,R0914,R0915,R0917
     finally:
         try:
             if node is not None:
-                ping_stop_event.set()
                 # Disable retrying
                 retry_invoker.max_tries = 1
                 delete_node()

--- a/src/py/flwr/client/rest_client/connection.py
+++ b/src/py/flwr/client/rest_client/connection.py
@@ -384,7 +384,6 @@ def http_request_response(  # pylint: disable=R0913,R0914,R0915,R0917
     finally:
         try:
             if node is not None:
-                ping_stop_event.set()
                 # Disable retrying
                 retry_invoker.max_tries = 1
                 delete_node()

--- a/src/py/flwr/client/rest_client/connection.py
+++ b/src/py/flwr/client/rest_client/connection.py
@@ -26,6 +26,7 @@ from typing import Callable, Optional, TypeVar, Union
 
 from cryptography.hazmat.primitives.asymmetric import ec
 from google.protobuf.message import Message as GrpcMessage
+from requests.exceptions import ConnectionError as RequestsConnectionError
 
 from flwr.client.heartbeat import start_ping_loop
 from flwr.client.message_handler.message_handler import validate_out_message
@@ -379,3 +380,13 @@ def http_request_response(  # pylint: disable=R0913,R0914,R0915,R0917
         yield (receive, send, create_node, delete_node, get_run, get_fab)
     except Exception as exc:  # pylint: disable=broad-except
         log(ERROR, exc)
+    # Cleanup
+    finally:
+        try:
+            if node is not None:
+                ping_stop_event.set()
+                # Disable retrying
+                retry_invoker.max_tries = 1
+                delete_node()
+        except RequestsConnectionError:
+            pass

--- a/src/py/flwr/client/supernode/app.py
+++ b/src/py/flwr/client/supernode/app.py
@@ -86,6 +86,11 @@ def run_supernode() -> None:
 
     log(DEBUG, "Isolation mode: %s", args.isolation)
 
+    # Register handlers for graceful shutdown
+    register_exit_handlers(
+        event_type=EventType.RUN_SUPERNODE_LEAVE,
+    )
+
     start_client_internal(
         server_address=args.superlink,
         load_client_app_fn=load_fn,
@@ -101,11 +106,6 @@ def run_supernode() -> None:
         flwr_path=args.flwr_dir,
         isolation=args.isolation,
         clientappio_api_address=args.clientappio_api_address,
-    )
-
-    # Graceful shutdown
-    register_exit_handlers(
-        event_type=EventType.RUN_SUPERNODE_LEAVE,
     )
 
 


### PR DESCRIPTION
## Test Shutdown Cases

| Test Case                                                                 | Now | Previous
|---------------------------------------------------------------------------|-------------|-------------|
| Run SuperNode without SuperLink, then shut down SuperNode                 | ✅      | ☑️ |
| Run SuperNode with SuperLink, then shut down SuperNode                 | ✅      | ✅ |
| Run SuperNode with SuperLink, shut down SuperLink first, then SuperNode   | ✅      | ✅ |
| Run SuperNode with SuperLink, start a run, and shut down SuperNode during ClientApp execution | ✅      | ✅ |
| Run SuperNode with SuperLink, start a run, shut down SuperLink, and finally shut down SuperNode during ClientApp execution | ✅      | ☑️  |
