### PR TITLE
refactor(framework): Remove `self.current_array = ...` line in `FedOpt` subclasses for consistency

### DIFF
--- a/framework/py/flwr/serverapp/strategy/fedadagrad.py
+++ b/framework/py/flwr/serverapp/strategy/fedadagrad.py
@@ -153,9 +153,6 @@ class FedAdagrad(FedOpt):
             for k, x in self.current_arrays.items()
         }
 
-        # Update current arrays
-        self.current_arrays = new_arrays
-
         return (
             ArrayRecord(OrderedDict({k: Array(v) for k, v in new_arrays.items()})),
             aggregated_metrics,

--- a/framework/py/flwr/serverapp/strategy/fedadam.py
+++ b/framework/py/flwr/serverapp/strategy/fedadam.py
@@ -172,9 +172,6 @@ class FedAdam(FedOpt):
             for k, x in self.current_arrays.items()
         }
 
-        # Update current arrays
-        self.current_arrays = new_arrays
-
         return (
             ArrayRecord(OrderedDict({k: Array(v) for k, v in new_arrays.items()})),
             aggregated_metrics,

--- a/framework/py/flwr/serverapp/strategy/fedyogi.py
+++ b/framework/py/flwr/serverapp/strategy/fedyogi.py
@@ -164,9 +164,6 @@ class FedYogi(FedOpt):
             for k, x in self.current_arrays.items()
         }
 
-        # Update current arrays
-        self.current_arrays = new_arrays
-
         return (
             ArrayRecord(OrderedDict({k: Array(v) for k, v in new_arrays.items()})),
             aggregated_metrics,


### PR DESCRIPTION
Based on discussion here: https://github.com/adap/flower/pull/5904#discussion_r2360308225

We decided to remove the line updating `self.current_arrays`.