### PR TITLE
fix(framework) Fix bugs related to objects and node availability

### DIFF
--- a/framework/py/flwr/server/grid/grpc_grid.py
+++ b/framework/py/flwr/server/grid/grpc_grid.py
@@ -305,7 +305,7 @@ class GrpcGrid(Grid):
             for msg_proto in res.messages_list:
                 msg_id = msg_proto.metadata.message_id
                 all_object_contents = pull_objects(
-                    list(res.objects_to_pull[msg_id].object_ids) + [msg_id],
+                    list(res.objects_to_pull[msg_id].object_ids),
                     pull_object_fn=make_pull_object_fn_grpc(
                         pull_object_grpc=self._stub.PullObject,
                         node=self.node,

--- a/framework/py/flwr/server/grid/grpc_grid.py
+++ b/framework/py/flwr/server/grid/grpc_grid.py
@@ -305,7 +305,7 @@ class GrpcGrid(Grid):
             for msg_proto in res.messages_list:
                 msg_id = msg_proto.metadata.message_id
                 all_object_contents = pull_objects(
-                    list(res.objects_to_pull[msg_id].object_ids),
+                    list(res.objects_to_pull[msg_id].object_ids) + [msg_id],
                     pull_object_fn=make_pull_object_fn_grpc(
                         pull_object_grpc=self._stub.PullObject,
                         node=self.node,

--- a/framework/py/flwr/server/superlink/linkstate/in_memory_linkstate.py
+++ b/framework/py/flwr/server/superlink/linkstate/in_memory_linkstate.py
@@ -249,7 +249,9 @@ class InMemoryLinkState(LinkState):  # pylint: disable=R0902,R0904
                 inquired_in_message_ids=message_ids,
                 found_in_message_dict=self.message_ins_store,
                 node_id_to_online_until={
-                    node_id: self.node_ids[node_id][0] for node_id in dst_node_ids
+                    node_id: self.node_ids[node_id][0]
+                    for node_id in dst_node_ids
+                    if node_id in self.node_ids
                 },
                 current_time=current,
             )

--- a/framework/py/flwr/server/superlink/serverappio/serverappio_servicer.py
+++ b/framework/py/flwr/server/superlink/serverappio/serverappio_servicer.py
@@ -25,7 +25,7 @@ from flwr.common import Message
 from flwr.common.constant import SUPERLINK_NODE_ID, Status
 from flwr.common.inflatable import (
     UnexpectedObjectContentError,
-    get_descendant_object_ids,
+    get_all_nested_objects,
     get_object_tree,
     no_object_id_recompute,
 )
@@ -181,7 +181,7 @@ class ServerAppIoServicer(serverappio_pb2_grpc.ServerAppIoServicer):
             objects_to_push=objects_to_push,
         )
 
-    def PullMessages(
+    def PullMessages(  # pylint: disable=R0914
         self, request: PullResMessagesRequest, context: grpc.ServicerContext
     ) -> PullResMessagesResponse:
         """Pull a set of Messages."""
@@ -209,14 +209,18 @@ class ServerAppIoServicer(serverappio_pb2_grpc.ServerAppIoServicer):
         for msg_res in messages_res:
             if msg_res.metadata.src_node_id == SUPERLINK_NODE_ID:
                 with no_object_id_recompute():
-                    descendants = list(get_descendant_object_ids(msg_res))
+                    all_objects = get_all_nested_objects(msg_res)
+                    descendants = list(all_objects.keys())[:-1]
                     message_obj_id = msg_res.metadata.message_id
-                # Store mapping
-                store.set_message_descendant_ids(
-                    msg_object_id=message_obj_id, descendant_ids=descendants
-                )
-                # Preregister
-                store.preregister(request.run_id, get_object_tree(msg_res))
+                    # Store mapping
+                    store.set_message_descendant_ids(
+                        msg_object_id=message_obj_id, descendant_ids=descendants
+                    )
+                    # Preregister
+                    store.preregister(request.run_id, get_object_tree(msg_res))
+                    # Store objects
+                    for obj_id, obj in all_objects.items():
+                        store.put(obj_id, obj.deflate())
 
         # Delete the instruction Messages and their replies if found
         message_ins_ids_to_delete = {

--- a/framework/py/flwr/server/superlink/serverappio/serverappio_servicer.py
+++ b/framework/py/flwr/server/superlink/serverappio/serverappio_servicer.py
@@ -247,10 +247,8 @@ class ServerAppIoServicer(serverappio_pb2_grpc.ServerAppIoServicer):
             try:
                 msg_object_id = msg.metadata.message_id
                 descendants = store.get_message_descendant_ids(msg_object_id)
-                # Include the object_id of the message itself
-                objects_to_pull[msg_object_id] = ObjectIDs(
-                    object_ids=descendants + [msg_object_id]
-                )
+                # Add mapping of message object ID to its descendants
+                objects_to_pull[msg_object_id] = ObjectIDs(object_ids=descendants)
             except NoObjectInStoreError as e:
                 log(ERROR, e.message)
                 # Delete message ins from state

--- a/framework/py/flwr/server/superlink/serverappio/serverappio_servicer_test.py
+++ b/framework/py/flwr/server/superlink/serverappio/serverappio_servicer_test.py
@@ -408,6 +408,7 @@ class TestServerAppIoServicer(unittest.TestCase):  # pylint: disable=R0902, R090
             for obj_ids in response.objects_to_pull.values()
             for obj_id in obj_ids.object_ids
         }
+        object_ids_in_response |= set(response.objects_to_pull.keys())
         if register_in_store:
             # Assert expected object_ids
             assert set(obj_ids_registered) == object_ids_in_response
@@ -541,9 +542,7 @@ class TestServerAppIoServicer(unittest.TestCase):  # pylint: disable=R0902, R090
             assert msg_res.has_error()
             # objects_to_pull is expected to be {msg_obj_id: msg_obj_id}
             assert list(response.objects_to_pull.keys()) == [msg_res.object_id]
-            assert list(response.objects_to_pull.values())[0].object_ids == [
-                msg_res.object_id
-            ]
+            assert list(response.objects_to_pull.values())[0].object_ids == []
 
     def test_push_serverapp_outputs_successful_if_running(self) -> None:
         """Test `PushServerAppOutputs` success."""

--- a/framework/py/flwr/server/superlink/serverappio/serverappio_servicer_test.py
+++ b/framework/py/flwr/server/superlink/serverappio/serverappio_servicer_test.py
@@ -540,7 +540,7 @@ class TestServerAppIoServicer(unittest.TestCase):  # pylint: disable=R0902, R090
             # Assert that objects to pull points to a message carrying an error
             msg_res = message_from_proto(response.messages_list[0])
             assert msg_res.has_error()
-            # objects_to_pull is expected to be {msg_obj_id: msg_obj_id}
+            # objects_to_pull is expected to be {msg_obj_id: []}
             assert list(response.objects_to_pull.keys()) == [msg_res.object_id]
             assert list(response.objects_to_pull.values())[0].object_ids == []
 


### PR DESCRIPTION
- The `InMemoryLinkState` now checks the existence of node ID before accessing it, avoiding raising `KeyError`
- SuperLink-generated error messages are now correctly stored in `ObjectStore`
- `ServerAppIoServicer.PullMessages` will not include message object ID unnecessarily in `object_ids_to_pull`