### PR TITLE
fix(examples): Fix `quickstart-pytorch` example

### DIFF
--- a/examples/quickstart-pytorch/pytorchexample/server_app.py
+++ b/examples/quickstart-pytorch/pytorchexample/server_app.py
@@ -5,7 +5,7 @@ from pprint import pprint
 import torch
 from flwr.common import ArrayRecord, ConfigRecord, Context, MetricRecord
 from flwr.server import Grid, ServerApp
-from flwr.serverapp import FedAvg
+from flwr.serverapp.strategy import FedAvg
 from pytorchexample.task import Net, load_centralized_dataset, test
 
 # Create ServerApp


### PR DESCRIPTION
From @jafermarq 