### PR TITLE
feat(intelligence): Support server sent event chunk KT

### DIFF
--- a/intelligence/kt/flwr/src/main/java/ai/flower/intelligence/Constants.kt
+++ b/intelligence/kt/flwr/src/main/java/ai/flower/intelligence/Constants.kt
@@ -21,6 +21,6 @@ internal object Constants {
   const val ENCRYPTION_PUBLIC_KEY_PATH = "encryption/public-key"
   const val ENCRYPTION_SERVER_PUBLIC_KEY_PATH = "encryption/server-public-key"
   const val SDK = "kt"
-  const val VERSION = "0.1.8"
+  const val VERSION = "0.2.0"
   val ALLOWED_ROLES = setOf("user", "system", "assistant")
 }

--- a/intelligence/kt/flwr/src/main/java/ai/flower/intelligence/Constants.kt
+++ b/intelligence/kt/flwr/src/main/java/ai/flower/intelligence/Constants.kt
@@ -20,7 +20,7 @@ internal object Constants {
   const val CHAT_COMPLETION_PATH = "v1/chat/completions"
   const val ENCRYPTION_PUBLIC_KEY_PATH = "encryption/public-key"
   const val ENCRYPTION_SERVER_PUBLIC_KEY_PATH = "encryption/server-public-key"
-  const val SDK = "kt"
+  const val SDK = "KT"
   const val VERSION = "0.2.0"
   val ALLOWED_ROLES = setOf("user", "system", "assistant")
 }

--- a/intelligence/kt/flwr/src/main/java/ai/flower/intelligence/RemoteEngine.kt
+++ b/intelligence/kt/flwr/src/main/java/ai/flower/intelligence/RemoteEngine.kt
@@ -72,11 +72,14 @@ internal class RemoteEngine(
         element = payload,
         authorization = authorization,
         url = url,
-      ) { streamElements: List<StreamChoice> ->
-        for (choice in streamElements) {
-          val deltaContent = choice.delta.content
-          onStreamEvent?.invoke(StreamEvent(deltaContent))
-          accumulatedResponse += deltaContent
+      ) { streamElements: List<ServerSentEvent> ->
+        for (event in streamElements) {
+          val chunk = Json.decodeFromString<StreamChunk>(sse.data)
+          for (choice in chunk.choices) {
+            val deltaContent = choice.delta.content
+            onStreamEvent?.invoke(StreamEvent(deltaContent))
+            accumulatedResponse += deltaContent
+          }
         }
       }
       Message(role = "assistant", content = accumulatedResponse)

--- a/intelligence/kt/flwr/src/main/java/ai/flower/intelligence/RemoteEngine.kt
+++ b/intelligence/kt/flwr/src/main/java/ai/flower/intelligence/RemoteEngine.kt
@@ -39,7 +39,7 @@ internal class RemoteEngine(
     HttpClient(CIO) {
       install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
       defaultRequest {
-        header("FI-SDK-Type", "KT")
+        header("FI-SDK-Type", Constants.SDK)
         header("FI-SDK-Version", Constants.VERSION)
       }
     }

--- a/intelligence/kt/flwr/src/main/java/ai/flower/intelligence/RemoteEngine.kt
+++ b/intelligence/kt/flwr/src/main/java/ai/flower/intelligence/RemoteEngine.kt
@@ -36,7 +36,13 @@ internal class RemoteEngine(
 ) : RemoteEngineProtocol {
 
   private val client =
-    HttpClient(CIO) { install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) } }
+    HttpClient(CIO) {
+      install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+      defaultRequest {
+        header("FI-SDK-Type", "KT")
+        header("FI-SDK-Version", Constants.VERSION)
+      }
+    }
 
   private val authorization: String
     get() = "Bearer $apiKey"

--- a/intelligence/kt/flwr/src/main/java/ai/flower/intelligence/Typing.kt
+++ b/intelligence/kt/flwr/src/main/java/ai/flower/intelligence/Typing.kt
@@ -165,11 +165,10 @@ internal data class ChoiceMessage(
 internal data class StreamChunk(
   val `object`: String,
   val model: String,
-  val choices: List<StreamChoice> = emptyList()
+  val choices: List<StreamChoice> = emptyList(),
 )
 
-@Serializable
-data class ServerSentEvent(val data: String)
+@Serializable data class ServerSentEvent(val data: String)
 
 @Serializable
 internal data class Usage(

--- a/intelligence/kt/flwr/src/main/java/ai/flower/intelligence/Typing.kt
+++ b/intelligence/kt/flwr/src/main/java/ai/flower/intelligence/Typing.kt
@@ -162,6 +162,16 @@ internal data class ChoiceMessage(
 @Serializable internal data class DeltaMessage(val content: String, val role: String)
 
 @Serializable
+internal data class StreamChunk(
+  val `object`: String,
+  val model: String,
+  val choices: List<StreamChoice> = emptyList()
+)
+
+@Serializable
+data class ServerSentEvent(val data: String)
+
+@Serializable
 internal data class Usage(
   @SerialName("completion_tokens") val completionTokens: Int,
   @SerialName("prompt_tokens") val promptTokens: Int,


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->
The OpenAI SDK uses SSE in chunk.

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->
Update chunk processing to support server sent event to comply to OpenAI SDK.

### Checklist

- [ ] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.ai/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
