### PR TITLE
refactor(docs) Extend table comparing `Simulation` vs `Deployment` runtimes

### DIFF
--- a/framework/docs/source/ref-simulation-deployment-runtimes.rst
+++ b/framework/docs/source/ref-simulation-deployment-runtimes.rst
@@ -12,8 +12,9 @@ executing the `flwr run` command via the `Flower CLI <ref-api-cli.html>`_.
 
 While Flower Apps can run in both simulation and deployment without making changes to
 their code, there are some differences on how they get executed depending on the
-runtime. The following table outlines the key characteristics that differentiate
-simulated Flower federations from deployed ones.
+runtime. The following table outlines the key characteristics that differ when executing
+a Flower App in a Flower federation with the simulation runtime from another using the
+deployment runtime.
 
 .. list-table::
     :widths: 15 25 25
@@ -47,8 +48,8 @@ simulated Flower federations from deployed ones.
       - In-memory communication.
       - TLS-enabled gRPC.
     - - **Server-side Infrastructure**
-      - Simulation runtime coordinates the spawning of multiple workers (Python process) which
-        act as `simulated` SuperNodes. There is no SuperLink.
+      - Simulation runtime coordinates the spawning of multiple workers (Python process)
+        which act as `simulated` SuperNodes. There is no SuperLink.
       - The SuperLink awaits for SuperNodes to connect. User interface with the
         SuperLink using the `Flower CLI <ref-api-cli.html>`_.
     - - **Server-side App execution**

--- a/framework/docs/source/ref-simulation-deployment-runtimes.rst
+++ b/framework/docs/source/ref-simulation-deployment-runtimes.rst
@@ -28,7 +28,7 @@ simulated Flower federations from deployed ones.
       - Deploy validated use cases in production, real-world privacy-preserving
         applications.
     - - **Environment**
-      - Local or remote, standalone, controlled.
+      - Local or remote, single-node or multi-node, controlled.
       - Distributed, remote.
     - - **Data**
       - Simulated data partitions, public or private datasets or artificially generated

--- a/framework/docs/source/ref-simulation-deployment-runtimes.rst
+++ b/framework/docs/source/ref-simulation-deployment-runtimes.rst
@@ -44,11 +44,11 @@ simulated Flower federations from deployed ones.
       - Parallel execution mode across a network of physical machines/devices or
         computing environment.
     - - **Communication**
-      - Managed via in-memory communication.
-      - Managed via Flower Deployment Runtime through TLS-enabled gRPC.
+      - In-memory communication.
+      - TLS-enabled gRPC.
     - - **Server-side Infrastructure**
-      - Simulation runtime coordinates the spawning of workers (python process) which
-        play the role of `simulated` SuperNodes. There is no SuperLink.
+      - Simulation runtime coordinates the spawning of multiple workers (Python process) which
+        act as `simulated` SuperNodes. There is no SuperLink.
       - The SuperLink awaits for SuperNodes to connect. User interface with the
         SuperLink using the `Flower CLI <ref-api-cli.html>`_.
     - - **Server-side App execution**
@@ -58,7 +58,7 @@ simulated Flower federations from deployed ones.
         runs independently from the SuperLink and communicates with it over gRPC via the
         ServerAppIO API.
     - - **Client-side Infrastructure**
-      - None. The Simulation runtime is standalone.
+      - None. The simulation runtime is self-contained.
       - SuperNodes connect to the SuperLink via TLS-enabled gRPC using the Fleet API.
         Node authentication can be enabled.
     - - **Client-side App execution**

--- a/framework/docs/source/ref-simulation-deployment-runtimes.rst
+++ b/framework/docs/source/ref-simulation-deployment-runtimes.rst
@@ -40,7 +40,7 @@ simulated Flower federations from deployed ones.
       - Multiple independent processes or subprocesses running in coordination with the
         SuperLink and SuperNodes.
     - - **Execution Mode**
-      - Multiprocessing execution where each process simulates being a distinct client.
+      - Multiprocessing execution where each process simulates a distinct client.
       - Parallel execution mode across a network of physical machines/devices or
         computing environment.
     - - **Communication**

--- a/framework/docs/source/ref-simulation-deployment-runtimes.rst
+++ b/framework/docs/source/ref-simulation-deployment-runtimes.rst
@@ -5,17 +5,15 @@
 Simulation vs. Deployment Runtime
 =================================
 
-From both a developer and user experience perspective, the only change required when
-moving from a simulated to a real-world Flower federation is to set the correct
-federation address pointing to a SuperLink deployed either in a `simulation
-<how-to-run-simulations.html>`_ or `deployment
-<how-to-run-flower-with-deployment-engine.html>`_ runtime. In this way, the same
-application developed using the Flower simulation runtime can be directly deployed to a
-`real-world Flower federation <explanation-flower-architecture.html>`_. Additionally,
-the `Flower CLI <ref-api-cli.html>`_ remains the same across both environments, ensuring
-a smooth transition without the need for additional configuration or tooling changes.
-The following table outlines the key characteristics that differentiate simulated Flower
-federations from deployed ones.
+Flower Apps can be executed with both with `simulation <how-to-run-simulations.html>`_
+or `deployment <how-to-run-flower-with-deployment-engine.html>`_ runtimes. Switching
+between runtimes simply requires specifying a different type of `federation` when
+executing the `flwr run` command via the `Flower CLI <ref-api-cli.html>`_.
+
+While Flower Apps can run in both simulation and deployment without making changes to
+their code, there are some differences on how they get executed depending on the
+runtime. The following table outlines the key characteristics that differentiate
+simulated Flower federations from deployed ones.
 
 .. list-table::
     :widths: 15 25 25
@@ -26,38 +24,48 @@ federations from deployed ones.
       - Deployment Runtime
     - - **Lifecycle Stage**
       - Ideal for rapid prototyping, algorithm validation, research, debugging, and
-        experimentation
+        experimentation.
       - Deploy validated use cases in production, real-world privacy-preserving
-        applications
+        applications.
     - - **Environment**
-      - Local, standalone, controlled
-      - Distributed, remote
+      - Local or remote, standalone, controlled.
+      - Distributed, remote.
     - - **Data**
-      - Simulated, e.g., academic sources or artificially generated - a natural fit for
-        `Flower Datasets <https://flower.ai/docs/datasets/>`_
-      - Real client-side data, residing on local databases or filesystems
+      - Simulated data partitions, public or private datasets or artificially generated
+        - a natural fit for `Flower Datasets <https://flower.ai/docs/datasets/>`_.
+      - Real client-side data, residing on local databases or filesystems.
     - - **Backend**
       - Multiple Python processes/workers coordinated using `Ray
-        <https://docs.ray.io/>`_
-      - Multiple independent processes or subprocesses deployed through SuperLink and
-        SuperNode components
+        <https://docs.ray.io/>`_.
+      - Multiple independent processes or subprocesses running in coordination with the
+        SuperLink and SuperNodes.
     - - **Execution Mode**
-      - Parallelized or concurrent worker execution mode depending on the available
-        resources of the simulated environment
+      - Multiprocessing execution where each process simulates being a distinct client.
       - Parallel execution mode across a network of physical machines/devices or
-        computing environment
+        computing environment.
     - - **Communication**
-      - Managed via in-memory communication
-      - Managed via Flower Deployment Runtime through TLS-enabled gRPC
-    - - **Server-side**
-      - A ``ServerApp`` process initialized inside a controlled environment,
-        coordinating multiple simulated clients
-      - ``ServerApp`` runs independently on a machine through the SuperLink and the
-        communication takes place over gRPC via the ServerAppIO API and users interface
-        with the SuperLink via the Exec API
-    - - **Client-side**
-      - Simulated ``ClientApp`` processes initialized inside a controlled environment
+      - Managed via in-memory communication.
+      - Managed via Flower Deployment Runtime through TLS-enabled gRPC.
+    - - **Server-side Infrastructure**
+      - Simulation runtime coordinates the spawning of workers (python process) which
+        play the role of `simulated` SuperNodes. There is no SuperLink.
+      - The SuperLink awaits for SuperNodes to connect. User interface with the
+        SuperLink using the `Flower CLI <ref-api-cli.html>`_.
+    - - **Server-side App execution**
+      - A ``ServerApp`` process is initialized inside a controlled environment and
+        communicates in-memory with workers.
+      - ``ServerApp`` `process or subprocess <ref-flower-network-communication.html>`_
+        runs independently from the SuperLink and communicates with it over gRPC via the
+        ServerAppIO API.
+    - - **Client-side Infrastructure**
+      - None. The Simulation runtime is standalone.
+      - SuperNodes connect to the SuperLink via TLS-enabled gRPC using the Fleet API.
+        Node authentication can be enabled.
+    - - **Client-side App execution**
+      - Each process executes a ``ClientApp`` on demand. They might execute multiple
+        instances of the same ``ClientApp`` to simulate large amounts of clients.
+        ``ClientApps`` are stateless.
       - Initialized as a ``ClientApp`` `process or subprocess
-        <ref-flower-network-communication.html>`_ connected to independent SuperNode
-        instances via the ClientAppIo API and SuperNodes communicate with the SuperLink
-        over gRPC via the Fleet API
+        <ref-flower-network-communication.html>`_ runs independently from the SuperNode
+        and communicates with it over gRPC via the ClientAppIo API. ``ClientApps`` are
+        stateless.


### PR DESCRIPTION
- tweaked intro paragraph
- splitting `server-side` and `client-side` into two sections: about infrastructure, and about app execution