### PR TITLE
refactor(framework) Rename constants for gRPC metadata keys for node auth / user auth

### DIFF
--- a/dev/update_version.py
+++ b/dev/update_version.py
@@ -130,9 +130,6 @@ if __name__ == "__main__":
     curr_version = _get_next_version(args.old_version, increment)
     next_version = _get_next_version(curr_version, "minor")
 
-    print(args.old_version, curr_version, next_version)
-    sys.exit(0)
-
     wrong = False
 
     # Update files with next version

--- a/dev/update_version.py
+++ b/dev/update_version.py
@@ -130,6 +130,9 @@ if __name__ == "__main__":
     curr_version = _get_next_version(args.old_version, increment)
     next_version = _get_next_version(curr_version, "minor")
 
+    print(args.old_version, curr_version, next_version)
+    sys.exit(0)
+
     wrong = False
 
     # Update files with next version

--- a/src/py/flwr/cli/auth_plugin/oidc_cli_plugin.py
+++ b/src/py/flwr/cli/auth_plugin/oidc_cli_plugin.py
@@ -26,7 +26,7 @@ import typer
 from flwr.common.auth_plugin import CliAuthPlugin
 from flwr.common.constant import (
     ACCESS_TOKEN_KEY,
-    AUTH_TYPE_KEY,
+    AUTH_TYPE_JSON_KEY,
     REFRESH_TOKEN_KEY,
     AuthType,
 )
@@ -97,7 +97,7 @@ class OidcCliPlugin(CliAuthPlugin):
         self.access_token = credentials.access_token
         self.refresh_token = credentials.refresh_token
         json_dict = {
-            AUTH_TYPE_KEY: AuthType.OIDC,
+            AUTH_TYPE_JSON_KEY: AuthType.OIDC,
             ACCESS_TOKEN_KEY: credentials.access_token,
             REFRESH_TOKEN_KEY: credentials.refresh_token,
         }

--- a/src/py/flwr/cli/utils.py
+++ b/src/py/flwr/cli/utils.py
@@ -28,7 +28,7 @@ import typer
 
 from flwr.cli.cli_user_auth_interceptor import CliUserAuthInterceptor
 from flwr.common.auth_plugin import CliAuthPlugin
-from flwr.common.constant import AUTH_TYPE_KEY, CREDENTIALS_DIR, FLWR_DIR
+from flwr.common.constant import AUTH_TYPE_JSON_KEY, CREDENTIALS_DIR, FLWR_DIR
 from flwr.common.grpc import (
     GRPC_MAX_MESSAGE_LENGTH,
     create_channel,
@@ -239,7 +239,7 @@ def try_obtain_cli_auth_plugin(
         try:
             with config_path.open("r", encoding="utf-8") as file:
                 json_file = json.load(file)
-            auth_type = json_file[AUTH_TYPE_KEY]
+            auth_type = json_file[AUTH_TYPE_JSON_KEY]
         except (FileNotFoundError, KeyError):
             typer.secho(
                 "❌ Missing or invalid credentials for user authentication. "

--- a/src/py/flwr/common/constant.py
+++ b/src/py/flwr/common/constant.py
@@ -108,7 +108,7 @@ MAX_RETRY_DELAY = 20  # Maximum delay duration between two consecutive retries.
 
 # Constants for user authentication
 CREDENTIALS_DIR = ".credentials"
-AUTH_TYPE_KEY = "auth_type"  # For key name in JSON file
+AUTH_TYPE_KEY = "auth-type"  # For key name in JSON file
 ACCESS_TOKEN_KEY = "flwr-oidc-access-token"
 REFRESH_TOKEN_KEY = "flwr-oidc-refresh-token"
 

--- a/src/py/flwr/common/constant.py
+++ b/src/py/flwr/common/constant.py
@@ -108,14 +108,14 @@ MAX_RETRY_DELAY = 20  # Maximum delay duration between two consecutive retries.
 
 # Constants for user authentication
 CREDENTIALS_DIR = ".credentials"
-AUTH_TYPE_KEY = "auth_type"
+AUTH_TYPE_KEY = "auth_type"  # For key name in JSON file
 ACCESS_TOKEN_KEY = "flwr-oidc-access-token"
 REFRESH_TOKEN_KEY = "flwr-oidc-refresh-token"
 
 # Constants for node authentication
-PUBLIC_KEY_HEADER = "public-key-bin"  # Must end with "-bin" for binary data
-SIGNATURE_HEADER = "signature-bin"  # Must end with "-bin" for binary data
-TIMESTAMP_HEADER = "timestamp"
+PUBLIC_KEY_HEADER = "flwr-public-key-bin"  # Must end with "-bin" for binary data
+SIGNATURE_HEADER = "flwr-signature-bin"  # Must end with "-bin" for binary data
+TIMESTAMP_HEADER = "flwr-timestamp"
 TIMESTAMP_TOLERANCE = 10  # Tolerance for timestamp verification
 
 

--- a/src/py/flwr/common/constant.py
+++ b/src/py/flwr/common/constant.py
@@ -108,7 +108,8 @@ MAX_RETRY_DELAY = 20  # Maximum delay duration between two consecutive retries.
 
 # Constants for user authentication
 CREDENTIALS_DIR = ".credentials"
-AUTH_TYPE_KEY = "auth-type"  # For key name in JSON file
+AUTH_TYPE_JSON_KEY = "auth-type"  # For key name in JSON file
+AUTH_TYPE_YAML_KEY = "auth_type"  # For key name in YAML file
 ACCESS_TOKEN_KEY = "flwr-oidc-access-token"
 REFRESH_TOKEN_KEY = "flwr-oidc-refresh-token"
 

--- a/src/py/flwr/common/constant.py
+++ b/src/py/flwr/common/constant.py
@@ -109,8 +109,8 @@ MAX_RETRY_DELAY = 20  # Maximum delay duration between two consecutive retries.
 # Constants for user authentication
 CREDENTIALS_DIR = ".credentials"
 AUTH_TYPE_KEY = "auth_type"
-ACCESS_TOKEN_KEY = "access_token"
-REFRESH_TOKEN_KEY = "refresh_token"
+ACCESS_TOKEN_KEY = "flwr-oidc-access-token"
+REFRESH_TOKEN_KEY = "flwr-oidc-refresh-token"
 
 # Constants for node authentication
 PUBLIC_KEY_HEADER = "public-key-bin"  # Must end with "-bin" for binary data

--- a/src/py/flwr/server/app.py
+++ b/src/py/flwr/server/app.py
@@ -40,7 +40,6 @@ from flwr.common.args import try_obtain_server_certificates
 from flwr.common.auth_plugin import ExecAuthPlugin
 from flwr.common.config import get_flwr_dir, parse_config_args
 from flwr.common.constant import (
-    AUTH_TYPE_JSON_KEY,
     AUTH_TYPE_YAML_KEY,
     CLIENT_OCTET,
     EXEC_API_DEFAULT_SERVER_ADDRESS,

--- a/src/py/flwr/server/app.py
+++ b/src/py/flwr/server/app.py
@@ -40,7 +40,8 @@ from flwr.common.args import try_obtain_server_certificates
 from flwr.common.auth_plugin import ExecAuthPlugin
 from flwr.common.config import get_flwr_dir, parse_config_args
 from flwr.common.constant import (
-    AUTH_TYPE_KEY,
+    AUTH_TYPE_JSON_KEY,
+    AUTH_TYPE_YAML_KEY,
     CLIENT_OCTET,
     EXEC_API_DEFAULT_SERVER_ADDRESS,
     FLEET_API_GRPC_BIDI_DEFAULT_ADDRESS,
@@ -578,7 +579,7 @@ def _try_obtain_exec_auth_plugin(
 
     # Load authentication configuration
     auth_config: dict[str, Any] = config.get("authentication", {})
-    auth_type: str = auth_config.get(AUTH_TYPE_KEY, "")
+    auth_type: str = auth_config.get(AUTH_TYPE_YAML_KEY, "")
 
     # Load authentication plugin
     try:


### PR DESCRIPTION
Rename constants so they don't include `_`. Using `_` isn't recommended when these keys travel in gRPC's metadata (https://www.grouparoo.com/blog/dont-use-underscores-in-http-headers).