### PR TITLE
refactor(*:skip): Log `Result` at the end of strategy `start` execution

### DIFF
--- a/examples/app-pytorch/app_pytorch/server_app.py
+++ b/examples/app-pytorch/app_pytorch/server_app.py
@@ -1,7 +1,5 @@
 """app-pytorch: A Flower / PyTorch app."""
 
-from pprint import pprint
-
 import torch
 from app_pytorch.task import Net, load_centralized_dataset, test
 from flwr.common import ArrayRecord, ConfigRecord, Context, MetricRecord
@@ -35,14 +33,6 @@ def main(grid: Grid, context: Context) -> None:
         num_rounds=num_rounds,
         evaluate_fn=global_evaluate,
     )
-
-    # Log resulting metrics
-    print("\nDistributed train metrics:")
-    pprint(result.train_metrics_clientapp)
-    print("\nDistributed evaluate metrics:")
-    pprint(result.evaluate_metrics_clientapp)
-    print("\nGlobal evaluate metrics:")
-    pprint(result.evaluate_metrics_serverapp)
 
     # Save final model to disk
     print("\nSaving final model to disk...")

--- a/examples/quickstart-pytorch/pytorchexample/server_app.py
+++ b/examples/quickstart-pytorch/pytorchexample/server_app.py
@@ -1,7 +1,5 @@
 """pytorchexample: A Flower / PyTorch app."""
 
-from pprint import pprint
-
 import torch
 from flwr.common import ArrayRecord, ConfigRecord, Context, MetricRecord
 from flwr.server import Grid, ServerApp
@@ -36,14 +34,6 @@ def main(grid: Grid, context: Context) -> None:
         num_rounds=num_rounds,
         evaluate_fn=global_evaluate,
     )
-
-    # Log resulting metrics
-    print("\nDistributed train metrics:")
-    pprint(result.train_metrics_clientapp)
-    print("\nDistributed evaluate metrics:")
-    pprint(result.evaluate_metrics_clientapp)
-    print("\nGlobal evaluate metrics:")
-    pprint(result.evaluate_metrics_serverapp)
 
     # Save final model to disk
     print("\nSaving final model to disk...")

--- a/framework/docs/source/tutorial-quickstart-pytorch.rst
+++ b/framework/docs/source/tutorial-quickstart-pytorch.rst
@@ -139,21 +139,21 @@ With default arguments you will see an output like this one:
     INFO :
     INFO :      Final results:
     INFO :
-    INFO :         Global Arrays:
-    INFO :                 ArrayRecord (0.238 MB)
+    INFO :          Global Arrays:
+    INFO :                  ArrayRecord (0.238 MB)
     INFO :
-    INFO :         Federated Train Metrics (per-round training metrics from ClientApps):
-    INFO :         { 1: {'train_loss': '2.1267e+00'},
-    INFO :           2: {'train_loss': '2.0586e+00'},
-    INFO :           3: {'train_loss': '1.9559e+00'}}
+    INFO :          Aggregated Client-side Train Metrics:
+    INFO :          { 1: {'train_loss': '2.1839e+00'},
+    INFO :            2: {'train_loss': '2.0512e+00'},
+    INFO :            3: {'train_loss': '1.9784e+00'}}
     INFO :
-    INFO :         Federated Evaluate Metrics (per-round evaluation metrics from ClientApps):
-    INFO :         { 1: {'eval_acc': '1.0040e-01', 'eval_loss': '2.2954e+00'},
-    INFO :           2: {'eval_acc': '2.4670e-01', 'eval_loss': '1.9911e+00'},
-    INFO :           3: {'eval_acc': '2.9830e-01', 'eval_loss': '1.8754e+00'}}
+    INFO :          Aggregated Client-side Evaluate Metrics:
+    INFO :          { 1: {'eval_acc': '1.0770e-01', 'eval_loss': '2.2858e+00'},
+    INFO :            2: {'eval_acc': '2.1810e-01', 'eval_loss': '1.9734e+00'},
+    INFO :            3: {'eval_acc': '2.7140e-01', 'eval_loss': '1.9069e+00'}}
     INFO :
-    INFO :         Centralized Evaluate Metrics (per-round evaluation metrics from ServerApp):
-    INFO :         {}
+    INFO :          Server-side Evaluate Metrics:
+    INFO :          {}
     INFO :
 
     Saving final model to disk...

--- a/framework/docs/source/tutorial-quickstart-pytorch.rst
+++ b/framework/docs/source/tutorial-quickstart-pytorch.rst
@@ -137,15 +137,24 @@ With default arguments you will see an output like this one:
     INFO :
     INFO :      Strategy execution finished in 16.56s
     INFO :
-    Distributed train metrics:
-    {1: {'train_loss': 2.149280443954468},
-    2: {'train_loss': 2.109740121269226},
-    3: {'train_loss': 1.947683771133423}}
-
-    Distributed evaluate metrics:
-    {1: {'eval_loss': 2.313199865818024, 'eval_acc': 0.1004},
-    2: {'eval_loss': 2.2529619082808496, 'eval_acc': 0.1420000002},
-    3: {'eval_loss': 1.9190230954438452, 'eval_acc': 0.2974000005}}
+    INFO :      Final results:
+    INFO :
+    INFO :         Global Arrays:
+    INFO :                 ArrayRecord (0.238 MB)
+    INFO :
+    INFO :         Federated Train Metrics (per-round training metrics from ClientApps):
+    INFO :         { 1: {'train_loss': '2.1267e+00'},
+    INFO :           2: {'train_loss': '2.0586e+00'},
+    INFO :           3: {'train_loss': '1.9559e+00'}}
+    INFO :
+    INFO :         Federated Evaluate Metrics (per-round evaluation metrics from ClientApps):
+    INFO :         { 1: {'eval_acc': '1.0040e-01', 'eval_loss': '2.2954e+00'},
+    INFO :           2: {'eval_acc': '2.4670e-01', 'eval_loss': '1.9911e+00'},
+    INFO :           3: {'eval_acc': '2.9830e-01', 'eval_loss': '1.8754e+00'}}
+    INFO :
+    INFO :         Centralized Evaluate Metrics (per-round evaluation metrics from ServerApp):
+    INFO :         {}
+    INFO :
 
     Saving final model to disk...
 
@@ -418,12 +427,6 @@ invoking its |strategy_start_link|_ method. To it we pass:
             train_config=ConfigRecord({"lr": lr}),
             num_rounds=num_rounds,
         )
-
-        # Log resulting metrics
-        print("\nDistributed train metrics:")
-        pprint(result.train_metrics_clientapp)
-        print("\nDistributed evaluate metrics:")
-        pprint(result.evaluate_metrics_clientapp)
 
         # Save final model to disk
         print("\nSaving final model to disk...")

--- a/framework/py/flwr/cli/new/templates/app/code/server.pytorch_msg_api.py.tpl
+++ b/framework/py/flwr/cli/new/templates/app/code/server.pytorch_msg_api.py.tpl
@@ -1,7 +1,5 @@
 """$project_name: A Flower / $framework_str app."""
 
-from pprint import pprint
-
 import torch
 from flwr.common import ArrayRecord, ConfigRecord, Context
 from flwr.server import Grid, ServerApp
@@ -36,12 +34,6 @@ def main(grid: Grid, context: Context) -> None:
         train_config=ConfigRecord({"lr": lr}),
         num_rounds=num_rounds,
     )
-
-    # Log resulting metrics
-    print("\nDistributed train metrics:")
-    pprint(result.train_metrics_clientapp)
-    print("\nDistributed evaluate metrics:")
-    pprint(result.evaluate_metrics_clientapp)
 
     # Save final model to disk
     print("\nSaving final model to disk...")

--- a/framework/py/flwr/serverapp/strategy/result.py
+++ b/framework/py/flwr/serverapp/strategy/result.py
@@ -31,25 +31,25 @@ class Result:
 
     def __repr__(self) -> str:
         """Create a representation of the Result instance."""
-        repr = ""
+        rep = ""
         arr_size = sum(len(array.data) for array in self.arrays.values()) / (1024**2)
-        repr += "\nResult (arrays):\n" + f"\tArrayRecord ({arr_size} MB)\n" + "\n"
-        repr += (
+        rep += "\nResult (arrays):\n" + f"\tArrayRecord ({arr_size} MB)\n" + "\n"
+        rep += (
             "Result (train_metrics_clientapp):\n"
             + pprint.pformat(self.train_metrics_clientapp, indent=2)
             + "\n\n"
         )
 
-        repr += (
+        rep += (
             "Result (evaluate_metrics_clientapp):\n"
             + pprint.pformat(self.evaluate_metrics_clientapp, indent=2)
             + "\n\n"
         )
 
-        repr += (
+        rep += (
             "Result (evaluate_metrics_serverapp):\n"
             + pprint.pformat(self.evaluate_metrics_serverapp, indent=2)
             + "\n"
         )
 
-        return repr
+        return rep

--- a/framework/py/flwr/serverapp/strategy/result.py
+++ b/framework/py/flwr/serverapp/strategy/result.py
@@ -22,7 +22,32 @@ from flwr.common import ArrayRecord, MetricRecord
 
 @dataclass
 class Result:
-    """Data class carrying records generated during the execution of a strategy."""
+    """Data class carrying records generated during the execution of a strategy.
+
+    This class encapsulates the results of a federated learning strategy execution,
+    including the final global model parameters and metrics collected throughout
+    the federated training and evaluation (both federated and centralized) stages.
+
+    Attributes
+    ----------
+    arrays : ArrayRecord
+        The final global model parameters. Contains the
+        aggregated model weights/parameters that resulted from the federated
+        learning process.
+    train_metrics_clientapp : dict[int, MetricRecord]
+        Training metrics collected from ClientApps, indexed by round number.
+        Contains aggregated metrics (e.g., loss, accuracy) from the training
+        phase of each federated learning round.
+    evaluate_metrics_clientapp : dict[int, MetricRecord]
+        Evaluation metrics collected from ClientApps, indexed by round number.
+        Contains aggregated metrics  (e.g. validation loss) from the evaluation
+        phase where ClientApps evaluate the global model on their local
+        validation/test data.
+    evaluate_metrics_serverapp : dict[int, MetricRecord]
+        Evaluation metrics generated at the ServerApp, indexed by round number.
+        Contains metrics from centralized evaluation performed by the ServerApp
+        (e.g., when the server evaluates the global model on a held-out dataset).
+    """
 
     arrays: ArrayRecord = field(default_factory=ArrayRecord)
     train_metrics_clientapp: dict[int, MetricRecord] = field(default_factory=dict)
@@ -33,23 +58,23 @@ class Result:
         """Create a representation of the Result instance."""
         rep = ""
         arr_size = sum(len(array.data) for array in self.arrays.values()) / (1024**2)
-        rep += "Result.arrays:\n" + f"\tArrayRecord ({arr_size:.3f} MB)\n" + "\n"
+        rep += "Global Arrays:\n" + f"\tArrayRecord ({arr_size:.3f} MB)\n" + "\n"
         rep += (
-            "Result.train_metrics_clientapp (per-round training metrics "
+            "Federated Train Metrics (per-round training metrics "
             "from ClientApps):\n"
             + pprint.pformat(self.train_metrics_clientapp, indent=2)
             + "\n\n"
         )
 
         rep += (
-            "Result.evaluate_metrics_clientapp (per-round evaluation metrics "
+            "Federated Evaluate Metrics (per-round evaluation metrics "
             "from ClientApps):\n"
             + pprint.pformat(self.evaluate_metrics_clientapp, indent=2)
             + "\n\n"
         )
 
         rep += (
-            "Result.evaluate_metrics_serverapp (per-round evaluation metrics "
+            "Centralized Evaluate Metrics (per-round evaluation metrics "
             "from ServerApp):\n"
             + pprint.pformat(self.evaluate_metrics_serverapp, indent=2)
             + "\n"

--- a/framework/py/flwr/serverapp/strategy/result.py
+++ b/framework/py/flwr/serverapp/strategy/result.py
@@ -35,19 +35,22 @@ class Result:
         arr_size = sum(len(array.data) for array in self.arrays.values()) / (1024**2)
         rep += "\nResult.arrays:\n" + f"\tArrayRecord ({arr_size:.3f} MB)\n" + "\n"
         rep += (
-            "Result.train_metrics_clientapp (per-round training metrics from clients):\n"
+            "Result.train_metrics_clientapp (per-round training metrics "
+            "from ClientApps):\n"
             + pprint.pformat(self.train_metrics_clientapp, indent=2)
             + "\n\n"
         )
 
         rep += (
-            "Result.evaluate_metrics_clientapp (per-round evaluation metrics from clients):\n"
+            "Result.evaluate_metrics_clientapp (per-round evaluation metrics "
+            "from ClientApps):\n"
             + pprint.pformat(self.evaluate_metrics_clientapp, indent=2)
             + "\n\n"
         )
 
         rep += (
-            "Result.evaluate_metrics_serverapp (per-round evaluation metrics from server):\n"
+            "Result.evaluate_metrics_serverapp (per-round evaluation metrics "
+            "from ServerApp):\n"
             + pprint.pformat(self.evaluate_metrics_serverapp, indent=2)
             + "\n"
         )

--- a/framework/py/flwr/serverapp/strategy/result.py
+++ b/framework/py/flwr/serverapp/strategy/result.py
@@ -61,22 +61,19 @@ class Result:
         arr_size = sum(len(array.data) for array in self.arrays.values()) / (1024**2)
         rep += "Global Arrays:\n" + f"\tArrayRecord ({arr_size:.3f} MB)\n" + "\n"
         rep += (
-            "Federated Train Metrics (per-round training metrics "
-            "from ClientApps):\n"
+            "Aggregated Client-side Train Metrics:\n"
             + pprint.pformat(stringify_dict(self.train_metrics_clientapp), indent=2)
             + "\n\n"
         )
 
         rep += (
-            "Federated Evaluate Metrics (per-round evaluation metrics "
-            "from ClientApps):\n"
+            "Aggregated Client-side Evaluate Metrics:\n"
             + pprint.pformat(stringify_dict(self.evaluate_metrics_clientapp), indent=2)
             + "\n\n"
         )
 
         rep += (
-            "Centralized Evaluate Metrics (per-round evaluation metrics "
-            "from ServerApp):\n"
+            "Server-side Evaluate Metrics:\n"
             + pprint.pformat(stringify_dict(self.evaluate_metrics_serverapp), indent=2)
             + "\n"
         )

--- a/framework/py/flwr/serverapp/strategy/result.py
+++ b/framework/py/flwr/serverapp/strategy/result.py
@@ -33,21 +33,21 @@ class Result:
         """Create a representation of the Result instance."""
         rep = ""
         arr_size = sum(len(array.data) for array in self.arrays.values()) / (1024**2)
-        rep += "\nResult (arrays):\n" + f"\tArrayRecord ({arr_size:.3f} MB)\n" + "\n"
+        rep += "\nResult.arrays:\n" + f"\tArrayRecord ({arr_size:.3f} MB)\n" + "\n"
         rep += (
-            "Result (round: train_metrics_clientapp):\n"
+            "Result.train_metrics_clientapp (per-round training metrics from clients):\n"
             + pprint.pformat(self.train_metrics_clientapp, indent=2)
             + "\n\n"
         )
 
         rep += (
-            "Result (round: evaluate_metrics_clientapp):\n"
+            "Result.evaluate_metrics_clientapp (per-round evaluation metrics from clients):\n"
             + pprint.pformat(self.evaluate_metrics_clientapp, indent=2)
             + "\n\n"
         )
 
         rep += (
-            "Result (round: evaluate_metrics_serverapp):\n"
+            "Result.evaluate_metrics_serverapp (per-round evaluation metrics from server):\n"
             + pprint.pformat(self.evaluate_metrics_serverapp, indent=2)
             + "\n"
         )

--- a/framework/py/flwr/serverapp/strategy/result.py
+++ b/framework/py/flwr/serverapp/strategy/result.py
@@ -14,7 +14,7 @@
 # ==============================================================================
 """Strategy results."""
 
-
+import pprint
 from dataclasses import dataclass, field
 
 from flwr.common import ArrayRecord, MetricRecord
@@ -28,3 +28,28 @@ class Result:
     train_metrics_clientapp: dict[int, MetricRecord] = field(default_factory=dict)
     evaluate_metrics_clientapp: dict[int, MetricRecord] = field(default_factory=dict)
     evaluate_metrics_serverapp: dict[int, MetricRecord] = field(default_factory=dict)
+
+    def __repr__(self) -> str:
+        """Create a representation of the Result instance."""
+        repr = ""
+        arr_size = sum(len(array.data) for array in self.arrays.values()) / (1024**2)
+        repr += "\nResult (arrays):\n" + f"\tArrayRecord ({arr_size} MB)\n" + "\n"
+        repr += (
+            "Result (train_metrics_clientapp):\n"
+            + pprint.pformat(self.train_metrics_clientapp, indent=2)
+            + "\n\n"
+        )
+
+        repr += (
+            "Result (evaluate_metrics_clientapp):\n"
+            + pprint.pformat(self.evaluate_metrics_clientapp, indent=2)
+            + "\n\n"
+        )
+
+        repr += (
+            "Result (evaluate_metrics_serverapp):\n"
+            + pprint.pformat(self.evaluate_metrics_serverapp, indent=2)
+            + "\n"
+        )
+
+        return repr

--- a/framework/py/flwr/serverapp/strategy/result.py
+++ b/framework/py/flwr/serverapp/strategy/result.py
@@ -33,21 +33,21 @@ class Result:
         """Create a representation of the Result instance."""
         rep = ""
         arr_size = sum(len(array.data) for array in self.arrays.values()) / (1024**2)
-        rep += "\nResult (arrays):\n" + f"\tArrayRecord ({arr_size} MB)\n" + "\n"
+        rep += "\nResult (arrays):\n" + f"\tArrayRecord ({arr_size:.3f} MB)\n" + "\n"
         rep += (
-            "Result (train_metrics_clientapp):\n"
+            "Result (round: train_metrics_clientapp):\n"
             + pprint.pformat(self.train_metrics_clientapp, indent=2)
             + "\n\n"
         )
 
         rep += (
-            "Result (evaluate_metrics_clientapp):\n"
+            "Result (round: evaluate_metrics_clientapp):\n"
             + pprint.pformat(self.evaluate_metrics_clientapp, indent=2)
             + "\n\n"
         )
 
         rep += (
-            "Result (evaluate_metrics_serverapp):\n"
+            "Result (round: evaluate_metrics_serverapp):\n"
             + pprint.pformat(self.evaluate_metrics_serverapp, indent=2)
             + "\n"
         )

--- a/framework/py/flwr/serverapp/strategy/result.py
+++ b/framework/py/flwr/serverapp/strategy/result.py
@@ -33,7 +33,7 @@ class Result:
         """Create a representation of the Result instance."""
         rep = ""
         arr_size = sum(len(array.data) for array in self.arrays.values()) / (1024**2)
-        rep += "\nResult.arrays:\n" + f"\tArrayRecord ({arr_size:.3f} MB)\n" + "\n"
+        rep += "Result.arrays:\n" + f"\tArrayRecord ({arr_size:.3f} MB)\n" + "\n"
         rep += (
             "Result.train_metrics_clientapp (per-round training metrics "
             "from ClientApps):\n"

--- a/framework/py/flwr/serverapp/strategy/strategy.py
+++ b/framework/py/flwr/serverapp/strategy/strategy.py
@@ -15,6 +15,7 @@
 """Flower message-based strategy."""
 
 
+import io
 import time
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
@@ -270,6 +271,10 @@ class Strategy(ABC):
 
         log(INFO, "")
         log(INFO, "Strategy execution finished in %.2fs", time.time() - t_start)
+        log(INFO, "")
+        log(INFO, "Final results:")
+        for line in io.StringIO(str(result)):
+            log(INFO, "\t%s", line.strip("\n"))
         log(INFO, "")
 
         return result

--- a/framework/py/flwr/serverapp/strategy/strategy.py
+++ b/framework/py/flwr/serverapp/strategy/strategy.py
@@ -273,6 +273,7 @@ class Strategy(ABC):
         log(INFO, "Strategy execution finished in %.2fs", time.time() - t_start)
         log(INFO, "")
         log(INFO, "Final results:")
+        log(INFO, "")
         for line in io.StringIO(str(result)):
             log(INFO, "\t%s", line.strip("\n"))
         log(INFO, "")


### PR DESCRIPTION
examples and template have also been updated to remove the `pprint` lines.

Would look like:

```shell
INFO :      Strategy execution finished in 28.58s
INFO :
INFO :      Final results:
INFO :
INFO :          Global Arrays:
INFO :                  ArrayRecord (0.238 MB)
INFO :
INFO :          Aggregated Client-side Train Metrics:
INFO :          { 1: {'train_loss': '2.0984e+00'},
INFO :            2: {'train_loss': '2.0229e+00'},
INFO :            3: {'train_loss': '1.9634e+00'},
INFO :            4: {'train_loss': '1.8861e+00'},
INFO :            5: {'train_loss': '1.8315e+00'}}
INFO :
INFO :          Aggregated Client-side Evaluate Metrics:
INFO :          { 1: {'eval_acc': '1.2780e-01', 'eval_loss': '2.2512e+00'},
INFO :            2: {'eval_acc': '2.2110e-01', 'eval_loss': '1.9931e+00'},
INFO :            3: {'eval_acc': '2.7460e-01', 'eval_loss': '1.9280e+00'},
INFO :            4: {'eval_acc': '3.4990e-01', 'eval_loss': '1.7833e+00'},
INFO :            5: {'eval_acc': '3.6460e-01', 'eval_loss': '1.7417e+00'}}
INFO :
INFO :          Server-side Evaluate Metrics:
INFO :          { 0: {'accuracy': '9.9400e-02', 'loss': '2.3053e+00'},
INFO :            1: {'accuracy': '1.2300e-01', 'loss': '2.2521e+00'},
INFO :            2: {'accuracy': '2.1880e-01', 'loss': '1.9957e+00'},
INFO :            3: {'accuracy': '2.7100e-01', 'loss': '1.9300e+00'},
INFO :            4: {'accuracy': '3.4830e-01', 'loss': '1.7802e+00'},
INFO :            5: {'accuracy': '3.6480e-01', 'loss': '1.7434e+00'}}
INFO :
```