### PR TITLE
refactor(framework) Convert `Driver.pull_messages` to no-arg

### DIFF
--- a/src/py/flwr/server/driver/driver.py
+++ b/src/py/flwr/server/driver/driver.py
@@ -89,7 +89,7 @@ class Driver(ABC):
         """Get node IDs."""
 
     @abstractmethod
-    def push_messages(self, messages: Iterable[Message]) -> Iterable[str]:
+    def push_messages(self, messages: Iterable[Message]) -> None:
         """Push messages to specified node IDs.
 
         This method takes an iterable of messages and sends each message
@@ -108,16 +108,21 @@ class Driver(ABC):
         """
 
     @abstractmethod
-    def pull_messages(self, message_ids: Iterable[str]) -> Iterable[Message]:
-        """Pull messages based on message IDs.
+    def pull_messages(
+        self, message_ids: Optional[Iterable[str]] = None
+    ) -> Iterable[Message]:
+        """Pull messages from the SuperLink.
 
-        This method is used to collect messages from the SuperLink
-        that correspond to a set of given message IDs.
+        This method is used to collect all available messages from the SuperLink.
+        If provided, it will only pull messages that correspond to a set of given
+        message IDs.
 
         Parameters
         ----------
-        message_ids : Iterable[str]
+        message_ids : Optional[Iterable[str]]
             An iterable of message IDs for which reply messages are to be retrieved.
+            If specified, the method will only pull messages that correspond to these
+            IDs. If `None`, all messages will be retrieved.
 
         Returns
         -------


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

### Checklist

- [ ] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.ai/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
