### PR TITLE
fix(framework) Avoid processing requests from non-FleetStub

### DIFF
--- a/src/py/flwr/server/superlink/fleet/grpc_rere/server_interceptor.py
+++ b/src/py/flwr/server/superlink/fleet/grpc_rere/server_interceptor.py
@@ -39,9 +39,11 @@ from flwr.proto.fleet_pb2 import (  # pylint: disable=E0611
 from flwr.server.superlink.linkstate import LinkStateFactory
 
 
-def _unary_unary_rpc_terminator(message: str) -> grpc.RpcMethodHandler:
+def _unary_unary_rpc_terminator(
+    message: str, code: Any = grpc.StatusCode.UNAUTHENTICATED
+) -> grpc.RpcMethodHandler:
     def terminate(_request: GrpcMessage, context: grpc.ServicerContext) -> GrpcMessage:
-        context.abort(grpc.StatusCode.UNAUTHENTICATED, message)
+        context.abort(code, message)
         raise RuntimeError("Should not reach this point")  # Make mypy happy
 
     return grpc.unary_unary_rpc_method_handler(terminate)
@@ -64,7 +66,7 @@ class AuthenticateServerInterceptor(grpc.ServerInterceptor):  # type: ignore
         self.state_factory = state_factory
         self.auto_auth = auto_auth
 
-    def intercept_service(
+    def intercept_service(  # pylint: disable=too-many-return-statements
         self,
         continuation: Callable[[Any], Any],
         handler_call_details: grpc.HandlerCallDetails,
@@ -75,6 +77,13 @@ class AuthenticateServerInterceptor(grpc.ServerInterceptor):  # type: ignore
         metadata sent by the node. Continue RPC call if node is authenticated, else,
         terminate RPC call by setting context to abort.
         """
+        # Filter out non-Fleet service calls
+        if not handler_call_details.method.startswith("/flwr.proto.Fleet/"):
+            return _unary_unary_rpc_terminator(
+                "This request should be sent to a different service.",
+                grpc.StatusCode.FAILED_PRECONDITION,
+            )
+
         state = self.state_factory.state()
         metadata_dict = dict(handler_call_details.invocation_metadata)
 


### PR DESCRIPTION
### Why This PR  
@jafermarq found that running `flwr ls` against a Fleet servicer results in an unauthenticated error triggered by the node authentication interceptor. A help message then appears, instructing users to run `flwr login`. This can be confusing, especially if the issue is simply due to a typo in the server address.  

### What This Does  
The node authentication server interceptor now first checks whether the request is for the Fleet API. If it is not, a `FAILED_PRECONDITION` error is raised instead of `UNAUTHENTICATED`.