### PR TITLE
refactor(framework) Create `utils.py` for `ObjectStore`

### DIFF
--- a/framework/py/flwr/server/superlink/fleet/message_handler/message_handler.py
+++ b/framework/py/flwr/server/superlink/fleet/message_handler/message_handler.py
@@ -61,8 +61,7 @@ from flwr.server.superlink.linkstate import LinkState
 from flwr.server.superlink.utils import check_abort
 from flwr.supercore.ffs import Ffs
 from flwr.supercore.object_store import NoObjectInStoreError, ObjectStore
-
-from ...utils import store_mapping_and_register_objects
+from flwr.supercore.object_store.utils import store_mapping_and_register_objects
 
 
 def create_node(

--- a/framework/py/flwr/server/superlink/serverappio/serverappio_servicer.py
+++ b/framework/py/flwr/server/superlink/serverappio/serverappio_servicer.py
@@ -87,8 +87,7 @@ from flwr.server.superlink.utils import abort_if
 from flwr.server.utils.validator import validate_message
 from flwr.supercore.ffs import Ffs, FfsFactory
 from flwr.supercore.object_store import NoObjectInStoreError, ObjectStoreFactory
-
-from ..utils import store_mapping_and_register_objects
+from flwr.supercore.object_store.utils import store_mapping_and_register_objects
 
 
 class ServerAppIoServicer(serverappio_pb2_grpc.ServerAppIoServicer):

--- a/framework/py/flwr/supercore/object_store/utils.py
+++ b/framework/py/flwr/supercore/object_store/utils.py
@@ -1,0 +1,47 @@
+# Copyright 2025 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Utils for ObjectStore."""
+
+from typing import Union
+
+from flwr.proto.appio_pb2 import PushAppMessagesRequest  # pylint: disable=E0611
+from flwr.proto.fleet_pb2 import PushMessagesRequest  # pylint: disable=E0611
+from flwr.proto.message_pb2 import ObjectIDs  # pylint: disable=E0611
+
+from . import ObjectStore
+
+
+def store_mapping_and_register_objects(
+    store: ObjectStore, request: Union[PushAppMessagesRequest, PushMessagesRequest]
+) -> dict[str, ObjectIDs]:
+    """Store Message object to descendants mapping and preregister objects."""
+    if not request.messages_list:
+        return {}
+
+    objects_to_push: dict[str, ObjectIDs] = {}
+
+    # Get run_id from the first message in the list
+    # All messages of a request should in the same run
+    run_id = request.messages_list[0].metadata.run_id
+
+    for object_tree in request.message_object_trees:
+        # Preregister
+        object_ids_just_registered = store.preregister(run_id, object_tree)
+        # Keep track of objects that need to be pushed
+        objects_to_push[object_tree.object_id] = ObjectIDs(
+            object_ids=object_ids_just_registered
+        )
+
+    return objects_to_push


### PR DESCRIPTION
The functionality in `store_mapping_and_register_objects` is going to be used by both `ServerAppIo` and `ClientAppIo` servicers when objects are pushed. Let's move it into a new `utils.py`