### PR TITLE
fix(*:skip) Make `ruff` ignore `.gitignore`

### DIFF
--- a/framework/dev/test.sh
+++ b/framework/dev/test.sh
@@ -48,7 +48,7 @@ docsig py/flwr
 echo "- docsig:  done"
 
 echo "- ruff: start"
-python -m ruff check py/flwr
+python -m ruff check py/flwr --no-respect-gitignore
 echo "- ruff: done"
 
 echo "- mypy: start"


### PR DESCRIPTION
By default, `ruff` will respect any of the regular ignore files, like `.gitignore`. We want `ruff` to run on all files whether or not `.gitignore` is present. 