### PR TITLE
ci(framework) Send GH info to correct Slack channel

### DIFF
--- a/.github/workflows/ping-stale-pr.yml
+++ b/.github/workflows/ping-stale-pr.yml
@@ -12,7 +12,7 @@ jobs:
       pull-requests: read
     env:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-      SLACK_CHANNEL_ID: ${{ secrets. SLACK_CHANNEL_ID_SUPPORT_GITHUB_ISSUES }}
+      SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID_SUPPORT_GITHUB_ISSUES }}
 
     steps:
       - name: Ping stale Contributor PRs via Slack

--- a/.github/workflows/ping-stale-pr.yml
+++ b/.github/workflows/ping-stale-pr.yml
@@ -12,7 +12,7 @@ jobs:
       pull-requests: read
     env:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-      SLACK_CHANNEL_ID: C0931FWLD7A
+      SLACK_CHANNEL_ID: ${{ secrets. SLACK_CHANNEL_ID_SUPPORT_GITHUB_ISSUES }}
 
     steps:
       - name: Ping stale Contributor PRs via Slack

--- a/.github/workflows/ping-stale-pr.yml
+++ b/.github/workflows/ping-stale-pr.yml
@@ -12,7 +12,7 @@ jobs:
       pull-requests: read
     env:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-      SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
+      SLACK_CHANNEL_ID: C0931FWLD7A
 
     steps:
       - name: Ping stale Contributor PRs via Slack

--- a/.github/workflows/ping-stale-under-discussion.yml
+++ b/.github/workflows/ping-stale-under-discussion.yml
@@ -12,7 +12,7 @@ jobs:
       issues: read
     env:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-      SLACK_CHANNEL_ID: C08AS39MWP7
+      SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID_SUPPORT_GITHUB_PRS }}
     steps:
       - name: Ping stale Under Discussion issues via Slack
         uses: actions/github-script@v6

--- a/.github/workflows/ping-stale-under-discussion.yml
+++ b/.github/workflows/ping-stale-under-discussion.yml
@@ -12,7 +12,7 @@ jobs:
       issues: read
     env:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-      SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
+      SLACK_CHANNEL_ID: C08AS39MWP7
     steps:
       - name: Ping stale Under Discussion issues via Slack
         uses: actions/github-script@v6


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue
Sending GitHub info to one slack channel. 
### Description
Send to different ones. 
<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal
Change to direct to specific channel, leave token as secret. 
### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

### Checklist

- [x] Implement proposed change
- [x] Write tests
- [x] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.ai/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
