### PR TITLE
refactor(framework) Modify `flwr build` command to build FAB in flwr directory

### DIFF
--- a/.github/workflows/framework-e2e.yml
+++ b/.github/workflows/framework-e2e.yml
@@ -381,7 +381,7 @@ jobs:
           flwr new tmp-${{ matrix.framework }} --framework ${{ matrix.framework }} --username gh_ci
           cd tmp-${{ matrix.framework }}
           flwr build
-          flwr install *.fab
+          flwr install $HOME/.flwr/*.fab
 
   numpy:
     runs-on: ubuntu-22.04

--- a/framework/py/flwr/cli/build.py
+++ b/framework/py/flwr/cli/build.py
@@ -172,16 +172,16 @@ def build(
 
     # Set the name of the zip file
     fab_filename = get_fab_filename(conf, fab_hash)
-    final_path = os.path.join(build_dir, fab_filename)
+    fab_final_path = os.path.join(build_dir, fab_filename)
 
     # Once the temporary zip file is created, rename it to the final filename
-    shutil.move(temp_filename, final_path)
+    shutil.move(temp_filename, fab_final_path)
 
     typer.secho(
         f"🎊 Successfully built {fab_filename}", fg=typer.colors.GREEN, bold=True
     )
 
-    return final_path, fab_hash
+    return fab_final_path, fab_hash
 
 
 def _load_gitignore(app: Path) -> pathspec.PathSpec:

--- a/framework/py/flwr/cli/build.py
+++ b/framework/py/flwr/cli/build.py
@@ -76,7 +76,7 @@ def build(
 
         ``flwr build --app ./apps/flower-hello-world --flwr-dir ./docs/flwr``
 
-    This will install ``flower-hello-world`` to ``./docs/flwr/``. By default,
+    This will build ``flower-hello-world`` to ``./docs/flwr/``. By default,
     ``flwr-dir`` is equal to:
 
         - ``$FLWR_HOME/`` if ``$FLWR_HOME`` is defined

--- a/framework/py/flwr/cli/build.py
+++ b/framework/py/flwr/cli/build.py
@@ -130,7 +130,9 @@ def build(
 
     toml_contents = tomli_w.dumps(conf)
 
-    with tempfile.NamedTemporaryFile(suffix=".zip", delete=False, dir=build_dir) as temp_file:
+    with tempfile.NamedTemporaryFile(
+        suffix=".zip", delete=False, dir=build_dir
+    ) as temp_file:
         temp_filename = temp_file.name
 
         with zipfile.ZipFile(temp_filename, "w", zipfile.ZIP_DEFLATED) as fab_file:

--- a/framework/py/flwr/cli/build.py
+++ b/framework/py/flwr/cli/build.py
@@ -71,6 +71,17 @@ def build(
     option to bundle an app located at the provided path. For example:
 
     ``flwr build --app ./apps/flower-hello-world``.
+
+    The target build directory can be specified with ``--flwr-dir``:
+
+        ``flwr build --app ./apps/flower-hello-world --flwr-dir ./docs/flwr``
+
+    This will install ``flower-hello-world`` to ``./docs/flwr/``. By default,
+    ``flwr-dir`` is equal to:
+
+        - ``$FLWR_HOME/`` if ``$FLWR_HOME`` is defined
+        - ``$XDG_DATA_HOME/.flwr/`` if ``$XDG_DATA_HOME`` is defined
+        - ``$HOME/.flwr/`` in all other cases
     """
     build_dir = get_flwr_dir() if not flwr_dir else flwr_dir
     build_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Issue
Currently, `flwr build` (and as an extension, `flwr run`) will build a temp `.zip` file in `/tmp/` and then copy the contents to a `.fab` file in the current working directory. This is generally not an issue, but it becomes an issue when trying to run in a TEE (i.e. a Intel(R) SGX enclave) which has strict trusted/allowed files. 

While the list of trusted/allowed files can theoretically be extended to accommodate, the best practice is to minimize where an app has read/write permissions. This is addressed by enabling the build command to build in the `flwr-dir`. This also makes it more consistent with other `flwr` CLI commands that make use of `get_flwr_dir`

### Description
This PR:
- uses the existing `get_flwr_dir()` command to retrieve flwr-dir and sets it as the build directory
- adds an optional flag to `flwr build` to accept `--flwr-dir` if running as CLI with expanded docstring
- builds both the temp `.zip` and `.fab` files in this build directory
- returns the full path since `flwr run` uses the full path
- updates `.github/workflows/framework-e2e.yml` to install from `$HOME/.flwr`

### Potential open
- Changes to CI/CD, needed to update the framework-e2e.yml to install from `$HOME/.flwr` to reflect the new changes. 
      - **Is it preferrable to install in current working dir if `flwr-dir` is not specified instead of defaulting to `$HOME/.flwr`?**
- This PR does not modify `flwr run` so only `app` is being passed through build when building/installing via `flwr run` [[ref](https://github.com/adap/flower/blob/main/framework/py/flwr/cli/run/run.py#L161)]. By design, this will then follow the standard path (i.e. `$FLWR_HOME/`, `$HOME/.flwr`, etc)


