### PR TITLE
fix(framework): Fix test for pulling objects

### DIFF
--- a/framework/py/flwr/supernode/servicer/clientappio/clientappio_servicer_test.py
+++ b/framework/py/flwr/supernode/servicer/clientappio/clientappio_servicer_test.py
@@ -35,6 +35,7 @@ from flwr.proto.appio_pb2 import (  # pylint:disable=E0611
 )
 from flwr.proto.message_pb2 import Context as ProtoContext  # pylint:disable=E0611
 from flwr.proto.message_pb2 import (  # pylint:disable=E0611
+    PullObjectRequest,
     PullObjectResponse,
     PushObjectRequest,
     PushObjectResponse,
@@ -83,7 +84,7 @@ class TestClientAppIoServicer(unittest.TestCase):
         all_objects[mock_message.object_id] = mock_message
 
         # Get the object tree and iterate in the correct order
-        def pull_object_side_effect(request):
+        def pull_object_side_effect(request: PullObjectRequest) -> PullObjectResponse:
             obj_id = request.object_id
             return PullObjectResponse(
                 object_found=True,


### PR DESCRIPTION
Update the side_effect from returning objects in a fixed order into a behaviour that returns the object specified in the request. 