### PR TITLE
refactor(framework) Move `flwr.supernode.app` to `flwr.supernode.cli.flower_supernode`

### DIFF
--- a/framework/docs/source/ref-api-cli.rst
+++ b/framework/docs/source/ref-api-cli.rst
@@ -29,7 +29,7 @@ Basic Commands
 ~~~~~~~~~~~~~~~~~~~~
 
 .. argparse::
-    :module: flwr.client.supernode.app
+    :module: flwr.supernode.cli.flower_supernode
     :func: _parse_args_run_supernode
     :prog: flower-supernode
 

--- a/framework/py/flwr/supernode/cli/__init__.py
+++ b/framework/py/flwr/supernode/cli/__init__.py
@@ -13,3 +13,8 @@
 # limitations under the License.
 # ==============================================================================
 """Flower command line interface for SuperNode."""
+
+
+from .flower_supernode import flower_supernode
+
+__all__ = ["flower_supernode"]

--- a/framework/py/flwr/supernode/cli/__init__.py
+++ b/framework/py/flwr/supernode/cli/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2025 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Flower command line interface for SuperNode."""

--- a/framework/py/flwr/supernode/cli/app.py
+++ b/framework/py/flwr/supernode/cli/app.py
@@ -43,7 +43,7 @@ from flwr.common.exit import ExitCode, flwr_exit
 from flwr.common.exit_handlers import register_exit_handlers
 from flwr.common.logger import log
 
-from .start_client_internal import start_client_internal
+from ..start_client_internal import start_client_internal
 
 
 def run_supernode() -> None:

--- a/framework/py/flwr/supernode/cli/flower_supernode.py
+++ b/framework/py/flwr/supernode/cli/flower_supernode.py
@@ -46,7 +46,7 @@ from flwr.common.logger import log
 from ..start_client_internal import start_client_internal
 
 
-def run_supernode() -> None:
+def flower_supernode() -> None:
     """Run Flower SuperNode."""
     args = _parse_args_run_supernode().parse_args()
 

--- a/framework/py/flwr/supernode/cli/flower_supernode.py
+++ b/framework/py/flwr/supernode/cli/flower_supernode.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Flower SuperNode."""
+"""`flower-supernode` command."""
 
 
 import argparse

--- a/framework/pyproject.toml
+++ b/framework/pyproject.toml
@@ -56,7 +56,7 @@ flwr-simulation = "flwr.simulation.app:flwr_simulation"
 flower-simulation = "flwr.simulation.run_simulation:run_simulation_from_cli"
 # Deployment Engine
 flower-superlink = "flwr.server.app:run_superlink"
-flower-supernode = "flwr.supernode.app:run_supernode"
+flower-supernode = "flwr.supernode.cli:flower_supernode"
 flwr-serverapp = "flwr.server.serverapp:flwr_serverapp"
 flwr-clientapp = "flwr.client.clientapp:flwr_clientapp"
 


### PR DESCRIPTION
Following the structure of `flwr.cli` module, the `app.py` has been moved to the `cli` submodule in `supernode` and renamed to `flower_supernode.py` to match the CLI. The function has also been renamed to `flower_supernode` from `run_supernode`