### PR TITLE
refactor(examples) Bump version of `torch` and `torchvision` used in examples

### DIFF
--- a/examples/advanced-pytorch/pyproject.toml
+++ b/examples/advanced-pytorch/pyproject.toml
@@ -10,8 +10,8 @@ license = "Apache-2.0"
 dependencies = [
     "flwr[simulation]>=1.18.0",
     "flwr-datasets[vision]>=0.5.0",
-    "torch==2.5.1",
-    "torchvision==0.20.1",
+    "torch==2.6.0",
+    "torchvision==0.21.0",
     "wandb==0.17.8",
 ]
 

--- a/examples/app-pytorch/pyproject.toml
+++ b/examples/app-pytorch/pyproject.toml
@@ -10,8 +10,8 @@ license = "Apache-2.0"
 dependencies = [
     "flwr[simulation]>=1.18.0",
     "flwr-datasets[vision]>=0.5.0",
-    "torch==2.5.1",
-    "torchvision==0.20.1",
+    "torch==2.6.0",
+    "torchvision==0.21.0",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/examples/embedded-devices/pyproject.toml
+++ b/examples/embedded-devices/pyproject.toml
@@ -10,8 +10,8 @@ license = "Apache-2.0"
 dependencies = [
     "flwr>=1.15.2",
     "flwr-datasets[vision]>=0.5.0",
-    "torch==2.5.1",
-    "torchvision==0.20.1",
+    "torch==2.6.0",
+    "torchvision==0.21.0",
 ]
 
 [tool.hatch.build]

--- a/examples/fl-dp-sa/pyproject.toml
+++ b/examples/fl-dp-sa/pyproject.toml
@@ -10,8 +10,8 @@ license = "Apache-2.0"
 dependencies = [
     "flwr[simulation]>=1.18.0",
     "flwr-datasets[vision]>=0.5.0",
-    "torch==2.5.1",
-    "torchvision==0.20.1",
+    "torch==2.6.0",
+    "torchvision==0.21.0",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/examples/fl-tabular/pyproject.toml
+++ b/examples/fl-tabular/pyproject.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 dependencies = [
     "flwr[simulation]>=1.18.0",
     "flwr-datasets>=0.5.0",
-    "torch==2.5.1",
+    "torch==2.6.0",
     "scikit-learn==1.6.1",
 ]
 

--- a/examples/flower-secure-aggregation/pyproject.toml
+++ b/examples/flower-secure-aggregation/pyproject.toml
@@ -10,8 +10,8 @@ license = "Apache-2.0"
 dependencies = [
     "flwr[simulation]>=1.18.0",
     "flwr-datasets[vision]>=0.5.0",
-    "torch==2.5.1",
-    "torchvision==0.20.1",
+    "torch==2.6.0",
+    "torchvision==0.21.0",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/examples/flower-simulation-step-by-step-pytorch/my-awesome-app/pyproject.toml
+++ b/examples/flower-simulation-step-by-step-pytorch/my-awesome-app/pyproject.toml
@@ -10,8 +10,8 @@ license = "Apache-2.0"
 dependencies = [
     "flwr[simulation]>=1.15.2",
     "flwr-datasets[vision]>=0.5.0",
-    "torch==2.5.1",
-    "torchvision==0.20.1",
+    "torch==2.6.0",
+    "torchvision==0.21.0",
     "wandb",
 ]
 

--- a/examples/flowertune-vit/pyproject.toml
+++ b/examples/flowertune-vit/pyproject.toml
@@ -10,8 +10,8 @@ license = "Apache-2.0"
 dependencies = [
     "flwr[simulation]>=1.18.0",
     "flwr-datasets[vision]>=0.5.0",
-    "torch==2.5.1",
-    "torchvision==0.20.1",
+    "torch==2.6.0",
+    "torchvision==0.21.0",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/examples/opacus/pyproject.toml
+++ b/examples/opacus/pyproject.toml
@@ -10,8 +10,8 @@ description = "Sample-level Differential Privacy with Opacus in Flower"
 dependencies = [
     "flwr[simulation]>=1.18.0",
     "flwr-datasets[vision]>=0.5.0",
-    "torch==2.5.1",
-    "torchvision==0.20.1",
+    "torch==2.6.0",
+    "torchvision==0.21.0",
     "opacus==v1.4.1",
 ]
 

--- a/examples/pytorch-federated-variational-autoencoder/pyproject.toml
+++ b/examples/pytorch-federated-variational-autoencoder/pyproject.toml
@@ -10,8 +10,8 @@ license = "Apache-2.0"
 dependencies = [
     "flwr[simulation]>=1.18.0",
     "flwr-datasets[vision]>=0.5.0",
-    "torch==2.5.1",
-    "torchvision==0.20.1",
+    "torch==2.6.0",
+    "torchvision==0.21.0",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/examples/quickstart-fastai/pyproject.toml
+++ b/examples/quickstart-fastai/pyproject.toml
@@ -11,8 +11,8 @@ dependencies = [
     "flwr[simulation]>=1.18.0",
     "flwr-datasets[vision]>=0.5.0",
     "fastai==2.7.18",
-    "torch==2.5.1",
-    "torchvision==0.20.1",
+    "torch==2.6.0",
+    "torchvision==0.21.0",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/examples/quickstart-pytorch-lightning/pyproject.toml
+++ b/examples/quickstart-pytorch-lightning/pyproject.toml
@@ -12,8 +12,8 @@ dependencies = [
     "flwr-datasets[vision]>=0.5.0",
     "pytorch-lightning<2.0.0; sys_platform == 'darwin'",
     "pytorch-lightning==2.4.0; sys_platform != 'darwin'",
-    "torch==2.5.1",
-    "torchvision==0.20.1",
+    "torch==2.6.0",
+    "torchvision==0.21.0",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/examples/quickstart-pytorch/pyproject.toml
+++ b/examples/quickstart-pytorch/pyproject.toml
@@ -10,8 +10,8 @@ license = "Apache-2.0"
 dependencies = [
     "flwr[simulation]>=1.18.0",
     "flwr-datasets[vision]>=0.5.0",
-    "torch==2.5.1",
-    "torchvision==0.20.1",
+    "torch==2.6.0",
+    "torchvision==0.21.0",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/examples/vertical-fl/pyproject.toml
+++ b/examples/vertical-fl/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "pandas==2.2.3",
     "numpy>=1.26.0",
     "scikit-learn==1.5.0",
-    "torch==2.5.1",
+    "torch==2.6.0",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/examples/whisper-federated-finetuning/pyproject.toml
+++ b/examples/whisper-federated-finetuning/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "flwr[simulation]>=1.18.0",
     "flwr-datasets[audio]>=0.5.0",
     "transformers==4.48.0",
-    "torch==2.5.1",
+    "torch==2.6.0",
 ]
 
 [tool.hatch.build.targets.wheel]


### PR DESCRIPTION
To address vulnerabilities found in `torch < 2.6.0`