### PR TITLE
ci(framework): Update CI tests to use `flwr ls` when checking for status of a run

### DIFF
--- a/framework/e2e/test_superlink.sh
+++ b/framework/e2e/test_superlink.sh
@@ -73,8 +73,7 @@ else
   echo -e $"\n[tool.flwr.federations.e2e]\naddress = \"127.0.0.1:9093\"\nroot-certificates = \"certificates/ca.crt\"" >> pyproject.toml
 fi
 
-timeout 5m flower-superlink $server_arg $db_arg $rest_arg_superlink $server_auth \
-  2>&1 | tee flwr_output.log &
+timeout 5m flower-superlink $server_arg $db_arg $rest_arg_superlink $server_auth &
 sl_pid=$(pgrep -f "flower-superlink")
 sleep 3
 
@@ -106,21 +105,24 @@ cleanup_and_exit() {
     exit $1
 }
 
-# Check for "Run finished" in a loop with a timeout
+# Check for "finished:completed" status in a loop with a timeout
 while [ "$found_success" = false ] && [ $elapsed -lt $timeout ]; do
-    if grep -q "ERROR" flwr_output.log; then
-        echo "An ERROR occurred during training. Exiting."
-        cleanup_and_exit 1
-    elif grep -q "Run finished" flwr_output.log; then
-        echo "Training worked correctly!"
-        found_success=true
-        cleanup_and_exit 0
+    # Run the command and capture output
+    output=$(flwr ls . e2e --format=json)
+
+    # Extract status from the first run (or loop over all if needed)
+    status=$(echo "$output" | jq -r '.runs[0].status')
+
+    echo "Current status: $status"
+
+    if [ "$status" == "finished:completed" ]; then
+      found_success=true
+      echo "Training worked correctly!"
+      cleanup_and_exit 0
     else
-        echo "Waiting for training ... ($elapsed seconds elapsed)"
+      echo "⏳ Not completed yet, retrying in 2s..."
+      sleep 2
     fi
-    # Sleep for a short period and increment the elapsed time
-    sleep 2
-    elapsed=$((elapsed + 2))
 done
 
 if [ "$found_success" = false ]; then

--- a/framework/e2e/test_windows.sh
+++ b/framework/e2e/test_windows.sh
@@ -8,7 +8,7 @@ cd e2e-tmp-test
 echo -e $"\n[tool.flwr.federations.e2e]\naddress = \"127.0.0.1:9093\"\ninsecure = true" >> pyproject.toml
 
 # Start Flower processes in the background
-flower-superlink --insecure 2>&1 | tee flwr_output.log &
+flower-superlink --insecure &
 sleep 2
 
 flower-supernode --insecure --superlink 127.0.0.1:9092 \
@@ -45,19 +45,22 @@ cleanup_and_exit() {
 
 # Check for "Run finished" in a loop with a timeout
 while [ "$found_success" = false ] && [ $elapsed -lt $timeout ]; do
-    if grep -q "ERROR" flwr_output.log; then
-        echo "An ERROR occurred during training. Exiting."
-        cleanup_and_exit 1
-    elif grep -q "Run finished" flwr_output.log; then
-        echo "Training worked correctly!"
-        found_success=true
-        cleanup_and_exit 0
+    # Run the command and capture output
+    output=$(flwr ls . e2e --format=json)
+
+    # Extract status from the first run (or loop over all if needed)
+    status=$(echo "$output" | jq -r '.runs[0].status')
+
+    echo "Current status: $status"
+
+    if [ "$status" == "finished:completed" ]; then
+      found_success=true
+      echo "Training worked correctly!"
+      cleanup_and_exit 0
     else
-        echo "Waiting for training ... ($elapsed seconds elapsed)"
+      echo "⏳ Not completed yet, retrying in 2s..."
+      sleep 2
     fi
-    # Sleep for a short period and increment the elapsed time
-    sleep 2
-    elapsed=$((elapsed + 2))
 done
 
 if [ "$found_success" = false ]; then

--- a/framework/e2e/test_windows.sh
+++ b/framework/e2e/test_windows.sh
@@ -43,7 +43,7 @@ cleanup_and_exit() {
     exit $1
 }
 
-# Check for "Run finished" in a loop with a timeout
+# Check for "finished:completed" status in a loop with a timeout
 while [ "$found_success" = false ] && [ $elapsed -lt $timeout ]; do
     # Run the command and capture output
     output=$(flwr ls . e2e --format=json)


### PR DESCRIPTION
Now using `flwr ls` just like in https://github.com/adap/flower/pull/5842