### PR TITLE
docs(*:skip) Add simpler theme update

### DIFF
--- a/datasets/docs/source/conf.py
+++ b/datasets/docs/source/conf.py
@@ -145,18 +145,6 @@ html_theme_options = {
     #     "color-brand-content": "#292F36",
     #     "color-admonition-background": "#F2B705",
     # },
-    "announcement": "Flower AI Summit 2025, March 26-27 "
-    "(🇬🇧 London & Online) "
-    "<a href='https://flower.ai/events/flower-ai-summit-2025/'>"
-    "<strong style='color: #f2b705;'>👉 Register Now!</strong></a>",
-    "light_css_variables": {
-        "color-announcement-background": "#292f36",
-        "color-announcement-text": "#ffffff",
-    },
-    "dark_css_variables": {
-        "color-announcement-background": "#292f36",
-        "color-announcement-text": "#ffffff",
-    },
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/dev/build-docs.sh
+++ b/dev/build-docs.sh
@@ -4,6 +4,10 @@ cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"/../
 
 ROOT=$(pwd)
 
+echo "Updating HTML theme options"
+cd "$ROOT"
+python dev/update-html-themes.py
+
 echo "Building baseline docs"
 cd "$ROOT"
 ./dev/build-baseline-docs.sh

--- a/dev/update-html-themes.py
+++ b/dev/update-html-themes.py
@@ -18,11 +18,12 @@
 import json
 import re
 from pathlib import Path
+from typing import Union
 
 # Change this if you want to search a different directory.
 ROOT_DIR = Path(".")
 
-NEW_FIELDS = {
+NEW_FIELDS: dict[str, Union[dict[str, str], str]] = {
     "announcement": (
         "Flower AI Summit 2025, March 26-27 (🇬🇧 London & Online) <br />"
         "<a href='https://flower.ai/events/flower-ai-summit-2025/'>"
@@ -39,7 +40,7 @@ NEW_FIELDS = {
 }
 
 
-def dict_to_fields_str(fields: dict) -> str:
+def dict_to_fields_str(fields: dict[str, Union[dict[str, str], str]]) -> str:
     """
     Convert a dictionary to a formatted string suitable for insertion
     into a Python dictionary literal (without the outer braces).

--- a/dev/update-html-themes.py
+++ b/dev/update-html-themes.py
@@ -25,10 +25,10 @@ ROOT_DIR = Path(".")
 
 NEW_FIELDS: dict[str, Union[dict[str, str], str]] = {
     "announcement": (
-        "Flower AI Summit 2025"
         "<a href='https://flower.ai/events/flower-ai-summit-2025/'>"
-        "<strong style='color: #f2b705;'>👉 Register Now!</strong></a><br />"
-        "March 26-27 (🇬🇧 London & Online)"
+        "<strong style='color: #f2b705;'>👉 Register now</strong></a> "
+        "for Flower AI Summit 2025!<br />"
+        "March 26-27, 🇬🇧 London & Online"
     ),
     "light_css_variables": {
         "color-announcement-background": "#292f36",

--- a/dev/update-html-themes.py
+++ b/dev/update-html-themes.py
@@ -1,0 +1,87 @@
+# Copyright 2025 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Update HTML themes in Flower docs."""
+
+
+import re
+from pathlib import Path
+
+# Change this if you want to search a different directory.
+ROOT_DIR = Path(".")
+
+# New fields to be added to html_theme_options.
+# If empty, no changes will be made.
+NEW_FIELDS = """
+    "announcement": "Flower AI Summit 2025, March 26-27 "
+    "(🇬🇧 London & Online) <br />"
+    "<a href='https://flower.ai/events/flower-ai-summit-2025/'>"
+    "<strong style='color: #f2b705;'>👉 Register Now!</strong></a>",
+    "light_css_variables": {
+        "color-announcement-background": "#292f36",
+        "color-announcement-text": "#ffffff"
+    },
+    "dark_css_variables": {
+        "color-announcement-background": "#292f36",
+        "color-announcement-text": "#ffffff"
+    },
+"""
+
+
+def find_conf_files(root_dir: Path):
+    """Recursively find all conf.py files under root_dir."""
+    return list(root_dir.rglob("conf.py"))
+
+
+def update_conf_file(file_path: Path, new_fields: str):
+    """Insert new_fields into the html_theme_options block of file_path."""
+    if not new_fields.strip():
+        print(f"Skipping {file_path} (NEW_FIELDS is empty)")
+        return
+
+    content = file_path.read_text(encoding="utf-8").splitlines()
+    updated_content = []
+    inside_options = False
+    modified = False
+
+    for line in content:
+        updated_content.append(line)
+        # Check for the start of the html_theme_options block.
+        if re.match(r"^\s*html_theme_options\s*=\s*{", line):
+            inside_options = True
+        # When encountering the closing brace, insert new_fields before it.
+        if inside_options and re.match(r"^\s*}", line):
+            updated_content.insert(-1, new_fields.rstrip() + "\n")
+            inside_options = False
+            modified = True
+
+    if modified:
+        file_path.write_text("\n".join(updated_content) + "\n", encoding="utf-8")
+        print(f"Updated: {file_path}")
+    else:
+        print(f"No html_theme_options block found in: {file_path}")
+
+
+def main():
+    conf_files = find_conf_files(ROOT_DIR)
+    if not conf_files:
+        print("No conf.py files found.")
+        return
+
+    for conf_file in conf_files:
+        update_conf_file(conf_file, NEW_FIELDS)
+
+
+if __name__ == "__main__":
+    main()

--- a/dev/update-html-themes.py
+++ b/dev/update-html-themes.py
@@ -18,12 +18,14 @@
 import json
 import re
 from pathlib import Path
-from typing import Union
+from typing import Optional, Union
 
 # Change this if you want to search a different directory.
 ROOT_DIR = Path(".")
 
-NEW_FIELDS: dict[str, Union[dict[str, str], str]] = {
+# Define new fields to be added to the `html_theme_options` dictionary in `conf.py`.
+# If no fields are needed, set to an empty dictionary.
+NEW_FIELDS: dict[str, Optional[Union[dict[str, str], str]]] = {
     "announcement": (
         "<a href='https://flower.ai/events/flower-ai-summit-2025/'>"
         "<strong style='color: #f2b705;'>👉 Register now</strong></a> "
@@ -41,7 +43,7 @@ NEW_FIELDS: dict[str, Union[dict[str, str], str]] = {
 }
 
 
-def dict_to_fields_str(fields: dict[str, Union[dict[str, str], str]]) -> str:
+def dict_to_fields_str(fields: dict[str, Optional[Union[dict[str, str], str]]]) -> str:
     """
     Convert a dictionary to a formatted string suitable for insertion
     into a Python dictionary literal (without the outer braces).

--- a/dev/update-html-themes.py
+++ b/dev/update-html-themes.py
@@ -25,9 +25,10 @@ ROOT_DIR = Path(".")
 
 NEW_FIELDS: dict[str, Union[dict[str, str], str]] = {
     "announcement": (
-        "Flower AI Summit 2025, March 26-27 (🇬🇧 London & Online) <br />"
+        "Flower AI Summit 2025"
         "<a href='https://flower.ai/events/flower-ai-summit-2025/'>"
-        "<strong style='color: #f2b705;'>👉 Register Now!</strong></a>"
+        "<strong style='color: #f2b705;'>👉 Register Now!</strong></a><br />"
+        "March 26-27 (🇬🇧 London & Online)"
     ),
     "light_css_variables": {
         "color-announcement-background": "#292f36",

--- a/examples/docs/source/conf.py
+++ b/examples/docs/source/conf.py
@@ -105,18 +105,6 @@ html_theme_options = {
     #     "color-brand-content": "#292F36",
     #     "color-admonition-background": "#F2B705",
     # },
-    "announcement": "Flower AI Summit 2025, March 26-27 "
-    "(🇬🇧 London & Online) "
-    "<a href='https://flower.ai/events/flower-ai-summit-2025/'>"
-    "<strong style='color: #f2b705;'>👉 Register Now!</strong></a>",
-    "light_css_variables": {
-        "color-announcement-background": "#292f36",
-        "color-announcement-text": "#ffffff",
-    },
-    "dark_css_variables": {
-        "color-announcement-background": "#292f36",
-        "color-announcement-text": "#ffffff",
-    },
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/framework/docs/source/conf.py
+++ b/framework/docs/source/conf.py
@@ -309,18 +309,6 @@ html_theme_options = {
     #     "color-brand-content": "#292F36",
     #     "color-admonition-background": "#F2B705",
     # },
-    "announcement": "Flower AI Summit 2025, March 26-27 "
-    "(🇬🇧 London & Online) "
-    "<a href='https://flower.ai/events/flower-ai-summit-2025/'>"
-    "<strong style='color: #f2b705;'>👉 Register Now!</strong></a>",
-    "light_css_variables": {
-        "color-announcement-background": "#292f36",
-        "color-announcement-text": "#ffffff",
-    },
-    "dark_css_variables": {
-        "color-announcement-background": "#292f36",
-        "color-announcement-text": "#ffffff",
-    },
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/intelligence/docs/source/conf.py
+++ b/intelligence/docs/source/conf.py
@@ -138,18 +138,6 @@ html_theme_options = {
     #     "color-brand-content": "#292F36",
     #     "color-admonition-background": "#F2B705",
     # },
-    "announcement": "Flower AI Summit 2025, March 26-27 "
-    "(🇬🇧 London & Online) "
-    "<a href='https://flower.ai/events/flower-ai-summit-2025/'>"
-    "<strong style='color: #f2b705;'>👉 Register Now!</strong></a>",
-    "light_css_variables": {
-        "color-announcement-background": "#292f36",
-        "color-announcement-text": "#ffffff",
-    },
-    "dark_css_variables": {
-        "color-announcement-background": "#292f36",
-        "color-announcement-text": "#ffffff",
-    },
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,


### PR DESCRIPTION
Moved the `html_theme_options` override to a `update-html-themes.py` script. The script will recursively update the `html_theme_options` dictionary in the following `conf.py`:
* `framework/docs/source/conf.py`
* `intelligence/docs/source/conf.py`
* `datasets/docs/source/conf.py`
* `examples/docs/source/conf.py`
* `baselines/docs/source/conf.py`

Web browser preview:
![image](https://github.com/user-attachments/assets/8f6a0657-a463-4ac6-a8db-83f8c84bc2fe)

Mobile browser preview:
![IMG_430CF166A8CB-1](https://github.com/user-attachments/assets/53c67a73-0c86-407f-8d44-a46fe5a8370e)
