### PR TITLE
refactor(framework) Move utils and add `SqliteStateMixin`

### DIFF
--- a/framework/py/flwr/common/sqlite_state_mixin.py
+++ b/framework/py/flwr/common/sqlite_state_mixin.py
@@ -1,0 +1,123 @@
+# Copyright 2025 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Mixin for adding SQLite state management functionality to classes."""
+
+
+import re
+import sqlite3
+from collections.abc import Sequence
+from logging import DEBUG, ERROR
+from typing import Any, Optional, Union
+
+from flwr.common import log
+
+DictOrTuple = Union[tuple[Any, ...], dict[str, Any]]
+
+
+class SqliteStateMixin:  # pylint: disable=R0904
+    """SQLite-based state management mixin."""
+
+    def __init__(
+        self,
+        database_path: str,
+    ) -> None:
+        """Initialize an SqliteStateMixin.
+
+        Parameters
+        ----------
+        database : (path-like object)
+            The path to the database file to be opened. Pass ":memory:" to open
+            a connection to a database that is in RAM, instead of on disk.
+        """
+        self.database_path = database_path
+        self.conn: Optional[sqlite3.Connection] = None
+
+    @property
+    def schema_setup_commands(self) -> list[str]:
+        """Return the schema setup commands."""
+        raise NotImplementedError
+
+    def initialize(self, log_queries: bool = False) -> list[tuple[str]]:
+        """Create tables if they don't exist yet.
+
+        Parameters
+        ----------
+        log_queries : bool
+            Log each query which is executed.
+
+        Returns
+        -------
+        list[tuple[str]]
+            The list of all tables in the DB.
+        """
+        self.conn = sqlite3.connect(self.database_path)
+        self.conn.execute("PRAGMA foreign_keys = ON;")
+        self.conn.row_factory = dict_factory
+        if log_queries:
+            self.conn.set_trace_callback(lambda query: log(DEBUG, query))
+        cur = self.conn.cursor()
+
+        # Create each table if not exists queries
+        for cmd in self.schema_setup_commands:
+            cur.execute(cmd)
+        res = cur.execute("SELECT name FROM sqlite_schema;")
+        return res.fetchall()
+
+    def query(
+        self,
+        query: str,
+        data: Optional[Union[Sequence[DictOrTuple], DictOrTuple]] = None,
+    ) -> list[dict[str, Any]]:
+        """Execute a SQL query."""
+        if self.conn is None:
+            raise AttributeError("LinkState is not initialized.")
+
+        if data is None:
+            data = []
+
+        # Clean up whitespace to make the logs nicer
+        query = re.sub(r"\s+", " ", query)
+
+        try:
+            with self.conn:
+                if (
+                    len(data) > 0
+                    and isinstance(data, (tuple, list))
+                    and isinstance(data[0], (tuple, dict))
+                ):
+                    rows = self.conn.executemany(query, data)
+                else:
+                    rows = self.conn.execute(query, data)
+
+                # Extract results before committing to support
+                #   INSERT/UPDATE ... RETURNING
+                # style queries
+                result = rows.fetchall()
+        except KeyError as exc:
+            log(ERROR, {"query": query, "data": data, "exception": exc})
+
+        return result
+
+
+def dict_factory(
+    cursor: sqlite3.Cursor,
+    row: sqlite3.Row,
+) -> dict[str, Any]:
+    """Turn SQLite results into dicts.
+
+    Less efficent for retrival of large amounts of data but easier to use.
+    """
+    fields = [column[0] for column in cursor.description]
+    return dict(zip(fields, row))

--- a/framework/py/flwr/common/state_utils.py
+++ b/framework/py/flwr/common/state_utils.py
@@ -1,0 +1,120 @@
+# Copyright 2025 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Common utility functions for state implementations."""
+
+
+from os import urandom
+from typing import Optional
+
+
+def convert_uint64_to_sint64(u: int) -> int:
+    """Convert a uint64 value to a sint64 value with the same bit sequence.
+
+    Parameters
+    ----------
+    u : int
+        The unsigned 64-bit integer to convert.
+
+    Returns
+    -------
+    int
+        The signed 64-bit integer equivalent.
+
+        The signed 64-bit integer will have the same bit pattern as the
+        unsigned 64-bit integer but may have a different decimal value.
+
+        For numbers within the range [0, `sint64` max value], the decimal
+        value remains the same. However, for numbers greater than the `sint64`
+        max value, the decimal value will differ due to the wraparound caused
+        by the sign bit.
+    """
+    if u >= (1 << 63):
+        return u - (1 << 64)
+    return u
+
+
+def convert_sint64_to_uint64(s: int) -> int:
+    """Convert a sint64 value to a uint64 value with the same bit sequence.
+
+    Parameters
+    ----------
+    s : int
+        The signed 64-bit integer to convert.
+
+    Returns
+    -------
+    int
+        The unsigned 64-bit integer equivalent.
+
+        The unsigned 64-bit integer will have the same bit pattern as the
+        signed 64-bit integer but may have a different decimal value.
+
+        For negative `sint64` values, the conversion adds 2^64 to the
+        signed value to obtain the equivalent `uint64` value. For non-negative
+        `sint64` values, the decimal value remains unchanged in the `uint64`
+        representation.
+    """
+    if s < 0:
+        return s + (1 << 64)
+    return s
+
+
+def convert_uint64_values_in_dict_to_sint64(
+    data_dict: dict[str, int], keys: list[str]
+) -> None:
+    """Convert uint64 values to sint64 in the given dictionary.
+
+    Parameters
+    ----------
+    data_dict : dict[str, int]
+        A dictionary where the values are integers to be converted.
+    keys : list[str]
+        A list of keys in the dictionary whose values need to be converted.
+    """
+    for key in keys:
+        if key in data_dict:
+            data_dict[key] = convert_uint64_to_sint64(data_dict[key])
+
+
+def convert_sint64_values_in_dict_to_uint64(
+    data_dict: dict[str, int], keys: list[str]
+) -> None:
+    """Convert sint64 values to uint64 in the given dictionary.
+
+    Parameters
+    ----------
+    data_dict : dict[str, int]
+        A dictionary where the values are integers to be converted.
+    keys : list[str]
+        A list of keys in the dictionary whose values need to be converted.
+    """
+    for key in keys:
+        if key in data_dict:
+            data_dict[key] = convert_sint64_to_uint64(data_dict[key])
+
+
+def generate_rand_int_from_bytes(
+    num_bytes: int, exclude: Optional[list[int]] = None
+) -> int:
+    """Generate a random unsigned integer from `num_bytes` bytes.
+
+    If `exclude` is set, this function guarantees such number is not returned.
+    """
+    num = int.from_bytes(urandom(num_bytes), "little", signed=False)
+
+    if exclude:
+        while num in exclude:
+            num = int.from_bytes(urandom(num_bytes), "little", signed=False)
+    return num

--- a/framework/py/flwr/common/state_utils_test.py
+++ b/framework/py/flwr/common/state_utils_test.py
@@ -1,0 +1,151 @@
+# Copyright 2025 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for utility functions for states."""
+
+
+import unittest
+
+from parameterized import parameterized
+
+from .state_utils import (
+    convert_sint64_to_uint64,
+    convert_sint64_values_in_dict_to_uint64,
+    convert_uint64_to_sint64,
+    convert_uint64_values_in_dict_to_sint64,
+    generate_rand_int_from_bytes,
+)
+
+
+class UtilsTest(unittest.TestCase):
+    """Test utils code."""
+
+    @parameterized.expand(  # type: ignore
+        [
+            # Test values within the positive range of sint64 (below 2^63)
+            (0, 0),  # Minimum positive value
+            (1, 1),  # 1 remains 1 in both uint64 and sint64
+            (2**62, 2**62),  # Mid-range positive value
+            (2**63 - 1, 2**63 - 1),  # Maximum positive value for sint64
+            # Test values at or above 2^63 (become negative in sint64)
+            (2**63, -(2**63)),  # Minimum negative value for sint64
+            (2**63 + 1, -(2**63) + 1),  # Slightly above the boundary
+            (9223372036854775811, -9223372036854775805),  # Some value > sint64 max
+            (2**64 - 1, -1),  # Maximum uint64 value becomes -1 in sint64
+        ]
+    )
+    def test_convert_uint64_to_sint64(self, before: int, after: int) -> None:
+        """Test conversion from uint64 to sint64."""
+        self.assertEqual(convert_uint64_to_sint64(before), after)
+
+    @parameterized.expand(  # type: ignore
+        [
+            # Test values within the negative range of sint64
+            (-(2**63), 2**63),  # Minimum sint64 value becomes 2^63 in uint64
+            (-(2**63) + 1, 2**63 + 1),  # Slightly above the minimum
+            (-9223372036854775805, 9223372036854775811),  # Some value > sint64 max
+            # Test zero-adjacent inputs
+            (-1, 2**64 - 1),  # -1 in sint64 becomes 2^64 - 1 in uint64
+            (0, 0),  # 0 remains 0 in both sint64 and uint64
+            (1, 1),  # 1 remains 1 in both sint64 and uint64
+            # Test values within the positive range of sint64
+            (2**63 - 1, 2**63 - 1),  # Maximum positive value in sint64
+            # Test boundary and maximum uint64 value
+            (2**63, 2**63),  # Exact boundary value for sint64
+            (2**64 - 1, 2**64 - 1),  # Maximum uint64 value, stays the same
+        ]
+    )
+    def test_sint64_to_uint64(self, before: int, after: int) -> None:
+        """Test conversion from sint64 to uint64."""
+        self.assertEqual(convert_sint64_to_uint64(before), after)
+
+    @parameterized.expand(  # type: ignore
+        [
+            (0),
+            (1),
+            (2**62),
+            (2**63 - 1),
+            (2**63),
+            (2**63 + 1),
+            (9223372036854775811),
+            (2**64 - 1),
+        ]
+    )
+    def test_uint64_to_sint64_to_uint64(self, expected: int) -> None:
+        """Test conversion from sint64 to uint64."""
+        actual = convert_sint64_to_uint64(convert_uint64_to_sint64(expected))
+        self.assertEqual(expected, actual)
+
+    @parameterized.expand(  # type: ignore
+        [
+            # Test cases with uint64 values
+            (
+                {"a": 0, "b": 2**63 - 1, "c": 2**63, "d": 2**64 - 1},
+                ["a", "b", "c", "d"],
+                {"a": 0, "b": 2**63 - 1, "c": -(2**63), "d": -1},
+            ),
+            (
+                {"a": 1, "b": 2**62, "c": 2**63 + 1},
+                ["a", "b", "c"],
+                {"a": 1, "b": 2**62, "c": -(2**63) + 1},
+            ),
+            # Edge cases with mixed uint64 values and keys
+            (
+                {"a": 2**64 - 1, "b": 12345, "c": 0},
+                ["a", "b"],
+                {"a": -1, "b": 12345, "c": 0},
+            ),
+        ]
+    )
+    def test_convert_uint64_values_in_dict_to_sint64(
+        self, input_dict: dict[str, int], keys: list[str], expected_dict: dict[str, int]
+    ) -> None:
+        """Test uint64 to sint64 conversion in a dictionary."""
+        convert_uint64_values_in_dict_to_sint64(input_dict, keys)
+        self.assertEqual(input_dict, expected_dict)
+
+    @parameterized.expand(  # type: ignore
+        [
+            # Test cases with sint64 values
+            (
+                {"a": 0, "b": 2**63 - 1, "c": -(2**63), "d": -1},
+                ["a", "b", "c", "d"],
+                {"a": 0, "b": 2**63 - 1, "c": 2**63, "d": 2**64 - 1},
+            ),
+            (
+                {"a": -1, "b": -(2**63) + 1, "c": 12345},
+                ["a", "b", "c"],
+                {"a": 2**64 - 1, "b": 2**63 + 1, "c": 12345},
+            ),
+            # Edge cases with mixed sint64 values and keys
+            (
+                {"a": -1, "b": 12345, "c": 0},
+                ["a", "b"],
+                {"a": 2**64 - 1, "b": 12345, "c": 0},
+            ),
+        ]
+    )
+    def test_convert_sint64_values_in_dict_to_uint64(
+        self, input_dict: dict[str, int], keys: list[str], expected_dict: dict[str, int]
+    ) -> None:
+        """Test sint64 to uint64 conversion in a dictionary."""
+        convert_sint64_values_in_dict_to_uint64(input_dict, keys)
+        self.assertEqual(input_dict, expected_dict)
+
+    def test_generate_rand_int_from_bytes_unsigned_int(self) -> None:
+        """Test that the generated integer is unsigned (non-negative)."""
+        for num_bytes in range(1, 9):
+            with self.subTest(num_bytes=num_bytes):
+                rand_int = generate_rand_int_from_bytes(num_bytes)
+                self.assertGreaterEqual(rand_int, 0)

--- a/framework/py/flwr/server/grid/inmemory_grid_test.py
+++ b/framework/py/flwr/server/grid/inmemory_grid_test.py
@@ -29,6 +29,7 @@ from flwr.common.constant import (
     Status,
 )
 from flwr.common.serde import message_from_proto
+from flwr.common.state_utils import generate_rand_int_from_bytes
 from flwr.common.typing import Run, RunStatus
 from flwr.server.superlink.linkstate import (
     InMemoryLinkState,
@@ -36,7 +37,6 @@ from flwr.server.superlink.linkstate import (
     SqliteLinkState,
 )
 from flwr.server.superlink.linkstate.linkstate_test import create_ins_message
-from flwr.server.superlink.linkstate.utils import generate_rand_int_from_bytes
 
 from .inmemory_grid import InMemoryGrid
 

--- a/framework/py/flwr/server/superlink/linkstate/in_memory_linkstate.py
+++ b/framework/py/flwr/server/superlink/linkstate/in_memory_linkstate.py
@@ -36,13 +36,13 @@ from flwr.common.constant import (
     SubStatus,
 )
 from flwr.common.record import ConfigRecord
+from flwr.common.state_utils import generate_rand_int_from_bytes
 from flwr.common.typing import Run, RunStatus, UserConfig
 from flwr.server.superlink.linkstate.linkstate import LinkState
 from flwr.server.utils import validate_message
 
 from .utils import (
     check_node_availability_for_in_message,
-    generate_rand_int_from_bytes,
     has_valid_sub_status,
     is_valid_transition,
     verify_found_message_replies,

--- a/framework/py/flwr/server/superlink/linkstate/utils.py
+++ b/framework/py/flwr/server/superlink/linkstate/utils.py
@@ -15,7 +15,6 @@
 """Utility functions for State."""
 
 
-from os import urandom
 from typing import Optional
 from uuid import UUID, uuid4
 
@@ -60,107 +59,6 @@ NODE_UNAVAILABLE_ERROR_REASON = (
     "Error: Node Unavailable — The destination node failed to report a heartbeat "
     f"within {HEARTBEAT_PATIENCE} × its expected interval."
 )
-
-
-def generate_rand_int_from_bytes(
-    num_bytes: int, exclude: Optional[list[int]] = None
-) -> int:
-    """Generate a random unsigned integer from `num_bytes` bytes.
-
-    If `exclude` is set, this function guarantees such number is not returned.
-    """
-    num = int.from_bytes(urandom(num_bytes), "little", signed=False)
-
-    if exclude:
-        while num in exclude:
-            num = int.from_bytes(urandom(num_bytes), "little", signed=False)
-    return num
-
-
-def convert_uint64_to_sint64(u: int) -> int:
-    """Convert a uint64 value to a sint64 value with the same bit sequence.
-
-    Parameters
-    ----------
-    u : int
-        The unsigned 64-bit integer to convert.
-
-    Returns
-    -------
-    int
-        The signed 64-bit integer equivalent.
-
-        The signed 64-bit integer will have the same bit pattern as the
-        unsigned 64-bit integer but may have a different decimal value.
-
-        For numbers within the range [0, `sint64` max value], the decimal
-        value remains the same. However, for numbers greater than the `sint64`
-        max value, the decimal value will differ due to the wraparound caused
-        by the sign bit.
-    """
-    if u >= (1 << 63):
-        return u - (1 << 64)
-    return u
-
-
-def convert_sint64_to_uint64(s: int) -> int:
-    """Convert a sint64 value to a uint64 value with the same bit sequence.
-
-    Parameters
-    ----------
-    s : int
-        The signed 64-bit integer to convert.
-
-    Returns
-    -------
-    int
-        The unsigned 64-bit integer equivalent.
-
-        The unsigned 64-bit integer will have the same bit pattern as the
-        signed 64-bit integer but may have a different decimal value.
-
-        For negative `sint64` values, the conversion adds 2^64 to the
-        signed value to obtain the equivalent `uint64` value. For non-negative
-        `sint64` values, the decimal value remains unchanged in the `uint64`
-        representation.
-    """
-    if s < 0:
-        return s + (1 << 64)
-    return s
-
-
-def convert_uint64_values_in_dict_to_sint64(
-    data_dict: dict[str, int], keys: list[str]
-) -> None:
-    """Convert uint64 values to sint64 in the given dictionary.
-
-    Parameters
-    ----------
-    data_dict : dict[str, int]
-        A dictionary where the values are integers to be converted.
-    keys : list[str]
-        A list of keys in the dictionary whose values need to be converted.
-    """
-    for key in keys:
-        if key in data_dict:
-            data_dict[key] = convert_uint64_to_sint64(data_dict[key])
-
-
-def convert_sint64_values_in_dict_to_uint64(
-    data_dict: dict[str, int], keys: list[str]
-) -> None:
-    """Convert sint64 values to uint64 in the given dictionary.
-
-    Parameters
-    ----------
-    data_dict : dict[str, int]
-        A dictionary where the values are integers to be converted.
-    keys : list[str]
-        A list of keys in the dictionary whose values need to be converted.
-    """
-    for key in keys:
-        if key in data_dict:
-            data_dict[key] = convert_sint64_to_uint64(data_dict[key])
 
 
 def context_to_bytes(context: Context) -> bytes:

--- a/framework/py/flwr/simulation/legacy_app.py
+++ b/framework/py/flwr/simulation/legacy_app.py
@@ -36,12 +36,12 @@ from flwr.common.logger import (
     warn_deprecated_feature,
     warn_unsupported_feature,
 )
+from flwr.common.state_utils import generate_rand_int_from_bytes
 from flwr.server.client_manager import ClientManager
 from flwr.server.history import History
 from flwr.server.server import Server, init_defaults, run_fl
 from flwr.server.server_config import ServerConfig
 from flwr.server.strategy import Strategy
-from flwr.server.superlink.linkstate.utils import generate_rand_int_from_bytes
 from flwr.simulation.ray_transport.ray_actor import (
     ClientAppActor,
     VirtualClientEngineActor,

--- a/framework/py/flwr/simulation/run_simulation.py
+++ b/framework/py/flwr/simulation/run_simulation.py
@@ -38,6 +38,7 @@ from flwr.common.logger import (
     update_console_handler,
     warn_deprecated_feature_with_example,
 )
+from flwr.common.state_utils import generate_rand_int_from_bytes
 from flwr.common.typing import Run, RunStatus, UserConfig
 from flwr.server.grid import Grid, InMemoryGrid
 from flwr.server.run_serverapp import run as _run
@@ -46,7 +47,6 @@ from flwr.server.superlink.fleet import vce
 from flwr.server.superlink.fleet.vce.backend.backend import BackendConfig
 from flwr.server.superlink.linkstate import LinkStateFactory
 from flwr.server.superlink.linkstate.in_memory_linkstate import RunRecord
-from flwr.server.superlink.linkstate.utils import generate_rand_int_from_bytes
 from flwr.simulation.ray_transport.utils import (
     enable_tf_gpu_growth as enable_gpu_growth,
 )


### PR DESCRIPTION
This reduces code duplication between `SqliteLinkState` and future `SqliteNodeState`

### Code moved without changes
The only change is in `SqliteLinkState` where it inherits `SqliteStateMixin` now.