### PR TITLE
feat(framework) Add Lithops backend support to simulation engine

### DIFF
--- a/examples/quickstart-pandas/pyproject.toml
+++ b/examples/quickstart-pandas/pyproject.toml
@@ -37,3 +37,4 @@ default = "local-simulation"
 
 [tool.flwr.federations.local-simulation]
 options.num-supernodes = 4
+options.backend-type = "ray"

--- a/framework/py/flwr/cli/run/run.py
+++ b/framework/py/flwr/cli/run/run.py
@@ -212,6 +212,7 @@ def _run_without_exec_api(
     try:
         num_supernodes = federation_config["options"]["num-supernodes"]
         verbose: Optional[bool] = federation_config["options"].get("verbose")
+        backend_type = federation_config["options"].get("backend-type", None)
         backend_cfg = federation_config["options"].get("backend", {})
     except KeyError as err:
         typer.secho(
@@ -232,6 +233,8 @@ def _run_without_exec_api(
         "--num-supernodes",
         f"{num_supernodes}",
     ]
+    if backend_type:
+        command.extend(["--backend", backend_type])
 
     if backend_cfg:
         # Stringify as JSON

--- a/framework/py/flwr/server/superlink/fleet/vce/backend/__init__.py
+++ b/framework/py/flwr/server/superlink/fleet/vce/backend/__init__.py
@@ -29,8 +29,10 @@ error_messages_backends: dict[str, str] = {}
 
 if is_ray_installed:
     from .raybackend import RayBackend
+    from .lithops_backend import LithopsBackend
 
     supported_backends["ray"] = RayBackend
+    supported_backends["lithops"] = LithopsBackend
 else:
     error_messages_backends[
         "ray"

--- a/framework/py/flwr/server/superlink/fleet/vce/backend/lithops_backend.py
+++ b/framework/py/flwr/server/superlink/fleet/vce/backend/lithops_backend.py
@@ -1,0 +1,55 @@
+from logging import ERROR
+from typing import Callable
+
+import lithops
+
+from flwr.client.client_app import ClientApp
+from .backend import Backend
+from flwr.common.message import Message
+from flwr.common.context import Context
+from flwr.common.logger import log
+
+
+class LithopsBackend(Backend):
+    """Backend for Lithops."""
+
+    def __init__(self, config: dict):
+        self._fexec = lithops.FunctionExecutor()
+
+    @property
+    def num_workers(self) -> int:
+        """Return the number of workers available in the backend."""
+        return 4
+
+    def build(self, app_fn: Callable[[], ClientApp]):
+        # TODO check if you need to initialize lithops here
+        self.app_fn = app_fn
+
+    def is_worker_idle(self) -> bool:
+        """Report whether a backend worker is idle and can therefore run a ClientApp."""
+        return True
+
+    def terminate(self) -> None:
+        """Terminate backend."""
+        pass
+
+    def process_message(
+        self,
+        message: Message,
+        context: Context,
+    ) -> tuple[Message, Context]:
+        """Submit a job to the backend."""
+        try:
+            future = self._fexec.call_async(
+                lambda a_fn, mssg, state: a_fn()(mssg, state),
+                (self.app_fn, message, context),
+            )
+            out_mssg = future.result()
+            return out_mssg, context
+        except Exception as ex:
+            log(
+                ERROR,
+                "An exception was raised when processing a message by %s",
+                self.__class__.__name__,
+            )
+            raise ex


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description
#### Summary
This PR adds native support for federated learning simulation on serverless and distributed computing backends using the [Lithops](https://github.com/lithops-cloud/lithops) framework. This integration allows Flower to run clients on-demand across multiple cloud providers like AWS, Google Cloud, and IBM Cloud.

#### Motivation
This feature addresses the need for scalable, cost-effective federated learning by moving client execution to a serverless model. This approach offers significant benefits:

Dynamic Scalability: Clients are executed as serverless functions, scaling dynamically with no need for persistent infrastructure.

Cost-Efficiency: You only pay for the exact compute time used by clients, leading to major cost savings compared to maintaining dedicated VMs.

Multi-Cloud Flexibility: A single Flower job can utilize clients on various cloud backends, providing a highly flexible and resilient deployment.
<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

### Checklist

- [x] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.ai/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
