### PR TITLE
docs(framework:skip) Set banner for framework docs

### DIFF
--- a/framework/docs/source/conf.py
+++ b/framework/docs/source/conf.py
@@ -309,6 +309,20 @@ html_theme_options = {
     #     "color-brand-content": "#292F36",
     #     "color-admonition-background": "#F2B705",
     # },
+    "announcement": (
+        "<a href='https://flower.ai/events/flower-ai-summit-2025/'>"
+        "<strong style='color: #f2b705;'>👉 Register now</strong></a> "
+        "for Flower AI Summit 2025!<br />"
+        "March 26-27, 🇬🇧 London & Online"
+    ),
+    "light_css_variables": {
+        "color-announcement-background": "#292f36",
+        "color-announcement-text": "#ffffff",
+    },
+    "dark_css_variables": {
+        "color-announcement-background": "#292f36",
+        "color-announcement-text": "#ffffff",
+    },
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,


### PR DESCRIPTION
PR to ensure the banner exists for `flower.ai/docs/framework`.