### PR TITLE
ci(intelligence): Guard release script to be run only after PR is merged

### DIFF
--- a/.github/workflows/intelligence-release.yml
+++ b/.github/workflows/intelligence-release.yml
@@ -5,14 +5,55 @@ on:
     tags:
       - "intelligence/v*.*.*"
 
+permissions:
+  contents: read
+  pull-requests: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
+  require-merged-pr:
+    name: Ensure tag is on main and from a merged PR
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout (full history)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify tag commit is reachable from main
+        run: |
+          git fetch origin main --depth=1
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "::error::Tag must point to a commit that is contained in branch 'main'."
+            exit 1
+          fi
+
+      - name: Verify there is a merged PR for this commit
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const res = await github.request('GET /repos/{owner}/{repo}/commits/{ref}/pulls', {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: context.sha,
+              mediaType: { previews: ['groot'] } // required for this endpoint
+            });
+            if (!res.data.length) {
+              core.setFailed('No PRs found that include this commit.');
+              return;
+            }
+            const merged = res.data.some(pr => pr.merged_at);
+            if (!merged) {
+              core.setFailed('A PR was found but is not merged yet.');
+            }
+
   check-version:
     name: Check version consistency
     runs-on: ubuntu-22.04
+    needs: require-merged-pr
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -27,7 +68,7 @@ jobs:
         run: ./intelligence/dev/check-version-consistency.sh
 
   publish-typescript:
-    needs: check-version
+    needs: [require-merged-pr, check-version]
     if: ${{ github.repository == 'adap/flower' }}
     name: Publish Flower Intelligence TypeScript SDK to NPM
     runs-on: ubuntu-22.04
@@ -60,7 +101,7 @@ jobs:
         run: pnpm publish . --access public --no-git-checks
 
   publish-kotlin:
-    needs: check-version
+    needs: [require-merged-pr, check-version]
     if: ${{ github.repository == 'adap/flower' }}
     name: Publish Flower Intelligence Kotlin SDK to Maven Central
     runs-on: ubuntu-22.04


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

### Checklist

- [ ] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.ai/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
