### PR TITLE
refactor(framework) Unify `get_fab_metadata` and `get_metadata_from_config`

### DIFF
--- a/src/py/flwr/cli/config_utils.py
+++ b/src/py/flwr/cli/config_utils.py
@@ -21,7 +21,7 @@ from typing import Any, Optional, Union
 import tomli
 import typer
 
-from flwr.common.config import get_fab_config, validate_config
+from flwr.common.config import get_fab_config, get_metadata_from_config, validate_config
 
 
 def get_fab_metadata(fab_file: Union[Path, bytes]) -> tuple[str, str]:
@@ -38,12 +38,7 @@ def get_fab_metadata(fab_file: Union[Path, bytes]) -> tuple[str, str]:
     Tuple[str, str]
         The `fab_id` and `fab_version` of the given Flower App Bundle.
     """
-    conf = get_fab_config(fab_file)
-
-    return (
-        f"{conf['tool']['flwr']['app']['publisher']}/{conf['project']['name']}",
-        conf["project"]["version"],
-    )
+    return get_metadata_from_config(get_fab_config(fab_file))
 
 
 def load_and_validate(

--- a/src/py/flwr/cli/install.py
+++ b/src/py/flwr/cli/install.py
@@ -154,7 +154,7 @@ def validate_and_install(
         )
         raise typer.Exit(code=1)
 
-    version, fab_id = get_metadata_from_config(config)
+    fab_id, version = get_metadata_from_config(config)
     publisher, project_name = fab_id.split("/")
     config_metadata = (publisher, project_name, version, fab_hash)
 

--- a/src/py/flwr/client/clientapp/utils.py
+++ b/src/py/flwr/client/clientapp/utils.py
@@ -66,7 +66,7 @@ def get_load_client_app_fn(
         # `fab_hash` is not required since the app is loaded from `runtime_app_dir`.
         elif app_path is not None:
             config = get_project_config(runtime_app_dir)
-            this_fab_version, this_fab_id = get_metadata_from_config(config)
+            this_fab_id, this_fab_version = get_metadata_from_config(config)
 
             if this_fab_version != fab_version or this_fab_id != fab_id:
                 raise LoadClientAppError(

--- a/src/py/flwr/common/config.py
+++ b/src/py/flwr/common/config.py
@@ -229,10 +229,10 @@ def parse_config_args(
 
 
 def get_metadata_from_config(config: dict[str, Any]) -> tuple[str, str]:
-    """Extract `fab_version` and `fab_id` from a project config."""
+    """Extract `fab_id` and `fab_version` from a project config."""
     return (
-        config["project"]["version"],
         f"{config['tool']['flwr']['app']['publisher']}/{config['project']['name']}",
+        config["project"]["version"],
     )
 
 


### PR DESCRIPTION
Based on #4838