### PR TITLE
feat(framework) Add client results strategy

### DIFF
--- a/framework/py/flwr/server/client_results_strategy/__init__.py
+++ b/framework/py/flwr/server/client_results_strategy/__init__.py
@@ -1,0 +1,19 @@
+# Copyright 2025 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Contains the detection strategy abstraction and different implementations."""
+
+from .default_client_results import AlwaysTrustClientResultsStrategy
+
+__all__ = ["AlwaysTrustClientResultsStrategy"]

--- a/framework/py/flwr/server/client_results_strategy/client_results_strategy.py
+++ b/framework/py/flwr/server/client_results_strategy/client_results_strategy.py
@@ -1,0 +1,64 @@
+# Copyright 2025 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Flower server client results strategy to detect malicious actors."""
+
+
+from abc import ABC, abstractmethod
+from typing import Union
+
+from flwr.common import FitRes
+from flwr.server.client_proxy import ClientProxy
+
+
+class ClientResultsStrategy(ABC):
+    """Abstract base class for server client results strategy implementations."""
+
+    @abstractmethod
+    def validate_client_results(
+        self,
+        server_round: int,
+        results: list[tuple[ClientProxy, FitRes]],
+        failures: list[Union[tuple[ClientProxy, FitRes], BaseException]],
+    ) -> tuple[
+        list[tuple[ClientProxy, FitRes]],
+        list[Union[tuple[ClientProxy, FitRes], BaseException]],
+    ]:
+        """Scan client training results for malicious activity.
+
+        Parameters
+        ----------
+        server_round : int
+            The current round of federated learning.
+        results : List[Tuple[ClientProxy, FitRes]]
+            Successful updates from the previously selected and configured
+            clients. Each pair of `(ClientProxy, FitRes)` constitutes a
+            successful update from one of the previously selected clients. Not
+            that not all previously selected clients are necessarily included in
+            this list: a client might drop out and not submit a result. For each
+            client that did not submit an update, there should be an `Exception`
+            in `failures`.
+        failures : List[Union[Tuple[ClientProxy, FitRes], BaseException]]
+            Exceptions that occurred while the server was waiting for client
+            updates.
+
+        Returns
+        -------
+        trusted_results : Tuple[
+            List[tuple[ClientProxy, FitRes]],
+            List[Union[tuple[ClientProxy, FitRes], BaseException]
+        ]
+            The tuple represents the results that should be used for the next evaluation
+            of the model training.
+        """

--- a/framework/py/flwr/server/client_results_strategy/default_client_results.py
+++ b/framework/py/flwr/server/client_results_strategy/default_client_results.py
@@ -1,0 +1,64 @@
+# Copyright 2025 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Always assume clients are safe to use, naive approach."""
+
+from typing import Union
+
+from flwr.common import FitRes
+from flwr.server.client_proxy import ClientProxy
+
+from .client_results_strategy import ClientResultsStrategy
+
+
+class AlwaysTrustClientResultsStrategy(ClientResultsStrategy):
+    """Always assume client results are safe to use, identity transformation."""
+
+    def validate_client_results(
+        self,
+        server_round: int,
+        results: list[tuple[ClientProxy, FitRes]],
+        failures: list[Union[tuple[ClientProxy, FitRes], BaseException]],
+    ) -> tuple[
+        list[tuple[ClientProxy, FitRes]],
+        list[Union[tuple[ClientProxy, FitRes], BaseException]],
+    ]:
+        """Scan client training results for malicious activity.
+
+        Parameters
+        ----------
+        server_round : int
+            The current round of federated learning.
+        results : List[Tuple[ClientProxy, FitRes]]
+            Successful updates from the previously selected and configured
+            clients. Each pair of `(ClientProxy, FitRes)` constitutes a
+            successful update from one of the previously selected clients. Not
+            that not all previously selected clients are necessarily included in
+            this list: a client might drop out and not submit a result. For each
+            client that did not submit an update, there should be an `Exception`
+            in `failures`.
+        failures : List[Union[Tuple[ClientProxy, FitRes], BaseException]]
+            Exceptions that occurred while the server was waiting for client
+            updates.
+
+        Returns
+        -------
+        trusted_results : Tuple[
+            List[tuple[ClientProxy, FitRes]],
+            List[Union[tuple[ClientProxy, FitRes], BaseException]
+        ]
+            The tuple represents the results that should be used for
+            the next evaluation of the model training.
+        """
+        return results, failures

--- a/framework/py/flwr/server/server.py
+++ b/framework/py/flwr/server/server.py
@@ -36,6 +36,10 @@ from flwr.common.logger import log
 from flwr.common.typing import GetParametersIns
 from flwr.server.client_manager import ClientManager, SimpleClientManager
 from flwr.server.client_proxy import ClientProxy
+from flwr.server.client_results_strategy import (
+    AlwaysTrustClientResultsStrategy,
+    ClientResultsStrategy,
+)
 from flwr.server.history import History
 from flwr.server.strategy import FedAvg, Strategy
 
@@ -63,12 +67,18 @@ class Server:
         *,
         client_manager: ClientManager,
         strategy: Optional[Strategy] = None,
+        client_results_strategy: Optional[ClientResultsStrategy] = None,
     ) -> None:
         self._client_manager: ClientManager = client_manager
         self.parameters: Parameters = Parameters(
             tensors=[], tensor_type="numpy.ndarray"
         )
         self.strategy: Strategy = strategy if strategy is not None else FedAvg()
+        self.client_results_strategy: ClientResultsStrategy = (
+            client_results_strategy
+            if client_results_strategy is not None
+            else AlwaysTrustClientResultsStrategy()
+        )
         self.max_workers: Optional[int] = None
 
     def set_max_workers(self, max_workers: Optional[int]) -> None:
@@ -244,11 +254,21 @@ class Server:
             len(failures),
         )
 
+        validated_client_results: tuple[
+            list[tuple[ClientProxy, FitRes]],
+            list[Union[tuple[ClientProxy, FitRes], BaseException]],
+        ] = self.client_results_strategy.validate_client_results(
+            server_round, results, failures
+        )
+        trusted_results, trusted_failures = validated_client_results
+
         # Aggregate training results
         aggregated_result: tuple[
             Optional[Parameters],
             dict[str, Scalar],
-        ] = self.strategy.aggregate_fit(server_round, results, failures)
+        ] = self.strategy.aggregate_fit(
+            server_round, trusted_results, trusted_failures
+        )
 
         parameters_aggregated, metrics_aggregated = aggregated_result
         return parameters_aggregated, metrics_aggregated, (results, failures)


### PR DESCRIPTION
## Issue
#2252 

### Description

This PR extends the capability to split the aggregation phase and the detection phase of malicious clients.
It is important to note that the detection of the malicious users cannot be solely handled in the client manager logic as it relies its detection in the results coming back from the different clients to be able to detect the malicious behaviour.


### Related issues/PRs
It can enable #4565 

## Proposal

### Explanation
This PR opens the door to implementations like FLDetector and FedDefender and others that are focusing more on the detection process rather than the aggregation function. So far, the logic has been coupled in together.

### Checklist

- [ x ] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?
I am not sure what documentation I should change at this point as it is expected to continue to work as is out of the box, but allow advanced use cases to focus on the detection mechanism.