### PR TITLE
fix(framework) Check `user_info` is valid when refreshing authentication tokens

### DIFF
--- a/framework/py/flwr/common/auth_plugin/auth_plugin.py
+++ b/framework/py/flwr/common/auth_plugin/auth_plugin.py
@@ -63,7 +63,7 @@ class ExecAuthPlugin(ABC):
     @abstractmethod
     def refresh_tokens(
         self, metadata: Sequence[tuple[str, Union[str, bytes]]]
-    ) -> Optional[Sequence[tuple[str, Union[str, bytes]]]]:
+    ) -> tuple[Optional[Sequence[tuple[str, Union[str, bytes]]]], Optional[UserInfo]]:
         """Refresh authentication tokens in the provided metadata."""
 
 

--- a/framework/py/flwr/superexec/exec_user_auth_interceptor.py
+++ b/framework/py/flwr/superexec/exec_user_auth_interceptor.py
@@ -16,7 +16,7 @@
 
 
 import contextvars
-from typing import Any, Callable, Union, cast
+from typing import Any, Callable, Union
 
 import grpc
 
@@ -95,13 +95,29 @@ class ExecUserAuthInterceptor(grpc.ServerInterceptor):  # type: ignore
                 metadata
             )
             if valid_tokens:
+                if user_info is None:
+                    context.abort(
+                        grpc.StatusCode.UNAUTHENTICATED,
+                        "Tokens validated, but user info not found",
+                    )
+                    raise grpc.RpcError()
                 # Store user info in contextvars for authenticated users
-                shared_user_info.set(cast(UserInfo, user_info))
+                shared_user_info.set(user_info)
                 return call(request, context)  # type: ignore
 
             # If the user is not authenticated, refresh tokens
-            tokens = self.auth_plugin.refresh_tokens(context.invocation_metadata())
+            tokens, user_info = self.auth_plugin.refresh_tokens(
+                context.invocation_metadata()
+            )
             if tokens is not None:
+                if user_info is None:
+                    context.abort(
+                        grpc.StatusCode.UNAUTHENTICATED,
+                        "Tokens refreshed, but user info not found",
+                    )
+                    raise grpc.RpcError()
+                # Store user info in contextvars for authenticated users
+                shared_user_info.set(user_info)
                 context.send_initial_metadata(tokens)
                 return call(request, context)  # type: ignore
 


### PR DESCRIPTION
This PR updates the `ExecAuthPlugin.refresh_tokens()` to return an optional `UserInfo`. This is used to check that the `user_info` is valid when refreshing authentication tokens.

It also includes some minor refactoring in the `ExecUserAuthInterceptor` to abort the context if `user_info` is `None` when users are authenticated.