### PR TITLE
break(framework): Deprecate `--executor*` arguments and introduce `--simulation` flag for `flower-superlink`

### DIFF
--- a/framework/e2e/test_control_api.sh
+++ b/framework/e2e/test_control_api.sh
@@ -9,13 +9,10 @@ case "$1" in
                   --ssl-certfile    ../certificates/server.pem
                   --ssl-keyfile     ../certificates/server.key'
       client_arg='--root-certificates ../certificates/ca.crt'
-      # For $executor_config, note special ordering of single- and double-quotes
-      executor_config='root-certificates="../certificates/ca.crt"'
       ;;
     insecure)
       server_arg='--insecure'
       client_arg=$server_arg
-      executor_config=''
     ;;
 esac
 
@@ -40,10 +37,10 @@ esac
 # Set engine
 case "$3" in
     deployment-engine)
-      executor_arg="--executor flwr.superexec.deployment:executor"
+      simulation_arg=""
       ;;
     simulation-engine)
-      executor_arg="--executor flwr.superexec.simulation:executor"
+      simulation_arg="--simulation"
       ;;
 esac
 
@@ -76,9 +73,9 @@ if [ "$3" = "simulation-engine" ]; then
 fi
 
 # Combine the arguments into a single command for flower-superlink
-combined_args="$server_arg $server_auth $executor_arg"
+combined_args="$server_arg $server_auth $simulation_arg"
 
-timeout 2m flower-superlink $combined_args --executor-config "$executor_config" 2>&1 | tee flwr_output.log &
+timeout 2m flower-superlink $combined_args 2>&1 | tee flwr_output.log &
 sl_pid=$(pgrep -f "flower-superlink")
 sleep 2
 

--- a/framework/e2e/test_serverapp_heartbeat.py
+++ b/framework/e2e/test_serverapp_heartbeat.py
@@ -49,17 +49,13 @@ def add_e2e_federation() -> None:
 
 def run_superlink() -> subprocess.Popen:
     """Run the SuperLink."""
-    return subprocess.Popen(
-        [
-            "flower-superlink",
-            "--insecure",
-            "--database",
-            "tmp.db",
-            "--simulation" if use_sim else "",
-            "--isolation",
-            "process",
-        ],
-    )
+    cmd = ["flower-superlink", "--insecure"]
+    cmd += ["--database", "tmp.db"]
+    cmd += ["--isolation", "process"]
+    if use_sim:
+        cmd += ["--simulation"]
+
+    return subprocess.Popen(cmd)
 
 
 def run_superexec() -> subprocess.Popen:

--- a/framework/e2e/test_serverapp_heartbeat.py
+++ b/framework/e2e/test_serverapp_heartbeat.py
@@ -23,7 +23,6 @@ address_arg = (
     if use_sim
     else SERVERAPPIO_API_DEFAULT_CLIENT_ADDRESS
 )
-executor_arg = f"flwr.superexec.{'simulation' if use_sim else 'deployment'}:executor"
 app_cmd = "flwr-simulation" if use_sim else "flwr-serverapp"
 
 
@@ -56,8 +55,7 @@ def run_superlink() -> subprocess.Popen:
             "--insecure",
             "--database",
             "tmp.db",
-            "--executor",
-            executor_arg,
+            "--simulation" if use_sim else "",
             "--isolation",
             "process",
         ],

--- a/framework/py/flwr/server/app.py
+++ b/framework/py/flwr/server/app.py
@@ -135,6 +135,15 @@ def run_superlink() -> None:
             WARN, "The `--flwr-dir` option is currently not in use and will be ignored."
         )
 
+    # Detect if `--executor*` arguments were set
+    if args.executor or args.executor_dir or args.executor_config:
+        flwr_exit(
+            ExitCode.SUPERLINK_INVALID_ARGS,
+            "The arguments `--executor`, `--executor-dir`, and `--executor-config` are "
+            "deprecated and will be removed in a future release. To run SuperLink with "
+            "the SimulationIo API, please use `--simulation`.",
+        )
+
     # Detect if both Control API and Exec API addresses were set explicitly
     explicit_args = set()
     for arg in sys.argv[1:]:
@@ -197,14 +206,13 @@ def run_superlink() -> None:
     objectstore_factory = ObjectStoreFactory()
 
     # Start Control API
-    is_simulation = args.executor == "flwr.superexec.simulation:executor"
     control_server: grpc.Server = run_control_api_grpc(
         address=control_address,
         state_factory=state_factory,
         ffs_factory=ffs_factory,
         objectstore_factory=objectstore_factory,
         certificates=certificates,
-        is_simulation=is_simulation,
+        is_simulation=args.simulation,
         auth_plugin=auth_plugin,
         authz_plugin=authz_plugin,
         event_log_plugin=event_log_plugin,
@@ -212,7 +220,7 @@ def run_superlink() -> None:
     grpc_servers = [control_server]
     bckg_threads: list[threading.Thread] = []
 
-    if is_simulation:
+    if args.simulation:
         simulationio_server: grpc.Server = run_simulationio_api_grpc(
             address=simulationio_address,
             state_factory=state_factory,
@@ -333,11 +341,11 @@ def run_superlink() -> None:
         command = ["flower-superexec", "--insecure"]
         command += [
             "--appio-api-address",
-            simulationio_address if is_simulation else io_address,
+            simulationio_address if args.simulation else io_address,
         ]
         command += [
             "--plugin-type",
-            ExecPluginType.SIMULATION if is_simulation else ExecPluginType.SERVER_APP,
+            ExecPluginType.SIMULATION if args.simulation else ExecPluginType.SERVER_APP,
         ]
         command += ["--parent-pid", str(os.getpid())]
         # pylint: disable-next=consider-using-with
@@ -733,20 +741,24 @@ def _add_args_control_api(parser: argparse.ArgumentParser) -> None:
     )
     parser.add_argument(
         "--executor",
-        help="For example: `deployment:exec` or `project.package.module:wrapper.exec`. "
-        "The default is `flwr.superexec.deployment:executor`",
-        default="flwr.superexec.deployment:executor",
+        help="This argument is deprecated and will be removed in a future release.",
+        default=None,
     )
     parser.add_argument(
         "--executor-dir",
-        help="The directory for the executor.",
-        default=".",
+        help="This argument is deprecated and will be removed in a future release.",
+        default=None,
     )
     parser.add_argument(
         "--executor-config",
-        help="Key-value pairs for the executor config, separated by spaces. "
-        "For example:\n\n`--executor-config 'verbose=true "
-        'root-certificates="certificates/superlink-ca.crt"\'`',
+        help="This argument is deprecated and will be removed in a future release.",
+        default=None,
+    )
+    parser.add_argument(
+        "--simulation",
+        action="store_true",
+        default=False,
+        help="Launch the SimulationIo API server in place of the ServerAppIo server.",
     )
 
 

--- a/framework/py/flwr/server/app.py
+++ b/framework/py/flwr/server/app.py
@@ -206,13 +206,14 @@ def run_superlink() -> None:
     objectstore_factory = ObjectStoreFactory()
 
     # Start Control API
+    is_simulation = args.simulation
     control_server: grpc.Server = run_control_api_grpc(
         address=control_address,
         state_factory=state_factory,
         ffs_factory=ffs_factory,
         objectstore_factory=objectstore_factory,
         certificates=certificates,
-        is_simulation=args.simulation,
+        is_simulation=is_simulation,
         auth_plugin=auth_plugin,
         authz_plugin=authz_plugin,
         event_log_plugin=event_log_plugin,
@@ -220,7 +221,7 @@ def run_superlink() -> None:
     grpc_servers = [control_server]
     bckg_threads: list[threading.Thread] = []
 
-    if args.simulation:
+    if is_simulation:
         simulationio_server: grpc.Server = run_simulationio_api_grpc(
             address=simulationio_address,
             state_factory=state_factory,
@@ -341,11 +342,11 @@ def run_superlink() -> None:
         command = ["flower-superexec", "--insecure"]
         command += [
             "--appio-api-address",
-            simulationio_address if args.simulation else io_address,
+            simulationio_address if is_simulation else io_address,
         ]
         command += [
             "--plugin-type",
-            ExecPluginType.SIMULATION if args.simulation else ExecPluginType.SERVER_APP,
+            ExecPluginType.SIMULATION if is_simulation else ExecPluginType.SERVER_APP,
         ]
         command += ["--parent-pid", str(os.getpid())]
         # pylint: disable-next=consider-using-with

--- a/framework/py/flwr/server/app.py
+++ b/framework/py/flwr/server/app.py
@@ -758,7 +758,8 @@ def _add_args_control_api(parser: argparse.ArgumentParser) -> None:
         "--simulation",
         action="store_true",
         default=False,
-        help="Launch the SimulationIo API server in place of the ServerAppIo server.",
+        help="Launch the SimulationIo API server in place of "
+        "the ServerAppIo API server.",
     )
 
 


### PR DESCRIPTION
### Merge after #5745 