### PR TITLE
ci(framework): Fix auto translation PRs title

### DIFF
--- a/.github/workflows/framework-docs-update-translations.yml
+++ b/.github/workflows/framework-docs-update-translations.yml
@@ -2,7 +2,7 @@ name: Framework Docs Translations
 
 on:
   schedule:
-    - cron: '0 0 * * *' # Runs every day at midnight
+    - cron: "0 0 * * *" # Runs every day at midnight
   workflow_dispatch: # Allows to manually trigger the workflow
 
 jobs:
@@ -26,7 +26,7 @@ jobs:
       - name: Bootstrap
         uses: ./.github/actions/bootstrap
         with:
-          python-version: '3.10'
+          python-version: "3.10"
 
       - name: Install dependencies
         run: |
@@ -57,7 +57,7 @@ jobs:
           git commit -m "Update text and language files"
         continue-on-error: true
 
-      - name: Calculate diff  # Even without doc changes the update-lang command will generate 228 additions and 60 deletions, so we only want to open a PR when there is more
+      - name: Calculate diff # Even without doc changes the update-lang command will generate 228 additions and 60 deletions, so we only want to open a PR when there is more
         id: calculate_diff
         run: |
           additions=$(git diff --numstat HEAD^1 | awk '{s+=$1} END {print s}')
@@ -82,6 +82,6 @@ jobs:
           branch: ${{ env.branch-name }}
           base: ${{ env.base-branch }}
           delete-branch: true
-          title: 'docs(framework:skip) Update source texts for translations (automated)'
-          body: 'This PR is auto-generated to update text and language files.'
+          title: "docs(framework:skip): Update source texts for translations (auto)"
+          body: "This PR is auto-generated to update text and language files."
           draft: false


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

### Checklist

- [ ] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.ai/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
