### PR TITLE
refactor(framework) Introduce `delivered_at` in `Message` metadata

### DIFF
--- a/src/py/flwr/client/message_handler/message_handler_test.py
+++ b/src/py/flwr/client/message_handler/message_handler_test.py
@@ -300,7 +300,7 @@ class TestMessageValidation(unittest.TestCase):
         invalid_metadata_list: list[Metadata] = []
         attrs = list(vars(self.valid_out_metadata).keys())
         for attr in attrs:
-            if attr == "_partition_id":
+            if attr == "_delivered_at":
                 continue
             if attr == "_ttl":  # Skip configurable ttl
                 continue
@@ -321,5 +321,6 @@ class TestMessageValidation(unittest.TestCase):
 
         # Assert
         for invalid_metadata in invalid_metadata_list:
+            print(invalid_metadata)
             msg.__dict__["_metadata"] = invalid_metadata
             self.assertFalse(validate_out_message(msg, self.in_metadata))

--- a/src/py/flwr/client/message_handler/message_handler_test.py
+++ b/src/py/flwr/client/message_handler/message_handler_test.py
@@ -321,6 +321,5 @@ class TestMessageValidation(unittest.TestCase):
 
         # Assert
         for invalid_metadata in invalid_metadata_list:
-            print(invalid_metadata)
             msg.__dict__["_metadata"] = invalid_metadata
             self.assertFalse(validate_out_message(msg, self.in_metadata))

--- a/src/py/flwr/common/message.py
+++ b/src/py/flwr/common/message.py
@@ -127,6 +127,16 @@ class Metadata:  # pylint: disable=too-many-instance-attributes
         self.__dict__["_created_at"] = value
 
     @property
+    def delivered_at(self) -> str:
+        """Unix timestamp when the message was delivered."""
+        return cast(str, self.__dict__["_delivered_at"])
+
+    @delivered_at.setter
+    def delivered_at(self, value: str) -> None:
+        """Set delivery timestamp of this message."""
+        self.__dict__["_delivered_at"] = value
+
+    @property
     def ttl(self) -> float:
         """Time-to-live for this message."""
         return cast(float, self.__dict__["_ttl"])
@@ -223,6 +233,7 @@ class Message:
             raise ValueError("Either `content` or `error` must be set, but not both.")
 
         metadata.created_at = time.time()  # Set the message creation timestamp
+        metadata.delivered_at = ""
         var_dict = {
             "_metadata": metadata,
             "_content": content,

--- a/src/py/flwr/server/utils/validator.py
+++ b/src/py/flwr/server/utils/validator.py
@@ -126,6 +126,8 @@ def validate_message(message: Message, is_reply_message: bool) -> list[str]:
             "`metadata.created_at` must be a float that records the unix timestamp "
             "in seconds when the message was created."
         )
+    if metadata.delivered_at != "":
+        validation_errors.append("`metadata.delivered_at` must be an empty str")
     if metadata.ttl <= 0:
         validation_errors.append("`metadata.ttl` must be higher than zero")
 


### PR DESCRIPTION
To ease the migration of `LinkState` from `TaskIns/Res` to pure `Messages` we need to introduce this element in the metadata since it's the mechanism to determine whether a message has been pulled for processing or not.