### PR TITLE
feat(framework): Introduce Error code for `Message`-based strategies receiving an unaggregatable set of reply messages

### DIFF
--- a/framework/docs/source/ref-exit-codes/200.rst
+++ b/framework/docs/source/ref-exit-codes/200.rst
@@ -1,5 +1,5 @@
-[200] SERVERAPP_REPLIES_PRECONDITION_UNMET_FOR_STRATEGIES
-=========================================================
+[200] SERVERAPP_STRATEGY_PRECONDITION_UNMET
+===========================================
 
 .. |arrayrecord_link| replace:: ``ArrayRecord``
 

--- a/framework/py/flwr/common/exit/exit_code.py
+++ b/framework/py/flwr/common/exit/exit_code.py
@@ -80,7 +80,7 @@ EXIT_CODE_HELP = {
         "usage. Alternatively, check the documentation."
     ),
     # ServerApp-specific exit codes (200-299)
-    ExitCode.SERVERAPP_REPLIES_PRECONDITION_UNMET_FOR_STRATEGIES: (
+    ExitCode.SERVERAPP_STRATEGY_PRECONDITION_UNMET: (
         "The strategy received replies that cannot be aggregated. Please ensure all "
         "replies returned by ClientApps have one `ArrayRecord` (none when replies are "
         "from a round of federated evaluation, i.e. when message type is "


### PR DESCRIPTION
Introduce `SERVERAPP_REPLIES_PRECONDITION_UNMET_FOR_STRATEGIES` error code. 