### PR TITLE
feat(framework) Adding the option to pass args into `run_supernode` and `run_superlink`

### DIFF
--- a/framework/py/flwr/client/supernode/app.py
+++ b/framework/py/flwr/client/supernode/app.py
@@ -47,9 +47,17 @@ from ..app import start_client_internal
 from ..clientapp.utils import get_load_client_app_fn
 
 
-def run_supernode() -> None:
-    """Run Flower SuperNode."""
-    args = _parse_args_run_supernode().parse_args()
+def run_supernode(args: Optional[argparse.Namespace] = None) -> None:
+    """Run Flower SuperNode.
+
+    Parameters
+    ----------
+    args : Optional[argparse.Namespace]
+        The arguments to pass to the SuperNode. If not provided, the arguments will be
+        parsed from the command line.
+    """
+    if args is None:
+        args = _parse_args_run_supernode().parse_args()
 
     log(INFO, "Starting Flower SuperNode")
 

--- a/framework/py/flwr/server/app.py
+++ b/framework/py/flwr/server/app.py
@@ -266,9 +266,17 @@ def start_server(  # pylint: disable=too-many-arguments,too-many-locals
 
 
 # pylint: disable=too-many-branches, too-many-locals, too-many-statements
-def run_superlink() -> None:
-    """Run Flower SuperLink (ServerAppIo API and Fleet API)."""
-    args = _parse_args_run_superlink().parse_args()
+def run_superlink(args: Optional[argparse.Namespace] = None) -> None:
+    """Run Flower SuperLink (ServerAppIo API and Fleet API).
+
+    Parameters
+    ----------
+    args : Optional[argparse.Namespace]
+        The arguments to pass to the SuperLink. If not provided, the arguments will be
+        parsed from the command line.
+    """
+    if args is None:
+        args = _parse_args_run_superlink().parse_args()
 
     log(INFO, "Starting Flower SuperLink")
 


### PR DESCRIPTION
## Issue

### Description

It's not possible to pass arguments into `run_supernode` and `run_superlink` when calling those functions programmatically in a script as opposed to calling them from the CLI.

### Related issues/PRs

NA

## Proposal

### Explanation

Add an optional `args` parameter that will override the local arguments variable if it's passed in. This way, I can call the function in a script with any parameters needed while it still works for the regular CLI use case.

### Checklist

- [ ] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?