### PR TITLE
refactor(intelligence) Use engine name only in engines

### DIFF
--- a/intelligence/ts/examples/streaming/package.json
+++ b/intelligence/ts/examples/streaming/package.json
@@ -10,7 +10,7 @@
   "keywords": [],
   "author": "",
   "dependencies": {
-    "@flwr/flwr": "^0.1.3",
+    "@flwr/flwr": "file:../..",
     "cross-spawn": "^7.0.5"
   },
   "devDependencies": {

--- a/intelligence/ts/examples/streaming/package.json
+++ b/intelligence/ts/examples/streaming/package.json
@@ -10,7 +10,7 @@
   "keywords": [],
   "author": "",
   "dependencies": {
-    "@flwr/flwr": "file:../..",
+    "@flwr/flwr": "^0.1.3",
     "cross-spawn": "^7.0.5"
   },
   "devDependencies": {

--- a/intelligence/ts/src/engines/common.ts
+++ b/intelligence/ts/src/engines/common.ts
@@ -54,7 +54,7 @@ export async function getEngineModelName(model: string, engine: string): Promise
         ok: false,
         failure: {
           code: FailureCode.UnsupportedModelError,
-          description: `Model '${model}' is not supported on the webllm engine.`,
+          description: `Model '${model}' is not supported on the ${engine} engine.`,
         },
       };
     }

--- a/intelligence/ts/src/engines/common.ts
+++ b/intelligence/ts/src/engines/common.ts
@@ -22,7 +22,7 @@ interface ModelResponse {
   model: string | undefined;
 }
 
-export async function checkSupport(model: string, engine: string): Promise<Result<string>> {
+export async function getEngineModelName(model: string, engine: string): Promise<Result<string>> {
   try {
     const response = await fetch(`${REMOTE_URL}/v1/fetch-model-config`, {
       method: 'POST',

--- a/intelligence/ts/src/engines/engine.ts
+++ b/intelligence/ts/src/engines/engine.ts
@@ -35,7 +35,7 @@ export interface Engine {
     encrypt?: boolean
   ): Promise<ChatResponseResult>;
   fetchModel(model: string, callback: (progress: Progress) => void): Promise<Result<void>>;
-  isSupported(model: string): Promise<Result<string>>;
+  isSupported(model: string): Promise<boolean>;
 }
 
 export abstract class BaseEngine implements Engine {
@@ -64,11 +64,8 @@ export abstract class BaseEngine implements Engine {
     };
   }
 
-  async isSupported(_model: string): Promise<Result<string>> {
+  async isSupported(_model: string): Promise<boolean> {
     await Promise.resolve();
-    return {
-      ok: false,
-      failure: { code: FailureCode.NotImplementedError, description: 'Method not implemented.' },
-    };
+    return false;
   }
 }

--- a/intelligence/ts/src/engines/remoteEngine.ts
+++ b/intelligence/ts/src/engines/remoteEngine.ts
@@ -126,12 +126,9 @@ export class RemoteEngine extends BaseEngine {
     };
   }
 
-  async isSupported(model: string): Promise<Result<string>> {
+  async isSupported(_model: string): Promise<boolean> {
     await Promise.resolve();
-    return {
-      ok: true,
-      value: model,
-    };
+    return true;
   }
 
   private createRequestData(

--- a/intelligence/ts/src/engines/transformersEngine.ts
+++ b/intelligence/ts/src/engines/transformersEngine.ts
@@ -26,7 +26,7 @@ import type { ProgressInfo, TextGenerationConfig } from '@huggingface/transforme
 import { FailureCode, Message, Result, Progress, ChatResponseResult } from '../typing';
 
 import { BaseEngine } from './engine';
-import { checkSupport } from './common';
+import { getEngineModelName } from './common';
 
 const stoppingCriteria = new InterruptableStoppingCriteria();
 const choice = 0;
@@ -42,10 +42,20 @@ export class TransformersEngine extends BaseEngine {
     stream?: boolean,
     onStreamEvent?: (event: { chunk: string }) => void
   ): Promise<ChatResponseResult> {
+    const modelNameRes = await getEngineModelName(model, 'onnx');
+    if (!modelNameRes.ok) {
+      return {
+        ok: false,
+        failure: {
+          code: FailureCode.UnsupportedModelError,
+          description: `The model ${model} is not supported on the Transformers.js engine.`,
+        },
+      };
+    }
     try {
       if (!(model in this.generationPipelines)) {
         let options = {};
-        const modelElems = model.split('|');
+        const modelElems = modelNameRes.value.split('|');
         const modelId = modelElems[0];
         if (modelElems.length > 1) {
           options = {
@@ -126,16 +136,26 @@ export class TransformersEngine extends BaseEngine {
         ok: false,
         failure: {
           code: FailureCode.LocalEngineChatError,
-          description: `TransformersEngine failed with: ${String(error)}`,
+          description: `Transformers.js engine failed with: ${String(error)}`,
         },
       };
     }
   }
 
   async fetchModel(model: string, callback: (progress: Progress) => void): Promise<Result<void>> {
+    const modelNameRes = await getEngineModelName(model, 'onnx');
+    if (!modelNameRes.ok) {
+      return {
+        ok: false,
+        failure: {
+          code: FailureCode.UnsupportedModelError,
+          description: `The model ${model} is not supported on the Transformers.js engine.`,
+        },
+      };
+    }
     try {
       if (!(model in this.generationPipelines)) {
-        this.generationPipelines.model = await pipeline('text-generation', model, {
+        this.generationPipelines.model = await pipeline('text-generation', modelNameRes.value, {
           dtype: 'q4',
           progress_callback: (progressInfo: ProgressInfo) => {
             let percentage = 0;
@@ -169,7 +189,8 @@ export class TransformersEngine extends BaseEngine {
     }
   }
 
-  async isSupported(model: string): Promise<Result<string>> {
-    return await checkSupport(model, 'onnx');
+  async isSupported(model: string): Promise<boolean> {
+    const modelNameRes = await getEngineModelName(model, 'onnx');
+    return modelNameRes.ok;
   }
 }

--- a/intelligence/ts/src/engines/webllmEngine.ts
+++ b/intelligence/ts/src/engines/webllmEngine.ts
@@ -29,7 +29,7 @@ import {
   Tool,
 } from '../typing';
 import { BaseEngine } from './engine';
-import { checkSupport } from './common';
+import { getEngineModelName } from './common';
 
 async function runQuery(
   engine: MLCEngineInterface,
@@ -72,10 +72,20 @@ export class WebllmEngine extends BaseEngine {
     onStreamEvent?: (event: StreamEvent) => void,
     _tools?: Tool[]
   ): Promise<ChatResponseResult> {
+    const modelNameRes = await getEngineModelName(model, 'webllm');
+    if (!modelNameRes.ok) {
+      return {
+        ok: false,
+        failure: {
+          code: FailureCode.UnsupportedModelError,
+          description: `The model ${model} is not supported on the WebLLM engine.`,
+        },
+      };
+    }
     try {
       if (!(model in this.#loadedEngines)) {
         this.#loadedEngines.model = await CreateMLCEngine(
-          model,
+          modelNameRes.value,
           {},
           {
             context_window_size: 2048,
@@ -109,10 +119,20 @@ export class WebllmEngine extends BaseEngine {
   }
 
   async fetchModel(model: string, callback: (progress: Progress) => void): Promise<Result<void>> {
+    const modelNameRes = await getEngineModelName(model, 'webllm');
+    if (!modelNameRes.ok) {
+      return {
+        ok: false,
+        failure: {
+          code: FailureCode.UnsupportedModelError,
+          description: `The model ${model} is not supported on the WebLLM engine.`,
+        },
+      };
+    }
     try {
       if (!(model in this.#loadedEngines)) {
         this.#loadedEngines.model = await CreateMLCEngine(
-          model,
+          modelNameRes.value,
           {
             initProgressCallback: (report: InitProgressReport) => {
               callback({ percentage: report.progress, description: report.text });
@@ -132,7 +152,8 @@ export class WebllmEngine extends BaseEngine {
     }
   }
 
-  async isSupported(model: string): Promise<Result<string>> {
-    return await checkSupport(model, 'webllm');
+  async isSupported(model: string): Promise<boolean> {
+    const modelNameRes = await getEngineModelName(model, 'webllm');
+    return modelNameRes.ok;
   }
 }

--- a/intelligence/ts/src/flowerintelligence.test.ts
+++ b/intelligence/ts/src/flowerintelligence.test.ts
@@ -43,7 +43,7 @@ describe('FlowerIntelligence', () => {
       const getEngineRes = await fi['getEngine']('meta/llama3.2-1b/instruct-fp16', true, false);
       expect(getEngineRes.ok).toBe(true);
       if (getEngineRes.ok) {
-        expect(getEngineRes.value[0]).toBeInstanceOf(RemoteEngine);
+        expect(getEngineRes.value).toBeInstanceOf(RemoteEngine);
       }
     });
 
@@ -51,7 +51,7 @@ describe('FlowerIntelligence', () => {
       const getEngineRes = await fi['getEngine']('meta/llama3.2-1b/instruct-fp16', false, false);
       expect(getEngineRes.ok).toBe(true);
       if (getEngineRes.ok) {
-        expect(getEngineRes.value[0]).toBeInstanceOf(TransformersEngine);
+        expect(getEngineRes.value).toBeInstanceOf(TransformersEngine);
       }
     });
 
@@ -88,7 +88,7 @@ describe('FlowerIntelligence', () => {
       const chooseEngineRes = await fi['chooseLocalEngine']('meta/llama3.2-1b/instruct-fp16');
       expect(chooseEngineRes.ok).toBe(true);
       if (chooseEngineRes.ok) {
-        expect(chooseEngineRes.value[0]).toBeInstanceOf(TransformersEngine);
+        expect(chooseEngineRes.value).toBeInstanceOf(TransformersEngine);
       }
     });
   });

--- a/intelligence/ts/src/flowerintelligence.ts
+++ b/intelligence/ts/src/flowerintelligence.ts
@@ -194,7 +194,7 @@ export class FlowerIntelligence {
       return localEngineResult;
     }
 
-    return this.getOrCreateRemoteEngine();
+    return this.getOrCreateRemoteEngine(localEngineResult);
   }
 
   private async chooseLocalEngine(modelId: string): Promise<Result<Engine>> {
@@ -220,7 +220,10 @@ export class FlowerIntelligence {
     }
   }
 
-  private getOrCreateRemoteEngine(): Result<Engine> {
+  private getOrCreateRemoteEngine(localFailure?: Result<Engine>): Result<Engine> {
+    if (localFailure && !FlowerIntelligence.#remoteHandoff && !FlowerIntelligence.#apiKey) {
+      return localFailure;
+    }
     if (!FlowerIntelligence.#remoteHandoff) {
       return {
         ok: false,

--- a/intelligence/ts/src/flowerintelligence.ts
+++ b/intelligence/ts/src/flowerintelligence.ts
@@ -83,8 +83,7 @@ export class FlowerIntelligence {
     if (!engineResult.ok) {
       return engineResult;
     } else {
-      const [engine, modelId] = engineResult.value;
-      return await engine.fetchModel(modelId, callback);
+      return await engineResult.value.fetchModel(model, callback);
     }
   }
 
@@ -153,8 +152,9 @@ export class FlowerIntelligence {
       ({ messages, ...options } = inputOrOptions);
     }
 
+    const model = options.model ?? DEFAULT_MODEL;
     const engineResult = await this.getEngine(
-      options.model ?? DEFAULT_MODEL,
+      model,
       options.forceRemote ?? false,
       options.forceLocal ?? false
     );
@@ -163,10 +163,9 @@ export class FlowerIntelligence {
       return engineResult;
     }
 
-    const [engine, modelId] = engineResult.value;
-    return await engine.chat(
+    return await engineResult.value.chat(
       messages,
-      modelId,
+      model,
       options.temperature,
       options.maxCompletionTokens,
       options.stream,
@@ -180,14 +179,14 @@ export class FlowerIntelligence {
     modelId: string,
     forceRemote: boolean,
     forceLocal: boolean
-  ): Promise<Result<[Engine, string]>> {
+  ): Promise<Result<Engine>> {
     const argsResult = this.validateArgs(forceRemote, forceLocal);
     if (!argsResult.ok) {
       return argsResult;
     }
 
     if (forceRemote) {
-      return this.getOrCreateRemoteEngine(modelId);
+      return this.getOrCreateRemoteEngine();
     }
 
     const localEngineResult = await this.chooseLocalEngine(modelId);
@@ -195,18 +194,17 @@ export class FlowerIntelligence {
       return localEngineResult;
     }
 
-    return this.getOrCreateRemoteEngine(modelId);
+    return this.getOrCreateRemoteEngine();
   }
 
-  private async chooseLocalEngine(modelId: string): Promise<Result<[Engine, string]>> {
+  private async chooseLocalEngine(modelId: string): Promise<Result<Engine>> {
     const compatibleEngines = (
       await Promise.all(
         this.#availableLocalEngines.map(async (engine) => {
-          const supportedResult = await engine.isSupported(modelId);
-          return supportedResult.ok ? [engine, supportedResult.value] : null;
+          return (await engine.isSupported(modelId)) ? engine : null;
         })
       )
-    ).filter((item): item is [Engine, string] => item !== null);
+    ).filter((item): item is Engine => item !== null);
 
     if (compatibleEngines.length > 0) {
       // Currently we just select the first compatible localEngine without further check
@@ -222,7 +220,7 @@ export class FlowerIntelligence {
     }
   }
 
-  private getOrCreateRemoteEngine(modelId: string): Result<[Engine, string]> {
+  private getOrCreateRemoteEngine(): Result<Engine> {
     if (!FlowerIntelligence.#remoteHandoff) {
       return {
         ok: false,
@@ -242,7 +240,7 @@ export class FlowerIntelligence {
       };
     }
     this.#remoteEngine = this.#remoteEngine ?? new RemoteEngine(FlowerIntelligence.#apiKey);
-    return { ok: true, value: [this.#remoteEngine, modelId] };
+    return { ok: true, value: this.#remoteEngine };
   }
 
   private validateArgs(forceRemote: boolean, forceLocal: boolean): Result<void> {


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

### Checklist

- [ ] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.ai/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
