### PR TITLE
ci(framework) Add file to mark stale issues 

### DIFF
--- a/.github/workflows/mark-stale.yml
+++ b/.github/workflows/mark-stale.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     # Runs every day at midnight UTC
     - cron: "0 0 * * *"
-  # workflow_dispatch: # Allows manual runs
+  workflow_dispatch: # Allows manual runs
 
 jobs:
   stale:
@@ -14,8 +14,13 @@ jobs:
       - name: Mark stale issues and pull requests
         uses: actions/stale@v8
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN}}
-          days-before-stale: 21 # 3 weeks
-          stale-issue-label: "stale"
-          # stale-pr-label: "stale" 
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
           
+          # Default settings for most issues
+          days-before-stale: 21
+          stale-issue-label: "stale"
+          # days-before-close: 7 # Optional
+
+          # Feature request-specific settings
+          only-labels: "feature request"
+          days-before-stale-for-labels: 90 # 90 days for feature requests

--- a/.github/workflows/mark-stale.yml
+++ b/.github/workflows/mark-stale.yml
@@ -1,0 +1,21 @@
+name: Mark Stale Issues
+
+on:
+  schedule:
+    # Runs every day at midnight UTC
+    - cron: "0 0 * * *"
+  # workflow_dispatch: # Allows manual runs
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Mark stale issues and pull requests
+        uses: actions/stale@v8
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN}}
+          days-before-stale: 21 # 3 weeks
+          stale-issue-label: "stale"
+          # stale-pr-label: "stale" 
+          


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue
Identifying stale issues. 
### Description
We want to mark stale issues automatically so that we can easily filter on these and try to resolve them. 
<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->

### Related issues/PRs
N/A
<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal
Automatically mark/label issues as `stale` if there has been no update for 3 weeks. 
### Explanation
This would help us identify which issues that have gone stale. Depending on the number of issues that have gone stale, it can be difficult to identify these if one has to go through all of them. This file can also be expanded to include PRs. 
<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

### Checklist

- [x] Implement proposed change
- [x] Write tests
- [x] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [x] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?
N/A
<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.ai/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
