### PR TITLE
feat(framework): Allow NumPy scalar types in `Array` constructor for better 0-dim NDArray support

### DIFF
--- a/framework/py/flwr/common/record/array.py
+++ b/framework/py/flwr/common/record/array.py
@@ -135,7 +135,7 @@ class Array(InflatableObject):
         shape: tuple[int, ...] | None = None,
         stype: str | None = None,
         data: bytes | None = None,
-        ndarray: NDArray | np.generic | None = None,  # type: ignore[type-arg]
+        ndarray: NDArray | np.generic | None = None,
         torch_tensor: torch.Tensor | None = None,
     ) -> None:
         # Determine the initialization method and validate input arguments.
@@ -214,9 +214,7 @@ class Array(InflatableObject):
         _raise_array_init_error()
 
     @classmethod
-    def from_numpy_ndarray(
-        cls, ndarray: NDArray | np.generic  # type: ignore[type-arg]
-    ) -> Array:
+    def from_numpy_ndarray(cls, ndarray: NDArray | np.generic) -> Array:
         """Create Array from NumPy ndarray."""
         assert isinstance(
             ndarray, (np.ndarray, np.generic)

--- a/framework/py/flwr/common/record/array.py
+++ b/framework/py/flwr/common/record/array.py
@@ -80,7 +80,7 @@ class Array(InflatableObject):
         A buffer of bytes containing the data. Only required if you are not passing in
         a ndarray or a tensor.
 
-    ndarray : Optional[Union[NDArray, np.generic]] (default: None)
+    ndarray : Optional[NDArray] (default: None)
         A NumPy ndarray. If provided, the `dtype`, `shape`, `stype`, and `data`
         fields are derived automatically from it. NumPy scalars (i.e., `np.generic`
         types) are also supported and will be converted to 0-dim ndarrays internally.
@@ -135,7 +135,7 @@ class Array(InflatableObject):
         shape: tuple[int, ...] | None = None,
         stype: str | None = None,
         data: bytes | None = None,
-        ndarray: NDArray | np.generic | None = None,
+        ndarray: NDArray | None = None,
         torch_tensor: torch.Tensor | None = None,
     ) -> None:
         # Determine the initialization method and validate input arguments.
@@ -214,7 +214,7 @@ class Array(InflatableObject):
         _raise_array_init_error()
 
     @classmethod
-    def from_numpy_ndarray(cls, ndarray: NDArray | np.generic) -> Array:
+    def from_numpy_ndarray(cls, ndarray: NDArray) -> Array:
         """Create Array from NumPy ndarray."""
         assert isinstance(
             ndarray, (np.ndarray, np.generic)

--- a/framework/py/flwr/common/record/array.py
+++ b/framework/py/flwr/common/record/array.py
@@ -135,7 +135,7 @@ class Array(InflatableObject):
         shape: tuple[int, ...] | None = None,
         stype: str | None = None,
         data: bytes | None = None,
-        ndarray: NDArray | np.generic | None = None,  # type: ignore
+        ndarray: NDArray | np.generic | None = None,
         torch_tensor: torch.Tensor | None = None,
     ) -> None:
         # Determine the initialization method and validate input arguments.
@@ -214,7 +214,7 @@ class Array(InflatableObject):
         _raise_array_init_error()
 
     @classmethod
-    def from_numpy_ndarray(cls, ndarray: NDArray | np.generic) -> Array:  # type: ignore
+    def from_numpy_ndarray(cls, ndarray: NDArray | np.generic) -> Array:
         """Create Array from NumPy ndarray."""
         assert isinstance(
             ndarray, (np.ndarray, np.generic)

--- a/framework/py/flwr/common/record/array.py
+++ b/framework/py/flwr/common/record/array.py
@@ -135,7 +135,7 @@ class Array(InflatableObject):
         shape: tuple[int, ...] | None = None,
         stype: str | None = None,
         data: bytes | None = None,
-        ndarray: NDArray | np.generic | None = None,
+        ndarray: NDArray | np.generic | None = None,  # type: ignore
         torch_tensor: torch.Tensor | None = None,
     ) -> None:
         # Determine the initialization method and validate input arguments.
@@ -214,7 +214,7 @@ class Array(InflatableObject):
         _raise_array_init_error()
 
     @classmethod
-    def from_numpy_ndarray(cls, ndarray: NDArray | np.generic) -> Array:
+    def from_numpy_ndarray(cls, ndarray: NDArray | np.generic) -> Array:  # type: ignore
         """Create Array from NumPy ndarray."""
         assert isinstance(
             ndarray, (np.ndarray, np.generic)

--- a/framework/py/flwr/common/record/array_test.py
+++ b/framework/py/flwr/common/record/array_test.py
@@ -79,7 +79,7 @@ class TestArray(unittest.TestCase):
         ]
     )
     def test_numpy_conversion_valid(
-        self, np_array: Union[NDArray, np.generic]  # type: ignore[type-arg]
+        self, np_array: Union[NDArray, np.generic]
     ) -> None:
         """Test the numpy method with valid Array instance."""
         # Prepare

--- a/framework/py/flwr/common/record/array_test.py
+++ b/framework/py/flwr/common/record/array_test.py
@@ -78,9 +78,7 @@ class TestArray(unittest.TestCase):
             (np.str_("test test!"),),  # NumPy scalar (string)
         ]
     )
-    def test_numpy_conversion_valid(
-        self, np_array: Union[NDArray, np.generic]  # type: ignore
-    ) -> None:
+    def test_numpy_conversion_valid(self, np_array: Union[NDArray, np.generic]) -> None:
         """Test the numpy method with valid Array instance."""
         # Prepare
         np_array = np.asarray(np_array)  # Ensure it's an ndarray

--- a/framework/py/flwr/common/record/array_test.py
+++ b/framework/py/flwr/common/record/array_test.py
@@ -78,9 +78,7 @@ class TestArray(unittest.TestCase):
             (np.str_("test test!"),),  # NumPy scalar (string)
         ]
     )
-    def test_numpy_conversion_valid(
-        self, np_array: Union[NDArray, np.generic]
-    ) -> None:
+    def test_numpy_conversion_valid(self, np_array: Union[NDArray, np.generic]) -> None:
         """Test the numpy method with valid Array instance."""
         # Prepare
         np_array = np.asarray(np_array)  # Ensure it's an ndarray

--- a/framework/py/flwr/common/record/array_test.py
+++ b/framework/py/flwr/common/record/array_test.py
@@ -20,7 +20,7 @@ import sys
 import unittest
 from io import BytesIO
 from types import ModuleType
-from typing import Any, Union, cast
+from typing import Any, cast
 from unittest.mock import Mock
 
 import numpy as np
@@ -78,7 +78,7 @@ class TestArray(unittest.TestCase):
             (np.str_("test test!"),),  # NumPy scalar (string)
         ]
     )
-    def test_numpy_conversion_valid(self, np_array: Union[NDArray, np.generic]) -> None:
+    def test_numpy_conversion_valid(self, np_array: Any) -> None:
         """Test the numpy method with valid Array instance."""
         # Prepare
         np_array = np.asarray(np_array)  # Ensure it's an ndarray

--- a/framework/py/flwr/common/record/array_test.py
+++ b/framework/py/flwr/common/record/array_test.py
@@ -78,7 +78,9 @@ class TestArray(unittest.TestCase):
             (np.str_("test test!"),),  # NumPy scalar (string)
         ]
     )
-    def test_numpy_conversion_valid(self, np_array: Union[NDArray, np.generic]) -> None:
+    def test_numpy_conversion_valid(
+        self, np_array: Union[NDArray, np.generic]  # type: ignore
+    ) -> None:
         """Test the numpy method with valid Array instance."""
         # Prepare
         np_array = np.asarray(np_array)  # Ensure it's an ndarray


### PR DESCRIPTION
Crazy NumPy will silently give a numpy scalar if you do numeric operations on 0-dim arrays, e.g.,
```
np.array(3) -> np.ndarray
np.array(3) * 0.5 -> np.float64(1.5)
np.array(3) * np.array(0.5) -> np.float64(1.5)
np.multiply(np.array(3), np.array(0.5)) -> np.float64(1.5)
```

~~Crazy `mypy` are not happy wwith `np.generic`. Have to use `# type: ignore` to suppress warnings:~~
- ~~When using `np.generic`: mypy is not happy due to lack of type argument for the generic type~~
- ~~When using `np.generic[Something]`: Python runtime is not happy b/c `np.generic` is not subscriptable.~~

~~Okay, I think that was something wrong with my `mypy`.~~

~~`mypy + numpy` is crazy, on it.~~

When `numpy >= 2.2.0`, `mypy` requires type arg for `np.generic`, e.g., `np.generic[Any]`, while the Python runtime doesn't allow that.
When `numpy < 2.2.0`, `mypy` does not require type arg for `np.generic`.

Our `python 3.11` env somehow uses `numpy >= 2.2.0` while `python 3.9/3.10` doesn't.

It's very hard to get all of them work. We actually needs an optional `# type: ignore` that will only be active for `numpy >= 2.2.0`, which is not really possible. So I have to give up type hinting it.