### PR TITLE
fix(framework) Fix `flwr log` test

### DIFF
--- a/src/py/flwr/cli/log_test.py
+++ b/src/py/flwr/cli/log_test.py
@@ -43,11 +43,12 @@ class TestFlwrLog(unittest.TestCase):
 
     def setUp(self) -> None:
         """Initialize mock ExecStub before each test."""
-        self.expected_calls = [
+        self.expected_stream_call = [
             call("log_output_1"),
             call("log_output_2"),
             call("log_output_3"),
         ]
+        self.expected_print_call = [call("log_output_1")]
         mock_response_iterator = [
             iter(
                 [StreamLogsResponse(log_output=f"log_output_{i}") for i in range(1, 4)]
@@ -75,11 +76,11 @@ class TestFlwrLog(unittest.TestCase):
                     run_id=123, stub=self.mock_stub, duration=1, after_timestamp=0.0
                 )
                 # Assert that mock print was called with the expected arguments
-                mock_print.assert_has_calls(self.expected_calls)
+                mock_print.assert_has_calls(self.expected_stream_call)
 
     def test_flwr_log_print_method(self) -> None:
         """Test print_logs."""
         with patch("builtins.print") as mock_print:
             print_logs(run_id=123, channel=self.mock_channel, timeout=0)
             # Assert that mock print was called with the expected arguments
-            mock_print.assert_has_calls(self.expected_calls)
+            mock_print.assert_has_calls(self.expected_print_call)


### PR DESCRIPTION
Since the `print_log` logic runs `print` once, the accompanying test needs to be updated. Only one call is expected. 