### PR TITLE
fix(framework) Fix node registration issue

### DIFF
--- a/src/py/flwr/server/compat/app.py
+++ b/src/py/flwr/server/compat/app.py
@@ -79,9 +79,13 @@ def start_driver(  # pylint: disable=too-many-arguments, too-many-locals
     log(INFO, "")
 
     # Start the thread updating nodes
-    thread, f_stop = start_update_client_manager_thread(
+    thread, f_stop, c_done = start_update_client_manager_thread(
         driver, initialized_server.client_manager()
     )
+
+    # Wait for 1 second until the node registration done
+    if not c_done.is_set():
+        c_done.wait(1)
 
     # Start training
     hist = run_fl(


### PR DESCRIPTION
## Issue
When using Strategy for FL runs, the drive doesn't have sufficient time to finish the node registration. This leads to wrong sampled number of clients/nodes in the first round.


## Proposal
Add a threading event for the node registration process. Only when the registration finished, it moves to FL training.


