### PR TITLE
refactor(framework) Make use of new object content validator

### DIFF
--- a/framework/py/flwr/common/inflatable.py
+++ b/framework/py/flwr/common/inflatable.py
@@ -18,11 +18,9 @@
 from __future__ import annotations
 
 import hashlib
-from logging import ERROR
 from typing import TypeVar, cast
 
 from .constant import HEAD_BODY_DIVIDER, HEAD_VALUE_DIVIDER
-from .logger import log
 
 
 class UnexpectedObjectContentError(Exception):
@@ -173,16 +171,6 @@ def get_object_children_ids_from_object_content(object_content: bytes) -> list[s
 def get_object_body_len_from_object_content(object_content: bytes) -> int:
     """Return length of the object body."""
     return get_object_head_values_from_object_content(object_content)[2]
-
-
-def check_body_len_consistency(object_content: bytes) -> bool:
-    """Check that the object body is of length as specified in the head."""
-    try:
-        body_len = get_object_body_len_from_object_content(object_content)
-        return body_len == len(_get_object_body(object_content))
-    except ValueError:
-        log(ERROR, "Object content does match the expected format.")
-        return False
 
 
 def get_object_head_values_from_object_content(

--- a/framework/py/flwr/common/inflatable_test.py
+++ b/framework/py/flwr/common/inflatable_test.py
@@ -29,11 +29,9 @@ from .inflatable import (
     _get_object_body,
     _get_object_head,
     add_header_to_object_body,
-    check_body_len_consistency,
     get_all_nested_objects,
     get_descendant_object_ids,
     get_object_body,
-    get_object_body_len_from_object_content,
     get_object_head_values_from_object_content,
     get_object_id,
     get_object_type_from_object_content,
@@ -199,29 +197,6 @@ def test_is_valid_sha256_hash_invalid() -> None:
 
     # Execute & assert
     assert not is_valid_sha256_hash(invalid_hash)
-
-
-def test_check_body_length() -> None:
-    """Test helper function that checks if the specified body length in the object head
-    matches the actual length of the object body."""
-    data = b"this is a test"
-    obj = CustomDataClass(data)
-    obj_b = obj.deflate()
-
-    # Body length is measured correctly
-    assert get_object_body_len_from_object_content(obj_b) == len(data)
-
-    # Consistent: passes
-    assert check_body_len_consistency(obj_b)
-
-    # Extend content artificially
-    obj_b_ = obj_b + b"more content"
-    # Inconsistent: fails
-    assert not check_body_len_consistency(obj_b_)
-
-    # Create object that doesn't comply with serialized object structure
-    obj_ = b"this is a test"
-    assert not check_body_len_consistency(obj_)
 
 
 @pytest.mark.parametrize(

--- a/framework/py/flwr/server/superlink/fleet/grpc_rere/fleet_servicer.py
+++ b/framework/py/flwr/server/superlink/fleet/grpc_rere/fleet_servicer.py
@@ -21,7 +21,8 @@ import grpc
 from google.protobuf.json_format import MessageToDict
 
 from flwr.common.constant import Status
-from flwr.common.inflatable import check_body_len_consistency
+from flwr.common.inflatable import UnexpectedObjectContentError
+from flwr.common.inflatable_utils import validate_object_content
 from flwr.common.logger import log
 from flwr.common.typing import InvalidRunStatusException
 from flwr.proto import fleet_pb2_grpc  # pylint: disable=E0611
@@ -200,11 +201,11 @@ class FleetServicer(fleet_pb2_grpc.FleetServicer):
             # Cancel insertion in ObjectStore
             context.abort(grpc.StatusCode.FAILED_PRECONDITION, "Unexpected node ID.")
 
-        if not check_body_len_consistency(request.object_content):
-            # Cancel insertion in ObjectStore
-            context.abort(
-                grpc.StatusCode.FAILED_PRECONDITION, "Unexpected object length"
-            )
+        # Ensure the object content is valid
+        try:
+            validate_object_content(content=request.object_content)
+        except UnexpectedObjectContentError as ex:
+            context.abort(grpc.StatusCode.FAILED_PRECONDITION, str(ex))
 
         # Init store
         store = self.objectstore_factory.store()

--- a/framework/py/flwr/server/superlink/fleet/grpc_rere/fleet_servicer_test.py
+++ b/framework/py/flwr/server/superlink/fleet/grpc_rere/fleet_servicer_test.py
@@ -417,22 +417,8 @@ class TestFleetServicer(unittest.TestCase):  # pylint: disable=R0902
             self._push_object(request=req)
         assert e.exception.code() == grpc.StatusCode.FAILED_PRECONDITION
 
-        # Correct node ID but invalid object_content
-        node_id = self.state.create_node(heartbeat_interval=30)
-        obj_b = b"extra content"
-        object_id = get_object_id(obj_b)
-        # Execute (doesn't match structure)
-        req = PushObjectRequest(
-            node=Node(node_id=node_id),
-            run_id=run_id,
-            object_id=object_id,
-            object_content=obj_b,
-        )
-        with self.assertRaises(grpc.RpcError) as e:
-            self._push_object(request=req)
-        assert e.exception.code() == grpc.StatusCode.FAILED_PRECONDITION
-
         # Prepare
+        node_id = self.state.create_node(heartbeat_interval=30)
         obj = ConfigRecord({"a": 123, "b": [4, 5, 6]})
         obj_b = obj.deflate()
 

--- a/framework/py/flwr/server/superlink/serverappio/serverappio_servicer_test.py
+++ b/framework/py/flwr/server/superlink/serverappio/serverappio_servicer_test.py
@@ -721,20 +721,6 @@ class TestServerAppIoServicer(unittest.TestCase):  # pylint: disable=R0902
             self._push_object(request=req)
         assert e.exception.code() == grpc.StatusCode.FAILED_PRECONDITION
 
-        # Correct node ID but invalid object_content
-        obj_b = b"extra content"
-        object_id = get_object_id(obj_b)
-        # Execute (doesn't match structure)
-        req = PushObjectRequest(
-            node=Node(node_id=SUPERLINK_NODE_ID),
-            run_id=run_id,
-            object_id=object_id,
-            object_content=obj_b,
-        )
-        with self.assertRaises(grpc.RpcError) as e:
-            self._push_object(request=req)
-        assert e.exception.code() == grpc.StatusCode.FAILED_PRECONDITION
-
         # Prepare
         obj = ConfigRecord({"a": 123, "b": [4, 5, 6]})
         obj_b = obj.deflate()

--- a/framework/py/flwr/supercore/object_store/in_memory_object_store.py
+++ b/framework/py/flwr/supercore/object_store/in_memory_object_store.py
@@ -18,6 +18,7 @@
 from typing import Optional
 
 from flwr.common.inflatable import get_object_id, is_valid_sha256_hash
+from flwr.common.inflatable_utils import validate_object_content
 
 from .object_store import NoObjectInStoreError, ObjectStore
 
@@ -52,11 +53,14 @@ class InMemoryObjectStore(ObjectStore):
                 f"Object with ID '{object_id}' was not pre-registered."
             )
 
-        # Verify object_id and object_content match
         if self.verify:
+            # Verify object_id and object_content match
             object_id_from_content = get_object_id(object_content)
             if object_id != object_id_from_content:
                 raise ValueError(f"Object ID {object_id} does not match content hash")
+
+            # Validate object content
+            validate_object_content(content=object_content)
 
         # Return if object is already present in the store
         if self.store[object_id] != b"":

--- a/framework/py/flwr/supercore/object_store/object_store_test.py
+++ b/framework/py/flwr/supercore/object_store/object_store_test.py
@@ -21,6 +21,7 @@ from abc import abstractmethod
 from parameterized import parameterized
 
 from flwr.common.inflatable import get_object_id
+from flwr.common.inflatable_test import CustomDataClass
 
 from .in_memory_object_store import InMemoryObjectStore
 from .object_store import NoObjectInStoreError, ObjectStore
@@ -53,7 +54,8 @@ class ObjectStoreTest(unittest.TestCase):
         """Test put and get methods."""
         # Prepare
         object_store = self.object_store_factory()
-        object_content = b"test_value"
+        obj = CustomDataClass(data=b"test_value")
+        object_content = obj.deflate()
         object_id = get_object_id(object_content)
         object_store.preregister(object_ids=[object_id])
 
@@ -68,7 +70,8 @@ class ObjectStoreTest(unittest.TestCase):
         """Test put method with an existing object_id."""
         # Prepare
         object_store = self.object_store_factory()
-        object_content = b"test_value"
+        obj = CustomDataClass(data=b"test_value")
+        object_content = obj.deflate()
         object_id = get_object_id(object_content)
         object_store.preregister(object_ids=[object_id])
 
@@ -84,7 +87,8 @@ class ObjectStoreTest(unittest.TestCase):
         """Test put method with an object_id that does not match that of content."""
         # Prepare
         object_store = self.object_store_factory()
-        object_content = b"test_value"
+        obj = CustomDataClass(data=b"test_value")
+        object_content = obj.deflate()
         object_id = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
         object_store.preregister(object_ids=[object_id])
 
@@ -101,7 +105,8 @@ class ObjectStoreTest(unittest.TestCase):
         """Test delete method."""
         # Prepare
         object_store = self.object_store_factory()
-        object_content = b"test_value"
+        obj = CustomDataClass(data=b"test_value")
+        object_content = obj.deflate()
         object_id = get_object_id(object_content)
         object_store.preregister(object_ids=[object_id])
         object_store.put(object_id, object_content)
@@ -126,10 +131,12 @@ class ObjectStoreTest(unittest.TestCase):
         """Test clear method."""
         # Prepare
         object_store = self.object_store_factory()
-        object_content1 = b"test_value1"
+        obj = CustomDataClass(data=b"test_value1")
+        object_content1 = obj.deflate()
         object_id1 = get_object_id(object_content1)
         object_store.preregister(object_ids=[object_id1])
-        object_content2 = b"test_value2"
+        obj = CustomDataClass(data=b"test_value2")
+        object_content2 = obj.deflate()
         object_id2 = get_object_id(object_content2)
         object_store.preregister(object_ids=[object_id2])
 
@@ -159,7 +166,8 @@ class ObjectStoreTest(unittest.TestCase):
         """Test __contains__ method."""
         # Prepare
         object_store = self.object_store_factory()
-        object_content = b"test_value"
+        obj = CustomDataClass(data=b"test_value1")
+        object_content = obj.deflate()
         object_id = get_object_id(object_content)
         object_store.preregister(object_ids=[object_id])
         object_store.put(object_id, object_content)
@@ -177,7 +185,8 @@ class ObjectStoreTest(unittest.TestCase):
         """Test put without preregistering first."""
         # Prepare
         object_store = self.object_store_factory()
-        object_content = b"test_value"
+        obj = CustomDataClass(data=b"test_value")
+        object_content = obj.deflate()
         object_id = get_object_id(object_content)
 
         # Execute
@@ -188,9 +197,11 @@ class ObjectStoreTest(unittest.TestCase):
         """Test preregister functionality."""
         # Prepare
         object_store = self.object_store_factory()
-        object_content1 = b"test_value1"
+        obj = CustomDataClass(data=b"test_value1")
+        object_content1 = obj.deflate()
         object_id1 = get_object_id(object_content1)
-        object_content2 = b"test_value2"
+        obj = CustomDataClass(data=b"test_value2")
+        object_content2 = obj.deflate()
         object_id2 = get_object_id(object_content2)
 
         # Execute (preregister all)
@@ -199,7 +210,8 @@ class ObjectStoreTest(unittest.TestCase):
         # Assert (none was present)
         self.assertEqual([object_id1, object_id2], not_present)
 
-        object_content3 = b"test_value3"
+        obj = CustomDataClass(data=b"test_value3")
+        object_content3 = obj.deflate()
         object_id3 = get_object_id(object_content3)
         # Execute (preregister new object)
         not_present = object_store.preregister(object_ids=[object_id3])
@@ -220,7 +232,8 @@ class ObjectStoreTest(unittest.TestCase):
         """Test setting and getting mapping of message object id and its descendants."""
         # Prepare
         object_store = self.object_store_factory()
-        object_content = b"test_value"
+        obj = CustomDataClass(data=b"test_value")
+        object_content = obj.deflate()
         object_id = get_object_id(object_content)
 
         # Execute


### PR DESCRIPTION
- Make use of `validate_object_content` when pushing objects to either servicer. 
- The `check_body_len_consistency` function and associated tests have been removed. This function was introduced as a primitive consistency check for the object content. The check that this function performed (and the associated test) are captured by `validate_object_content` and its tests.