### PR TITLE
Update Embedded Device Example for Latest Jetson Compatibility

### DIFF
--- a/examples/embedded-devices/Dockerfile
+++ b/examples/embedded-devices/Dockerfile
@@ -1,0 +1,20 @@
+# NVIDIA JetPack 6.0 기반 이미지 사용
+FROM nvcr.io/nvidia/l4t-base:r36.2.0
+
+# 필수 패키지 업데이트 및 설치
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get install -y python3-pip python3-dev git && \
+    rm -rf /var/lib/apt/lists/*
+
+# Python 패키지 업데이트
+RUN pip3 install --upgrade pip
+
+# Flower 및 기타 필요한 Python 패키지 설치
+RUN pip3 install flwr
+
+RUN pip3 install flwr>=1.0
+RUN pip3 install flwr-datasets>=0.0.2
+RUN pip3 install tqdm==4.65.0
+
+# 작업 디렉토리 설정
+WORKDIR /client

--- a/examples/embedded-devices/README.md
+++ b/examples/embedded-devices/README.md
@@ -6,7 +6,7 @@ framework: [torch]
 
 # Federated AI with Embedded Devices using Flower
 
-This example will show you how Flower makes it very easy to run Federated Learning workloads on edge devices. Here we'll be showing how to use **NVIDIA Jetson devices and** Raspberry Pi as Flower clients, or better said, `SuperNodes`.  The FL workload (i.e. model, dataset and training loop) is mostly borrowed from the [quickstart-pytorch](https://github.com/adap/flower/tree/main/examples/simulation-pytorch) example, but you could adjust it to follow [quickstart-tensorflow](https://github.com/adap/flower/tree/main/examples/quickstart-tensorflow) if you prefere using TensorFlow. The main difference compare to those examples is that here you'll learn how to use Flower's Deployment Engine to run FL across multiple embedded devices.
+This example will show you how Flower makes it very easy to run Federated Learning workloads on edge devices. Here we'll be showing how to use NVIDIA Jetson devices and Raspberry Pi as Flower clients, or better said, `SuperNodes`.  The FL workload (i.e. model, dataset and training loop) is mostly borrowed from the [quickstart-pytorch](https://github.com/adap/flower/tree/main/examples/simulation-pytorch) example, but you could adjust it to follow [quickstart-tensorflow](https://github.com/adap/flower/tree/main/examples/quickstart-tensorflow) if you prefere using TensorFlow. The main difference compare to those examples is that here you'll learn how to use Flower's Deployment Engine to run FL across multiple embedded devices.
 
 ![Different was of running Flower FL on embedded devices](_static/diagram.png)
 
@@ -18,8 +18,8 @@ This example will show you how Flower makes it very easy to run Federated Learni
 This tutorial allows for a variety of settings (some shown in the diagrams above). As long as you have access to one embedded device, you can follow along. This is a list of components that you'll need:
 
 - For Flower server: A machine running Linux/macOS (e.g. your laptop). You can run the server on an embedded device too!
-- For Flower clients (one or more): Raspberry Pi 5 or 4 (or Zero 2), **or an NVIDIA Jetson Orin NX,** or anything similar to these.
-- A uSD card with 32GB or more. **While 32GB is enough for the RPi, a larger 64GB uSD card works best for the NVIDIA Jetson.**
+- For Flower clients (one or more): Raspberry Pi 5 or 4 (or Zero 2), or an NVIDIA Jetson Orin NX, or anything similar to these.
+- A uSD card with 32GB or more. While 32GB is enough for the RPi, a larger 64GB uSD card works best for the NVIDIA Jetson.
 - Software to flash the images to a uSD card:
   - For Raspberry Pi we recommend the [Raspberry Pi Imager](https://www.raspberrypi.com/software/)
   - For other devices [balenaEtcher](https://www.balena.io/etcher/) it's a great option.

--- a/examples/embedded-devices/build_jetson_flower_client.sh
+++ b/examples/embedded-devices/build_jetson_flower_client.sh
@@ -1,0 +1,33 @@
+# Depending on your choice of ML framework (TF or PyTorch), the appropiate
+# base image from NVIDIA will be pulled. This ensures you get the best
+# performance out of your Jetson device.
+
+BASE_PYTORCH=dustynv/l4t-pytorch:r36.2.0
+BASE_TF=dustynv/l4t-tensorflow:tf2-r36.2.0
+EXTRA=""
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -p|--pytorch)
+      BASE_IMAGE=$BASE_PYTORCH
+      shift
+      ;;
+    -t|--tensorflow)
+      BASE_IMAGE=$BASE_TF
+      shift
+      ;;
+    -r|--no-cache)
+      EXTRA="--no-cache"
+      shift
+      ;;
+    -*|--*)
+      echo "Unknown option $1 (pass either --pytorch or --tensorflow)"
+      exit 1
+      ;;
+  esac
+done
+
+DOCKER_BUILDKIT=${BUILDKIT} docker build $EXTRA \
+                                        --build-arg BASE_IMAGE=$BASE_IMAGE \
+                                        . \
+                                        -t flower_client:latest


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

Recent versions of Flower removed prior documentation related to Jetson devices. This PR reintroduces support and guidance for running Flower on embedded platforms by providing an updated example tailored to Jetson Orin NX with JetPack 6.0.

The lack of up-to-date instructions for recent Jetson hardware (e.g., reComputer J4012)  has made it difficult for users to deploy Flower in real embedded use cases. This change addresses that gap.


### Related issues/PRs

#4399 

## Proposal


### Explanation

This PR:

- Adds updated setup instructions for Jetson Orin NX (tested on JetPack 6.0)
- Rewrites the embedded device section in the documentation for clarity and consistency
- Rewrites a `Dockerfile` and accompanying shell script (`build_jetson_flower_client.sh`) to streamline building Flower client images using NVIDIA’s Jetson-optimized base images (e.g., DustyNV containers)
- Ensures compatibility with PyTorch >= 2.0.0 and recent container runtime environments (with `--runtime nvidia`)
- Uses Seeed Studio’s flashing method as a reference for setting up the reComputer J4012

Together, these updates make it easier for users to deploy Flower on newer Jetson devices using officially supported tools and containers.


### Checklist

- [x] Implement proposed change
- [ ] Write tests
- [x] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [x] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

The example was tested on Jetson Orin NX (reComputer J4012). Feedback on extending this to other Jetson devices is welcome.
