### PR TITLE
refactor(framework) Extend test for `ServerAppIo` servicer and `InMemoryDriver`

### DIFF
--- a/src/py/flwr/server/driver/inmemory_driver_test.py
+++ b/src/py/flwr/server/driver/inmemory_driver_test.py
@@ -19,7 +19,7 @@ import time
 import unittest
 from collections.abc import Iterable
 from unittest.mock import MagicMock, patch
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 from flwr.common import ConfigsRecord, Message, RecordSet, now
 from flwr.common.constant import (
@@ -165,6 +165,10 @@ class TestInMemoryDriver(unittest.TestCase):
         # Assert
         self.assertEqual(len(pulled_msgs), 2)
         self.assertEqual(reply_tos, msg_ids)
+        # Ensure messages are deleted
+        self.state.delete_messages.assert_called_once_with(
+            message_ins_ids={UUID(m_id) for m_id in msg_ids}
+        )
 
     def test_send_and_receive_messages_complete(self) -> None:
         """Test send and receive all messages successfully."""

--- a/src/py/flwr/server/superlink/driver/serverappio_servicer_test.py
+++ b/src/py/flwr/server/superlink/driver/serverappio_servicer_test.py
@@ -278,11 +278,10 @@ class TestServerAppIoServicer(unittest.TestCase):  # pylint: disable=R0902
 
     @parameterized.expand(
         [
-            (
-                RecordSet(),
-                None,
-            ),  # Reply with Message
-            (None, Error(code=0)),  # Reply with Error
+            # Reply with Message
+            (RecordSet(), None),
+            # Reply with Error
+            (None, Error(code=0)),
         ]
     )  # type: ignore
     def test_successful_pull_messages_deletes_messages_in_linkstate(

--- a/src/py/flwr/server/superlink/driver/serverappio_servicer_test.py
+++ b/src/py/flwr/server/superlink/driver/serverappio_servicer_test.py
@@ -21,13 +21,13 @@ import unittest
 import grpc
 from parameterized import parameterized
 
-from flwr.common import ConfigsRecord, Context
+from flwr.common import ConfigsRecord, Context, RecordSet
 from flwr.common.constant import (
     SERVERAPPIO_API_DEFAULT_SERVER_ADDRESS,
     SUPERLINK_NODE_ID,
     Status,
 )
-from flwr.common.serde import context_to_proto, run_status_to_proto
+from flwr.common.serde import context_to_proto, message_from_proto, run_status_to_proto
 from flwr.common.serde_test import RecordMaker
 from flwr.common.typing import RunStatus
 from flwr.proto.message_pb2 import Message  # pylint: disable=E0611
@@ -275,6 +275,37 @@ class TestServerAppIoServicer(unittest.TestCase):  # pylint: disable=R0902
         # Assert
         assert isinstance(response, PullResMessagesResponse)
         assert grpc.StatusCode.OK == call.code()
+
+    def test_successful_pull_messages_deletes_messages_in_linkstate(self) -> None:
+        """Test `PullMessages` deletes messages from LinkState."""
+        # Prepare
+        node_id = self.state.create_node(ping_interval=30)
+        run_id = self.state.create_run("", "", "", {}, ConfigsRecord())
+
+        # Transition status to running.
+        self._transition_run_status(run_id, 2)
+
+        # Push Messages and reply
+        message_ins = message_from_proto(
+            create_ins_message(
+                src_node_id=SUPERLINK_NODE_ID, dst_node_id=node_id, run_id=run_id
+            )
+        )
+        msg_ids = self.state.store_message_ins(message=message_ins)
+        msg_ = self.state.get_message_ins(node_id=node_id, limit=1)[0]
+        reply_msg = msg_.create_reply(content=RecordSet())
+        self.state.store_message_res(message=reply_msg)
+
+        request = PullResMessagesRequest(message_ids=[str(msg_ids)], run_id=run_id)
+
+        # Execute
+        response, call = self._pull_messages.with_call(request=request)
+
+        # Assert
+        assert isinstance(response, PullResMessagesResponse)
+        assert grpc.StatusCode.OK == call.code()
+        assert self.state.num_message_ins() == 0
+        assert self.state.num_message_res() == 0
 
     def _assert_pull_messages_not_allowed(self, run_id: int) -> None:
         """Assert `PullMessages` not allowed."""


### PR DESCRIPTION
Add test that checks `Messages` are erased from `LinkState` once pulled