### PR TITLE
refactor(framework): Use `│` instead of `|` to ensure consistency and make it prettier

### DIFF
--- a/framework/py/flwr/serverapp/strategy/fedavgm.py
+++ b/framework/py/flwr/serverapp/strategy/fedavgm.py
@@ -126,9 +126,9 @@ class FedAvgM(FedAvg):
         """Log summary configuration of the strategy."""
         opt_status = "ON" if self.server_opt else "OFF"
         log(INFO, "\t├──> FedAvgM settings:")
-        log(INFO, "\t|\t├── Server optimization: %s", opt_status)
-        log(INFO, "\t|\t├── Server learning rate: %s", self.server_learning_rate)
-        log(INFO, "\t|\t└── Server Momentum: %s", self.server_momentum)
+        log(INFO, "\t│\t├── Server optimization: %s", opt_status)
+        log(INFO, "\t│\t├── Server learning rate: %s", self.server_learning_rate)
+        log(INFO, "\t│\t└── Server Momentum: %s", self.server_momentum)
         super().summary()
 
     def configure_train(

--- a/framework/py/flwr/serverapp/strategy/fedprox.py
+++ b/framework/py/flwr/serverapp/strategy/fedprox.py
@@ -162,7 +162,7 @@ class FedProx(FedAvg):
     def summary(self) -> None:
         """Log summary configuration of the strategy."""
         log(INFO, "\t├──> FedProx settings:")
-        log(INFO, "\t|\t└── Proximal mu: %s", self.proximal_mu)
+        log(INFO, "\t│\t└── Proximal mu: %s", self.proximal_mu)
         super().summary()
 
     def configure_train(

--- a/framework/py/flwr/serverapp/strategy/fedtrimmedavg.py
+++ b/framework/py/flwr/serverapp/strategy/fedtrimmedavg.py
@@ -108,7 +108,7 @@ class FedTrimmedAvg(FedAvg):
     def summary(self) -> None:
         """Log summary configuration of the strategy."""
         log(INFO, "\t├──> FedTrimmedAvg settings:")
-        log(INFO, "\t|\t└── beta: %s", self.beta)
+        log(INFO, "\t│\t└── beta: %s", self.beta)
         super().summary()
 
     def aggregate_train(

--- a/framework/py/flwr/serverapp/strategy/krum.py
+++ b/framework/py/flwr/serverapp/strategy/krum.py
@@ -116,8 +116,8 @@ class Krum(FedAvg):
     def summary(self) -> None:
         """Log summary configuration of the strategy."""
         log(INFO, "\t├──> Krum settings:")
-        log(INFO, "\t|\t├── Number of malicious nodes: %d", self.num_malicious_nodes)
-        log(INFO, "\t|\t└── Number of nodes to keep: %d", self.num_nodes_to_keep)
+        log(INFO, "\t│\t├── Number of malicious nodes: %d", self.num_malicious_nodes)
+        log(INFO, "\t│\t└── Number of nodes to keep: %d", self.num_nodes_to_keep)
         super().summary()
 
     def _compute_distances(self, records: list[ArrayRecord]) -> NDArray:


### PR DESCRIPTION
### Now
<img width="446" height="108" alt="image" src="https://github.com/user-attachments/assets/0cde9be2-dd6c-4ee5-931d-241e6f3ce63a" />

### Before
<img width="453" height="107" alt="image" src="https://github.com/user-attachments/assets/5ad25110-42f1-40e4-a66d-5f2d093a46a2" />
