### PR TITLE
fix(framework) Add option to label bot PRs as Bot

### DIFF
--- a/.github/workflows/label-pr-author.yaml
+++ b/.github/workflows/label-pr-author.yaml
@@ -28,10 +28,22 @@ jobs:
 
             for (const pr of prs.data) {
               const labels = pr.labels.map(l => l.name);
-              const hasLabel = labels.includes("Maintainer") || labels.includes("Contributor");
+              const hasLabel = labels.includes("Maintainer") || labels.includes("Contributor") || labels.includes("Bot");
               if (hasLabel) continue;
 
               const author = pr.user.login;
+              const isBot = pr.user.type === "Bot";
+
+              if (isBot) {
+                console.log(`Labeling PR #${pr.number} by ${author} as Bot`);
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  labels: ["Bot"],
+                });
+                continue;
+              }
 
               let isMaintainer = false;
               try {
@@ -41,11 +53,7 @@ jobs:
                 });
                 isMaintainer = result.status === 204;
               } catch (e) {
-                if (e.status === 404) {
-                  isMaintainer = false;
-                } else {
-                  throw e;
-                }
+                if (e.status !== 404) throw e;
               }
 
               const label = isMaintainer ? "Maintainer" : "Contributor";
@@ -58,3 +66,6 @@ jobs:
                 labels: [label],
               });
             }
+
+              console.log("All PRs processed");
+              return `Labeled ${prs.data.length} PRs successfully.`;


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue
Bot PRs get labeled `Contributor` 
### Description
This is not accurate. 
<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal
Label bot PRs with new label `Bot` instead. 
### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

### Checklist

- [x] Implement proposed change
- [x] Write tests
- [x] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.ai/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
