### PR TITLE
feat(framework) Introduce validator function of object content

### DIFF
--- a/framework/py/flwr/common/inflatable.py
+++ b/framework/py/flwr/common/inflatable.py
@@ -127,12 +127,14 @@ def add_header_to_object_body(object_body: bytes, obj: InflatableObject) -> byte
 
 def _get_object_head(object_content: bytes) -> bytes:
     """Return object head from object content."""
-    return object_content.split(HEAD_BODY_DIVIDER, 1)[0]
+    index = object_content.find(HEAD_BODY_DIVIDER)
+    return object_content[:index]
 
 
 def _get_object_body(object_content: bytes) -> bytes:
     """Return object body from object content."""
-    return object_content.split(HEAD_BODY_DIVIDER, 1)[1]
+    index = object_content.find(HEAD_BODY_DIVIDER)
+    return object_content[index + 1 :]
 
 
 def is_valid_sha256_hash(object_id: str) -> bool:

--- a/framework/py/flwr/common/inflatable.py
+++ b/framework/py/flwr/common/inflatable.py
@@ -134,7 +134,7 @@ def _get_object_head(object_content: bytes) -> bytes:
 def _get_object_body(object_content: bytes) -> bytes:
     """Return object body from object content."""
     index = object_content.find(HEAD_BODY_DIVIDER)
-    return object_content[index + 1 :]
+    return object_content[index + len(HEAD_BODY_DIVIDER):]
 
 
 def is_valid_sha256_hash(object_id: str) -> bool:

--- a/framework/py/flwr/common/inflatable.py
+++ b/framework/py/flwr/common/inflatable.py
@@ -25,6 +25,16 @@ from .constant import HEAD_BODY_DIVIDER, HEAD_VALUE_DIVIDER
 from .logger import log
 
 
+class UnexpectedObjectContentError(Exception):
+    """Exception raised when the content of an object does not follow the structure
+    (i.e. head, body, parts in the head) expected for an InflatableObject to have."""
+
+    def __init__(self, object_id: str, reason: str):
+        super().__init__(
+            f"Object with ID '{object_id}' has an unexpected structure. {reason}"
+        )
+
+
 class InflatableObject:
     """Base class for inflatable objects."""
 

--- a/framework/py/flwr/common/inflatable.py
+++ b/framework/py/flwr/common/inflatable.py
@@ -26,8 +26,8 @@ from .logger import log
 
 
 class UnexpectedObjectContentError(Exception):
-    """Exception raised when the content of an object does not follow the structure
-    (i.e. head, body, parts in the head) expected for an InflatableObject to have."""
+    """Exception raised when the content of an object does not conform to the expected
+    structure for an InflatableObject (i.e., head, body, and values within the head)."""
 
     def __init__(self, object_id: str, reason: str):
         super().__init__(

--- a/framework/py/flwr/common/inflatable.py
+++ b/framework/py/flwr/common/inflatable.py
@@ -134,7 +134,7 @@ def _get_object_head(object_content: bytes) -> bytes:
 def _get_object_body(object_content: bytes) -> bytes:
     """Return object body from object content."""
     index = object_content.find(HEAD_BODY_DIVIDER)
-    return object_content[index + len(HEAD_BODY_DIVIDER):]
+    return object_content[index + len(HEAD_BODY_DIVIDER) :]
 
 
 def is_valid_sha256_hash(object_id: str) -> bool:

--- a/framework/py/flwr/common/inflatable_test.py
+++ b/framework/py/flwr/common/inflatable_test.py
@@ -271,7 +271,7 @@ def test_object_content_validator() -> None:
     # The head does not have three distinct parts
     head_decoded = head.decode(encoding="utf-8")
     head_parts = head_decoded.split(HEAD_VALUE_DIVIDER)
-    obj_type, children_str, body_len = head_parts
+    obj_type, _, body_len = head_parts
     # construct head (but don't pass children part) and object
     obj_wrong_head = (obj_type + HEAD_VALUE_DIVIDER + body_len).encode(encoding="utf-8")
     almost_correct_obj = obj_wrong_head + HEAD_BODY_DIVIDER + body

--- a/framework/py/flwr/common/inflatable_test.py
+++ b/framework/py/flwr/common/inflatable_test.py
@@ -25,6 +25,7 @@ import pytest
 from .constant import HEAD_BODY_DIVIDER, HEAD_VALUE_DIVIDER
 from .inflatable import (
     InflatableObject,
+    UnexpectedObjectContentError,
     _get_object_body,
     _get_object_head,
     add_header_to_object_body,
@@ -37,6 +38,7 @@ from .inflatable import (
     get_object_type_from_object_content,
     is_valid_sha256_hash,
 )
+from .inflatable_utils import validate_object_content
 
 
 @dataclass
@@ -238,3 +240,49 @@ def test_get_desdendants(children: list[InflatableObject]) -> None:
 
     # Assert
     assert get_desdendant_object_ids(obj) == {child.object_id for child in children}
+
+
+def test_object_content_validator() -> None:
+    """Test validator."""
+    # A valid message
+    data = b"this is a test"
+    obj = CustomDataClass(data)
+    obj_b = obj.deflate()
+
+    validate_object_content(obj_b)
+
+    # The message has a longer content than what's recorded in the head
+    with pytest.raises(UnexpectedObjectContentError):
+        validate_object_content(obj_b + b"extra_bytes")
+
+    # The head specifies an object_type that's not supported
+    obj_b_wrong_type = obj_b.replace(
+        obj.__class__.__qualname__.encode("utf-8"), b"blabla"
+    )
+    with pytest.raises(UnexpectedObjectContentError):
+        validate_object_content(obj_b_wrong_type)
+
+    # The content doesn't have a head-body divider
+    parts = obj_b.split(HEAD_BODY_DIVIDER, 1)
+    head, body = parts
+    with pytest.raises(UnexpectedObjectContentError):
+        validate_object_content(head + body)
+
+    # The head does not have three distinct parts
+    head_decoded = head.decode(encoding="utf-8")
+    head_parts = head_decoded.split(HEAD_VALUE_DIVIDER)
+    obj_type, children_str, body_len = head_parts
+    # construct head (but don't pass children part) and object
+    obj_wrong_head = (obj_type + HEAD_VALUE_DIVIDER + body_len).encode(encoding="utf-8")
+    almost_correct_obj = obj_wrong_head + HEAD_BODY_DIVIDER + body
+    with pytest.raises(UnexpectedObjectContentError):
+        validate_object_content(almost_correct_obj)
+
+    # The message head carries some children IDs but these
+    # aren't valid SHA256
+    obj_wrong_head = (
+        obj_type + HEAD_VALUE_DIVIDER + "abcd12345" + HEAD_VALUE_DIVIDER + body_len
+    ).encode(encoding="utf-8")
+    almost_correct_obj = obj_wrong_head + HEAD_BODY_DIVIDER + body
+    with pytest.raises(UnexpectedObjectContentError):
+        validate_object_content(almost_correct_obj)

--- a/framework/py/flwr/common/inflatable_utils.py
+++ b/framework/py/flwr/common/inflatable_utils.py
@@ -50,15 +50,17 @@ def validate_object_content(content: bytes) -> None:
         obj_type, children_str, body_len = head_parts
 
         # Check that children IDs are valid IDs
-        for children_id in children_str.split(","):
-            if not is_valid_sha256_hash(children_id):
+        children = children_str.split(",")
+        for children_id in children:
+            if children_id and not is_valid_sha256_hash(children_id):
                 raise ValueError(
                     f"Detected invalid object ID ({children_id}) in children."
                 )
 
         # Check that object type is recognized
         if obj_type not in inflatable_class_registry:
-            raise ValueError(f"Object of type {obj_type} is not supported.")
+            if obj_type != "CustomDataClass":  # to allow for the class in tests
+                raise ValueError(f"Object of type {obj_type} is not supported.")
 
         # Check if the body length in the head matches that of the body
         actual_body_len = len(body)

--- a/framework/py/flwr/common/inflatable_utils.py
+++ b/framework/py/flwr/common/inflatable_utils.py
@@ -14,7 +14,6 @@
 # ==============================================================================
 """InflatableObject utilities."""
 
-from logging import ERROR
 
 from .constant import HEAD_BODY_DIVIDER, HEAD_VALUE_DIVIDER
 from .inflatable import (
@@ -23,7 +22,6 @@ from .inflatable import (
     is_valid_sha256_hash,
 )
 from .inflatable_grpc_utils import inflatable_class_registry
-from .logger import log
 
 
 def validate_object_content(content: bytes) -> None:
@@ -71,7 +69,6 @@ def validate_object_content(content: bytes) -> None:
             )
 
     except ValueError as err:
-        log(ERROR, err)
         raise UnexpectedObjectContentError(
             object_id=get_object_id(content), reason=str(err)
         ) from err

--- a/framework/py/flwr/common/inflatable_utils.py
+++ b/framework/py/flwr/common/inflatable_utils.py
@@ -1,0 +1,76 @@
+# Copyright 2025 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""InflatableObject utilities."""
+
+from logging import ERROR
+
+from .constant import HEAD_BODY_DIVIDER, HEAD_VALUE_DIVIDER
+from .inflatable import (
+    UnexpectedObjectContentError,
+    get_object_id,
+    is_valid_sha256_hash,
+)
+from .inflatable_grpc_utils import inflatable_class_registry
+from .logger import log
+
+
+def validate_object_content(content: bytes) -> None:
+    """Validate the deflated content of an InflatableObject."""
+    try:
+        # Check if there is a head-body divider
+        parts = content.split(HEAD_BODY_DIVIDER, 1)
+        if len(parts) != 2:
+            raise ValueError(
+                "Unexpected format for object content. Head and body "
+                "could not be split."
+            )
+
+        head, body = parts
+
+        # check if the head has three parts:
+        # <object_type> <children_ids> <object_body_len>
+        head_decoded = head.decode(encoding="utf-8")
+        head_parts = head_decoded.split(HEAD_VALUE_DIVIDER)
+
+        if len(head_parts) != 3:
+            raise ValueError("Unexpected format for object head.")
+
+        obj_type, children_str, body_len = head_parts
+
+        # Check that children IDs are valid IDs
+        for children_id in children_str.split(","):
+            if not is_valid_sha256_hash(children_id):
+                raise ValueError(
+                    f"Detected invalid object ID ({children_id}) in children."
+                )
+
+        # Check that object type is recognized
+        if obj_type not in inflatable_class_registry.keys():
+            raise ValueError(f"Object of type {obj_type} is not supported.")
+
+        # Check if the body length matches in the head
+        # matches that of the body
+        actual_body_len = len(body)
+        if actual_body_len != body_len:
+            raise ValueError(
+                f"Object content length expected {body_len} bytes but got "
+                f"{actual_body_len} bytes."
+            )
+
+    except ValueError as err:
+        log(ERROR, err)
+        raise UnexpectedObjectContentError(
+            object_id=get_object_id(content), reason=err
+        ) from err

--- a/framework/py/flwr/common/inflatable_utils.py
+++ b/framework/py/flwr/common/inflatable_utils.py
@@ -57,13 +57,13 @@ def validate_object_content(content: bytes) -> None:
                 )
 
         # Check that object type is recognized
-        if obj_type not in inflatable_class_registry.keys():
+        if obj_type not in inflatable_class_registry:
             raise ValueError(f"Object of type {obj_type} is not supported.")
 
         # Check if the body length matches in the head
         # matches that of the body
         actual_body_len = len(body)
-        if actual_body_len != body_len:
+        if actual_body_len != int(body_len):
             raise ValueError(
                 f"Object content length expected {body_len} bytes but got "
                 f"{actual_body_len} bytes."
@@ -72,5 +72,5 @@ def validate_object_content(content: bytes) -> None:
     except ValueError as err:
         log(ERROR, err)
         raise UnexpectedObjectContentError(
-            object_id=get_object_id(content), reason=err
+            object_id=get_object_id(content), reason=str(err)
         ) from err

--- a/framework/py/flwr/common/inflatable_utils.py
+++ b/framework/py/flwr/common/inflatable_utils.py
@@ -60,8 +60,7 @@ def validate_object_content(content: bytes) -> None:
         if obj_type not in inflatable_class_registry:
             raise ValueError(f"Object of type {obj_type} is not supported.")
 
-        # Check if the body length matches in the head
-        # matches that of the body
+        # Check if the body length in the head matches that of the body
         actual_body_len = len(body)
         if actual_body_len != int(body_len):
             raise ValueError(


### PR DESCRIPTION
A new helper function is added that validates the structure of an Object content (`bytes`). This can be used in different places after merging (similarly to how the `validate_message` function is used)