### PR TITLE
fix(framework) Remove dashboard plugin

### DIFF
--- a/src/py/flwr/server/app.py
+++ b/src/py/flwr/server/app.py
@@ -90,11 +90,7 @@ BASE_DIR = get_flwr_dir() / "superlink" / "ffs"
 
 
 try:
-    from flwr.ee import (
-        add_ee_args_superlink,
-        get_dashboard_server,
-        get_exec_auth_plugins,
-    )
+    from flwr.ee import add_ee_args_superlink, get_exec_auth_plugins
 except ImportError:
 
     # pylint: disable-next=unused-argument
@@ -434,17 +430,6 @@ def run_superlink() -> None:
         )
         scheduler_th.start()
         bckg_threads.append(scheduler_th)
-
-    # Add Dashboard server if available
-    if dashboard_address := getattr(args, "dashboard_address", None):
-        dashboard_address_str, _, _ = _format_address(dashboard_address)
-        dashboard_server = get_dashboard_server(
-            address=dashboard_address_str,
-            state_factory=state_factory,
-            certificates=None,
-        )
-
-        grpc_servers.append(dashboard_server)
 
     # Graceful shutdown
     register_exit_handlers(


### PR DESCRIPTION
The `get_dashboard_server` cannot be imported currently, and is causing the auth plugin to break.