### PR TITLE
refactor(framework) Add allowance for system time drift in the node authentication

### DIFF
--- a/src/py/flwr/common/constant.py
+++ b/src/py/flwr/common/constant.py
@@ -116,7 +116,8 @@ REFRESH_TOKEN_KEY = "refresh_token"
 PUBLIC_KEY_HEADER = "public-key-bin"  # Must end with "-bin" for binary data
 SIGNATURE_HEADER = "signature-bin"  # Must end with "-bin" for binary data
 TIMESTAMP_HEADER = "timestamp"
-TIMESTAMP_TOLERANCE = 10  # Tolerance for timestamp verification
+TIMESTAMP_TOLERANCE = 10  # General tolerance for timestamp verification
+SYSTEM_TIME_TOLERANCE = 2  # Allowance for system time drift
 
 
 class MessageType:

--- a/src/py/flwr/common/constant.py
+++ b/src/py/flwr/common/constant.py
@@ -117,7 +117,7 @@ PUBLIC_KEY_HEADER = "public-key-bin"  # Must end with "-bin" for binary data
 SIGNATURE_HEADER = "signature-bin"  # Must end with "-bin" for binary data
 TIMESTAMP_HEADER = "timestamp"
 TIMESTAMP_TOLERANCE = 10  # General tolerance for timestamp verification
-SYSTEM_TIME_TOLERANCE = 2  # Allowance for system time drift
+SYSTEM_TIME_TOLERANCE = 5  # Allowance for system time drift
 
 
 class MessageType:

--- a/src/py/flwr/server/superlink/fleet/grpc_rere/server_interceptor.py
+++ b/src/py/flwr/server/superlink/fleet/grpc_rere/server_interceptor.py
@@ -25,6 +25,7 @@ from flwr.common import now
 from flwr.common.constant import (
     PUBLIC_KEY_HEADER,
     SIGNATURE_HEADER,
+    SYSTEM_TIME_TOLERANCE,
     TIMESTAMP_HEADER,
     TIMESTAMP_TOLERANCE,
 )
@@ -37,6 +38,9 @@ from flwr.proto.fleet_pb2 import (  # pylint: disable=E0611
     CreateNodeResponse,
 )
 from flwr.server.superlink.linkstate import LinkStateFactory
+
+MIN_TIMESTAMP_DIFF = -SYSTEM_TIME_TOLERANCE
+MAX_TIMESTAMP_DIFF = TIMESTAMP_TOLERANCE + SYSTEM_TIME_TOLERANCE
 
 
 def _unary_unary_rpc_terminator(message: str) -> grpc.RpcMethodHandler:
@@ -100,7 +104,7 @@ class AuthenticateServerInterceptor(grpc.ServerInterceptor):  # type: ignore
         current = now()
         time_diff = current - datetime.datetime.fromisoformat(timestamp_iso)
         # Abort the RPC call if the timestamp is too old or in the future
-        if not 0 < time_diff.total_seconds() < TIMESTAMP_TOLERANCE:
+        if not MIN_TIMESTAMP_DIFF < time_diff.total_seconds() < MAX_TIMESTAMP_DIFF:
             return _unary_unary_rpc_terminator("Invalid timestamp")
 
         # Continue the RPC call


### PR DESCRIPTION
### Why This PR
In cases of unsynchronized system time, the received timestamp may appear to be in the future relative to the server. In a test case, a Raspberry Pi was likely less than one second ahead of the SuperLink’s system time, causing the SuperLink to reject all its connections due to future timestamps.

### What This Does
Allows timestamps to be within the range (-2, 12) seconds instead of (0, 10) seconds.