### PR TITLE
feat(framework) Allow empty `Array`

### DIFF
--- a/framework/py/flwr/common/record/array.py
+++ b/framework/py/flwr/common/record/array.py
@@ -321,7 +321,7 @@ class Array(InflatableObject):
         Array
             The inflated Array.
         """
-        if not children:
+        if children is None:
             children = {}
 
         obj_body = get_object_body(object_content, cls)

--- a/framework/py/flwr/common/record/array.py
+++ b/framework/py/flwr/common/record/array.py
@@ -321,9 +321,6 @@ class Array(InflatableObject):
         Array
             The inflated Array.
         """
-        if not children:
-            raise ValueError("`Array` objects must have children.")
-
         obj_body = get_object_body(object_content, cls)
 
         # Extract children IDs from head

--- a/framework/py/flwr/common/record/array.py
+++ b/framework/py/flwr/common/record/array.py
@@ -321,6 +321,9 @@ class Array(InflatableObject):
         Array
             The inflated Array.
         """
+        if not children:
+            children = {}
+
         obj_body = get_object_body(object_content, cls)
 
         # Extract children IDs from head

--- a/framework/py/flwr/common/record/array_test.py
+++ b/framework/py/flwr/common/record/array_test.py
@@ -232,7 +232,7 @@ class TestArray(unittest.TestCase):
         arr_ = Array.inflate(arr.deflate(), children=arr.children)
 
         # Assert: Array has no children
-        assert arr.children == {}
+        assert not arr.children
         # Assert: Both objects are identical
         assert arr.object_id == arr_.object_id
 

--- a/framework/py/flwr/common/record/array_test.py
+++ b/framework/py/flwr/common/record/array_test.py
@@ -223,6 +223,19 @@ class TestArray(unittest.TestCase):
             ValueError, Array.inflate, arr_b, children={"123": ArrayChunk(b"")}
         )
 
+    def test_deflate_and_inflate_empty_array(self) -> None:
+        """Ensure an empty Array can be (de)inflated correctly."""
+        # Prepare: Create an empty Array
+        arr = Array(dtype="", shape=(), stype="", data=b"")
+
+        # Execute: Deflate, and then inflate
+        arr_ = Array.inflate(arr.deflate(), children=arr.children)
+
+        # Assert: Array has no children
+        assert arr.children == {}
+        # Assert: Both objects are identical
+        assert arr.object_id == arr_.object_id
+
     def test_slicing_and_concatenation(self) -> None:
         """Test Array slicing."""
         arr = Array(np.random.randn(3000, 3000))


### PR DESCRIPTION
In the e2e-pandas tests, it always raises an error saying "Array must have children", which is not true if the array is like `Array(..., data=b"")`.