### PR TITLE
refactor(framework) Set upper limit for `click`

### DIFF
--- a/framework/pyproject.toml
+++ b/framework/pyproject.toml
@@ -76,7 +76,7 @@ pathspec = "^0.12.1"
 rich = "^13.5.0"
 pyyaml = "^6.0.2"
 requests = "^2.31.0"
-click = <8.2.0"
+click = "<8.2.0"
 # Optional dependencies (Simulation Engine)
 ray = { version = "==2.31.0", optional = true, python = ">=3.9,<3.13" }
 # Optional dependencies (REST transport layer)

--- a/framework/pyproject.toml
+++ b/framework/pyproject.toml
@@ -76,6 +76,7 @@ pathspec = "^0.12.1"
 rich = "^13.5.0"
 pyyaml = "^6.0.2"
 requests = "^2.31.0"
+click = "<=8.1.8"
 # Optional dependencies (Simulation Engine)
 ray = { version = "==2.31.0", optional = true, python = ">=3.9,<3.13" }
 # Optional dependencies (REST transport layer)

--- a/framework/pyproject.toml
+++ b/framework/pyproject.toml
@@ -76,7 +76,7 @@ pathspec = "^0.12.1"
 rich = "^13.5.0"
 pyyaml = "^6.0.2"
 requests = "^2.31.0"
-click = "<=8.1.8"
+click = <8.2.0"
 # Optional dependencies (Simulation Engine)
 ray = { version = "==2.31.0", optional = true, python = ">=3.9,<3.13" }
 # Optional dependencies (REST transport layer)


### PR DESCRIPTION
The latest version of `click` isn't compatible with the latest of `type`. We se an upper limit for `click`.