### PR TITLE
feat(framework): Implement dummy behaviour `flwr supernode list/ls`

### DIFF
--- a/framework/proto/flwr/proto/node.proto
+++ b/framework/proto/flwr/proto/node.proto
@@ -24,8 +24,8 @@ message NodeInfo {
   string owner_aid = 2;
   string status = 3;
   string created_at = 4;
-  string activated_at = 5;
-  string deactivated_at = 6;
+  string last_activated_at = 5;
+  string last_deactivated_at = 6;
   string deleted_at = 7;
   float online_until = 8;
   float heartbeat_interval = 9;

--- a/framework/py/flwr/cli/supernode/ls.py
+++ b/framework/py/flwr/cli/supernode/ls.py
@@ -148,10 +148,10 @@ def _format_nodes(
 
         # Calculate elapsed times
         elapsed_time_activated = timedelta()
-        if node.activated_at:
+        if node.last_activated_at:
             end_time = datetime.fromisoformat(now_isoformat)
             elapsed_time_activated = end_time - datetime.fromisoformat(
-                node.activated_at
+                node.last_activated_at
             )
 
         formatted_nodes.append(
@@ -160,8 +160,8 @@ def _format_nodes(
                 node.owner_aid,
                 node.status,
                 _format_datetime(node.created_at),
-                _format_datetime(node.activated_at),
-                _format_datetime(node.deactivated_at),
+                _format_datetime(node.last_activated_at),
+                _format_datetime(node.last_deactivated_at),
                 _format_datetime(node.deleted_at),
                 format_timedelta(elapsed_time_activated),
             )
@@ -189,18 +189,18 @@ def _to_table(nodes_info: list[_NodeListType], verbose: bool) -> Table:
             owner_aid,
             status,
             _,
-            activated_at,
-            deactivated_at,
+            last_activated_at,
+            last_deactivated_at,
             deleted_at,
             elapse_activated,
         ) = row
 
         if status == "online":
             status_style = "green"
-            time_at = activated_at
+            time_at = last_activated_at
         elif status == "offline":
             status_style = "bright_yellow"
-            time_at = deactivated_at
+            time_at = last_deactivated_at
         elif status == "deleted":
             if not verbose:
                 continue

--- a/framework/py/flwr/proto/node_pb2.py
+++ b/framework/py/flwr/proto/node_pb2.py
@@ -14,7 +14,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x15\x66lwr/proto/node.proto\x12\nflwr.proto\"\x17\n\x04Node\x12\x0f\n\x07node_id\x18\x01 \x01(\x04\"\xc6\x01\n\x08NodeInfo\x12\x0f\n\x07node_id\x18\x01 \x01(\x04\x12\x11\n\towner_aid\x18\x02 \x01(\t\x12\x0e\n\x06status\x18\x03 \x01(\t\x12\x12\n\ncreated_at\x18\x04 \x01(\t\x12\x14\n\x0c\x61\x63tivated_at\x18\x05 \x01(\t\x12\x16\n\x0e\x64\x65\x61\x63tivated_at\x18\x06 \x01(\t\x12\x12\n\ndeleted_at\x18\x07 \x01(\t\x12\x14\n\x0conline_until\x18\x08 \x01(\x02\x12\x1a\n\x12heartbeat_interval\x18\t \x01(\x02\x62\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x15\x66lwr/proto/node.proto\x12\nflwr.proto\"\x17\n\x04Node\x12\x0f\n\x07node_id\x18\x01 \x01(\x04\"\xd0\x01\n\x08NodeInfo\x12\x0f\n\x07node_id\x18\x01 \x01(\x04\x12\x11\n\towner_aid\x18\x02 \x01(\t\x12\x0e\n\x06status\x18\x03 \x01(\t\x12\x12\n\ncreated_at\x18\x04 \x01(\t\x12\x19\n\x11last_activated_at\x18\x05 \x01(\t\x12\x1b\n\x13last_deactivated_at\x18\x06 \x01(\t\x12\x12\n\ndeleted_at\x18\x07 \x01(\t\x12\x14\n\x0conline_until\x18\x08 \x01(\x02\x12\x1a\n\x12heartbeat_interval\x18\t \x01(\x02\x62\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -24,5 +24,5 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   _globals['_NODE']._serialized_start=37
   _globals['_NODE']._serialized_end=60
   _globals['_NODEINFO']._serialized_start=63
-  _globals['_NODEINFO']._serialized_end=261
+  _globals['_NODEINFO']._serialized_end=271
 # @@protoc_insertion_point(module_scope)

--- a/framework/py/flwr/proto/node_pb2.pyi
+++ b/framework/py/flwr/proto/node_pb2.pyi
@@ -27,8 +27,8 @@ class NodeInfo(google.protobuf.message.Message):
     OWNER_AID_FIELD_NUMBER: builtins.int
     STATUS_FIELD_NUMBER: builtins.int
     CREATED_AT_FIELD_NUMBER: builtins.int
-    ACTIVATED_AT_FIELD_NUMBER: builtins.int
-    DEACTIVATED_AT_FIELD_NUMBER: builtins.int
+    LAST_ACTIVATED_AT_FIELD_NUMBER: builtins.int
+    LAST_DEACTIVATED_AT_FIELD_NUMBER: builtins.int
     DELETED_AT_FIELD_NUMBER: builtins.int
     ONLINE_UNTIL_FIELD_NUMBER: builtins.int
     HEARTBEAT_INTERVAL_FIELD_NUMBER: builtins.int
@@ -36,8 +36,8 @@ class NodeInfo(google.protobuf.message.Message):
     owner_aid: typing.Text
     status: typing.Text
     created_at: typing.Text
-    activated_at: typing.Text
-    deactivated_at: typing.Text
+    last_activated_at: typing.Text
+    last_deactivated_at: typing.Text
     deleted_at: typing.Text
     online_until: builtins.float
     heartbeat_interval: builtins.float
@@ -47,11 +47,11 @@ class NodeInfo(google.protobuf.message.Message):
         owner_aid: typing.Text = ...,
         status: typing.Text = ...,
         created_at: typing.Text = ...,
-        activated_at: typing.Text = ...,
-        deactivated_at: typing.Text = ...,
+        last_activated_at: typing.Text = ...,
+        last_deactivated_at: typing.Text = ...,
         deleted_at: typing.Text = ...,
         online_until: builtins.float = ...,
         heartbeat_interval: builtins.float = ...,
         ) -> None: ...
-    def ClearField(self, field_name: typing_extensions.Literal["activated_at",b"activated_at","created_at",b"created_at","deactivated_at",b"deactivated_at","deleted_at",b"deleted_at","heartbeat_interval",b"heartbeat_interval","node_id",b"node_id","online_until",b"online_until","owner_aid",b"owner_aid","status",b"status"]) -> None: ...
+    def ClearField(self, field_name: typing_extensions.Literal["created_at",b"created_at","deleted_at",b"deleted_at","heartbeat_interval",b"heartbeat_interval","last_activated_at",b"last_activated_at","last_deactivated_at",b"last_deactivated_at","node_id",b"node_id","online_until",b"online_until","owner_aid",b"owner_aid","status",b"status"]) -> None: ...
 global___NodeInfo = NodeInfo

--- a/framework/py/flwr/superlink/servicer/control/control_servicer.py
+++ b/framework/py/flwr/superlink/servicer/control/control_servicer.py
@@ -429,8 +429,8 @@ class ControlServicer(control_pb2_grpc.ControlServicer):
                 owner_aid="owner_aid_1",
                 status="created",
                 created_at=(now()).isoformat(),
-                activated_at="",
-                deactivated_at="",
+                last_activated_at="",
+                last_deactivated_at="",
                 deleted_at="",
             )
         )
@@ -442,8 +442,8 @@ class ControlServicer(control_pb2_grpc.ControlServicer):
                 owner_aid="owner_aid_2",
                 status="online",
                 created_at=(now()).isoformat(),
-                activated_at=(now() + timedelta(hours=0.5)).isoformat(),
-                deactivated_at="",
+                last_activated_at=(now() + timedelta(hours=0.5)).isoformat(),
+                last_deactivated_at="",
                 deleted_at="",
             )
         )
@@ -455,8 +455,8 @@ class ControlServicer(control_pb2_grpc.ControlServicer):
                 owner_aid="owner_aid_3",
                 status="deleted",
                 created_at=(now()).isoformat(),
-                activated_at="",
-                deactivated_at="",
+                last_activated_at="",
+                last_deactivated_at="",
                 deleted_at=(now() + timedelta(hours=1)).isoformat(),
             )
         )
@@ -468,8 +468,8 @@ class ControlServicer(control_pb2_grpc.ControlServicer):
                 owner_aid="owner_aid_4",
                 status="offline",
                 created_at=(now()).isoformat(),
-                activated_at=(now() + timedelta(hours=0.5)).isoformat(),
-                deactivated_at=(now() + timedelta(hours=1)).isoformat(),
+                last_activated_at=(now() + timedelta(hours=0.5)).isoformat(),
+                last_deactivated_at=(now() + timedelta(hours=1)).isoformat(),
                 deleted_at=(now() + timedelta(hours=1.5)).isoformat(),
             )
         )


### PR DESCRIPTION
This PR introduces the logic on the Flower CLI side for `flwr supernode list/ls` and can now display the info about nodes connected to the `SuperLink` as a table or in JSON format.

Concretely, info about 4 hardcoded nodes is shown:
- node 1: a `SuperNode` created via `flwr supernode add` but never connected
- node 2: same as node 1 but the `SuperNode` actually connected to the `SuperLink` and remains connected
- node 3: same as node 1 but the admin did `flwr supernode delete` before it was ever connected
- node 4: a node that was added, the, connected, then disconnected, and finally deleted.

```shell
flwr supernode list . remote-federation
Loading project configuration...
Success
📄 Listing all nodes...
┏━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━┓
┃       Node ID        ┃    Owner    ┃ Status  ┃ Elapsed  ┃   Status Changed @   ┃
┡━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━┩
│ 15390646978706312628 │ owner_aid_1 │ created │          │ N/A                  │
├──────────────────────┼─────────────┼─────────┼──────────┼──────────────────────┤
│ 2941141058168602545  │ owner_aid_2 │ online  │ 23:30:00 │ 2025-10-06 11:54:54Z │
├──────────────────────┼─────────────┼─────────┼──────────┼──────────────────────┤
│ 1781174086018058152  │ owner_aid_4 │ offline │          │ 2025-10-06 12:24:54Z │
└──────────────────────┴─────────────┴─────────┴──────────┴──────────────────────┘
```

or as a JSON:
```
flwr supernode list . remote-federation --format=json
{
  "success": true,
  "nodes": [
    {
      "node-id": 15390646978706312628,
      "owner-aid": "owner_aid_1",
      "status": "created",
      "created-at": "2025-10-06 11:32:57Z",
      "online-at": "N/A",
      "online-elapsed": "00:00:00",
      "offline-at": "N/A",
      "deleted-at": "N/A"
    },
    {
      "node-id": 2941141058168602545,
      "owner-aid": "owner_aid_2",
      "status": "online",
      "created-at": "2025-10-06 11:32:57Z",
      "online-at": "2025-10-06 12:02:57Z",
      "online-elapsed": "23:30:00",
      "offline-at": "N/A",
      "deleted-at": "N/A"
    },
    {
      "node-id": 1781174086018058152,
      "owner-aid": "owner_aid_4",
      "status": "offline",
      "created-at": "2025-10-06 11:32:57Z",
      "online-at": "2025-10-06 12:02:57Z",
      "online-elapsed": "23:30:00",
      "offline-at": "2025-10-06 12:32:57Z",
      "deleted-at": "2025-10-06 13:02:57Z"
    }
  ]
}
```

When passing flag `--verbose`, `SuperNodes` with `deleted` status will also be shown.