### PR TITLE
fix(intelligence): Use correct value type for tool_call args

### DIFF
--- a/intelligence/ts/src/index.ts
+++ b/intelligence/ts/src/index.ts
@@ -21,6 +21,7 @@ export type {
   Failure,
   JsonSchema,
   JsonSchemaPayload,
+  JsonValue,
   Message,
   Progress,
   ResponseFormat,

--- a/intelligence/ts/src/typing.ts
+++ b/intelligence/ts/src/typing.ts
@@ -19,9 +19,9 @@ export type JsonValue =
   | string
   | number
   | boolean
-  | null
   | JsonValue[]
-  | { [key: string]: JsonValue };
+  | { [key: string]: JsonValue }
+  | null;
 
 /**
  * Represents a message in a chat session.

--- a/intelligence/ts/src/typing.ts
+++ b/intelligence/ts/src/typing.ts
@@ -15,6 +15,14 @@
 
 import { ALLOWED_ROLES } from './constants';
 
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
 /**
  * Represents a message in a chat session.
  */
@@ -69,7 +77,7 @@ export type ToolCall = Record<
     /**
      * The arguments passed to the tool as key-value pairs.
      */
-    arguments: Record<string, string>;
+    arguments: Record<string, JsonValue>;
   }
 >;
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

### Checklist

- [ ] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.ai/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
