### PR TITLE
docs(framework) Fix paths in docker docs

### DIFF
--- a/framework/docs/source/docker/run-quickstart-examples-docker-compose.rst
+++ b/framework/docs/source/docker/run-quickstart-examples-docker-compose.rst
@@ -37,13 +37,13 @@ Run the Quickstart Example
             && rm -rf flower && cd quickstart-pytorch
 
 2. Download the `compose.yml
-   <https://github.com/adap/flower/blob/main/src/docker/complete/compose.yml>`_ file
-   into the example directory:
+   <https://github.com/adap/flower/tree/main/framework/docker/complete/compose.yml>`_
+   file into the example directory:
 
    .. code-block:: bash
        :substitutions:
 
-       $ curl https://raw.githubusercontent.com/adap/flower/refs/tags/v|stable_flwr_version|/src/docker/complete/compose.yml \
+       $ curl https://raw.githubusercontent.com/adap/flower/refs/tags/v|stable_flwr_version|/framework/docker/complete/compose.yml \
            -o compose.yml
 
 3. Export the version of Flower that your environment uses. Then, build and start the

--- a/framework/docs/source/docker/run-quickstart-examples-docker-compose.rst
+++ b/framework/docs/source/docker/run-quickstart-examples-docker-compose.rst
@@ -37,7 +37,7 @@ Run the Quickstart Example
             && rm -rf flower && cd quickstart-pytorch
 
 2. Download the `compose.yml
-   <https://github.com/adap/flower/tree/main/framework/docker/complete/compose.yml>`_
+   <https://github.com/adap/flower/blob/main/framework/docker/complete/compose.yml>`_
    file into the example directory:
 
    .. code-block:: bash

--- a/framework/docs/source/docker/tutorial-deploy-on-multiple-machines.rst
+++ b/framework/docs/source/docker/tutorial-deploy-on-multiple-machines.rst
@@ -45,7 +45,7 @@ Step 1: Set Up
        :substitutions:
 
        $ git clone --depth=1 --branch v|stable_flwr_version| https://github.com/adap/flower.git
-       $ cd flower/src/docker/distributed
+       $ cd flower/framework/docker/distributed
 
 2. Get the IP address from the remote machine and save it for later.
 3. Use the ``certs.yml`` Compose file to generate your own self-signed certificates. If
@@ -149,7 +149,7 @@ Here, we have named our remote federation ``remote-deployment``:
 
     [tool.flwr.federations.remote-deployment]
     address = "192.168.2.33:9093"
-    root-certificates = "../../src/docker/distributed/superlink-certificates/ca.crt"
+    root-certificates = "../../framework/docker/distributed/superlink-certificates/ca.crt"
 
 .. note::
 

--- a/framework/docs/source/docker/tutorial-quickstart-docker-compose.rst
+++ b/framework/docs/source/docker/tutorial-quickstart-docker-compose.rst
@@ -31,7 +31,7 @@ Step 1: Set Up
        :substitutions:
 
        $ git clone --depth=1 --branch v|stable_flwr_version| https://github.com/adap/flower.git _tmp \
-                   && mv _tmp/src/docker/complete . \
+                   && mv _tmp/framework/docker/complete . \
                    && rm -rf _tmp && cd complete
 
 2. Create a new Flower project (PyTorch):


### PR DESCRIPTION
Updated `src/` to `framework/` to reflect the latest(?) change in the repo.