### PR TITLE
docs(*:skip) Add Flower AI Day 2025 banner to documentation and `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
     <a href="https://flower.ai/blog">Blog</a> |
     <a href="https://flower.ai/docs/">Docs</a> |
     <a href="https://flower.ai/events/flower-ai-summit-2025">Summit</a> |
+    <a href="https://flower.ai/events/flower-ai-day-2025">AI Day</a> |
     <a href="https://flower.ai/join-slack">Slack</a>
     <br /><br />
 </p>

--- a/dev/update-html-themes.py
+++ b/dev/update-html-themes.py
@@ -26,20 +26,20 @@ ROOT_DIR = Path(".")
 # Define new fields to be added to the `html_theme_options` dictionary in `conf.py`.
 # If no fields are needed, set to an empty dictionary.
 NEW_FIELDS: dict[str, Optional[Union[dict[str, str], str]]] = {
-    #     "announcement": (
-    #         "<a href='https://flower.ai/events/flower-ai-summit-2025/'>"
-    #         "<strong style='color: #f2b705;'>👉 Register now</strong></a> "
-    #         "for Flower AI Summit 2025!<br />"
-    #         "March 26-27, 🇬🇧 London & Online"
-    #     ),
-    #     "light_css_variables": {
-    #         "color-announcement-background": "#292f36",
-    #         "color-announcement-text": "#ffffff",
-    #     },
-    #     "dark_css_variables": {
-    #         "color-announcement-background": "#292f36",
-    #         "color-announcement-text": "#ffffff",
-    #     },
+    "announcement": (
+        "<a href='https://flower.ai/events/flower-ai-day-2025/'>"
+        "<strong style='color: #f2b705;'>👉 Register now</strong></a> "
+        "for Flower AI Day 2025!<br />"
+        "September 25, 🇺🇸 San Francisco"
+    ),
+    "light_css_variables": {
+        "color-announcement-background": "#292f36",
+        "color-announcement-text": "#ffffff",
+    },
+    "dark_css_variables": {
+        "color-announcement-background": "#292f36",
+        "color-announcement-text": "#ffffff",
+    },
 }
 
 

--- a/framework/docs/source/conf.py
+++ b/framework/docs/source/conf.py
@@ -312,6 +312,20 @@ html_theme_options = {
     #     "color-brand-content": "#292F36",
     #     "color-admonition-background": "#F2B705",
     # },
+    "announcement": (
+        "<a href='https://flower.ai/events/flower-ai-day-2025/'>"
+        "<strong style='color: #f2b705;'>👉 Register now</strong></a> "
+        "for Flower AI Day 2025!<br />"
+        "September 25, 🇺🇸 San Francisco"
+    ),
+    "light_css_variables": {
+        "color-announcement-background": "#292f36",
+        "color-announcement-text": "#ffffff",
+    },
+    "dark_css_variables": {
+        "color-announcement-background": "#292f36",
+        "color-announcement-text": "#ffffff",
+    },
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,


### PR DESCRIPTION
To increase awareness of our Flower AI Day 2025 in SF, this PR:
1. Adds a banner to the top of all of our framework docs.
2. Adds an additional link to `AI Day` at the top of this repository's `README.md`. 

The banner will look like this:
<img width="887" alt="image" src="https://github.com/user-attachments/assets/7c7e4a37-bbdd-421d-84ff-840b2571fc30" />
