### PR TITLE
ci(framework) Fix wheel building

### DIFF
--- a/.github/workflows/framework-e2e.yml
+++ b/.github/workflows/framework-e2e.yml
@@ -37,27 +37,22 @@ jobs:
 
   wheel:
     runs-on: ubuntu-22.04
-    needs: changes
     name: Build, test and upload wheel
     steps:
       - uses: actions/checkout@v4
       - name: Bootstrap
-        if: ${{ needs.changes.outputs.framework == 'true' }}
         uses: ./.github/actions/bootstrap
       - name: Install dependencies (mandatory only)
-        if: ${{ needs.changes.outputs.framework == 'true' }}
         run: |
           cd framework
           python -m poetry install --all-extras
           python -m pip install -U setuptools==70.3.0
       - name: Build wheel
-        if: ${{ needs.changes.outputs.framework == 'true' }}
         run: ./framework/dev/build.sh
       - name: Test wheel
-        if: ${{ needs.changes.outputs.framework == 'true' }}
         run: ./framework/dev/test-wheel.sh
       - name: Upload wheel
-        if: ${{ needs.changes.outputs.framework == 'true' && github.repository == 'adap/flower' && !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
+        if: ${{ github.repository == 'adap/flower' && !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
         id: upload
         env:
           AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

Currently, we run the wheel building and uploading only on framework changes, this can break the release process, as the process requires the artifacts from the latest commit on main in order to work, and if the latest commit didn't contain any framework changes, this won't work.

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

### Checklist

- [ ] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.ai/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
