### PR TITLE
docs(framework) Add exit code 103 for invalid license URL

### DIFF
--- a/framework/docs/source/ref-exit-codes/103.rst
+++ b/framework/docs/source/ref-exit-codes/103.rst
@@ -1,0 +1,16 @@
+[103] SUPERLINK_LICENSE_URL_INVALID
+===================================
+
+Description
+-----------
+
+The SuperLink license URL is invalid, causing it to exit prematurely on startup.
+
+How to Resolve
+--------------
+
+1. Set the `FLWR_LICENSE_URL` environment variable with a valid license URL when
+   starting the SuperLink.
+2. Ensure that the URL points to a valid license server that can provide the necessary
+   license information.
+3. If the issue persists, please contact support for further assistance.

--- a/framework/py/flwr/common/exit/exit_code.py
+++ b/framework/py/flwr/common/exit/exit_code.py
@@ -31,6 +31,7 @@ class ExitCode:
     SUPERLINK_THREAD_CRASH = 100
     SUPERLINK_LICENSE_INVALID = 101
     SUPERLINK_LICENSE_MISSING = 102
+    SUPERLINK_LICENSE_URL_INVALID = 103
 
     # ServerApp-specific exit codes (200-299)
 
@@ -69,6 +70,10 @@ EXIT_CODE_HELP = {
     ExitCode.SUPERLINK_LICENSE_MISSING: (
         "The license is missing. Please specify the license key by setting the "
         "environment variable `FLWR_LICENSE_KEY`."
+    ),
+    ExitCode.SUPERLINK_LICENSE_URL_INVALID: (
+        "The license URL is invalid. Please ensure that the `FLWR_LICENSE_URL` "
+        "environment variable is set to a valid URL."
     ),
     # ServerApp-specific exit codes (200-299)
     # SuperNode-specific exit codes (300-399)


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

### Checklist

- [ ] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.ai/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
