### PR TITLE
ci(framework) Remove declaring const fetch, already in actions github-script v6

### DIFF
--- a/.github/workflows/ping-stale-under-discussion.yml
+++ b/.github/workflows/ping-stale-under-discussion.yml
@@ -19,7 +19,6 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const fetch = require("node-fetch");
 
             const owner = context.repo.owner;
             const repo = context.repo.repo;


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue
Can't dispatch workflow "Ping Stale Under Discussion Issues"
### Description
It is caused by already having declared it in `actions/github-issues@v6` workflow. 
<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->

### Related issues/PRs
#5257 
<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal
Remove `const fetch = require("node-fetch");` since it causes `SyntaxError: Identifier 'fetch' has already been declared`
### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

### Checklist

- [x] Implement proposed change
- [x] Write tests
- [x] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.ai/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
