### PR TITLE
feat(framework) Set the log level via environment variable

### DIFF
--- a/framework/docs/source/conf.py
+++ b/framework/docs/source/conf.py
@@ -271,7 +271,6 @@ redirects = {
     "contributor-explanation-architecture": "explanation-flower-architecture.html",
     "example-pytorch-from-centralized-to-federated": "tutorial-quickstart-pytorch.html",
     "example-fedbn-pytorch-from-centralized-to-federated": "how-to-implement-fedbn.html",
-    "how-to-configure-logging": "index.html",
     "how-to-monitor-simulation": "how-to-run-simulations.html",
     "fed/index": "index.html",
     "fed/0000-20200102-fed-template": "index.html",

--- a/framework/docs/source/how-to-configure-logging.rst
+++ b/framework/docs/source/how-to-configure-logging.rst
@@ -8,7 +8,7 @@ Configure logging
 By default, the Flower logger uses logging level ``INFO``. This can be changed via the
 ``PYTHONLOGLEVEL`` environment variable to any other levels that Python's `logging
 module <https://docs.python.org/3/library/logging.html#logging-levels>`_ supports. For
-example, launch your ``SuperLink`` showing ``DEBUG`` logs:
+example, to launch your ``SuperLink`` showing ``DEBUG`` logs do:
 
 .. code-block:: shell
     :emphasize-lines: 2,11,12

--- a/framework/docs/source/how-to-configure-logging.rst
+++ b/framework/docs/source/how-to-configure-logging.rst
@@ -1,0 +1,34 @@
+:og:description: Configure the logging level for your Flower processes.
+.. meta::
+    :description: Configure the logging level for your Flower processes.
+
+Configure logging
+=================
+
+By default, the Flower logger uses logging level ``INFO``. This can be changed via the
+``PYTHONLOGLEVEL`` environment variable to any other levels that Python's `logging
+module <https://docs.python.org/3/library/logging.html#logging-levels>`_ supports. For
+example, launch your ``SuperLink`` showing ``DEBUG`` logs:
+
+.. code-block:: shell
+    :emphasize-lines: 2,11,12
+
+    # Launch the SuperLink with TLS (or use --insecure)
+    PYTHONLOGLEVEL=DEBUG flower-superlink \
+        --ssl-ca-certfile certificates/ca.crt \
+        --ssl-certfile certificates/server.pem \
+        --ssl-keyfile certificates/server.key
+
+    INFO 2025-01-27 11:46:41,690:      Starting Flower SuperLink
+    INFO 2025-01-27 11:46:41,697:      Flower Deployment Engine: Starting Exec API on 0.0.0.0:9093
+    INFO 2025-01-27 11:46:41,724:      Flower ECE: Starting ServerAppIo API (gRPC-rere) on 0.0.0.0:9091
+    INFO 2025-01-27 11:46:41,728:      Flower ECE: Starting Fleet API (gRPC-rere) on 0.0.0.0:9092
+    DEBUG 2025-01-27 11:46:41,730:     Started flwr-serverapp scheduler thread.
+    DEBUG 2025-01-27 11:46:41,730:     Using InMemoryState
+
+.. note::
+
+    You can make use of the ``PYTHONLOGLEVEL`` environment variable when executing other
+    Flower commands to provision the different components in a Flower Federation (see
+    :doc:`how-to-run-flower-with-deployment-engine`) or using the `flwr CLI
+    <ref-api-cli.html>`_.

--- a/framework/docs/source/index.rst
+++ b/framework/docs/source/index.rst
@@ -97,6 +97,7 @@ Problem-oriented how-to guides show step-by-step how to achieve a specific goal.
     how-to-run-flower-with-deployment-engine
     how-to-enable-tls-connections
     how-to-authenticate-supernodes
+    how-to-configure-logging
     how-to-use-built-in-mods
     how-to-use-differential-privacy
     how-to-implement-fedbn

--- a/src/py/flwr/common/logger.py
+++ b/src/py/flwr/common/logger.py
@@ -136,7 +136,7 @@ if log_level := os.getenv("PYTHONLOGLEVEL"):
         )
     except Exception:  # pylint: disable=broad-exception-caught
         # Alert user but don't raise exception
-        FLOWER_LOGGER.log(
+       log(
             ERROR,
             "Failed to set logging level %s. Using default level: %s",
             log_level,

--- a/src/py/flwr/common/logger.py
+++ b/src/py/flwr/common/logger.py
@@ -136,7 +136,7 @@ if log_level := os.getenv("PYTHONLOGLEVEL"):
         )
     except Exception:  # pylint: disable=broad-exception-caught
         # Alert user but don't raise exception
-       log(
+        log(
             ERROR,
             "Failed to set logging level %s. Using default level: %s",
             log_level,

--- a/src/py/flwr/common/logger.py
+++ b/src/py/flwr/common/logger.py
@@ -126,7 +126,7 @@ console_handler = ConsoleHandler(
 console_handler.setLevel(logging.INFO)
 FLOWER_LOGGER.addHandler(console_handler)
 
-# Change log level via env (always get timestamp)
+# Set log level via env var (show timestamps for `DEBUG`)
 if log_level := os.getenv("PYTHONLOGLEVEL"):
     try:
         use_time_stamps = log_level.upper() == "DEBUG"

--- a/src/py/flwr/common/logger.py
+++ b/src/py/flwr/common/logger.py
@@ -129,8 +129,11 @@ FLOWER_LOGGER.addHandler(console_handler)
 # Change log level via env (always get timestamp)
 if log_level := os.getenv("PYTHONLOGLEVEL"):
     try:
-        update_console_handler(level=log_level, timestamps=True, colored=True)
-    except:
+        use_time_stamps = log_level.upper() == "DEBUG"
+        update_console_handler(
+            level=log_level, timestamps=use_time_stamps, colored=True
+        )
+    except Exception:  # pylint: disable=broad-exception-caught
         # Alert user but don't raise exception
         FLOWER_LOGGER.log(
             ERROR,

--- a/src/py/flwr/common/logger.py
+++ b/src/py/flwr/common/logger.py
@@ -17,6 +17,7 @@
 
 import json as _json
 import logging
+import os
 import re
 import sys
 import threading
@@ -124,6 +125,10 @@ console_handler = ConsoleHandler(
 )
 console_handler.setLevel(logging.INFO)
 FLOWER_LOGGER.addHandler(console_handler)
+
+# Change log level via env (always get timestamp)
+if log_level := os.getenv("PYTHONLOGLEVEL"):
+    update_console_handler(level=log_level, timestamps=True, colored=True)
 
 
 class CustomHTTPHandler(HTTPHandler):

--- a/src/py/flwr/common/logger.py
+++ b/src/py/flwr/common/logger.py
@@ -43,6 +43,7 @@ from .constant import LOG_UPLOAD_INTERVAL
 LOGGER_NAME = "flwr"
 FLOWER_LOGGER = logging.getLogger(LOGGER_NAME)
 FLOWER_LOGGER.setLevel(logging.DEBUG)
+log = FLOWER_LOGGER.log  # pylint: disable=invalid-name
 
 LOG_COLORS = {
     "DEBUG": "\033[94m",  # Blue
@@ -200,10 +201,6 @@ def configure(
         http_handler.setLevel(logging.DEBUG)
         # Override mapLogRecords as setFormatter has no effect on what is send via http
         FLOWER_LOGGER.addHandler(http_handler)
-
-
-logger = logging.getLogger(LOGGER_NAME)  # pylint: disable=invalid-name
-log = logger.log  # pylint: disable=invalid-name
 
 
 def warn_preview_feature(name: str) -> None:

--- a/src/py/flwr/common/logger.py
+++ b/src/py/flwr/common/logger.py
@@ -23,7 +23,7 @@ import sys
 import threading
 import time
 from io import StringIO
-from logging import WARN, LogRecord
+from logging import ERROR, WARN, LogRecord
 from logging.handlers import HTTPHandler
 from queue import Empty, Queue
 from typing import TYPE_CHECKING, Any, Optional, TextIO, Union
@@ -102,7 +102,7 @@ class ConsoleHandler(StreamHandler):
 
 
 def update_console_handler(
-    level: Optional[int] = None,
+    level: Optional[Union[int, str]] = None,
     timestamps: Optional[bool] = None,
     colored: Optional[bool] = None,
 ) -> None:
@@ -128,7 +128,16 @@ FLOWER_LOGGER.addHandler(console_handler)
 
 # Change log level via env (always get timestamp)
 if log_level := os.getenv("PYTHONLOGLEVEL"):
-    update_console_handler(level=log_level, timestamps=True, colored=True)
+    try:
+        update_console_handler(level=log_level, timestamps=True, colored=True)
+    except:
+        # Alert user but don't raise exception
+        FLOWER_LOGGER.log(
+            ERROR,
+            "Failed to set logging level %s. Using default level: %s",
+            log_level,
+            logging.getLevelName(console_handler.level),
+        )
 
 
 class CustomHTTPHandler(HTTPHandler):


### PR DESCRIPTION
Run as:
```shell 
(env) PYTHONLOGLEVEL=DEBUG flower-superlink --insecure
INFO 2025-01-27 09:58:35,460:      Starting Flower SuperLink
WARNING 2025-01-27 09:58:35,460:   Option `--insecure` was set. Starting insecure HTTP server.
INFO 2025-01-27 09:58:35,465:      Flower Deployment Engine: Starting Exec API on 0.0.0.0:9093
INFO 2025-01-27 09:58:35,469:      Flower ECE: Starting ServerAppIo API (gRPC-rere) on 0.0.0.0:9091
INFO 2025-01-27 09:58:35,473:      Flower ECE: Starting Fleet API (gRPC-rere) on 0.0.0.0:9092
DEBUG 2025-01-27 09:58:35,474:     Started flwr-serverapp scheduler thread.
DEBUG 2025-01-27 09:58:35,474:     Using InMemoryState
```