### PR TITLE
feat(framework) Bump `grpcio` version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ flower-client-app = "flwr.client.supernode:run_client_app" # Deprecated
 python = "^3.9"
 # Mandatory dependencies
 numpy = ">=1.26.0,<3.0.0"
-grpcio = "^1.60.0,!=1.64.2,<=1.64.3"
+grpcio = "^1.60.0,!=1.64.2"
 protobuf = "^4.25.2"
 cryptography = "^42.0.4"
 pycryptodome = "^3.18.0"

--- a/src/py/flwr/client/grpc_client/connection.py
+++ b/src/py/flwr/client/grpc_client/connection.py
@@ -15,6 +15,7 @@
 """Contextmanager for a gRPC streaming channel to the Flower server."""
 
 
+import os
 import uuid
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -47,10 +48,9 @@ from flwr.proto.transport_pb2 import (  # pylint: disable=E0611
 )
 from flwr.proto.transport_pb2_grpc import FlowerServiceStub  # pylint: disable=E0611
 
+os.environ["GRPC_VERBOSITY"] = "error"
 # The following flags can be uncommented for debugging. Other possible values:
 # https://github.com/grpc/grpc/blob/master/doc/environment_variables.md
-# import os
-# os.environ["GRPC_VERBOSITY"] = "debug"
 # os.environ["GRPC_TRACE"] = "tcp,http"
 
 


### PR DESCRIPTION
Based on the comment [here](https://github.com/grpc/grpc/issues/37642#issuecomment-2510582968), we can control the verbosity of `grpcio` using `os.environ["GRPC_VERBOSITY"]`. For now, we set it to `= "error"` which is recommended for production systems ([ref link](https://github.com/grpc/grpc/blob/master/doc/environment_variables.md)).

As a result, the max `grpcio` version is unpinned from `pyproject.toml`.