### PR TITLE
feat(framework) Add `enable-user-auth` field in TOML file and require TLS for user authentication

### DIFF
--- a/src/py/flwr/cli/config_utils.py
+++ b/src/py/flwr/cli/config_utils.py
@@ -169,7 +169,7 @@ def validate_certificate_in_federation_config(
         root_certificates_bytes = (app / root_certificates).read_bytes()
         if insecure := bool(insecure_str):
             typer.secho(
-                "❌ `root_certificates` were provided but the `insecure` parameter "
+                "❌ `root-certificates` were provided but the `insecure` parameter "
                 "is set to `True`.",
                 fg=typer.colors.RED,
                 bold=True,

--- a/src/py/flwr/cli/log.py
+++ b/src/py/flwr/cli/log.py
@@ -172,7 +172,7 @@ def _log_with_exec_api(
     run_id: int,
     stream: bool,
 ) -> None:
-    auth_plugin = try_obtain_cli_auth_plugin(app, federation)
+    auth_plugin = try_obtain_cli_auth_plugin(app, federation, federation_config)
     channel = init_channel(app, federation_config, auth_plugin)
 
     if stream:

--- a/src/py/flwr/cli/login/login.py
+++ b/src/py/flwr/cli/login/login.py
@@ -57,6 +57,18 @@ def login(  # pylint: disable=R0914
         federation, config
     )
     exit_if_no_address(federation_config, "login")
+
+    # Check if `enable-user-auth` is set to `true`
+    if not federation_config.get("enable-user-auth", False):
+        typer.secho(
+            f"❌ User authentication is not enabled for the federation '{federation}'. "
+            "To enable it, set `enable-user-auth = true` in the federation "
+            "configuration.",
+            fg=typer.colors.RED,
+            bold=True,
+        )
+        raise typer.Exit(code=1)
+
     channel = init_channel(app, federation_config, None)
     stub = ExecStub(channel)
 
@@ -65,7 +77,9 @@ def login(  # pylint: disable=R0914
 
     # Get the auth plugin
     auth_type = login_response.auth_type
-    auth_plugin = try_obtain_cli_auth_plugin(app, federation, auth_type)
+    auth_plugin = try_obtain_cli_auth_plugin(
+        app, federation, federation_config, auth_type
+    )
     if auth_plugin is None:
         typer.secho(
             f'❌ Authentication type "{auth_type}" not found',

--- a/src/py/flwr/cli/ls.py
+++ b/src/py/flwr/cli/ls.py
@@ -115,7 +115,7 @@ def ls(  # pylint: disable=too-many-locals, too-many-branches
                 raise ValueError(
                     "The options '--runs' and '--run-id' are mutually exclusive."
                 )
-            auth_plugin = try_obtain_cli_auth_plugin(app, federation)
+            auth_plugin = try_obtain_cli_auth_plugin(app, federation, federation_config)
             channel = init_channel(app, federation_config, auth_plugin)
             stub = ExecStub(channel)
 

--- a/src/py/flwr/cli/run/run.py
+++ b/src/py/flwr/cli/run/run.py
@@ -148,7 +148,7 @@ def _run_with_exec_api(
     stream: bool,
     output_format: str,
 ) -> None:
-    auth_plugin = try_obtain_cli_auth_plugin(app, federation)
+    auth_plugin = try_obtain_cli_auth_plugin(app, federation, federation_config)
     channel = init_channel(app, federation_config, auth_plugin)
     stub = ExecStub(channel)
 

--- a/src/py/flwr/cli/stop.py
+++ b/src/py/flwr/cli/stop.py
@@ -78,7 +78,7 @@ def stop(  # pylint: disable=R0914
         exit_if_no_address(federation_config, "stop")
 
         try:
-            auth_plugin = try_obtain_cli_auth_plugin(app, federation)
+            auth_plugin = try_obtain_cli_auth_plugin(app, federation, federation_config)
             channel = init_channel(app, federation_config, auth_plugin)
             stub = ExecStub(channel)  # pylint: disable=unused-variable # noqa: F841
 

--- a/src/py/flwr/cli/utils.py
+++ b/src/py/flwr/cli/utils.py
@@ -217,9 +217,25 @@ def get_user_auth_config_path(root_dir: Path, federation: str) -> Path:
 def try_obtain_cli_auth_plugin(
     root_dir: Path,
     federation: str,
+    federation_config: dict[str, Any],
     auth_type: Optional[str] = None,
 ) -> Optional[CliAuthPlugin]:
     """Load the CLI-side user auth plugin for the given auth type."""
+    # Check if user auth is enabled
+    if not federation_config.get("enable-user-auth", False):
+        return None
+
+    # Check if TLS is enabled. If not, raise an error
+    if federation_config.get("root-certificates") is None:
+        typer.secho(
+            "❌ User authentication requires TLS to be enabled. "
+            "Please provide 'root-certificates' in the federation"
+            " configuration.",
+            fg=typer.colors.RED,
+            bold=True,
+        )
+        raise typer.Exit(code=1)
+
     config_path = get_user_auth_config_path(root_dir, federation)
 
     # Load the config file if it exists


### PR DESCRIPTION
- Added `enable-user-auth` field to federation config to enable user auth feature or not. Default to `False`
- Required TLS when using user auth.