### PR TITLE
refactor(framework) Update package versions in templates

### DIFF
--- a/src/py/flwr/cli/new/templates/app/README.md.tpl
+++ b/src/py/flwr/cli/new/templates/app/README.md.tpl
@@ -18,8 +18,9 @@ Refer to the [How to Run Simulations](https://flower.ai/docs/framework/how-to-ru
 
 ## Run with the Deployment Engine
 
-> \[!NOTE\]
-> An update to this example will show how to run this Flower application with the Deployment Engine and TLS certificates, or with Docker.
+Follow this [how-to guide](https://flower.ai/docs/framework/how-to-run-flower-with-deployment-engine.html) to run the same app in this example but with Flower's Deployment Engine. After that, you might be intersted in setting up [secure TLS-enabled communications](https://flower.ai/docs/framework/how-to-enable-tls-connections.html) and [SuperNode authentication](https://flower.ai/docs/framework/how-to-authenticate-supernodes.html) in your federation. 
+
+You can run Flower on Docker too! Check out the [Flower with Docker](https://flower.ai/docs/framework/docker/index.html) documentation.
 
 ## Resources
 

--- a/src/py/flwr/cli/new/templates/app/pyproject.baseline.toml.tpl
+++ b/src/py/flwr/cli/new/templates/app/pyproject.baseline.toml.tpl
@@ -9,9 +9,9 @@ description = ""
 license = "Apache-2.0"
 dependencies = [
     "flwr[simulation]>=1.14.0",
-    "flwr-datasets[vision]>=0.3.0",
-    "torch==2.2.1",
-    "torchvision==0.17.1",
+    "flwr-datasets[vision]>=0.5.0",
+    "torch==2.5.1",
+    "torchvision==0.20.1",
 ]
 
 [tool.hatch.metadata]

--- a/src/py/flwr/cli/new/templates/app/pyproject.flowertune.toml.tpl
+++ b/src/py/flwr/cli/new/templates/app/pyproject.flowertune.toml.tpl
@@ -9,7 +9,7 @@ description = ""
 license = "Apache-2.0"
 dependencies = [
     "flwr[simulation]>=1.14.0",
-    "flwr-datasets>=0.3.0",
+    "flwr-datasets>=0.5.0",
     "torch==2.3.1",
     "trl==0.8.1",
     "bitsandbytes==0.45.0",

--- a/src/py/flwr/cli/new/templates/app/pyproject.huggingface.toml.tpl
+++ b/src/py/flwr/cli/new/templates/app/pyproject.huggingface.toml.tpl
@@ -9,8 +9,8 @@ description = ""
 license = "Apache-2.0"
 dependencies = [
     "flwr[simulation]>=1.14.0",
-    "flwr-datasets>=0.3.0",
-    "torch==2.2.1",
+    "flwr-datasets>=0.5.0",
+    "torch==2.5.1",
     "transformers>=4.30.0,<5.0",
     "evaluate>=0.4.0,<1.0",
     "datasets>=2.0.0, <3.0",

--- a/src/py/flwr/cli/new/templates/app/pyproject.huggingface.toml.tpl
+++ b/src/py/flwr/cli/new/templates/app/pyproject.huggingface.toml.tpl
@@ -14,7 +14,7 @@ dependencies = [
     "transformers>=4.30.0,<5.0",
     "evaluate>=0.4.0,<1.0",
     "datasets>=2.0.0, <3.0",
-    "scikit-learn>=1.3.1, <2.0",
+    "scikit-learn>=1.6.1, <2.0",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/src/py/flwr/cli/new/templates/app/pyproject.jax.toml.tpl
+++ b/src/py/flwr/cli/new/templates/app/pyproject.jax.toml.tpl
@@ -11,7 +11,7 @@ dependencies = [
     "flwr[simulation]>=1.14.0",
     "jax==0.4.30",
     "jaxlib==0.4.30",
-    "scikit-learn==1.3.2",
+    "scikit-learn==1.6.1",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/src/py/flwr/cli/new/templates/app/pyproject.mlx.toml.tpl
+++ b/src/py/flwr/cli/new/templates/app/pyproject.mlx.toml.tpl
@@ -9,7 +9,7 @@ description = ""
 license = "Apache-2.0"
 dependencies = [
     "flwr[simulation]>=1.14.0",
-    "flwr-datasets[vision]>=0.3.0",
+    "flwr-datasets[vision]>=0.5.0",
     "mlx==0.21.1",
 ]
 

--- a/src/py/flwr/cli/new/templates/app/pyproject.numpy.toml.tpl
+++ b/src/py/flwr/cli/new/templates/app/pyproject.numpy.toml.tpl
@@ -9,7 +9,7 @@ description = ""
 license = "Apache-2.0"
 dependencies = [
     "flwr[simulation]>=1.14.0",
-    "numpy>=1.21.0",
+    "numpy>=1.26.0",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/src/py/flwr/cli/new/templates/app/pyproject.numpy.toml.tpl
+++ b/src/py/flwr/cli/new/templates/app/pyproject.numpy.toml.tpl
@@ -9,6 +9,7 @@ description = ""
 license = "Apache-2.0"
 dependencies = [
     "flwr[simulation]>=1.14.0",
+    "numpy>=2.2.2",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/src/py/flwr/cli/new/templates/app/pyproject.numpy.toml.tpl
+++ b/src/py/flwr/cli/new/templates/app/pyproject.numpy.toml.tpl
@@ -9,7 +9,7 @@ description = ""
 license = "Apache-2.0"
 dependencies = [
     "flwr[simulation]>=1.14.0",
-    "numpy>=2.2.2",
+    "numpy>=2.0.2",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/src/py/flwr/cli/new/templates/app/pyproject.numpy.toml.tpl
+++ b/src/py/flwr/cli/new/templates/app/pyproject.numpy.toml.tpl
@@ -9,7 +9,6 @@ description = ""
 license = "Apache-2.0"
 dependencies = [
     "flwr[simulation]>=1.14.0",
-    "numpy>=2.2.2",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/src/py/flwr/cli/new/templates/app/pyproject.numpy.toml.tpl
+++ b/src/py/flwr/cli/new/templates/app/pyproject.numpy.toml.tpl
@@ -9,7 +9,7 @@ description = ""
 license = "Apache-2.0"
 dependencies = [
     "flwr[simulation]>=1.14.0",
-    "numpy>=1.26.0",
+    "numpy>=2.2.2",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/src/py/flwr/cli/new/templates/app/pyproject.pytorch.toml.tpl
+++ b/src/py/flwr/cli/new/templates/app/pyproject.pytorch.toml.tpl
@@ -9,7 +9,7 @@ description = ""
 license = "Apache-2.0"
 dependencies = [
     "flwr[simulation]>=1.14.0",
-    "flwr-datasets[vision]>=0.3.0",
+    "flwr-datasets[vision]>=0.5.0",
     "torch==2.5.1",
     "torchvision==0.20.1",
 ]

--- a/src/py/flwr/cli/new/templates/app/pyproject.sklearn.toml.tpl
+++ b/src/py/flwr/cli/new/templates/app/pyproject.sklearn.toml.tpl
@@ -9,7 +9,7 @@ description = ""
 license = "Apache-2.0"
 dependencies = [
     "flwr[simulation]>=1.14.0",
-    "flwr-datasets[vision]>=0.3.0",
+    "flwr-datasets[vision]>=0.5.0",
     "scikit-learn>=1.1.1",
 ]
 

--- a/src/py/flwr/cli/new/templates/app/pyproject.sklearn.toml.tpl
+++ b/src/py/flwr/cli/new/templates/app/pyproject.sklearn.toml.tpl
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 dependencies = [
     "flwr[simulation]>=1.14.0",
     "flwr-datasets[vision]>=0.5.0",
-    "scikit-learn>=1.1.1",
+    "scikit-learn>=1.6.1",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/src/py/flwr/cli/new/templates/app/pyproject.tensorflow.toml.tpl
+++ b/src/py/flwr/cli/new/templates/app/pyproject.tensorflow.toml.tpl
@@ -9,7 +9,7 @@ description = ""
 license = "Apache-2.0"
 dependencies = [
     "flwr[simulation]>=1.14.0",
-    "flwr-datasets[vision]>=0.3.0",
+    "flwr-datasets[vision]>=0.5.0",
     "tensorflow>=2.11.1,<2.18.0",
 ]
 


### PR DESCRIPTION
Updating versions in `flwr new` templates. In particular, if a `pyproject.toml` sets `torch`, we need a version that's compatible with `numpy2+`.