### PR TITLE
fix(framework) Fix labelling of bot PR

### DIFF
--- a/.github/workflows/label-pr-author.yaml
+++ b/.github/workflows/label-pr-author.yaml
@@ -1,0 +1,46 @@
+name: Label PR Author as Internal or External
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review, synchronize, labeled, unlabeled]
+
+permissions:  
+  pull-requests: write
+  issues: write       
+  members: read
+
+jobs:
+  label-author-type:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Auto-label PR author
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = context.payload.pull_request;
+            const labels = pr.labels.map(label => label.name.toLowerCase());
+
+            const hasLabel = labels.includes("internal") || labels.includes("external");
+            if (hasLabel || pr.state !== "open") {
+              console.log("PR already labeled or not open — skipping.");
+              return;
+            }
+
+            const org = "adap";
+            const author = pr.user.login;
+            const { status } = await github.rest.orgs.checkMembershipForUser({
+              org,
+              username: author
+            }).catch(e => ({ status: e.status }));
+
+            const label = status === 204 ? "Internal" : "External";
+
+            console.log(`Adding label: ${label}`);
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              labels: [label]
+            });

--- a/.github/workflows/label-pr-author.yaml
+++ b/.github/workflows/label-pr-author.yaml
@@ -28,10 +28,22 @@ jobs:
 
             for (const pr of prs.data) {
               const labels = pr.labels.map(l => l.name);
-              const hasLabel = labels.includes("Maintainer") || labels.includes("Contributor");
+              const hasLabel = labels.includes("Maintainer") || labels.includes("Contributor") || labels.includes("Bot");
               if (hasLabel) continue;
 
               const author = pr.user.login;
+              const isBot = pr.user.type === "Bot";
+
+              if (isBot) {
+                console.log(`Labeling PR #${pr.number} by ${author} as Bot`);
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  labels: ["Bot"],
+                });
+                continue;
+              }
 
               let isMaintainer = false;
               try {
@@ -41,11 +53,7 @@ jobs:
                 });
                 isMaintainer = result.status === 204;
               } catch (e) {
-                if (e.status === 404) {
-                  isMaintainer = false;
-                } else {
-                  throw e;
-                }
+                if (e.status !== 404) throw e;
               }
 
               const label = isMaintainer ? "Maintainer" : "Contributor";
@@ -58,3 +66,5 @@ jobs:
                 labels: [label],
               });
             }
+
+              console.log("All PRs processed");

--- a/.github/workflows/label-pr-author.yaml
+++ b/.github/workflows/label-pr-author.yaml
@@ -1,45 +1,60 @@
-name: Label PR Author as Internal or External
+name: Label PR Authors (Scheduled)
 
 on:
-  pull_request:
-    types: [opened, reopened, ready_for_review, synchronize, labeled, unlabeled]
+  schedule:
+    - cron: '0 * * * *'  # every hour
+  workflow_dispatch:     # allow manual run too
 
-permissions:  
+permissions:
   pull-requests: write
-  issues: write       
+  issues: write
 
 jobs:
-  label-author-type:
+  label-prs:
     runs-on: ubuntu-22.04
-
     steps:
-      - name: Auto-label PR author
-        uses: actions/github-script@v7
+      - uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const pr = context.payload.pull_request;
-            const labels = pr.labels.map(label => label.name);
-
-            const hasLabel = labels.includes("Maintainer") || labels.includes("Contributor");
-            if (hasLabel || pr.state !== "open") {
-              console.log("PR already labeled or not open — skipping.");
-              return;
-            }
-
             const org = "adap";
-            const author = pr.user.login;
-            const { status } = await github.rest.orgs.checkMembershipForUser({
-              org,
-              username: author
-            }).catch(e => ({ status: e.status }));
 
-            const label = status === 204 ? "Maintainer" : "Contributor";
-
-            console.log(`Adding label: ${label}`);
-            await github.rest.issues.addLabels({
+            const prs = await github.rest.pulls.list({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: pr.number,
-              labels: [label]
+              state: "open",
+              per_page: 100,
             });
+
+            for (const pr of prs.data) {
+              const labels = pr.labels.map(l => l.name);
+              const hasLabel = labels.includes("Maintainer") || labels.includes("Contributor");
+              if (hasLabel) continue;
+
+              const author = pr.user.login;
+
+              let isMaintainer = false;
+              try {
+                const result = await github.rest.orgs.checkMembershipForUser({
+                  org,
+                  username: author
+                });
+                isMaintainer = result.status === 204;
+              } catch (e) {
+                if (e.status === 404) {
+                  isMaintainer = false;
+                } else {
+                  throw e;
+                }
+              }
+
+              const label = isMaintainer ? "Maintainer" : "Contributor";
+              console.log(`Labeling PR #${pr.number} by ${author} as ${label}`);
+
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                labels: [label],
+              });
+            }

--- a/.github/workflows/label-pr-author.yaml
+++ b/.github/workflows/label-pr-author.yaml
@@ -7,7 +7,6 @@ on:
 permissions:  
   pull-requests: write
   issues: write       
-  members: read
 
 jobs:
   label-author-type:

--- a/.github/workflows/label-pr-author.yaml
+++ b/.github/workflows/label-pr-author.yaml
@@ -20,9 +20,9 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const pr = context.payload.pull_request;
-            const labels = pr.labels.map(label => label.name.toLowerCase());
+            const labels = pr.labels.map(label => label.name);
 
-            const hasLabel = labels.includes("maintainer") || labels.includes("contributor");
+            const hasLabel = labels.includes("Maintainer") || labels.includes("Contributor");
             if (hasLabel || pr.state !== "open") {
               console.log("PR already labeled or not open — skipping.");
               return;

--- a/.github/workflows/label-pr-author.yaml
+++ b/.github/workflows/label-pr-author.yaml
@@ -22,7 +22,7 @@ jobs:
             const pr = context.payload.pull_request;
             const labels = pr.labels.map(label => label.name.toLowerCase());
 
-            const hasLabel = labels.includes("internal") || labels.includes("external");
+            const hasLabel = labels.includes("maintainer") || labels.includes("contributor");
             if (hasLabel || pr.state !== "open") {
               console.log("PR already labeled or not open — skipping.");
               return;
@@ -35,7 +35,7 @@ jobs:
               username: author
             }).catch(e => ({ status: e.status }));
 
-            const label = status === 204 ? "Internal" : "External";
+            const label = status === 204 ? "Maintainer" : "Contributor";
 
             console.log(`Adding label: ${label}`);
             await github.rest.issues.addLabels({


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue
Bot PR should get `Bot` label, not `Maintainer` nor `Contributor`
### Description
Currently, doesn't account for bot PRs. 
<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal
Add label `Bot` to PRs created by bots. 
### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

### Checklist

- [x] Implement proposed change
- [x] Write tests
- [x] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.ai/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
