### PR TITLE
refactor(examples): Migrate `federated-kaplan-meier-fitter` example to `Message API`

### DIFF
--- a/examples/federated-kaplan-meier-fitter/README.md
+++ b/examples/federated-kaplan-meier-fitter/README.md
@@ -14,7 +14,7 @@ The aim of this example is to estimate the survival function using the
 lifelines library (see [KaplanMeierFitter](https://lifelines.readthedocs.io/en/stable/fitters/univariate/KaplanMeierFitter.html#lifelines.fitters.kaplan_meier_fitter.KaplanMeierFitter)). The distributed/federated aspect of this example
 is the data sending to the server. You can think of it as a federated analytics example. However, it's worth noting that this procedure violates privacy since the raw data is exchanged.
 
-Finally, many other estimators beyond KaplanMeierFitter can be used with the provided strategy:
+Finally, many other estimators beyond KaplanMeierFitter can be used:
 AalenJohansenFitter, GeneralizedGammaFitter, LogLogisticFitter,
 SplineFitter, and WeibullFitter.
 
@@ -69,7 +69,7 @@ flwr run .
 You can also override some of the settings for your `ClientApp` and `ServerApp` defined in `pyproject.toml`. For example:
 
 ```bash
-flwr run . --run-config "num-server-rounds=5 learning-rate=0.05"
+flwr run . --run-config "num-server-rounds=5"
 ```
 
 You can also check that the results match the centralized version.

--- a/examples/federated-kaplan-meier-fitter/README.md
+++ b/examples/federated-kaplan-meier-fitter/README.md
@@ -32,7 +32,10 @@ the group it comes from therefore to simulate the division that might occur.
 Start by cloning the example project:
 
 ```shell
-$ git clone --depth=1 https://github.com/adap/flower.git _tmp && mv _tmp/examples/federated-kaplan-meier-fitter . && rm -rf _tmp && cd federated-kaplan-meier-fitter
+$ git clone --depth=1 https://github.com/adap/flower.git _tmp \
+        && mv _tmp/examples/federated-kaplan-meier-fitter . \
+        && rm -rf _tmp \
+        && cd federated-kaplan-meier-fitter
 ```
 
 This will create a new directory called `federated-kaplan-meier-fitter` with the following structure:

--- a/examples/federated-kaplan-meier-fitter/examplefkm/client_app.py
+++ b/examples/federated-kaplan-meier-fitter/examplefkm/client_app.py
@@ -1,58 +1,32 @@
 """examplefkm: A Flower / Lifelines app."""
 
-from typing import Dict, List, Tuple
-
-import flwr as fl
-import numpy as np
-from flwr.client import Client, ClientApp
-from flwr.common import Context, NDArray, NDArrays
-
 from examplefkm.task import load_partition
-
-
-class FlowerClient(fl.client.NumPyClient):
-    """Flower client that holds and sends the events and times data.
-
-    Parameters
-    ----------
-    times: NDArray
-        Times of the `events`.
-    events: NDArray
-        Events represented by 0 - no event, 1 - event occurred.
-
-    Raises
-    ------
-    ValueError
-        If the `times` and `events` are not the same shape.
-    """
-
-    def __init__(self, times: NDArray, events: NDArray):
-        if len(times) != len(events):
-            raise ValueError("The times and events arrays have to be same shape.")
-        self._times = times
-        self._events = events
-
-    def fit(
-        self, parameters: List[np.ndarray], config: Dict[str, str]
-    ) -> Tuple[NDArrays, int, Dict]:
-        return (
-            [self._times, self._events],
-            len(self._times),
-            {},
-        )
-
-
-def client_fn(context: Context) -> Client:
-    """Construct a Client that will be run in a ClientApp.
-
-    You can use settings in `context.run_config` to parameterize the
-    construction of your Client. You could use the `context.node_config` to, for
-    example, indicate which dataset to load (e.g accesing the partition-id).
-    """
-    partition_id = context.node_config["partition-id"]
-    times, events = load_partition(partition_id)
-    return FlowerClient(times=times, events=events).to_client()
-
+from flwr.app import Array, ArrayRecord, Context, Message, MetricRecord, RecordDict
+from flwr.clientapp import ClientApp
 
 # Flower ClientApp
-app = ClientApp(client_fn=client_fn)
+app = ClientApp()
+
+
+@app.query()
+def query(msg: Message, context: Context):
+    """Query time to event data."""
+
+    # Load the data
+    partition_id = context.node_config["partition-id"]
+    # Times and events
+    #   Times: times of the events
+    #   Events: 0 - no event, 1 - event occurred
+    times, events = load_partition(partition_id)
+
+    if len(times) != len(events):
+        raise ValueError("The times and events arrays have to be same shape.")
+
+    # Construct and return reply Message
+    model_record = ArrayRecord({"T": Array(times), "E": Array(events)})
+    metrics = {
+        "num-examples": len(times),
+    }
+    metric_record = MetricRecord(metrics)
+    content = RecordDict({"survival-data": model_record, "metrics": metric_record})
+    return Message(content=content, reply_to=msg)

--- a/examples/federated-kaplan-meier-fitter/examplefkm/server_app.py
+++ b/examples/federated-kaplan-meier-fitter/examplefkm/server_app.py
@@ -14,144 +14,86 @@
 # ==============================================================================
 """Strategy that supports many univariate fitters from lifelines library."""
 
-from typing import Any, Dict, List, Optional, Tuple, Union
+
+from logging import INFO
+from time import sleep
 
 import numpy as np
-from flwr.common import (
-    Context,
-    EvaluateIns,
-    EvaluateRes,
-    FitIns,
-    FitRes,
-    Parameters,
-    Scalar,
-    parameters_to_ndarrays,
-)
-from flwr.server import ServerApp, ServerAppComponents, ServerConfig
-from flwr.server.client_manager import ClientManager
-from flwr.server.client_proxy import ClientProxy
-from flwr.server.strategy import Strategy
+from flwr.app import Context, Message, MessageType, RecordDict
+from flwr.common.logger import log
+from flwr.serverapp import Grid, ServerApp
 from lifelines import KaplanMeierFitter
 
+# Create ServerApp
+app = ServerApp()
 
-class EventTimeFitterStrategy(Strategy):
-    """Federated strategy to aggregate the data that consist of events and times.
 
-    It works with the following uni-variate fitters from the lifelines library:
-    AalenJohansenFitter, GeneralizedGammaFitter, KaplanMeierFitter, LogLogisticFitter,
-    SplineFitter, WeibullFitter. Note that each of them might require slightly different
-    initialization but constructed fitter object are required to be passed.
+@app.main()
+def main(grid: Grid, context: Context) -> None:
+    """Main entry point for the ServerApp."""
 
-    This strategy recreates the event and time data based on the data received from the
-    nodes.
+    # Read run config
+    min_num_clients = context.run_config["min-num-clients"]
+    num_rounds = context.run_config["num-server-rounds"]
 
-    Parameters
-    ----------
-    min_num_clients: int
-        pass
-    fitter: Any
-        uni-variate fitter from lifelines library that works with event, time data e.g.
-        KaplanMeierFitter
-    """
+    # Define the filter
+    fitter = KaplanMeierFitter()  # You can choose other method that work on E, T data
 
-    def __init__(self, min_num_clients: int, fitter: Any):
-        # Fitter can be access after the federated training ends
-        self._min_num_clients = min_num_clients
-        self.fitter = fitter
+    # Define FL round
+    for server_round in range(num_rounds):
+        log(INFO, "")  # Add newline for log readability
+        log(INFO, "Starting round %s/%s", server_round + 1, num_rounds)
 
-    def configure_fit(
-        self, server_round: int, parameters: Parameters, client_manager: ClientManager
-    ) -> List[Tuple[ClientProxy, FitIns]]:
-        """Configure the fit method."""
-        config = {}
-        fit_ins = FitIns(parameters, config)
-        clients = client_manager.sample(
-            num_clients=self._min_num_clients,
-            min_num_clients=self._min_num_clients,
-        )
-        return [(client, fit_ins) for client in clients]
+        # Loop and wait until enough nodes are available.
+        all_node_ids: list[int] = []
+        while len(all_node_ids) < min_num_clients:
+            all_node_ids = list(grid.get_node_ids())
+            if len(all_node_ids) >= min_num_clients:
+                break
+            log(INFO, "Waiting for nodes to connect...")
+            sleep(2)
 
-    def aggregate_fit(
-        self,
-        server_round: int,
-        results: List[Tuple[ClientProxy, FitRes]],
-        failures: List[Union[Tuple[ClientProxy, FitRes], BaseException]],
-    ) -> Tuple[Optional[Parameters], Dict[str, Scalar]]:
-        """Merge data and perform the fitting of the fitter from lifelines library.
+        log(INFO, "Sampled %s nodes (out of %s)", len(all_node_ids), len(all_node_ids))
 
-        Assume just a single federated learning round. Assume the data comes as a list
-        with two elements of 1-dim numpy arrays of events and times.
-        """
-        remote_data = [
-            (parameters_to_ndarrays(fit_res.parameters)) for _, fit_res in results
-        ]
+        # Create messages
+        recorddict = RecordDict()
+        messages = []
+        for node_id in all_node_ids:  # one message for each node
+            message = Message(
+                content=recorddict,
+                message_type=MessageType.QUERY,  # target `query` method in ClientApp
+                dst_node_id=node_id,
+            )
+            messages.append(message)
 
-        combined_times = remote_data[0][0]
-        combined_events = remote_data[0][1]
+        # Send messages and wait for all results
+        replies = grid.send_and_receive(messages)
+        log(INFO, "Received %s/%s results", len(replies), len(messages))
 
-        for te_list in remote_data[1:]:
-            combined_times = np.concatenate((combined_times, te_list[0]))
-            combined_events = np.concatenate((combined_events, te_list[1]))
+        # Use lifelines filter to fit the data
+        remote_times = []
+        remote_events = []
+        for reply in replies:
+            if reply.has_error():
+                continue
+
+            # Both `T` and `E` are `Array` objects, let's convert them to numpy
+            remote_times.append(reply.content["survival-data"]["T"].numpy())
+            remote_events.append(reply.content["survival-data"]["E"].numpy())
+
+        combined_times = remote_times[0]
+        combined_events = remote_events[0]
+
+        for t, e in zip(remote_times[1:], remote_events[1:]):
+            combined_times = np.concatenate((combined_times, t))
+            combined_events = np.concatenate((combined_events, e))
 
         args_sorted = np.argsort(combined_times)
         sorted_times = combined_times[args_sorted]
         sorted_events = combined_events[args_sorted]
-        self.fitter.fit(sorted_times, sorted_events)
+        fitter.fit(sorted_times, sorted_events)
         print("Survival function:")
-        print(self.fitter.survival_function_)
+        print(fitter.survival_function_)
         print("Mean survival time:")
-        print(self.fitter.median_survival_time_)
-        return None, {}
+        print(fitter.median_survival_time_)
 
-    # The methods below return None or empty results.
-    # They need to be implemented to since the methods are abstract in the parent class
-    def initialize_parameters(
-        self, client_manager: Optional[ClientManager] = None
-    ) -> Optional[Parameters]:
-        """No parameter initialization is needed."""
-        return None
-
-    def evaluate(
-        self, server_round: int, parameters: Parameters
-    ) -> Optional[Tuple[float, Dict[str, Scalar]]]:
-        """No centralized evaluation."""
-        return None
-
-    def aggregate_evaluate(
-        self,
-        server_round: int,
-        results: List[Tuple[ClientProxy, EvaluateRes]],
-        failures: List[Union[Tuple[ClientProxy, EvaluateRes], BaseException]],
-    ) -> Tuple[Optional[float], Dict[str, Scalar]]:
-        """No federated evaluation."""
-        return None, {}
-
-    def configure_evaluate(
-        self, server_round: int, parameters: Parameters, client_manager: ClientManager
-    ) -> List[Tuple[ClientProxy, EvaluateIns]]:
-        """No federated evaluation."""
-        return []
-
-
-def server_fn(context: Context) -> ServerAppComponents:
-    """Construct components that set the ServerApp behaviour.
-
-    You can use settings in `context.run_config` to parameterize the
-    construction of all elements (e.g the strategy or the number of rounds)
-    wrapped in the returned ServerAppComponents object.
-    """
-
-    # Define the strategy
-    fitter = KaplanMeierFitter()  # You can choose other method that work on E, T data
-    min_num_clients = context.run_config["min-num-clients"]
-    strategy = EventTimeFitterStrategy(min_num_clients=min_num_clients, fitter=fitter)
-
-    # Construct ServerConfig
-    num_rounds = context.run_config["num-server-rounds"]
-    config = ServerConfig(num_rounds=num_rounds)
-
-    return ServerAppComponents(strategy=strategy, config=config)
-
-
-# Create ServerApp
-app = ServerApp(server_fn=server_fn)

--- a/examples/federated-kaplan-meier-fitter/examplefkm/server_app.py
+++ b/examples/federated-kaplan-meier-fitter/examplefkm/server_app.py
@@ -1,19 +1,4 @@
-# Copyright 2024 Flower Labs GmbH. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-# ==============================================================================
-"""Strategy that supports many univariate fitters from lifelines library."""
-
+"""examplefkm: A Flower / Lifelines app."""
 
 from logging import INFO
 from time import sleep

--- a/examples/federated-kaplan-meier-fitter/examplefkm/task.py
+++ b/examples/federated-kaplan-meier-fitter/examplefkm/task.py
@@ -1,8 +1,9 @@
 """examplefkm: A Flower / Lifelines app."""
 
-from datasets import Dataset
 from flwr_datasets.partitioner import NaturalIdPartitioner
 from lifelines.datasets import load_waltons
+
+from datasets import Dataset
 
 X = load_waltons()
 


### PR DESCRIPTION
This example is more about Fed Analytics more than actual Fed Learning, because of this i've decided to now use a strategy and instead use the lower level `Message` with `MessageType.Query` messages.