### PR TITLE
fix(framework) Fix the CLI output for `flwr ls/stop/log` when run ID is not found

### DIFF
--- a/framework/py/flwr/cli/ls.py
+++ b/framework/py/flwr/cli/ls.py
@@ -130,23 +130,16 @@ def ls(  # pylint: disable=too-many-locals, too-many-branches, R0913, R0917
             # Display information about a specific run ID
             if run_id is not None:
                 typer.echo(f"🔍 Displaying information for run ID {run_id}...")
-                restore_output()
-                _display_one_run(stub, run_id, output_format)
+                formatted_runs = _display_one_run(stub, run_id)
             # By default, list all runs
             else:
                 typer.echo("📄 Listing all runs...")
-                restore_output()
-                _list_runs(stub, output_format)
-
-        except ValueError as err:
-            if suppress_output:
-                redirect_output(captured_output)
-            typer.secho(
-                f"❌ {err}",
-                fg=typer.colors.RED,
-                bold=True,
-            )
-            raise typer.Exit(code=1) from err
+                formatted_runs = _list_runs(stub)
+            restore_output()
+            if output_format == CliOutputFormat.JSON:
+                Console().print_json(_to_json(formatted_runs))
+            else:
+                Console().print(_to_table(formatted_runs))
         finally:
             if channel:
                 channel.close()
@@ -300,37 +293,23 @@ def _to_json(run_list: list[_RunListType]) -> str:
     return json.dumps({"success": True, "runs": runs_list})
 
 
-def _list_runs(
-    stub: ExecStub,
-    output_format: str = CliOutputFormat.DEFAULT,
-) -> None:
+def _list_runs(stub: ExecStub) -> list[_RunListType]:
     """List all runs."""
     with flwr_cli_grpc_exc_handler():
         res: ListRunsResponse = stub.ListRuns(ListRunsRequest())
     run_dict = {run_id: run_from_proto(proto) for run_id, proto in res.run_dict.items()}
 
-    formatted_runs = _format_runs(run_dict, res.now)
-    if output_format == CliOutputFormat.JSON:
-        Console().print_json(_to_json(formatted_runs))
-    else:
-        Console().print(_to_table(formatted_runs))
+    return _format_runs(run_dict, res.now)
 
 
-def _display_one_run(
-    stub: ExecStub,
-    run_id: int,
-    output_format: str = CliOutputFormat.DEFAULT,
-) -> None:
+def _display_one_run(stub: ExecStub, run_id: int) -> list[_RunListType]:
     """Display information about a specific run."""
     with flwr_cli_grpc_exc_handler():
         res: ListRunsResponse = stub.ListRuns(ListRunsRequest(run_id=run_id))
     if not res.run_dict:
+        # This won't be reached as an gRPC error is raised if run_id is invalid
         raise ValueError(f"Run ID {run_id} not found")
 
     run_dict = {run_id: run_from_proto(proto) for run_id, proto in res.run_dict.items()}
 
-    formatted_runs = _format_runs(run_dict, res.now)
-    if output_format == CliOutputFormat.JSON:
-        Console().print_json(_to_json(formatted_runs))
-    else:
-        Console().print(_to_table(formatted_runs))
+    return _format_runs(run_dict, res.now)

--- a/framework/py/flwr/cli/utils.py
+++ b/framework/py/flwr/cli/utils.py
@@ -28,7 +28,12 @@ import typer
 
 from flwr.cli.cli_user_auth_interceptor import CliUserAuthInterceptor
 from flwr.common.auth_plugin import CliAuthPlugin
-from flwr.common.constant import AUTH_TYPE_JSON_KEY, CREDENTIALS_DIR, FLWR_DIR
+from flwr.common.constant import (
+    AUTH_TYPE_JSON_KEY,
+    CREDENTIALS_DIR,
+    FLWR_DIR,
+    RUN_ID_NOT_FOUND_MESSAGE,
+)
 from flwr.common.grpc import (
     GRPC_MAX_MESSAGE_LENGTH,
     create_channel,
@@ -323,7 +328,10 @@ def flwr_cli_grpc_exc_handler() -> Iterator[None]:
             # pylint: disable=E1101
             typer.secho(e.details(), fg=typer.colors.RED, bold=True)
             raise typer.Exit(code=1) from None
-        if e.code() == grpc.StatusCode.NOT_FOUND and e.details() == "Run ID not found":
+        if (
+            e.code() == grpc.StatusCode.NOT_FOUND
+            and e.details() == RUN_ID_NOT_FOUND_MESSAGE
+        ):
             typer.secho(
                 "❌ Run ID not found.",
                 fg=typer.colors.RED,

--- a/framework/py/flwr/cli/utils.py
+++ b/framework/py/flwr/cli/utils.py
@@ -323,4 +323,11 @@ def flwr_cli_grpc_exc_handler() -> Iterator[None]:
             # pylint: disable=E1101
             typer.secho(e.details(), fg=typer.colors.RED, bold=True)
             raise typer.Exit(code=1) from None
+        if e.code() == grpc.StatusCode.NOT_FOUND and e.details() == "Run ID not found":
+            typer.secho(
+                "❌ Run ID not found.",
+                fg=typer.colors.RED,
+                bold=True,
+            )
+            raise typer.Exit(code=1) from None
         raise

--- a/framework/py/flwr/common/constant.py
+++ b/framework/py/flwr/common/constant.py
@@ -150,6 +150,10 @@ PULL_INITIAL_BACKOFF = 1  # Initial backoff time for pulling objects
 PULL_BACKOFF_CAP = 10  # Maximum backoff time for pulling objects
 
 
+# ExecServicer constants
+RUN_ID_NOT_FOUND_MESSAGE = "Run ID not found"
+
+
 class MessageType:
     """Message type."""
 

--- a/framework/py/flwr/server/superlink/linkstate/in_memory_linkstate.py
+++ b/framework/py/flwr/server/superlink/linkstate/in_memory_linkstate.py
@@ -478,7 +478,9 @@ class InMemoryLinkState(LinkState):  # pylint: disable=R0902,R0904
         if they have not sent a heartbeat before `active_until`.
         """
         current = now()
-        for record in [self.run_ids[run_id] for run_id in run_ids]:
+        for record in (self.run_ids.get(run_id) for run_id in run_ids):
+            if record is None:
+                continue
             with record.lock:
                 if record.run.status.status in (Status.STARTING, Status.RUNNING):
                     if record.active_until < current.timestamp():

--- a/framework/py/flwr/superexec/exec_servicer.py
+++ b/framework/py/flwr/superexec/exec_servicer.py
@@ -24,7 +24,12 @@ import grpc
 
 from flwr.common import now
 from flwr.common.auth_plugin import ExecAuthPlugin
-from flwr.common.constant import LOG_STREAM_INTERVAL, Status, SubStatus
+from flwr.common.constant import (
+    LOG_STREAM_INTERVAL,
+    RUN_ID_NOT_FOUND_MESSAGE,
+    Status,
+    SubStatus,
+)
 from flwr.common.logger import log
 from flwr.common.serde import (
     config_record_from_proto,
@@ -103,7 +108,7 @@ class ExecServicer(exec_pb2_grpc.ExecServicer):
 
         # Exit if `run_id` not found
         if not run:
-            context.abort(grpc.StatusCode.NOT_FOUND, "Run ID not found")
+            context.abort(grpc.StatusCode.NOT_FOUND, RUN_ID_NOT_FOUND_MESSAGE)
 
         # If user auth is enabled, check if `flwr_aid` matches the run's `flwr_aid`
         if self.auth_plugin:
@@ -165,7 +170,7 @@ class ExecServicer(exec_pb2_grpc.ExecServicer):
 
             # Exit if `run_id` not found
             if not run:
-                context.abort(grpc.StatusCode.NOT_FOUND, "Run ID not found")
+                context.abort(grpc.StatusCode.NOT_FOUND, RUN_ID_NOT_FOUND_MESSAGE)
 
             # If user auth is enabled, check if `flwr_aid` matches the run's `flwr_aid`
             if self.auth_plugin:
@@ -191,7 +196,7 @@ class ExecServicer(exec_pb2_grpc.ExecServicer):
 
         # Exit if `run_id` not found
         if not run:
-            context.abort(grpc.StatusCode.NOT_FOUND, "Run ID not found")
+            context.abort(grpc.StatusCode.NOT_FOUND, RUN_ID_NOT_FOUND_MESSAGE)
 
         # If user auth is enabled, check if `flwr_aid` matches the run's `flwr_aid`
         if self.auth_plugin:


### PR DESCRIPTION
# Now
![image](https://github.com/user-attachments/assets/02c8712b-404b-4db0-b03f-dd0e9ea85590)
