### PR TITLE
Fix small padding issue

### DIFF
--- a/intelligence/ts/examples/chat/app/page.tsx
+++ b/intelligence/ts/examples/chat/app/page.tsx
@@ -193,17 +193,15 @@ export default function ClientSideChatPage() {
 
       {/* Input Area with Model Select and Remote Handoff Toggle */}
       <div className="border-t p-4 bg-gray-50 flex items-center">
-        <select
-          value={model}
-          onChange={(e) => setModel(e.target.value)}
-          className="mr-4 p-2 border border-gray-300 rounded bg-white text-gray-800"
-        >
-          {availableModels.map((modelName) => (
-            <option key={modelName} value={modelName}>
-              {modelName}
-            </option>
-          ))}
-        </select>
+        <div className="mr-4 p-2 border border-gray-300 rounded bg-white text-gray-800">
+          <select value={model} onChange={(e) => setModel(e.target.value)}>
+            {availableModels.map((modelName) => (
+              <option key={modelName} value={modelName}>
+                {modelName}
+              </option>
+            ))}
+          </select>
+        </div>
         <label className="mr-4 flex items-center space-x-2">
           <input
             type="checkbox"


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

Improves a padding issue on macos
<img width="284" alt="image" src="https://github.com/user-attachments/assets/2e4424c5-5a6e-47db-a12b-aef3b7687864" />

instead of
<img width="286" alt="image" src="https://github.com/user-attachments/assets/cf804e01-eb16-48c1-be18-81528dd13650" />



<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

### Checklist

- [ ] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.ai/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
