### PR TITLE
docs(datasets:skip) Fixup seed argument documentation in Dirichlet partitioners

### DIFF
--- a/datasets/flwr_datasets/partitioner/dirichlet_partitioner.py
+++ b/datasets/flwr_datasets/partitioner/dirichlet_partitioner.py
@@ -63,7 +63,9 @@ class DirichletPartitioner(Partitioner):
         Whether to randomize the order of samples. Shuffling applied after the
         samples assignment to partitions.
     seed: int
-        Seed used for dataset shuffling. It has no effect if `shuffle` is False.
+        Seed used for initializing the random number generator (RNG),
+        which affects dataset shuffling (if `shuffle` is True)
+        and sampling from the Dirichlet distribution.
 
     Examples
     --------

--- a/datasets/flwr_datasets/partitioner/inner_dirichlet_partitioner.py
+++ b/datasets/flwr_datasets/partitioner/inner_dirichlet_partitioner.py
@@ -51,7 +51,9 @@ class InnerDirichletPartitioner(Partitioner):  # pylint: disable=R0902
         Whether to randomize the order of samples. Shuffling applied after the
         samples assignment to partitions.
     seed: int
-        Seed used for dataset shuffling. It has no effect if `shuffle` is False.
+        Seed used for initializing the random number generator (RNG),
+        which affects dataset shuffling (if `shuffle` is True)
+        and sampling from the Dirichlet distribution.
 
     Examples
     --------


### PR DESCRIPTION
## Issue

Invalid documentation for the `seed` argument in `DirichletPartitioner` and `InnerDirichletPartitioner`

### Description

The documentation for the `seed` argument in the aforementioned classes (in the `flwr_datasets.partitioner` package) is not correct and claims a wrong proposition (... has no effect if `shuffle` is False).

https://github.com/adap/flower/blob/aa128571a583bf449f7c95d69700c163a2cfe476/datasets/flwr_datasets/partitioner/dirichlet_partitioner.py#L65-L66

The `seed` argument is used in initializing a NumPy RNG:
https://github.com/adap/flower/blob/aa128571a583bf449f7c95d69700c163a2cfe476/datasets/flwr_datasets/partitioner/dirichlet_partitioner.py#L108
And that RNG (`self._rng`) is used for sampling from the Dirichlet distribution and an optional data shuffling (if `shuffle` is True):
https://github.com/adap/flower/blob/aa128571a583bf449f7c95d69700c163a2cfe476/datasets/flwr_datasets/partitioner/dirichlet_partitioner.py#L230
https://github.com/adap/flower/blob/aa128571a583bf449f7c95d69700c163a2cfe476/datasets/flwr_datasets/partitioner/dirichlet_partitioner.py#L322

### Related issues/PRs

Related to #2794 and #2795.

## Proposal

### Explanation

Updated the respective documentation.

### Checklist

- [x] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

-