### PR TITLE
ci(framework) Assign new issues automatically to Flower dev

### DIFF
--- a/.github/workflows/auto-assign-issues.yml
+++ b/.github/workflows/auto-assign-issues.yml
@@ -1,5 +1,5 @@
 name: Auto Assign Issues
-# This workflow automatically assigns the user "WilliamLindskog" to new issues when they are opened.
+# This workflow automatically assigns "WilliamLindskog" to new issues when they are opened.
 
 on:
   issues:

--- a/.github/workflows/auto-assign-issues.yml
+++ b/.github/workflows/auto-assign-issues.yml
@@ -1,0 +1,24 @@
+name: Auto Assign Issues
+# This workflow automatically assigns the user "WilliamLindskog" to new issues when they are opened.
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign WilliamLindskog
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const currentAssignees = context.payload.issue.assignees.map(a => a.login);
+            const newAssignees = new Set([...currentAssignees, 'WilliamLindskog']);
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              assignees: Array.from(newAssignees),
+            });
+            console.log('Assigned WilliamLindskog (preserving any existing assignees)');


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue
Assign Flower dev when new issue is opened. 
### Description
We should be notified when a new issue is opened to reduce time for triaging. 
<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal
Assign @WilliamLindskog as assignee to new issue. 
### Explanation
This works even if someone is already assigned to issue, say the developer assigns themselves. More than one can be assigned and if @WilliamLindskog gets assigned when new issue opens, we can start issue process asap. 
<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

### Checklist

- [x] Implement proposed change
- [x] Write tests
- [x] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.ai/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
