### PR TITLE
refactor(framework:skip) Update the release date for `v1.18.0`

### DIFF
--- a/framework/docs/source/ref-changelog.md
+++ b/framework/docs/source/ref-changelog.md
@@ -56,7 +56,7 @@ We would like to give our special thanks to all the contributors who made the ne
 
   Restructures the Flower repository by moving all framework-related code, configs, and dev tools into the `framework/` subdirectory. This includes relocating all files under `src/`, dev scripts, `pyproject.toml` and other configs. Contributor documentation has been updated to reflect these changes.
 
-  Switching to the new structure is straightforward and should require only minimal adjustments for most contributors, though this is a breaking change—refer to the [contributor guide](https://flower.ai/docs/framework/v1.17.0/en/contribute.html) for updated instructions.
+  Switching to the new structure is straightforward and should require only minimal adjustments for most contributors, though this is a breaking change—refer to the [contributor guide](https://flower.ai/docs/framework/v1.18.0/en/contribute.html) for updated instructions.
 
 ## v1.17.0 (2025-03-24)
 

--- a/framework/docs/source/ref-changelog.md
+++ b/framework/docs/source/ref-changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v1.18.0 (2025-04-22)
+## v1.18.0 (2025-04-23)
 
 ### Thanks to our contributors
 


### PR DESCRIPTION
This PR also fixes the URL in the last item. The URL should point to the `v1.18.0` version doc (not exist until release.)