### PR TITLE
refactor(framework) Order CLI args alphabetically

### DIFF
--- a/src/py/flwr/client/clientapp/app.py
+++ b/src/py/flwr/client/clientapp/app.py
@@ -26,6 +26,7 @@ from flwr.cli.install import install_from_fab
 from flwr.client.client_app import ClientApp, LoadClientAppError
 from flwr.common import Context, Message
 from flwr.common.args import add_args_flwr_app_common
+from flwr.common.args_utils import SortingHelpFormatter
 from flwr.common.config import get_flwr_dir
 from flwr.common.constant import CLIENTAPPIO_API_DEFAULT_CLIENT_ADDRESS, ErrorCode
 from flwr.common.exit import ExitCode, flwr_exit
@@ -235,6 +236,7 @@ def _parse_args_run_flwr_clientapp() -> argparse.ArgumentParser:
     """Parse flwr-clientapp command line arguments."""
     parser = argparse.ArgumentParser(
         description="Run a Flower ClientApp",
+        formatter_class=SortingHelpFormatter,
     )
     parser.add_argument(
         "--clientappio-api-address",

--- a/src/py/flwr/client/supernode/app.py
+++ b/src/py/flwr/client/supernode/app.py
@@ -29,6 +29,7 @@ from cryptography.hazmat.primitives.serialization import (
 
 from flwr.common import EventType, event
 from flwr.common.args import try_obtain_root_certificates
+from flwr.common.args_utils import SortingHelpFormatter
 from flwr.common.config import parse_config_args
 from flwr.common.constant import (
     CLIENTAPPIO_API_DEFAULT_SERVER_ADDRESS,
@@ -112,6 +113,7 @@ def _parse_args_run_supernode() -> argparse.ArgumentParser:
     """Parse flower-supernode command line arguments."""
     parser = argparse.ArgumentParser(
         description="Start a Flower SuperNode",
+        formatter_class=SortingHelpFormatter,
     )
     _parse_args_common(parser)
     parser.add_argument(

--- a/src/py/flwr/common/args_utils.py
+++ b/src/py/flwr/common/args_utils.py
@@ -1,0 +1,42 @@
+# Copyright 2025 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Flower argument utilities."""
+
+
+import argparse
+from argparse import Action, _MutuallyExclusiveGroup
+from typing import Iterable, List, Optional
+
+
+class SortingHelpFormatter(argparse.HelpFormatter):
+    """Sort the arguments alphabetically in the help text."""
+
+    def add_usage(
+        self,
+        usage: Optional[str],
+        actions: Iterable[Action],
+        groups: Iterable[_MutuallyExclusiveGroup],
+        prefix: Optional[str] = None,
+    ) -> None:
+
+        # def add_usage(self, usage, actions, groups, prefix=None) -> None:
+        # Sort the usage actions alphabetically
+        sorted_actions: List[Action] = sorted(actions, key=lambda action: action.dest)
+        super().add_usage(usage, sorted_actions, groups, prefix)
+
+    def add_arguments(self, actions: Iterable[Action]) -> None:
+        # Sort the argument actions alphabetically
+        sorted_actions: List[Action] = sorted(actions, key=lambda action: action.dest)
+        super().add_arguments(sorted_actions)

--- a/src/py/flwr/server/app.py
+++ b/src/py/flwr/server/app.py
@@ -37,6 +37,7 @@ from cryptography.hazmat.primitives.serialization import load_ssh_public_key
 from flwr.common import GRPC_MAX_MESSAGE_LENGTH, EventType, event
 from flwr.common.address import parse_address
 from flwr.common.args import try_obtain_server_certificates
+from flwr.common.args_utils import SortingHelpFormatter
 from flwr.common.auth_plugin import ExecAuthPlugin
 from flwr.common.config import get_flwr_dir, parse_config_args
 from flwr.common.constant import (
@@ -691,8 +692,50 @@ def _run_fleet_api_rest(
 
 def _parse_args_run_superlink() -> argparse.ArgumentParser:
     """Parse command line arguments for both ServerAppIo API and Fleet API."""
+
+    # Custom ArgumentParser to sort arguments
+    # class SortingHelpFormatter(argparse.HelpFormatter):
+    #     def add_arguments(self, actions):
+    #         actions = sorted(actions, key=lambda action: action.dest)
+    #         super(SortingHelpFormatter, self).add_arguments(actions)
+    # class SortingHelpFormatter(argparse.HelpFormatter):
+    #     def add_usage(self, usage, actions, groups, prefix=None):
+    #         # Sort all actions (both optionals and positionals) alphabetically.
+    #         # For optionals, sort by their option strings; for positionals, sort by their destination.
+    #         actions = sorted(actions, key=lambda action: action.dest)
+    #         # actions = sorted(
+    #         #     actions,
+    #         #     key=lambda a: a.option_strings if a.option_strings else [a.dest],
+    #         # )
+    #         super(SortingHelpFormatter, self).add_usage(usage, actions, groups, prefix)
+
+    #     def add_arguments(self, actions):
+    #         # Sort the actions the same way for the help text.
+    #         actions = sorted(actions, key=lambda action: action.dest)
+    #         # actions = sorted(
+    #         #     actions,
+    #         #     key=lambda a: a.option_strings if a.option_strings else [a.dest],
+    #         # )
+    #         super(SortingHelpFormatter, self).add_arguments(actions)
+
+    # class SortedUsageFormatter(argparse.HelpFormatter):
+    #     def _format_usage(self, usage, actions, groups, prefix):
+    #         # Sort actions: if option_strings exist, sort by the first one,
+    #         # otherwise (for positionals) sort by the destination name.
+    #         actions = sorted(actions, key=lambda action: action.dest)
+    #         # sorted_actions = sorted(
+    #         #     actions,
+    #         #     key=lambda action: (
+    #         #         action.option_strings[0] if action.option_strings else action.dest
+    #         #     ),
+    #         # )
+    #         return super(SortedUsageFormatter, self)._format_usage(
+    #             usage, actions, groups, prefix
+    #         )
+
     parser = argparse.ArgumentParser(
         description="Start a Flower SuperLink",
+        formatter_class=SortingHelpFormatter,
     )
 
     _add_args_common(parser=parser)

--- a/src/py/flwr/server/serverapp/app.py
+++ b/src/py/flwr/server/serverapp/app.py
@@ -26,6 +26,7 @@ from flwr.cli.config_utils import get_fab_metadata
 from flwr.cli.install import install_from_fab
 from flwr.cli.utils import get_sha256_hash
 from flwr.common.args import add_args_flwr_app_common
+from flwr.common.args_utils import SortingHelpFormatter
 from flwr.common.config import (
     get_flwr_dir,
     get_fused_config_from_dir,
@@ -240,6 +241,7 @@ def _parse_args_run_flwr_serverapp() -> argparse.ArgumentParser:
     """Parse flwr-serverapp command line arguments."""
     parser = argparse.ArgumentParser(
         description="Run a Flower ServerApp",
+        formatter_class=SortingHelpFormatter,
     )
     parser.add_argument(
         "--serverappio-api-address",


### PR DESCRIPTION
Sets the help output in `flower-superlink`, `flower-supernode`, `flwr-serverapp`, and `flwr-clientapp` to be alphabetical. This improves readability.

Example before
```shell
➜ flower-supernode -h
usage: flower-supernode [-h] [--insecure] [--grpc-rere | --grpc-adapter | --rest] [--root-certificates ROOT_CERT] [--superlink SUPERLINK] [--max-retries MAX_RETRIES]
                        [--max-wait-time MAX_WAIT_TIME] [--auth-supernode-private-key AUTH_SUPERNODE_PRIVATE_KEY]
                        [--auth-supernode-public-key AUTH_SUPERNODE_PUBLIC_KEY] [--node-config NODE_CONFIG] [--flwr-dir FLWR_DIR] [--isolation {subprocess,process}]
                        [--clientappio-api-address CLIENTAPPIO_API_ADDRESS]

Start a Flower SuperNode

options:
  -h, --help            show this help message and exit
  --insecure            Run the client without HTTPS. By default, the client runs with HTTPS enabled. Use this flag only if you understand the risks.
  --grpc-rere           Use grpc-rere as a transport layer for the client.
  --grpc-adapter        Use grpc-adapter as a transport layer for the client.
  --rest                Use REST as a transport layer for the client.
...
```

Example after
```shell
➜ flower-supernode -h
usage: flower-supernode [--auth-supernode-private-key AUTH_SUPERNODE_PRIVATE_KEY] [--auth-supernode-public-key AUTH_SUPERNODE_PUBLIC_KEY]
                        [--clientappio-api-address CLIENTAPPIO_API_ADDRESS] [--flwr-dir FLWR_DIR] [-h] [--insecure] [--isolation {subprocess,process}]
                        [--max-retries MAX_RETRIES] [--max-wait-time MAX_WAIT_TIME] [--node-config NODE_CONFIG] [--root-certificates ROOT_CERT] [--superlink SUPERLINK]
                        [--grpc-rere | --grpc-adapter | --rest]

Start a Flower SuperNode

options:
  --auth-supernode-private-key AUTH_SUPERNODE_PRIVATE_KEY
                        The SuperNode's private key (as a path str) to enable authentication.
  --auth-supernode-public-key AUTH_SUPERNODE_PUBLIC_KEY
                        The SuperNode's public key (as a path str) to enable authentication.
  --clientappio-api-address CLIENTAPPIO_API_ADDRESS
                        ClientAppIo API (gRPC) server address (IPv4, IPv6, or a domain name). By default, it is set to 0.0.0.0:9094.
  --flwr-dir FLWR_DIR   The path containing installed Flower Apps. The default directory is: - `$FLWR_HOME/` if `$FLWR_HOME` is defined - `$XDG_DATA_HOME/.flwr/` if
                        `$XDG_DATA_HOME` is defined - `$HOME/.flwr/` in all other cases
  -h, --help            show this help message and exit
  --insecure            Run the client without HTTPS. By default, the client runs with HTTPS enabled. Use this flag only if you understand the risks.
...
```