### PR TITLE
fix(framework) Fix FlowerTune typos in example and template

### DIFF
--- a/examples/flowertune-llm/flowertune_llm/client_app.py
+++ b/examples/flowertune-llm/flowertune_llm/client_app.py
@@ -49,7 +49,7 @@ class FlowerClient(NumPyClient):
     ):  # pylint: disable=too-many-arguments
         self.device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
         self.train_cfg = train_cfg
-        self.training_argumnets = TrainingArguments(**train_cfg.training_arguments)
+        self.training_arguments = TrainingArguments(**train_cfg.training_arguments)
         self.tokenizer = tokenizer
         self.formatting_prompts_func = formatting_prompts_func
         self.data_collator = data_collator
@@ -72,14 +72,14 @@ class FlowerClient(NumPyClient):
             self.train_cfg.learning_rate_min,
         )
 
-        self.training_argumnets.learning_rate = new_lr
-        self.training_argumnets.output_dir = config["save_path"]
+        self.training_arguments.learning_rate = new_lr
+        self.training_arguments.output_dir = config["save_path"]
 
         # Construct trainer
         trainer = SFTTrainer(
             model=self.model,
             tokenizer=self.tokenizer,
-            args=self.training_argumnets,
+            args=self.training_arguments,
             max_seq_length=self.train_cfg.seq_length,
             train_dataset=self.trainset,
             formatting_func=self.formatting_prompts_func,

--- a/framework/py/flwr/cli/new/templates/app/code/flwr_tune/client_app.py.tpl
+++ b/framework/py/flwr/cli/new/templates/app/code/flwr_tune/client_app.py.tpl
@@ -49,7 +49,7 @@ class FlowerClient(NumPyClient):
     ):  # pylint: disable=too-many-arguments
         self.device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
         self.train_cfg = train_cfg
-        self.training_argumnets = TrainingArguments(**train_cfg.training_arguments)
+        self.training_arguments = TrainingArguments(**train_cfg.training_arguments)
         self.tokenizer = tokenizer
         self.formatting_prompts_func = formatting_prompts_func
         self.data_collator = data_collator
@@ -72,14 +72,14 @@ class FlowerClient(NumPyClient):
             self.train_cfg.learning_rate_min,
         )
 
-        self.training_argumnets.learning_rate = new_lr
-        self.training_argumnets.output_dir = config["save_path"]
+        self.training_arguments.learning_rate = new_lr
+        self.training_arguments.output_dir = config["save_path"]
 
         # Construct trainer
         trainer = SFTTrainer(
             model=self.model,
             tokenizer=self.tokenizer,
-            args=self.training_argumnets,
+            args=self.training_arguments,
             max_seq_length=self.train_cfg.seq_length,
             train_dataset=self.trainset,
             formatting_func=self.formatting_prompts_func,


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->

There are typos in FlowerTune example and template `client_app.py` : `self.training_argumnets` .

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

Fixes #5271 

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

Rename `self.training_argumnets` to `self.training_arguments`

### Checklist

- [x] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

Omit.

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.ai/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
