### PR TITLE
refactor(framework) Make `Array` one `ArrayChunk` to carry all its data

### DIFF
--- a/framework/py/flwr/common/inflatable_utils.py
+++ b/framework/py/flwr/common/inflatable_utils.py
@@ -40,9 +40,11 @@ from .inflatable import (
 )
 from .message import Message
 from .record import Array, ArrayRecord, ConfigRecord, MetricRecord, RecordDict
+from .record.arraychunk import ArrayChunk
 
 # Helper registry that maps names of classes to their type
 inflatable_class_registry: dict[str, type[InflatableObject]] = {
+    ArrayChunk.__qualname__: ArrayChunk,
     Array.__qualname__: Array,
     ArrayRecord.__qualname__: ArrayRecord,
     ConfigRecord.__qualname__: ConfigRecord,

--- a/framework/py/flwr/common/record/arraychunk.py
+++ b/framework/py/flwr/common/record/arraychunk.py
@@ -1,0 +1,62 @@
+# Copyright 2025 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""ArrayChunk."""
+
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ..inflatable import InflatableObject, add_header_to_object_body, get_object_body
+
+
+@dataclass
+class ArrayChunk(InflatableObject):
+    """ArrayChunk type."""
+
+    data: memoryview
+
+    def __init__(self, data: bytes) -> None:
+        self.data = memoryview(data)
+
+    def deflate(self) -> bytes:
+        """Deflate the ArrayChunk."""
+        return add_header_to_object_body(object_body=self.data, obj=self)
+
+    @classmethod
+    def inflate(
+        cls, object_content: bytes, children: dict[str, InflatableObject] | None = None
+    ) -> ArrayChunk:
+        """Inflate an ArrayChunk from bytes.
+
+        Parameters
+        ----------
+        object_content : bytes
+            The deflated object content of the ArrayChunk.
+
+        children : Optional[dict[str, InflatableObject]] (default: None)
+            Must be ``None``. ``ArrayChunk`` does not support child objects.
+            Providing any children will raise a ``ValueError``.
+
+        Returns
+        -------
+        ArrayChunk
+            The inflated ArrayChunk.
+        """
+        if children:
+            raise ValueError("`ArrayChunk` objects do not have children.")
+
+        obj_body = get_object_body(object_content, cls)
+        return cls(data=memoryview(obj_body))

--- a/framework/py/flwr/common/record/arraychunk_test.py
+++ b/framework/py/flwr/common/record/arraychunk_test.py
@@ -1,0 +1,50 @@
+# Copyright 2025 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Unit tests for ArrayChunk."""
+
+
+import pytest
+
+from .arraychunk import ArrayChunk
+
+
+def test_deflate_inflate() -> None:
+    """Test deflate/inflate."""
+    # Prepare
+    data = b"some data"
+    ac = ArrayChunk(data)
+
+    # Deflate
+    ac_deflated = ac.deflate()
+
+    # Inflate
+    ac_inflated = ArrayChunk.inflate(ac_deflated)
+
+    # Assert (objects are identical)
+    assert ac.object_id == ac_inflated.object_id
+
+
+def test_inflate_passing_children() -> None:
+    """ArrayChunk do not have children."""
+    # Prepare
+    data = b"some data"
+    ac = ArrayChunk(data)
+
+    # Deflate
+    ac_deflated = ac.deflate()
+
+    # Inflate
+    with pytest.raises(ValueError):
+        ArrayChunk.inflate(ac_deflated, children={"123": ac})


### PR DESCRIPTION
A follow up PR will slice the `<Array>.data` and generate in that way multiple `ArrayChunk` objects per array.