### PR TITLE
feat(framework): Add `PyTorch` `flwr new` template with `Message API`

### DIFF
--- a/framework/py/flwr/cli/new/new.py
+++ b/framework/py/flwr/cli/new/new.py
@@ -35,6 +35,7 @@ class MlFramework(str, Enum):
     """Available frameworks."""
 
     PYTORCH = "PyTorch"
+    PYTORCH_MSG_API = "PyTorch (Message API)"
     TENSORFLOW = "TensorFlow"
     SKLEARN = "sklearn"
     HUGGINGFACE = "HuggingFace"
@@ -154,6 +155,9 @@ def new(
     if framework_str == MlFramework.BASELINE:
         framework_str = "baseline"
 
+    if framework_str == MlFramework.PYTORCH_MSG_API:
+        framework_str = "pytorch_msg_api"
+
     print(
         typer.style(
             f"\n🔨 Creating Flower App {app_name}...",
@@ -243,10 +247,17 @@ def new(
             MlFramework.TENSORFLOW.value,
             MlFramework.SKLEARN.value,
             MlFramework.NUMPY.value,
+            "pytorch_msg_api",
         ]
         if framework_str in frameworks_with_tasks:
             files[f"{import_name}/task.py"] = {
                 "template": f"app/code/task.{template_name}.py.tpl"
+            }
+
+        if framework_str == "pytorch_msg_api":
+            # Use custom __init__ that better captures name of framework
+            files[f"{import_name}/__init__.py"] = {
+                "template": f"app/code/__init__.{framework_str}.py.tpl"
             }
 
         if framework_str == "baseline":

--- a/framework/py/flwr/cli/new/templates/app/code/__init__.pytorch_msg_api.py.tpl
+++ b/framework/py/flwr/cli/new/templates/app/code/__init__.pytorch_msg_api.py.tpl
@@ -1,0 +1,1 @@
+"""$project_name: A Flower (Message API) / PyTorch app."""

--- a/framework/py/flwr/cli/new/templates/app/code/__init__.pytorch_msg_api.py.tpl
+++ b/framework/py/flwr/cli/new/templates/app/code/__init__.pytorch_msg_api.py.tpl
@@ -1,1 +1,1 @@
-"""$project_name: A Flower (Message API) / PyTorch app."""
+"""$project_name: A Flower / PyTorch app."""

--- a/framework/py/flwr/cli/new/templates/app/code/client.pytorch_msg_api.py.tpl
+++ b/framework/py/flwr/cli/new/templates/app/code/client.pytorch_msg_api.py.tpl
@@ -1,0 +1,80 @@
+"""$project_name: A Flower / $framework_str app."""
+
+import torch
+from flwr.client import ClientApp
+from flwr.common import ArrayRecord, Context, Message, MetricRecord, RecordDict
+
+from $import_name.task import Net, load_data
+from $import_name.task import test as test_fn
+from $import_name.task import train as train_fn
+
+# Flower ClientApp
+app = ClientApp()
+
+
+@app.train()
+def train(msg: Message, context: Context):
+    """Train the model on local data."""
+
+    # Load the model and initialize it with the received weights
+    model = Net()
+    model.load_state_dict(msg.content["arrays"].to_torch_state_dict())
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    model.to(device)
+
+    # Load the data
+    partition_id = context.node_config["partition-id"]
+    num_partitions = context.node_config["num-partitions"]
+    trainloader, _ = load_data(partition_id, num_partitions)
+
+    # Call the training function
+    train_loss = train_fn(
+        model,
+        trainloader,
+        context.run_config["local-epochs"],
+        msg.content["config"]["lr"],
+        device,
+    )
+
+    # Construct and return reply Message
+    model_record = ArrayRecord(model.state_dict())
+    metrics = {
+        "train_loss": train_loss,
+        "num-examples": len(trainloader.dataset),
+    }
+    metric_record = MetricRecord(metrics)
+    content = RecordDict({"arrays": model_record, "metrics": metric_record})
+    return Message(content=content, reply_to=msg)
+
+
+@app.evaluate()
+def evaluate(msg: Message, context: Context):
+    """Evaluate the model on local data."""
+
+    # Load the model and initialize it with the received weights
+    model = Net()
+    model.load_state_dict(msg.content["arrays"].to_torch_state_dict())
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    model.to(device)
+
+    # Load the data
+    partition_id = context.node_config["partition-id"]
+    num_partitions = context.node_config["num-partitions"]
+    _, valloader = load_data(partition_id, num_partitions)
+
+    # Call the evaluation function
+    eval_loss, eval_acc = test_fn(
+        model,
+        valloader,
+        device,
+    )
+
+    # Construct and return reply Message
+    metrics = {
+        "eval_loss": eval_loss,
+        "eval_acc": eval_acc,
+        "num-examples": len(valloader.dataset),
+    }
+    metric_record = MetricRecord(metrics)
+    content = RecordDict({"metrics": metric_record})
+    return Message(content=content, reply_to=msg)

--- a/framework/py/flwr/cli/new/templates/app/code/server.pytorch_msg_api.py.tpl
+++ b/framework/py/flwr/cli/new/templates/app/code/server.pytorch_msg_api.py.tpl
@@ -1,0 +1,49 @@
+"""$project_name: A Flower / $framework_str app."""
+
+from pprint import pprint
+
+import torch
+from flwr.common import ArrayRecord, ConfigRecord, Context
+from flwr.server import Grid, ServerApp
+from flwr.serverapp import FedAvg
+
+from $import_name.task import Net
+
+# Create ServerApp
+app = ServerApp()
+
+
+@app.main()
+def main(grid: Grid, context: Context) -> None:
+    """Main entry point for the ServerApp."""
+
+    # Read run config
+    fraction_train: float = context.run_config["fraction-train"]
+    num_rounds: int = context.run_config["num-server-rounds"]
+    lr: float = context.run_config["lr"]
+
+    # Load global model
+    global_model = Net()
+    arrays = ArrayRecord(global_model.state_dict())
+
+    # Initialize FedAvg strategy
+    strategy = FedAvg(fraction_train=fraction_train)
+
+    # Start strategy, run FedAvg for `num_rounds`
+    result = strategy.start(
+        grid=grid,
+        initial_arrays=arrays,
+        train_config=ConfigRecord({"lr": lr}),
+        num_rounds=num_rounds,
+    )
+
+    # Log resulting metrics
+    print("\nDistributed train metrics:")
+    pprint(result.train_metrics_clientapp)
+    print("\nDistributed evaluate metrics:")
+    pprint(result.evaluate_metrics_clientapp)
+
+    # Save final model to disk
+    print("\nSaving final model to disk...")
+    state_dict = result.arrays.to_torch_state_dict()
+    torch.save(state_dict, "final_model.pt")

--- a/framework/py/flwr/cli/new/templates/app/code/task.pytorch_msg_api.py.tpl
+++ b/framework/py/flwr/cli/new/templates/app/code/task.pytorch_msg_api.py.tpl
@@ -1,0 +1,98 @@
+"""$project_name: A Flower / $framework_str app."""
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from flwr_datasets import FederatedDataset
+from flwr_datasets.partitioner import IidPartitioner
+from torch.utils.data import DataLoader
+from torchvision.transforms import Compose, Normalize, ToTensor
+
+
+class Net(nn.Module):
+    """Model (simple CNN adapted from 'PyTorch: A 60 Minute Blitz')"""
+
+    def __init__(self):
+        super(Net, self).__init__()
+        self.conv1 = nn.Conv2d(3, 6, 5)
+        self.pool = nn.MaxPool2d(2, 2)
+        self.conv2 = nn.Conv2d(6, 16, 5)
+        self.fc1 = nn.Linear(16 * 5 * 5, 120)
+        self.fc2 = nn.Linear(120, 84)
+        self.fc3 = nn.Linear(84, 10)
+
+    def forward(self, x):
+        x = self.pool(F.relu(self.conv1(x)))
+        x = self.pool(F.relu(self.conv2(x)))
+        x = x.view(-1, 16 * 5 * 5)
+        x = F.relu(self.fc1(x))
+        x = F.relu(self.fc2(x))
+        return self.fc3(x)
+
+
+fds = None  # Cache FederatedDataset
+
+pytorch_transforms = Compose([ToTensor(), Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))])
+
+
+def apply_transforms(batch):
+    """Apply transforms to the partition from FederatedDataset."""
+    batch["img"] = [pytorch_transforms(img) for img in batch["img"]]
+    return batch
+
+
+def load_data(partition_id: int, num_partitions: int):
+    """Load partition CIFAR10 data."""
+    # Only initialize `FederatedDataset` once
+    global fds
+    if fds is None:
+        partitioner = IidPartitioner(num_partitions=num_partitions)
+        fds = FederatedDataset(
+            dataset="uoft-cs/cifar10",
+            partitioners={"train": partitioner},
+        )
+    partition = fds.load_partition(partition_id)
+    # Divide data on each node: 80% train, 20% test
+    partition_train_test = partition.train_test_split(test_size=0.2, seed=42)
+    # Construct dataloaders
+    partition_train_test = partition_train_test.with_transform(apply_transforms)
+    trainloader = DataLoader(partition_train_test["train"], batch_size=32, shuffle=True)
+    testloader = DataLoader(partition_train_test["test"], batch_size=32)
+    return trainloader, testloader
+
+
+def train(net, trainloader, epochs, lr, device):
+    """Train the model on the training set."""
+    net.to(device)  # move model to GPU if available
+    criterion = torch.nn.CrossEntropyLoss().to(device)
+    optimizer = torch.optim.Adam(net.parameters(), lr=lr)
+    net.train()
+    running_loss = 0.0
+    for _ in range(epochs):
+        for batch in trainloader:
+            images = batch["img"].to(device)
+            labels = batch["label"].to(device)
+            optimizer.zero_grad()
+            loss = criterion(net(images), labels)
+            loss.backward()
+            optimizer.step()
+            running_loss += loss.item()
+    avg_trainloss = running_loss / len(trainloader)
+    return avg_trainloss
+
+
+def test(net, testloader, device):
+    """Validate the model on the test set."""
+    net.to(device)
+    criterion = torch.nn.CrossEntropyLoss()
+    correct, loss = 0, 0.0
+    with torch.no_grad():
+        for batch in testloader:
+            images = batch["img"].to(device)
+            labels = batch["label"].to(device)
+            outputs = net(images)
+            loss += criterion(outputs, labels).item()
+            correct += (torch.max(outputs.data, 1)[1] == labels).sum().item()
+    accuracy = correct / len(testloader.dataset)
+    loss = loss / len(testloader)
+    return loss, accuracy

--- a/framework/py/flwr/cli/new/templates/app/pyproject.pytorch_msg_api.toml.tpl
+++ b/framework/py/flwr/cli/new/templates/app/pyproject.pytorch_msg_api.toml.tpl
@@ -1,0 +1,54 @@
+# =====================================================================
+# For a full TOML configuration guide, check the Flower docs:
+# https://flower.ai/docs/framework/how-to-configure-pyproject-toml.html
+# =====================================================================
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "$package_name"
+version = "1.0.0"
+description = ""
+license = "Apache-2.0"
+# Dependencies for your Flower App
+dependencies = [
+    "flwr[simulation]>=1.21.0",
+    "flwr-datasets[vision]>=0.5.0",
+    "torch==2.7.1",
+    "torchvision==0.22.1",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.flwr.app]
+publisher = "$username"
+
+# Point to your ServerApp and ClientApp objects
+# Format: "<module>:<object>"
+[tool.flwr.app.components]
+serverapp = "$import_name.server_app:app"
+clientapp = "$import_name.client_app:app"
+
+# Custom config values accessible via `context.run_config`
+[tool.flwr.app.config]
+num-server-rounds = 3
+fraction-train = 0.5
+local-epochs = 1
+lr = 0.01
+
+# Default federation to use when running the app
+[tool.flwr.federations]
+default = "local-simulation"
+
+# Local simulation federation with 10 virtual SuperNodes
+[tool.flwr.federations.local-simulation]
+options.num-supernodes = 10
+
+# Remote federation example for use with SuperLink
+[tool.flwr.federations.remote-federation]
+address = "<SUPERLINK-ADDRESS>:<PORT>"
+insecure = true  # Remove this line to enable TLS
+# root-certificates = "<PATH/TO/ca.crt>"  # For TLS setup

--- a/framework/py/flwr/cli/new/templates/app/pyproject.pytorch_msg_api.toml.tpl
+++ b/framework/py/flwr/cli/new/templates/app/pyproject.pytorch_msg_api.toml.tpl
@@ -27,7 +27,6 @@ packages = ["."]
 publisher = "$username"
 
 # Point to your ServerApp and ClientApp objects
-# Format: "<module>:<object>"
 [tool.flwr.app.components]
 serverapp = "$import_name.server_app:app"
 clientapp = "$import_name.client_app:app"


### PR DESCRIPTION
Adds a new template based on the `app-pytorch` example. It will be the second in the list.

<img width="846" height="411" alt="Screenshot 2025-08-30 at 16 46 00" src="https://github.com/user-attachments/assets/b942071d-556f-4be6-99de-3d63eadad3f1" />


> [!NOTE]
> Note global evaluation stage has been removed -- as we do with templates in general.




