### PR TITLE
fix(framework) Add `try`-`except` to `run.py` for graceful exit

### DIFF
--- a/framework/py/flwr/cli/run/run.py
+++ b/framework/py/flwr/cli/run/run.py
@@ -150,50 +150,57 @@ def _run_with_exec_api(
     stream: bool,
     output_format: str,
 ) -> None:
-    auth_plugin = try_obtain_cli_auth_plugin(app, federation, federation_config)
-    channel = init_channel(app, federation_config, auth_plugin)
-    stub = ExecStub(channel)
+    channel = None
+    try:
+        auth_plugin = try_obtain_cli_auth_plugin(app, federation, federation_config)
+        channel = init_channel(app, federation_config, auth_plugin)
+        stub = ExecStub(channel)
 
-    fab_bytes, fab_hash, config = build_fab(app)
-    fab_id, fab_version = get_metadata_from_config(config)
+        fab_bytes, fab_hash, config = build_fab(app)
+        fab_id, fab_version = get_metadata_from_config(config)
 
-    fab = Fab(fab_hash, fab_bytes)
+        fab = Fab(fab_hash, fab_bytes)
 
-    # Construct a `ConfigRecord` out of a flattened `UserConfig`
-    fed_config = flatten_dict(federation_config.get("options", {}))
-    c_record = user_config_to_configrecord(fed_config)
+        # Construct a `ConfigRecord` out of a flattened `UserConfig`
+        fed_config = flatten_dict(federation_config.get("options", {}))
+        c_record = user_config_to_configrecord(fed_config)
 
-    req = StartRunRequest(
-        fab=fab_to_proto(fab),
-        override_config=user_config_to_proto(parse_config_args(config_overrides)),
-        federation_options=config_record_to_proto(c_record),
-    )
-    with flwr_cli_grpc_exc_handler():
-        res = stub.StartRun(req)
-
-    if res.HasField("run_id"):
-        typer.secho(f"🎊 Successfully started run {res.run_id}", fg=typer.colors.GREEN)
-    else:
-        typer.secho("❌ Failed to start run", fg=typer.colors.RED)
-        raise typer.Exit(code=1)
-
-    if output_format == CliOutputFormat.JSON:
-        run_output = json.dumps(
-            {
-                "success": res.HasField("run_id"),
-                "run-id": res.run_id if res.HasField("run_id") else None,
-                "fab-id": fab_id,
-                "fab-name": fab_id.rsplit("/", maxsplit=1)[-1],
-                "fab-version": fab_version,
-                "fab-hash": fab_hash[:8],
-                "fab-filename": get_fab_filename(config, fab_hash),
-            }
+        req = StartRunRequest(
+            fab=fab_to_proto(fab),
+            override_config=user_config_to_proto(parse_config_args(config_overrides)),
+            federation_options=config_record_to_proto(c_record),
         )
-        restore_output()
-        Console().print_json(run_output)
+        with flwr_cli_grpc_exc_handler():
+            res = stub.StartRun(req)
 
-    if stream:
-        start_stream(res.run_id, channel, CONN_REFRESH_PERIOD)
+        if res.HasField("run_id"):
+            typer.secho(
+                f"🎊 Successfully started run {res.run_id}", fg=typer.colors.GREEN
+            )
+        else:
+            typer.secho("❌ Failed to start run", fg=typer.colors.RED)
+            raise typer.Exit(code=1)
+
+        if output_format == CliOutputFormat.JSON:
+            run_output = json.dumps(
+                {
+                    "success": res.HasField("run_id"),
+                    "run-id": res.run_id if res.HasField("run_id") else None,
+                    "fab-id": fab_id,
+                    "fab-name": fab_id.rsplit("/", maxsplit=1)[-1],
+                    "fab-version": fab_version,
+                    "fab-hash": fab_hash[:8],
+                    "fab-filename": get_fab_filename(config, fab_hash),
+                }
+            )
+            restore_output()
+            Console().print_json(run_output)
+
+        if stream:
+            start_stream(res.run_id, channel, CONN_REFRESH_PERIOD)
+    finally:
+        if channel:
+            channel.close()
 
 
 def _run_without_exec_api(


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

### Checklist

- [ ] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.ai/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
