### PR TITLE
fix(baselines) Upgrade torch versions

### DIFF
--- a/baselines/fedbn/pyproject.toml
+++ b/baselines/fedbn/pyproject.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 dependencies = [
     "flwr[simulation]==1.17.0",
     "flwr-datasets[vision]>=0.5.0",
-    "torch>=2.6.0",
+    "torch==2.6.0",
     "torchvision==0.21.0",
 ]
 

--- a/baselines/fedbn/pyproject.toml
+++ b/baselines/fedbn/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "flwr[simulation]==1.17.0",
     "flwr-datasets[vision]>=0.5.0",
     "torch>=2.6.0",
-    "torchvision>=0.21.0",
+    "torchvision==0.21.0",
 ]
 
 [tool.hatch.metadata]

--- a/baselines/fedbn/pyproject.toml
+++ b/baselines/fedbn/pyproject.toml
@@ -10,8 +10,8 @@ license = "Apache-2.0"
 dependencies = [
     "flwr[simulation]==1.17.0",
     "flwr-datasets[vision]>=0.5.0",
-    "torch==2.5.1",
-    "torchvision==0.20.1",
+    "torch>=2.6.0",
+    "torchvision>=0.21.0",
 ]
 
 [tool.hatch.metadata]

--- a/baselines/feddebug/pyproject.toml
+++ b/baselines/feddebug/pyproject.toml
@@ -41,7 +41,7 @@ python = ">=3.8.15, <3.12.0"  # don't change this
 flwr = { extras = ["simulation"], version = "1.9.0" }
 hydra-core = "1.3.2" # don't change this
 torch = ">=2.6.0"
-torchvision = "0.19.0"
+torchvision = ">=0.21.0"
 flwr-datasets = "0.3.0"
 
 [tool.poetry.dev-dependencies]

--- a/baselines/feddebug/pyproject.toml
+++ b/baselines/feddebug/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
 python = ">=3.8.15, <3.12.0"  # don't change this
 flwr = { extras = ["simulation"], version = "1.9.0" }
 hydra-core = "1.3.2" # don't change this
-torch = "2.4.0"
+torch = ">=2.6.0"
 torchvision = "0.19.0"
 flwr-datasets = "0.3.0"
 

--- a/baselines/feddebug/pyproject.toml
+++ b/baselines/feddebug/pyproject.toml
@@ -40,8 +40,8 @@ classifiers = [
 python = ">=3.8.15, <3.12.0"  # don't change this
 flwr = { extras = ["simulation"], version = "1.9.0" }
 hydra-core = "1.3.2" # don't change this
-torch = ">=2.6.0"
-torchvision = ">=0.21.0"
+torch = "2.6.0"
+torchvision = "0.21.0"
 flwr-datasets = "0.3.0"
 
 [tool.poetry.dev-dependencies]

--- a/baselines/fedprox/pyproject.toml
+++ b/baselines/fedprox/pyproject.toml
@@ -10,8 +10,8 @@ license = "Apache-2.0"
 dependencies = [
     "flwr[simulation]>=1.15.2",
     "flwr-datasets[vision]>=0.5.0",
-    "torch>=2.6.0",
-    "torchvision>=0.21.0",
+    "torch==2.6.0",
+    "torchvision==0.21.0",
     "easydict==1.11"
 ]
 

--- a/baselines/fedprox/pyproject.toml
+++ b/baselines/fedprox/pyproject.toml
@@ -10,8 +10,8 @@ license = "Apache-2.0"
 dependencies = [
     "flwr[simulation]>=1.15.2",
     "flwr-datasets[vision]>=0.5.0",
-    "torch==2.5.1",
-    "torchvision==0.20.1",
+    "torch>=2.6.0",
+    "torchvision>=0.21.0",
     "easydict==1.11"
 ]
 

--- a/baselines/fedrep/pyproject.toml
+++ b/baselines/fedrep/pyproject.toml
@@ -10,8 +10,8 @@ license = "Apache-2.0"
 dependencies = [
     "flwr[simulation]>=1.13.1",
     "flwr-datasets[vision]>=0.4.0",
-    "torch>=2.6.0",
-    "torchvision>=0.21.0",
+    "torch==2.6.0",
+    "torchvision==0.21.0",
 ]
 
 [tool.hatch.metadata]

--- a/baselines/fedrep/pyproject.toml
+++ b/baselines/fedrep/pyproject.toml
@@ -10,8 +10,8 @@ license = "Apache-2.0"
 dependencies = [
     "flwr[simulation]>=1.13.1",
     "flwr-datasets[vision]>=0.4.0",
-    "torch==2.4.0",
-    "torchvision==0.19.0",
+    "torch>=2.6.0",
+    "torchvision>=0.21.0",
 ]
 
 [tool.hatch.metadata]

--- a/baselines/fjord/pyproject.toml
+++ b/baselines/fjord/pyproject.toml
@@ -44,8 +44,8 @@ matplotlib = "3.7.1"
 coloredlogs = "15.0.1"
 omegaconf = "2.3.0"
 tqdm = "4.66.3"
-torch = { url = "https://download.pytorch.org/whl/cu118/torch-2.2.0%2Bcu118-cp310-cp310-linux_x86_64.whl" }
-torchvision = { url = "https://download.pytorch.org/whl/cu118/torchvision-0.17.0%2Bcu118-cp310-cp310-linux_x86_64.whl" }
+torch = ">=2.6.0"
+torchvision = ">=0.21.0"
 
 [tool.poetry.dev-dependencies]
 isort = "==5.13.2"

--- a/baselines/fjord/pyproject.toml
+++ b/baselines/fjord/pyproject.toml
@@ -44,8 +44,8 @@ matplotlib = "3.7.1"
 coloredlogs = "15.0.1"
 omegaconf = "2.3.0"
 tqdm = "4.66.3"
-torch = ">=2.6.0"
-torchvision = ">=0.21.0"
+torch = "2.6.0"
+torchvision = "0.21.0"
 
 [tool.poetry.dev-dependencies]
 isort = "==5.13.2"

--- a/baselines/fjord/requirements.txt
+++ b/baselines/fjord/requirements.txt
@@ -2,6 +2,6 @@ coloredlogs==15.0.1
 hydra-core==1.3.2
 flwr[simulation]==1.5.0
 omegaconf==2.3.0
-torch==2.4.0
-torchvision==0.19.0
+torch==2.6.0
+torchvision==0.21.0
 tqdm==4.66.3

--- a/baselines/hfedxgboost/pyproject.toml
+++ b/baselines/hfedxgboost/pyproject.toml
@@ -40,12 +40,12 @@ classifiers = [
 python = ">=3.10.0, <3.11.0"  # don't change this
 flwr = { extras = ["simulation"], version = "1.5.0" }
 hydra-core = "1.3.2" # don't change this
-torch = ">=2.6.0"
+torch = "2.6.0"
 scikit-learn = "1.5.0"
 xgboost = "2.0.0"
 torchmetrics = "1.1.2"
 tqdm = "4.66.3"
-torchvision = ">=0.21.0"
+torchvision = "0.21.0"
 wandb = "0.15.12"
 
 [tool.poetry.dev-dependencies]

--- a/baselines/hfedxgboost/pyproject.toml
+++ b/baselines/hfedxgboost/pyproject.toml
@@ -40,12 +40,12 @@ classifiers = [
 python = ">=3.10.0, <3.11.0"  # don't change this
 flwr = { extras = ["simulation"], version = "1.5.0" }
 hydra-core = "1.3.2" # don't change this
-torch = "2.5.1"
+torch = ">=2.6.0"
 scikit-learn = "1.5.0"
 xgboost = "2.0.0"
 torchmetrics = "1.1.2"
 tqdm = "4.66.3"
-torchvision = "0.20.1"
+torchvision = ">=0.21.0"
 wandb = "0.15.12"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
## Issue

### Description

Upgrade of `torch` (and `torchvision` if present) to 2.6 (and 0.21.0) as lower versions ( `torch< 2.6`) have a critical security vulnerability.

### Related issues/PRs
n/a
## Proposal

### Explanation
Bumping to correct versions in the relevant `pyproject.toml` files.

### Checklist

- [x] Implement proposed change
- [x] Write tests
- [x] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?
n/a