### PR TITLE
refactor(framework) Improve user-facing error message when permission is denied

### DIFF
--- a/framework/py/flwr/cli/utils.py
+++ b/framework/py/flwr/cli/utils.py
@@ -320,7 +320,8 @@ def flwr_cli_grpc_exc_handler() -> Iterator[None]:
             raise typer.Exit(code=1) from None
         if e.code() == grpc.StatusCode.PERMISSION_DENIED:
             typer.secho(
-                "❌ Permission denied. Please contact the SuperLink administrator.",
+                "❌ Permission denied. You may need to contact the SuperLink "
+                "administrator.",
                 fg=typer.colors.RED,
                 bold=True,
             )

--- a/framework/py/flwr/cli/utils.py
+++ b/framework/py/flwr/cli/utils.py
@@ -320,8 +320,7 @@ def flwr_cli_grpc_exc_handler() -> Iterator[None]:
             raise typer.Exit(code=1) from None
         if e.code() == grpc.StatusCode.PERMISSION_DENIED:
             typer.secho(
-                "❌ Permission denied. You may need to contact the SuperLink "
-                "administrator.",
+                "❌ Permission denied. Please contact the SuperLink administrator.",
                 fg=typer.colors.RED,
                 bold=True,
             )

--- a/framework/py/flwr/cli/utils.py
+++ b/framework/py/flwr/cli/utils.py
@@ -320,7 +320,7 @@ def flwr_cli_grpc_exc_handler() -> Iterator[None]:
             raise typer.Exit(code=1) from None
         if e.code() == grpc.StatusCode.PERMISSION_DENIED:
             typer.secho(
-                "❌ Permission denied. Please contact the SuperLink administrator.",
+                "❌ Permission denied.",
                 fg=typer.colors.RED,
                 bold=True,
             )

--- a/framework/py/flwr/superexec/exec_license_interceptor.py
+++ b/framework/py/flwr/superexec/exec_license_interceptor.py
@@ -58,7 +58,11 @@ class ExecLicenseInterceptor(grpc.ServerInterceptor):  # type: ignore
             call = method_handler.unary_unary or method_handler.unary_stream
 
             if not self.license_plugin.check_license():
-                context.abort(grpc.StatusCode.PERMISSION_DENIED, "License check failed")
+                context.abort(
+                    grpc.StatusCode.PERMISSION_DENIED,
+                    "❗️ License check failed. Please try again soon. If you continue "
+                    "to see this error, please contact the SuperLink administrator.",
+                )
                 raise grpc.RpcError()
 
             return call(request, context)  # type: ignore

--- a/framework/py/flwr/superexec/exec_license_interceptor.py
+++ b/framework/py/flwr/superexec/exec_license_interceptor.py
@@ -60,8 +60,8 @@ class ExecLicenseInterceptor(grpc.ServerInterceptor):  # type: ignore
             if not self.license_plugin.check_license():
                 context.abort(
                     grpc.StatusCode.PERMISSION_DENIED,
-                    "❗️ License check failed. Please try again soon. If you continue "
-                    "to see this error, please contact the SuperLink administrator.",
+                    "❗️ License check failed. Please contact the SuperLink "
+                    "administrator.",
                 )
                 raise grpc.RpcError()
 

--- a/framework/py/flwr/superexec/exec_license_interceptor_test.py
+++ b/framework/py/flwr/superexec/exec_license_interceptor_test.py
@@ -123,6 +123,5 @@ class TestExecLicenseInterceptor(unittest.TestCase):
         # The interceptor should have called context.abort(...) once
         dummy_ctx.abort.assert_called_once_with(
             grpc.StatusCode.PERMISSION_DENIED,
-            "❗️ License check failed. Please try again soon. If you continue to "
-            "see this error, please contact the SuperLink administrator.",
+            "❗️ License check failed. Please contact the SuperLink administrator.",
         )

--- a/framework/py/flwr/superexec/exec_license_interceptor_test.py
+++ b/framework/py/flwr/superexec/exec_license_interceptor_test.py
@@ -123,5 +123,6 @@ class TestExecLicenseInterceptor(unittest.TestCase):
         # The interceptor should have called context.abort(...) once
         dummy_ctx.abort.assert_called_once_with(
             grpc.StatusCode.PERMISSION_DENIED,
-            "License check failed",
+            "❗️ License check failed. Please try again soon. If you continue to "
+            "see this error, please contact the SuperLink administrator.",
         )

--- a/framework/py/flwr/superexec/exec_user_auth_interceptor.py
+++ b/framework/py/flwr/superexec/exec_user_auth_interceptor.py
@@ -108,7 +108,9 @@ class ExecUserAuthInterceptor(grpc.ServerInterceptor):  # type: ignore
                 # Check if the user is authorized
                 if not self.authz_plugin.verify_user_authorization(account_info):
                     context.abort(
-                        grpc.StatusCode.PERMISSION_DENIED, "User not authorized"
+                        grpc.StatusCode.PERMISSION_DENIED,
+                        "❗️ User not authorized. "
+                        "Please contact the SuperLink administrator.",
                     )
                     raise grpc.RpcError()
                 return call(request, context)  # type: ignore
@@ -127,7 +129,9 @@ class ExecUserAuthInterceptor(grpc.ServerInterceptor):  # type: ignore
                 # Check if the user is authorized
                 if not self.authz_plugin.verify_user_authorization(account_info):
                     context.abort(
-                        grpc.StatusCode.PERMISSION_DENIED, "User not authorized"
+                        grpc.StatusCode.PERMISSION_DENIED,
+                        "❗️ User not authorized. "
+                        "Please contact the SuperLink administrator.",
                     )
                     raise grpc.RpcError()
 

--- a/framework/py/flwr/superexec/exec_user_auth_interceptor_test.py
+++ b/framework/py/flwr/superexec/exec_user_auth_interceptor_test.py
@@ -392,5 +392,6 @@ class TestExecUserAuthInterceptorAuthorization(unittest.TestCase):
 
         # Ensure abort was called with PERMISSION_DENIED
         dummy_context.abort.assert_called_once_with(
-            grpc.StatusCode.PERMISSION_DENIED, "User not authorized"
+            grpc.StatusCode.PERMISSION_DENIED,
+            "❗️ User not authorized. Please contact the SuperLink administrator.",
         )


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

This PR improves the error message if permission is denied due to an expired license:
```shell
➜ flwr ls # same for `run`, `stop`, `log`
Loading project configuration...
Success
📄 Listing all runs...
❌ Permission denied.
❗️ License check failed. Please contact the SuperLink administrator.
```

<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

### Checklist

- [ ] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.ai/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
