### PR TITLE
refactor(framework) Centralize connection code in `start_client_internal.py`

### DIFF
--- a/framework/py/flwr/supernode/start_client_internal.py
+++ b/framework/py/flwr/supernode/start_client_internal.py
@@ -20,7 +20,8 @@ import os
 import sys
 import threading
 import time
-from contextlib import AbstractContextManager
+from collections.abc import Iterator
+from contextlib import contextmanager
 from logging import ERROR, INFO, WARN
 from os import urandom
 from pathlib import Path
@@ -74,7 +75,6 @@ def start_client_internal(
     *,
     server_address: str,
     node_config: UserConfig,
-    grpc_max_message_length: int = GRPC_MAX_MESSAGE_LENGTH,
     root_certificates: Optional[Union[bytes, str]] = None,
     insecure: Optional[bool] = None,
     transport: str,
@@ -97,13 +97,6 @@ def start_client_internal(
         would be `"[::]:8080"`.
     node_config: UserConfig
         The configuration of the node.
-    grpc_max_message_length : int (default: 536_870_912, this equals 512MB)
-        The maximum length of gRPC messages that can be exchanged with the
-        Flower server. The default should be sufficient for most models.
-        Users who train very large models might need to increase this
-        value. Note that the Flower server needs to be started with the
-        same value (see `flwr.server.start_server`), otherwise it will not
-        know about the increased limit and block larger messages.
     root_certificates : Optional[Union[bytes, str]] (default: None)
         The PEM-encoded root certificates as a byte string or a path string.
         If provided, a secure connection using the certificates will be
@@ -150,49 +143,6 @@ def start_client_internal(
         certificates=None,
     )
 
-    # Initialize connection context manager
-    connection, address, connection_error_type = _init_connection(
-        transport, server_address
-    )
-
-    def _on_sucess(retry_state: RetryState) -> None:
-        if retry_state.tries > 1:
-            log(
-                INFO,
-                "Connection successful after %.2f seconds and %s tries.",
-                retry_state.elapsed_time,
-                retry_state.tries,
-            )
-
-    def _on_backoff(retry_state: RetryState) -> None:
-        if retry_state.tries == 1:
-            log(WARN, "Connection attempt failed, retrying...")
-        else:
-            log(
-                WARN,
-                "Connection attempt failed, retrying in %.2f seconds",
-                retry_state.actual_wait,
-            )
-
-    retry_invoker = RetryInvoker(
-        wait_gen_factory=lambda: exponential(max_delay=MAX_RETRY_DELAY),
-        recoverable_exceptions=connection_error_type,
-        max_tries=max_retries + 1 if max_retries is not None else None,
-        max_time=max_wait_time,
-        on_giveup=lambda retry_state: (
-            log(
-                WARN,
-                "Giving up reconnection after %.2f seconds and %s tries.",
-                retry_state.elapsed_time,
-                retry_state.tries,
-            )
-            if retry_state.tries > 1
-            else None
-        ),
-        on_success=_on_sucess,
-        on_backoff=_on_backoff,
-    )
-
     # DeprecatedRunInfoStore gets initialized when the first connection is established
     run_info_store: Optional[DeprecatedRunInfoStore] = None
     state_factory = NodeStateFactory()
@@ -203,13 +153,14 @@ def start_client_internal(
 
     while True:
         sleep_duration: int = 0
-        with connection(
-            address,
-            insecure,
-            retry_invoker,
-            grpc_max_message_length,
-            root_certificates,
-            authentication_keys,
+        with _init_connection(
+            transport=transport,
+            server_address=server_address,
+            insecure=insecure,
+            root_certificates=root_certificates,
+            authentication_keys=authentication_keys,
+            max_retries=max_retries,
+            max_wait_time=max_wait_time,
         ) as conn:
             receive, send, create_node, delete_node, get_run, get_fab = conn
 
@@ -402,30 +353,28 @@ def start_client_internal(
         time.sleep(sleep_duration)
 
 
-def _init_connection(transport: str, server_address: str) -> tuple[
-    Callable[
-        [
-            str,
-            bool,
-            RetryInvoker,
-            int,
-            Union[bytes, str, None],
-            Optional[tuple[ec.EllipticCurvePrivateKey, ec.EllipticCurvePublicKey]],
-        ],
-        AbstractContextManager[
-            tuple[
-                Callable[[], Optional[Message]],
-                Callable[[Message], None],
-                Callable[[], Optional[int]],
-                Callable[[], None],
-                Callable[[int], Run],
-                Callable[[str, int], Fab],
-            ]
-        ],
-    ],
-    str,
-    type[Exception],
+@contextmanager
+def _init_connection(  # pylint: disable=too-many-positional-arguments
+    transport: str,
+    server_address: str,
+    insecure: bool,
+    root_certificates: Optional[Union[bytes, str]] = None,
+    authentication_keys: Optional[
+        tuple[ec.EllipticCurvePrivateKey, ec.EllipticCurvePublicKey]
+    ] = None,
+    max_retries: Optional[int] = None,
+    max_wait_time: Optional[float] = None,
+) -> Iterator[
+    tuple[
+        Callable[[], Optional[Message]],
+        Callable[[Message], None],
+        Callable[[], Optional[int]],
+        Callable[[], None],
+        Callable[[int], Run],
+        Callable[[str, int], Fab],
+    ]
 ]:
+    """Establish a connection to the Fleet API server at SuperLink."""
     # Parse IP address
     parsed_address = parse_address(server_address)
     if not parsed_address:
@@ -456,7 +405,69 @@ def _init_connection(transport: str, server_address: str) -> tuple[
             f"Unknown transport type: {transport} (possible: {TRANSPORT_TYPES})"
         )
 
-    return connection, address, error_type
+    # Create RetryInvoker
+    retry_invoker = _make_fleet_connection_retry_invoker(
+        max_retries=max_retries,
+        max_wait_time=max_wait_time,
+        connection_error_type=error_type,
+    )
+
+    # Establish connection
+    with connection(
+        address,
+        insecure,
+        retry_invoker,
+        GRPC_MAX_MESSAGE_LENGTH,
+        root_certificates,
+        authentication_keys,
+    ) as conn:
+        yield conn
+
+
+def _make_fleet_connection_retry_invoker(
+    max_retries: Optional[int] = None,
+    max_wait_time: Optional[float] = None,
+    connection_error_type: type[Exception] = RpcError,
+) -> RetryInvoker:
+    """Create a retry invoker for fleet connection."""
+
+    def _on_success(retry_state: RetryState) -> None:
+        if retry_state.tries > 1:
+            log(
+                INFO,
+                "Connection successful after %.2f seconds and %s tries.",
+                retry_state.elapsed_time,
+                retry_state.tries,
+            )
+
+    def _on_backoff(retry_state: RetryState) -> None:
+        if retry_state.tries == 1:
+            log(WARN, "Connection attempt failed, retrying...")
+        else:
+            log(
+                WARN,
+                "Connection attempt failed, retrying in %.2f seconds",
+                retry_state.actual_wait,
+            )
+
+    return RetryInvoker(
+        wait_gen_factory=lambda: exponential(max_delay=MAX_RETRY_DELAY),
+        recoverable_exceptions=connection_error_type,
+        max_tries=max_retries + 1 if max_retries is not None else None,
+        max_time=max_wait_time,
+        on_giveup=lambda retry_state: (
+            log(
+                WARN,
+                "Giving up reconnection after %.2f seconds and %s tries.",
+                retry_state.elapsed_time,
+                retry_state.tries,
+            )
+            if retry_state.tries > 1
+            else None
+        ),
+        on_success=_on_success,
+        on_backoff=_on_backoff,
+    )
 
 
 def _run_flwr_clientapp(args: list[str], main_pid: int) -> None:


### PR DESCRIPTION
This PR also deletes `grpc_max_message_length` argument as it is no longer in use (it was used by `start_client` only).