### PR TITLE
refactor(framework): Reorder settings shown in strategy summary

### DIFF
--- a/framework/py/flwr/serverapp/strategy/fedavg.py
+++ b/framework/py/flwr/serverapp/strategy/fedavg.py
@@ -127,10 +127,10 @@ class FedAvg(Strategy):
             self.min_evaluate_nodes,
         )  # pylint: disable=line-too-long
         log(INFO, "\t│\t└──Minimum available nodes: %d", self.min_available_nodes)
-        log(INFO, "\t└──> Keys in records:")
-        log(INFO, "\t\t├── Weighted by: '%s'", self.weighted_by_key)
-        log(INFO, "\t\t├── ArrayRecord key: '%s'", self.arrayrecord_key)
-        log(INFO, "\t\t└── ConfigRecord key: '%s'", self.configrecord_key)
+        log(INFO, "\t├──> Keys in records:")
+        log(INFO, "\t│\t├── Weighted by: '%s'", self.weighted_by_key)
+        log(INFO, "\t│\t├── ArrayRecord key: '%s'", self.arrayrecord_key)
+        log(INFO, "\t│\t└── ConfigRecord key: '%s'", self.configrecord_key)
 
     def _construct_messages(
         self, record: RecordDict, node_ids: list[int], message_type: str

--- a/framework/py/flwr/serverapp/strategy/strategy.py
+++ b/framework/py/flwr/serverapp/strategy/strategy.py
@@ -176,10 +176,10 @@ class Strategy(ABC):
             metrics and global evaluation metrics (if provided) from all rounds.
         """
         log(INFO, "Starting %s strategy:", self.__class__.__name__)
+        self.summary()
         log_strategy_start_info(
             num_rounds, initial_arrays, train_config, evaluate_config
         )
-        self.summary()
         log(INFO, "")
 
         # Initialize if None

--- a/framework/py/flwr/serverapp/strategy/strategy_utils.py
+++ b/framework/py/flwr/serverapp/strategy/strategy_utils.py
@@ -73,7 +73,7 @@ def log_strategy_start_info(
     )
     log(
         INFO,
-        "\t├── ConfigRecord (evaluate): %s",
+        "\t└── ConfigRecord (evaluate): %s",
         config_to_str(evaluate_config) if evaluate_config else "(empty!)",
     )
 


### PR DESCRIPTION
Reorder of content to show first strategy specific settings. This helps when strategies inheriting from `FedAvg` want to extend their summary (e.g. to include some of their unique hyperparams).

With this change the `FedAdam` summary would look like:

<img width="1289" height="595" alt="Screenshot 2025-09-03 at 12 16 07" src="https://github.com/user-attachments/assets/c3a69351-189e-462a-b397-0f35dd506c76" />

while before this change it would look: