### PR TITLE
refactor(framework): Throw exception if consistency in replies is not met

### DIFF
--- a/framework/py/flwr/serverapp/fedavg.py
+++ b/framework/py/flwr/serverapp/fedavg.py
@@ -202,12 +202,11 @@ class FedAvg(Strategy):
         )
 
         # Ensure expected ArrayRecords and MetricRecords are received
-        if not validate_message_reply_consistency(
+        validate_message_reply_consistency(
             replies=replies_with_content,
             weighted_by_key=self.weighted_by_key,
             check_arrayrecord=True,
-        ):
-            return None, None
+        )
 
         # Aggregate ArrayRecords
         arrays = aggregate_arrayrecords(
@@ -279,12 +278,11 @@ class FedAvg(Strategy):
         )
 
         # Ensure expected ArrayRecords and MetricRecords are received
-        if not validate_message_reply_consistency(
+        validate_message_reply_consistency(
             replies=replies_with_content,
             weighted_by_key=self.weighted_by_key,
             check_arrayrecord=False,
-        ):
-            return None
+        )
 
         # Aggregate MetricRecords
         metrics = self.evaluate_metrics_aggr_fn(

--- a/framework/py/flwr/serverapp/strategy.py
+++ b/framework/py/flwr/serverapp/strategy.py
@@ -272,8 +272,8 @@ class Strategy(ABC):
                     res = evaluate_fn(current_round, arrays)
                     log(INFO, "\t└──> MetricRecord: %s", res)
                     result.evaluate_metrics_serverapp[current_round] = res
-        except InconsistentMessageReplies as e:
-            log(INFO,"Terminating Strategy execution")
+        except InconsistentMessageReplies:
+            log(INFO, "Terminating Strategy execution")
             flwr_exit(ExitCode.SERVERAPP_STRATEGY_PRECONDITION_UNMET)
 
         log(INFO, "")

--- a/framework/py/flwr/serverapp/strategy.py
+++ b/framework/py/flwr/serverapp/strategy.py
@@ -18,7 +18,7 @@
 import time
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
-from logging import INFO
+from logging import ERROR, INFO
 from typing import Callable, Optional
 
 from flwr.common import ArrayRecord, ConfigRecord, Message, MetricRecord, log
@@ -223,9 +223,8 @@ class Strategy(ABC):
                     current_round,
                     train_replies,
                 )
-            except InconsistentMessageReplies:
-                log(INFO, "Terminating Strategy execution")
-                flwr_exit(ExitCode.SERVERAPP_STRATEGY_PRECONDITION_UNMET)
+            except InconsistentMessageReplies as e:
+                flwr_exit(ExitCode.SERVERAPP_STRATEGY_PRECONDITION_UNMET, message=str(e))
 
             # Log training metrics and append to history
             if agg_arrays is not None:
@@ -257,9 +256,8 @@ class Strategy(ABC):
                     current_round,
                     evaluate_replies,
                 )
-            except InconsistentMessageReplies:
-                log(INFO, "Terminating Strategy execution")
-                flwr_exit(ExitCode.SERVERAPP_STRATEGY_PRECONDITION_UNMET)
+            except InconsistentMessageReplies as e:
+                flwr_exit(ExitCode.SERVERAPP_STRATEGY_PRECONDITION_UNMET, message=str(e))
 
             # Log training metrics and append to history
             if agg_evaluate_metrics is not None:

--- a/framework/py/flwr/serverapp/strategy.py
+++ b/framework/py/flwr/serverapp/strategy.py
@@ -18,7 +18,7 @@
 import time
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
-from logging import ERROR, INFO
+from logging import INFO
 from typing import Callable, Optional
 
 from flwr.common import ArrayRecord, ConfigRecord, Message, MetricRecord, log
@@ -224,7 +224,9 @@ class Strategy(ABC):
                     train_replies,
                 )
             except InconsistentMessageReplies as e:
-                flwr_exit(ExitCode.SERVERAPP_STRATEGY_PRECONDITION_UNMET, message=str(e))
+                flwr_exit(
+                    ExitCode.SERVERAPP_STRATEGY_PRECONDITION_UNMET, message=str(e)
+                )
 
             # Log training metrics and append to history
             if agg_arrays is not None:
@@ -257,7 +259,9 @@ class Strategy(ABC):
                     evaluate_replies,
                 )
             except InconsistentMessageReplies as e:
-                flwr_exit(ExitCode.SERVERAPP_STRATEGY_PRECONDITION_UNMET, message=str(e))
+                flwr_exit(
+                    ExitCode.SERVERAPP_STRATEGY_PRECONDITION_UNMET, message=str(e)
+                )
 
             # Log training metrics and append to history
             if agg_evaluate_metrics is not None:

--- a/framework/py/flwr/serverapp/strategy.py
+++ b/framework/py/flwr/serverapp/strategy.py
@@ -196,85 +196,86 @@ class Strategy(ABC):
             result.evaluate_metrics_serverapp[0] = res
 
         arrays = initial_arrays
-        try:
-            for current_round in range(1, num_rounds + 1):
-                log(INFO, "")
-                log(INFO, "[ROUND %s/%s]", current_round, num_rounds)
 
-                # -----------------------------------------------------------------
-                # --- TRAINING ----------------------------------------------------
-                # -----------------------------------------------------------------
+        for current_round in range(1, num_rounds + 1):
+            log(INFO, "")
+            log(INFO, "[ROUND %s/%s]", current_round, num_rounds)
 
-                # Call strategy to configure training round
-                # Send messages and wait for replies
-                train_replies = grid.send_and_receive(
-                    messages=self.configure_train(
-                        current_round,
-                        arrays,
-                        train_config,
-                        grid,
-                    ),
-                    timeout=timeout,
-                )
+            # -----------------------------------------------------------------
+            # --- TRAINING ----------------------------------------------------
+            # -----------------------------------------------------------------
 
-                # Aggregate train
+            # Call strategy to configure training round
+            # Send messages and wait for replies
+            train_replies = grid.send_and_receive(
+                messages=self.configure_train(
+                    current_round,
+                    arrays,
+                    train_config,
+                    grid,
+                ),
+                timeout=timeout,
+            )
+
+            # Aggregate train
+            try:
                 agg_arrays, agg_train_metrics = self.aggregate_train(
                     current_round,
                     train_replies,
                 )
+            except InconsistentMessageReplies:
+                log(INFO, "Terminating Strategy execution")
+                flwr_exit(ExitCode.SERVERAPP_STRATEGY_PRECONDITION_UNMET)
 
-                # Log training metrics and append to history
-                if agg_arrays is not None:
-                    result.arrays = agg_arrays
-                    arrays = agg_arrays
-                if agg_train_metrics is not None:
-                    log(INFO, "\t└──> Aggregated MetricRecord: %s", agg_train_metrics)
-                    result.train_metrics_clientapp[current_round] = agg_train_metrics
+            # Log training metrics and append to history
+            if agg_arrays is not None:
+                result.arrays = agg_arrays
+                arrays = agg_arrays
+            if agg_train_metrics is not None:
+                log(INFO, "\t└──> Aggregated MetricRecord: %s", agg_train_metrics)
+                result.train_metrics_clientapp[current_round] = agg_train_metrics
 
-                # -----------------------------------------------------------------
-                # --- EVALUATION (LOCAL) ------------------------------------------
-                # -----------------------------------------------------------------
+            # -----------------------------------------------------------------
+            # --- EVALUATION (LOCAL) ------------------------------------------
+            # -----------------------------------------------------------------
 
-                # Call strategy to configure evaluation round
-                # Send messages and wait for replies
-                evaluate_replies = grid.send_and_receive(
-                    messages=self.configure_evaluate(
-                        current_round,
-                        arrays,
-                        evaluate_config,
-                        grid,
-                    ),
-                    timeout=timeout,
-                )
+            # Call strategy to configure evaluation round
+            # Send messages and wait for replies
+            evaluate_replies = grid.send_and_receive(
+                messages=self.configure_evaluate(
+                    current_round,
+                    arrays,
+                    evaluate_config,
+                    grid,
+                ),
+                timeout=timeout,
+            )
 
-                # Aggregate evaluate
+            # Aggregate evaluate
+            try:
                 agg_evaluate_metrics = self.aggregate_evaluate(
                     current_round,
                     evaluate_replies,
                 )
+            except InconsistentMessageReplies:
+                log(INFO, "Terminating Strategy execution")
+                flwr_exit(ExitCode.SERVERAPP_STRATEGY_PRECONDITION_UNMET)
 
-                # Log training metrics and append to history
-                if agg_evaluate_metrics is not None:
-                    log(
-                        INFO, "\t└──> Aggregated MetricRecord: %s", agg_evaluate_metrics
-                    )
-                    result.evaluate_metrics_clientapp[current_round] = (
-                        agg_evaluate_metrics
-                    )
+            # Log training metrics and append to history
+            if agg_evaluate_metrics is not None:
+                log(INFO, "\t└──> Aggregated MetricRecord: %s", agg_evaluate_metrics)
+                result.evaluate_metrics_clientapp[current_round] = agg_evaluate_metrics
 
-                # -----------------------------------------------------------------
-                # --- EVALUATION (GLOBAL) -----------------------------------------
-                # -----------------------------------------------------------------
+            # -----------------------------------------------------------------
+            # --- EVALUATION (GLOBAL) -----------------------------------------
+            # -----------------------------------------------------------------
 
-                # Centralized evaluation
-                if evaluate_fn:
-                    log(INFO, "Global evaluation")
-                    res = evaluate_fn(current_round, arrays)
-                    log(INFO, "\t└──> MetricRecord: %s", res)
-                    result.evaluate_metrics_serverapp[current_round] = res
-        except InconsistentMessageReplies:
-            log(INFO, "Terminating Strategy execution")
-            flwr_exit(ExitCode.SERVERAPP_STRATEGY_PRECONDITION_UNMET)
+            # Centralized evaluation
+            if evaluate_fn:
+                log(INFO, "Global evaluation")
+                res = evaluate_fn(current_round, arrays)
+                log(INFO, "\t└──> MetricRecord: %s", res)
+                result.evaluate_metrics_serverapp[current_round] = res
 
         log(INFO, "")
         log(INFO, "Strategy execution finished in %.2fs", time.time() - t_start)

--- a/framework/py/flwr/serverapp/strategy_utils.py
+++ b/framework/py/flwr/serverapp/strategy_utils.py
@@ -17,7 +17,7 @@
 
 import random
 from collections import OrderedDict
-from logging import ERROR, INFO
+from logging import INFO
 from time import sleep
 from typing import Optional, cast
 
@@ -37,6 +37,9 @@ from flwr.server import Grid
 class InconsistentMessageReplies(Exception):
     """Exception triggered when replies are inconsistent and therefore aggregation must
     be skipped."""
+
+    def __init__(self, reason: str):
+        super().__init__(reason)
 
 
 def config_to_str(config: ConfigRecord) -> str:
@@ -206,59 +209,48 @@ def validate_message_reply_consistency(
     # Checking for ArrayRecord consistency
     if check_arrayrecord:
         if any(len(msg.array_records) != 1 for msg in replies):
-            log(
-                ERROR,
-                "Expected exactly one ArrayRecord in replies.Skipping aggregation.",
+            raise InconsistentMessageReplies(
+                reason="Expected exactly one ArrayRecord in replies. "
+                "Skipping aggregation."
             )
-            raise InconsistentMessageReplies
 
         # Ensure all key are present in all ArrayRecords
         record_key = next(iter(replies[0].array_records.keys()))
         all_keys = set(replies[0][record_key].keys())
         if any(set(msg.get(record_key, {}).keys()) != all_keys for msg in replies[1:]):
-            log(
-                ERROR,
-                "All ArrayRecords must have the same keys for aggregation. "
-                "This condition wasn't met. Skipping aggregation.",
+            raise InconsistentMessageReplies(
+                reason="All ArrayRecords must have the same keys for aggregation. "
+                "This condition wasn't met. Skipping aggregation."
             )
-            raise InconsistentMessageReplies
 
     # Checking for MetricRecord consistency
     if any(len(msg.metric_records) != 1 for msg in replies):
-        log(
-            ERROR,
-            "Expected exactly one MetricRecord in replies, but found more. "
-            "Skipping aggregation.",
+        raise InconsistentMessageReplies(
+            reason="Expected exactly one MetricRecord in replies, but found more. "
+            "Skipping aggregation."
         )
-        raise InconsistentMessageReplies
 
     # Ensure all key are present in all MetricRecords
     record_key = next(iter(replies[0].metric_records.keys()))
     all_keys = set(replies[0][record_key].keys())
     if any(set(msg.get(record_key, {}).keys()) != all_keys for msg in replies[1:]):
-        log(
-            ERROR,
-            "All MetricRecords must have the same keys for aggregation. "
-            "This condition wasn't met. Skipping aggregation.",
+        raise InconsistentMessageReplies(
+            reason="All MetricRecords must have the same keys for aggregation. "
+            "This condition wasn't met. Skipping aggregation."
         )
-        raise InconsistentMessageReplies
 
     # Verify the weight factor key presence in all MetricRecords
     if weighted_by_key not in all_keys:
-        log(
-            ERROR,
-            "Missing required key `%s` in the MetricRecord of reply messages. "
-            "Cannot average ArrayRecords and MetricRecords. Skipping aggregation.",
-            weighted_by_key,
+        raise InconsistentMessageReplies(
+            reason=f"Missing required key `{weighted_by_key}` in the MetricRecord of "
+            "reply messages. Cannot average ArrayRecords and MetricRecords. Skipping "
+            "aggregation."
         )
-        raise InconsistentMessageReplies
 
     # Check that it is not a list
     if any(isinstance(msg[record_key][weighted_by_key], list) for msg in replies):
-        log(
-            ERROR,
-            "Key `%s` in the MetricRecord of reply messages must be a single value "
-            "(int or float), but a list was found. Skipping aggregation.",
-            weighted_by_key,
+        raise InconsistentMessageReplies(
+            reason=f"Key `{weighted_by_key}` in the MetricRecord of reply messages "
+            "must be a single value (int or float), but a list was found. Skipping "
+            "aggregation."
         )
-        raise InconsistentMessageReplies


### PR DESCRIPTION
This PR introduces `InconsistentMessageReplies`, which is thrown if replies can't be aggregated. This exception is catched in the for loop of `<strategy>.start()` and it triggers a `flwr_exit` with code `SERVERAPP_STRATEGY_PRECONDITION_UNMET`