### PR TITLE
refactor(framework): Rename environment variables related to Object pushing/pulling

### DIFF
--- a/framework/py/flwr/common/constant.py
+++ b/framework/py/flwr/common/constant.py
@@ -137,8 +137,8 @@ GC_THRESHOLD = 200_000_000  # 200 MB
 # Constants for Inflatable
 HEAD_BODY_DIVIDER = b"\x00"
 HEAD_VALUE_DIVIDER = " "
-FLWR_MAX_ARRAY_CHUNK_SIZE = int(
-    os.getenv("FLWR_MAX_ARRAY_CHUNK_SIZE", "5242880")
+FLWR_PRIVATE_MAX_ARRAY_CHUNK_SIZE = int(
+    os.getenv("FLWR_PRIVATE_MAX_ARRAY_CHUNK_SIZE", "5242880")
 )  # 5 MB
 
 # Constants for serialization
@@ -148,11 +148,11 @@ INT64_MAX_VALUE = 9223372036854775807  # (1 << 63) - 1
 FLWR_APP_TOKEN_LENGTH = 128  # Length of the token used
 
 # Constants for object pushing and pulling
-FLWR_MAX_CONCURRENT_OBJ_PUSHES = int(
-    os.getenv("FLWR_MAX_CONCURRENT_OBJ_PUSHES", "2")
+FLWR_PRIVATE_MAX_CONCURRENT_OBJ_PUSHES = int(
+    os.getenv("FLWR_PRIVATE_MAX_CONCURRENT_OBJ_PUSHES", "2")
 )  # Default maximum number of concurrent pushes
-FLWR_MAX_CONCURRENT_OBJ_PULLS = int(
-    os.getenv("FLWR_MAX_CONCURRENT_OBJ_PULLS", "2")
+FLWR_PRIVATE_MAX_CONCURRENT_OBJ_PULLS = int(
+    os.getenv("FLWR_PRIVATE_MAX_CONCURRENT_OBJ_PULLS", "2")
 )  # Default maximum number of concurrent pulls
 PULL_MAX_TIME = 7200  # Default maximum time to wait for pulling objects
 PULL_MAX_TRIES_PER_OBJECT = 500  # Default maximum number of tries to pull an object

--- a/framework/py/flwr/common/inflatable_utils.py
+++ b/framework/py/flwr/common/inflatable_utils.py
@@ -25,8 +25,8 @@ from typing import Callable, Optional, TypeVar
 from flwr.proto.message_pb2 import ObjectTree  # pylint: disable=E0611
 
 from .constant import (
-    FLWR_MAX_CONCURRENT_OBJ_PULLS,
-    FLWR_MAX_CONCURRENT_OBJ_PUSHES,
+    FLWR_PRIVATE_MAX_CONCURRENT_OBJ_PULLS,
+    FLWR_PRIVATE_MAX_CONCURRENT_OBJ_PUSHES,
     HEAD_BODY_DIVIDER,
     HEAD_VALUE_DIVIDER,
     PULL_BACKOFF_CAP,
@@ -118,7 +118,7 @@ def push_objects(
     *,
     object_ids_to_push: Optional[set[str]] = None,
     keep_objects: bool = False,
-    max_concurrent_pushes: int = FLWR_MAX_CONCURRENT_OBJ_PUSHES,
+    max_concurrent_pushes: int = FLWR_PRIVATE_MAX_CONCURRENT_OBJ_PUSHES,
 ) -> None:
     """Push multiple objects to the servicer.
 
@@ -137,7 +137,7 @@ def push_objects(
         If `True`, the original objects will be kept in the `objects` dictionary
         after pushing. If `False`, they will be removed from the dictionary to avoid
         high memory usage.
-    max_concurrent_pushes : int (default: FLWR_MAX_CONCURRENT_OBJ_PUSHES)
+    max_concurrent_pushes : int (default: FLWR_PRIVATE_MAX_CONCURRENT_OBJ_PUSHES)
         The maximum number of concurrent pushes to perform.
     """
     lock = threading.Lock()
@@ -168,7 +168,7 @@ def push_object_contents_from_iterable(
     object_contents: Iterable[tuple[str, bytes]],
     push_object_fn: Callable[[str, bytes], None],
     *,
-    max_concurrent_pushes: int = FLWR_MAX_CONCURRENT_OBJ_PUSHES,
+    max_concurrent_pushes: int = FLWR_PRIVATE_MAX_CONCURRENT_OBJ_PUSHES,
 ) -> None:
     """Push multiple object contents to the servicer.
 
@@ -181,7 +181,7 @@ def push_object_contents_from_iterable(
         A function that takes an object ID and its content as bytes, and pushes
         it to the servicer. This function should raise `ObjectIdNotPreregisteredError`
         if the object ID is not pre-registered.
-    max_concurrent_pushes : int (default: FLWR_MAX_CONCURRENT_OBJ_PUSHES)
+    max_concurrent_pushes : int (default: FLWR_PRIVATE_MAX_CONCURRENT_OBJ_PUSHES)
         The maximum number of concurrent pushes to perform.
     """
 
@@ -210,7 +210,7 @@ def pull_objects(  # pylint: disable=too-many-arguments,too-many-locals
     object_ids: list[str],
     pull_object_fn: Callable[[str], bytes],
     *,
-    max_concurrent_pulls: int = FLWR_MAX_CONCURRENT_OBJ_PULLS,
+    max_concurrent_pulls: int = FLWR_PRIVATE_MAX_CONCURRENT_OBJ_PULLS,
     max_time: Optional[float] = PULL_MAX_TIME,
     max_tries_per_object: Optional[int] = PULL_MAX_TRIES_PER_OBJECT,
     initial_backoff: float = PULL_INITIAL_BACKOFF,
@@ -227,7 +227,7 @@ def pull_objects(  # pylint: disable=too-many-arguments,too-many-locals
         The function should raise `ObjectUnavailableError` if the object is not yet
         available, or `ObjectIdNotPreregisteredError` if the object ID is not
         pre-registered.
-    max_concurrent_pulls : int (default: FLWR_MAX_CONCURRENT_OBJ_PULLS)
+    max_concurrent_pulls : int (default: FLWR_PRIVATE_MAX_CONCURRENT_OBJ_PULLS)
         The maximum number of concurrent pulls to perform.
     max_time : Optional[float] (default: PULL_MAX_TIME)
         The maximum time to wait for all pulls to complete. If `None`, waits
@@ -442,7 +442,7 @@ def pull_and_inflate_object_from_tree(  # pylint: disable=R0913
     confirm_object_received_fn: Callable[[str], None],
     *,
     return_type: type[T] = InflatableObject,  # type: ignore
-    max_concurrent_pulls: int = FLWR_MAX_CONCURRENT_OBJ_PULLS,
+    max_concurrent_pulls: int = FLWR_PRIVATE_MAX_CONCURRENT_OBJ_PULLS,
     max_time: Optional[float] = PULL_MAX_TIME,
     max_tries_per_object: Optional[int] = PULL_MAX_TRIES_PER_OBJECT,
     initial_backoff: float = PULL_INITIAL_BACKOFF,
@@ -460,7 +460,7 @@ def pull_and_inflate_object_from_tree(  # pylint: disable=R0913
         A function to confirm that the object has been received.
     return_type : type[T] (default: InflatableObject)
         The type of the object to return. Must be a subclass of `InflatableObject`.
-    max_concurrent_pulls : int (default: FLWR_MAX_CONCURRENT_OBJ_PULLS)
+    max_concurrent_pulls : int (default: FLWR_PRIVATE_MAX_CONCURRENT_OBJ_PULLS)
         The maximum number of concurrent pulls to perform.
     max_time : Optional[float] (default: PULL_MAX_TIME)
         The maximum time to wait for all pulls to complete. If `None`, waits

--- a/framework/py/flwr/common/record/array.py
+++ b/framework/py/flwr/common/record/array.py
@@ -25,7 +25,7 @@ from typing import TYPE_CHECKING, Any, cast, overload
 
 import numpy as np
 
-from ..constant import FLWR_MAX_ARRAY_CHUNK_SIZE, SType
+from ..constant import FLWR_PRIVATE_MAX_ARRAY_CHUNK_SIZE, SType
 from ..inflatable import (
     InflatableObject,
     add_header_to_object_body,
@@ -272,8 +272,8 @@ class Array(InflatableObject):
         chunks: list[tuple[str, InflatableObject]] = []
         # memoryview allows for zero-copy slicing
         data_view = memoryview(self.data)
-        for start in range(0, len(data_view), FLWR_MAX_ARRAY_CHUNK_SIZE):
-            end = min(start + FLWR_MAX_ARRAY_CHUNK_SIZE, len(data_view))
+        for start in range(0, len(data_view), FLWR_PRIVATE_MAX_ARRAY_CHUNK_SIZE):
+            end = min(start + FLWR_PRIVATE_MAX_ARRAY_CHUNK_SIZE, len(data_view))
             ac = ArrayChunk(data_view[start:end])
             chunks.append((ac.object_id, ac))
 

--- a/framework/py/flwr/common/record/array_test.py
+++ b/framework/py/flwr/common/record/array_test.py
@@ -26,7 +26,7 @@ from unittest.mock import Mock
 import numpy as np
 from parameterized import parameterized
 
-from ..constant import FLWR_MAX_ARRAY_CHUNK_SIZE, SType
+from ..constant import FLWR_PRIVATE_MAX_ARRAY_CHUNK_SIZE, SType
 from ..inflatable import get_object_body, get_object_type_from_object_content
 from ..typing import NDArray
 from .array import Array
@@ -175,7 +175,7 @@ class TestArray(unittest.TestCase):
             (np.random.randn(5, 5),),  # single ArrayChunk
             (
                 np.random.randn(3000, 3000),
-            ),  # 14 ArrayChunks (if FLWR_MAX_ARRAY_CHUNK_SIZE = 5 MB )
+            ),  # 14 ArrayChunks (if FLWR_PRIVATE_MAX_ARRAY_CHUNK_SIZE = 5 MB )
         ]
     )
     def test_deflate_and_inflate(self, ndarray) -> None:
@@ -188,7 +188,9 @@ class TestArray(unittest.TestCase):
         assert arr.children == dict(children_list)
 
         # Ensure the number of children is the expected one
-        expected_num_children = np.ceil(len(arr.data) / FLWR_MAX_ARRAY_CHUNK_SIZE)
+        expected_num_children = np.ceil(
+            len(arr.data) / FLWR_PRIVATE_MAX_ARRAY_CHUNK_SIZE
+        )
         assert len(arr.children) == expected_num_children
 
         arr_b = arr.deflate()
@@ -244,7 +246,9 @@ class TestArray(unittest.TestCase):
         arr = Array(np.random.randn(3000, 3000))
 
         # Ensure the number of children is the expected one
-        expected_num_children = np.ceil(len(arr.data) / FLWR_MAX_ARRAY_CHUNK_SIZE)
+        expected_num_children = np.ceil(
+            len(arr.data) / FLWR_PRIVATE_MAX_ARRAY_CHUNK_SIZE
+        )
         assert len(arr.children) == expected_num_children
 
         # Concatenate all slices


### PR DESCRIPTION
Now making use of `FLWR_` prefix