### PR TITLE
feat(framework): Introduce `flwr supernode xyz` commands

### DIFF
--- a/framework/py/flwr/cli/app.py
+++ b/framework/py/flwr/cli/app.py
@@ -28,6 +28,9 @@ from .new import new
 from .pull import pull
 from .run import run
 from .stop import stop
+from .supernode.add import add as supernode_add
+from .supernode.ls import ls as supernode_ls
+from .supernode.rm import rm as supernode_rm
 
 app = typer.Typer(
     help=typer.style(
@@ -48,6 +51,13 @@ app.command()(ls)
 app.command()(stop)
 app.command()(login)
 app.command()(pull)
+
+# Create supernode command group
+supernode_app = typer.Typer(help="Manage SuperNodes")
+supernode_app.command()(supernode_add)
+supernode_app.command()(supernode_rm)
+supernode_app.command()(supernode_ls)
+app.add_typer(supernode_app, name="supernode")
 
 typer_click_object = get_command(app)
 

--- a/framework/py/flwr/cli/supernode/add.py
+++ b/framework/py/flwr/cli/supernode/add.py
@@ -13,3 +13,29 @@
 # limitations under the License.
 # ==============================================================================
 """Flower command line interface `supernode add` command."""
+
+from pathlib import Path
+from typing import Annotated, Optional
+
+import typer
+
+
+def add(  # pylint: disable=R0914
+    app: Annotated[
+        Path,
+        typer.Argument(help="Path of the Flower project"),
+    ] = Path("."),
+    federation: Annotated[
+        Optional[str],
+        typer.Argument(help="Name of the federation"),
+    ] = None,
+    pub_key: Annotated[
+        Path,
+        typer.Option(
+            "--pub-key",
+            help="Path to the public key file.",
+        ),
+    ] = None,
+) -> None:
+    """Add a SuperNode to the federation."""
+    typer.secho("Loading project configuration... ", fg=typer.colors.BLUE)

--- a/framework/py/flwr/cli/supernode/ls.py
+++ b/framework/py/flwr/cli/supernode/ls.py
@@ -13,3 +13,23 @@
 # limitations under the License.
 # ==============================================================================
 """Flower command line interface `supernode ls` command."""
+
+
+from pathlib import Path
+from typing import Annotated, Optional
+
+import typer
+
+
+def ls(  # pylint: disable=R0914
+    app: Annotated[
+        Path,
+        typer.Argument(help="Path of the Flower project"),
+    ] = Path("."),
+    federation: Annotated[
+        Optional[str],
+        typer.Argument(help="Name of the federation"),
+    ] = None,
+) -> None:
+    """List SuperNodes in the federation."""
+    typer.secho("Loading project configuration... ", fg=typer.colors.BLUE)

--- a/framework/py/flwr/cli/supernode/rm.py
+++ b/framework/py/flwr/cli/supernode/rm.py
@@ -13,3 +13,29 @@
 # limitations under the License.
 # ==============================================================================
 """Flower command line interface `supernode rm` command."""
+
+from pathlib import Path
+from typing import Annotated, Optional
+
+import typer
+
+
+def rm(  # pylint: disable=R0914
+    app: Annotated[
+        Path,
+        typer.Argument(help="Path of the Flower project"),
+    ] = Path("."),
+    federation: Annotated[
+        Optional[str],
+        typer.Argument(help="Name of the federation"),
+    ] = None,
+    node_id: Annotated[
+        Path,
+        typer.Option(
+            "--node-id",
+            help="ID of the SuperNode to remove.",
+        ),
+    ] = None,
+) -> None:
+    """Remove a SuperNode from the federation."""
+    typer.secho("Loading project configuration... ", fg=typer.colors.BLUE)


### PR DESCRIPTION
This PR introduces the basic structure for `flwr supernode add/rm/ls` but not their implementation. A command group is created to encapsulate `app/rm/ls` sub-commands. 


```
(flwr-py3.11) ➜  framework git:(add-flwr-supernode) ✗ flwr supernode --help
                                                                                
 Usage: flwr supernode [OPTIONS] COMMAND [ARGS]...                              
                                                                                
 Manage SuperNodes                                                              
                                                                                
╭─ Options ─────────────────────────────────────────────────────────────────────
│ --help  -h        Show this message and exit.                                 
╰───────────────────────────────────────────────────────────────────────────────
╭─ Commands ────────────────────────────────────────────────────────────────────
│ add   Add a SuperNode to the federation.                                      
│ ls    List SuperNodes in the federation.                                      
│ rm    Remove a SuperNode from the federation.                                 
╰───────────────────────────────────────────────────────────────────────────────
```