### PR TITLE
feat(framework) Remove `DashboardServicer`

### DIFF
--- a/framework/py/flwr/server/app.py
+++ b/framework/py/flwr/server/app.py
@@ -91,7 +91,6 @@ P = TypeVar("P", ExecAuthPlugin, ExecAuthzPlugin)
 try:
     from flwr.ee import (
         add_ee_args_superlink,
-        get_dashboard_server,
         get_exec_auth_plugins,
         get_exec_authz_plugins,
         get_exec_event_log_writer_plugins,
@@ -332,17 +331,6 @@ def run_superlink() -> None:
         )
         scheduler_th.start()
         bckg_threads.append(scheduler_th)
-
-    # Add Dashboard server if available
-    if dashboard_address := getattr(args, "dashboard_address", None):
-        dashboard_address_str, _, _ = _format_address(dashboard_address)
-        dashboard_server = get_dashboard_server(
-            address=dashboard_address_str,
-            state_factory=state_factory,
-            certificates=None,
-        )
-
-        grpc_servers.append(dashboard_server)
 
     # Graceful shutdown
     register_exit_handlers(


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

The DashboardServicer is removed in favour of using the Exec API's `ListRuns` endpoint.
<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

### Checklist

- [x] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.ai/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
