### PR TITLE
ci(*) Add torch as an optional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,10 +81,13 @@ ray = { version = "==2.31.0", optional = true, python = ">=3.9,<3.13" }
 # Optional dependencies (REST transport layer)
 starlette = { version = "^0.45.2", optional = true }
 uvicorn = { version = "^0.34.0", extras = ["standard"], optional = true }
+# Optional dependencies (PyTorch)
+torch = { version = ">=1.8.0", optional = true }
 
 [tool.poetry.extras]
 simulation = ["ray"]
 rest = ["starlette", "uvicorn"]
+torch = ["torch"]
 
 [tool.poetry.group.dev.dependencies]
 types-dataclasses = "==0.6.6"


### PR DESCRIPTION
- [x] Add `torch` as an optional dependency.  
- [ ] Skip the `torch` extra when setting up the CI environment.  
- [ ] Skip the `torch` extra when setting up the development environment.  
- [ ] Skip the `torch` extra during license checking. 