### PR TITLE
docs(framework): Remove `flower-simulation` for CLI reference documentation

### DIFF
--- a/framework/docs/source/ref-api-cli.rst
+++ b/framework/docs/source/ref-api-cli.rst
@@ -55,16 +55,3 @@ Advanced Commands
     :module: flwr.client.clientapp.app
     :func: _parse_args_run_flwr_clientapp
     :prog: flwr-clientapp
-
-Technical Commands
-------------------
-
-.. _flower-simulation-apiref:
-
-``flower-simulation``
-~~~~~~~~~~~~~~~~~~~~~
-
-.. argparse::
-    :module: flwr.simulation.run_simulation
-    :func: _parse_args_run_simulation
-    :prog: flower-simulation


### PR DESCRIPTION
The `flower-simulation` is an internal command used by `flwr run` and therefore shouldn't be used in other contexts