### PR TITLE
refactor(framework): Move conversion utils for signed/unsigned int to `supercore`

### DIFF
--- a/framework/py/flwr/server/superlink/linkstate/sqlite_linkstate.py
+++ b/framework/py/flwr/server/superlink/linkstate/sqlite_linkstate.py
@@ -52,6 +52,7 @@ from flwr.proto.recorddict_pb2 import RecordDict as ProtoRecordDict
 from flwr.server.utils.validator import validate_message
 from flwr.supercore.constant import NodeStatus
 from flwr.supercore.sqlite_mixin import SqliteMixin
+from flwr.supercore.utils import int64_to_uint64, uint64_to_int64
 
 from .linkstate import LinkState
 from .utils import (
@@ -60,9 +61,7 @@ from .utils import (
     configrecord_to_bytes,
     context_from_bytes,
     context_to_bytes,
-    convert_sint64_to_uint64,
     convert_sint64_values_in_dict_to_uint64,
-    convert_uint64_to_sint64,
     convert_uint64_values_in_dict_to_sint64,
     generate_rand_int_from_bytes,
     has_valid_sub_status,
@@ -265,7 +264,7 @@ class SqliteLinkState(LinkState, SqliteMixin):  # pylint: disable=R0904
         data: dict[str, Union[str, int]] = {}
 
         # Convert the uint64 value to sint64 for SQLite
-        data["node_id"] = convert_uint64_to_sint64(node_id)
+        data["node_id"] = uint64_to_int64(node_id)
 
         # Retrieve all Messages for node_id
         query = """
@@ -340,8 +339,7 @@ class SqliteLinkState(LinkState, SqliteMixin):  # pylint: disable=R0904
         if (
             msg_ins
             and message
-            and convert_sint64_to_uint64(msg_ins["dst_node_id"])
-            != res_metadata.src_node_id
+            and int64_to_uint64(msg_ins["dst_node_id"]) != res_metadata.src_node_id
         ):
             return None
 
@@ -417,7 +415,7 @@ class SqliteLinkState(LinkState, SqliteMixin):  # pylint: disable=R0904
         dst_node_ids: set[int] = set()
         for message_id in message_ids:
             in_message = found_message_ins_dict[message_id]
-            sint_node_id = convert_uint64_to_sint64(in_message.metadata.dst_node_id)
+            sint_node_id = uint64_to_int64(in_message.metadata.dst_node_id)
             dst_node_ids.add(sint_node_id)
         query = f"""
             SELECT node_id, online_until
@@ -430,8 +428,7 @@ class SqliteLinkState(LinkState, SqliteMixin):  # pylint: disable=R0904
             inquired_in_message_ids=message_ids,
             found_in_message_dict=found_message_ins_dict,
             node_id_to_online_until={
-                convert_sint64_to_uint64(row["node_id"]): row["online_until"]
-                for row in rows
+                int64_to_uint64(row["node_id"]): row["online_until"] for row in rows
             },
             current_time=current,
         )
@@ -532,7 +529,7 @@ class SqliteLinkState(LinkState, SqliteMixin):  # pylint: disable=R0904
             WHERE run_id = :run_id;
         """
 
-        sint64_run_id = convert_uint64_to_sint64(run_id)
+        sint64_run_id = uint64_to_int64(run_id)
         data = {"run_id": sint64_run_id}
 
         with self.conn:
@@ -550,7 +547,7 @@ class SqliteLinkState(LinkState, SqliteMixin):  # pylint: disable=R0904
         )
 
         # Convert the uint64 value to sint64 for SQLite
-        sint64_node_id = convert_uint64_to_sint64(uint64_node_id)
+        sint64_node_id = uint64_to_int64(uint64_node_id)
 
         query = """
             INSERT INTO node
@@ -589,7 +586,7 @@ class SqliteLinkState(LinkState, SqliteMixin):  # pylint: disable=R0904
 
     def delete_node(self, owner_aid: str, node_id: int) -> None:
         """Delete a node."""
-        sint64_node_id = convert_uint64_to_sint64(node_id)
+        sint64_node_id = uint64_to_int64(node_id)
 
         query = """
             UPDATE node
@@ -628,7 +625,7 @@ class SqliteLinkState(LinkState, SqliteMixin):  # pylint: disable=R0904
             raise AttributeError("LinkState not initialized")
 
         # Convert the uint64 value to sint64 for SQLite
-        sint64_run_id = convert_uint64_to_sint64(run_id)
+        sint64_run_id = uint64_to_int64(run_id)
 
         # Validate run ID
         query = "SELECT COUNT(*) FROM run WHERE run_id = ?"
@@ -673,9 +670,7 @@ class SqliteLinkState(LinkState, SqliteMixin):  # pylint: disable=R0904
             conditions = []
             params = []
             if node_ids is not None:
-                sint64_node_ids = [
-                    convert_uint64_to_sint64(node_id) for node_id in node_ids
-                ]
+                sint64_node_ids = [uint64_to_int64(node_id) for node_id in node_ids]
                 placeholders = ",".join(["?"] * len(sint64_node_ids))
                 conditions.append(f"node_id IN ({placeholders})")
                 params.extend(sint64_node_ids)
@@ -698,7 +693,7 @@ class SqliteLinkState(LinkState, SqliteMixin):  # pylint: disable=R0904
             result: list[NodeInfo] = []
             for row in rows:
                 # Convert sint64 node_id to uint64
-                row["node_id"] = convert_sint64_to_uint64(row["node_id"])
+                row["node_id"] = int64_to_uint64(row["node_id"])
                 result.append(NodeInfo(**row))
 
             return result
@@ -706,7 +701,7 @@ class SqliteLinkState(LinkState, SqliteMixin):  # pylint: disable=R0904
     def get_node_public_key(self, node_id: int) -> bytes:
         """Get `public_key` for the specified `node_id`."""
         # Convert the uint64 value to sint64 for SQLite
-        sint64_node_id = convert_uint64_to_sint64(node_id)
+        sint64_node_id = uint64_to_int64(node_id)
 
         # Query the public key for the given node_id
         query = "SELECT public_key FROM node WHERE node_id = ? AND status != ?;"
@@ -730,7 +725,7 @@ class SqliteLinkState(LinkState, SqliteMixin):  # pylint: disable=R0904
             return None
 
         # Convert sint64 node_id to uint64
-        node_id = convert_sint64_to_uint64(rows[0]["node_id"])
+        node_id = int64_to_uint64(rows[0]["node_id"])
         return node_id
 
     # pylint: disable=too-many-arguments,too-many-positional-arguments
@@ -748,7 +743,7 @@ class SqliteLinkState(LinkState, SqliteMixin):  # pylint: disable=R0904
         uint64_run_id = generate_rand_int_from_bytes(RUN_ID_NUM_BYTES)
 
         # Convert the uint64 value to sint64 for SQLite
-        sint64_run_id = convert_uint64_to_sint64(uint64_run_id)
+        sint64_run_id = uint64_to_int64(uint64_run_id)
 
         # Check conflicts
         query = "SELECT COUNT(*) FROM run WHERE run_id = ?;"
@@ -796,7 +791,7 @@ class SqliteLinkState(LinkState, SqliteMixin):  # pylint: disable=R0904
             )
         else:
             rows = self.query("SELECT run_id FROM run;", ())
-        return {convert_sint64_to_uint64(row["run_id"]) for row in rows}
+        return {int64_to_uint64(row["run_id"]) for row in rows}
 
     def _check_and_tag_inactive_run(self, run_ids: set[int]) -> None:
         """Check if any runs are no longer active.
@@ -804,7 +799,7 @@ class SqliteLinkState(LinkState, SqliteMixin):  # pylint: disable=R0904
         Marks runs with status 'starting' or 'running' as failed
         if they have not sent a heartbeat before `active_until`.
         """
-        sint_run_ids = [convert_uint64_to_sint64(run_id) for run_id in run_ids]
+        sint_run_ids = [uint64_to_int64(run_id) for run_id in run_ids]
         query = "UPDATE run SET finished_at = ?, sub_status = ?, details = ? "
         query += "WHERE starting_at != '' AND finished_at = '' AND active_until < ?"
         query += f" AND run_id IN ({','.join(['?'] * len(run_ids))});"
@@ -826,13 +821,13 @@ class SqliteLinkState(LinkState, SqliteMixin):  # pylint: disable=R0904
         self._check_and_tag_inactive_run(run_ids={run_id})
 
         # Convert the uint64 value to sint64 for SQLite
-        sint64_run_id = convert_uint64_to_sint64(run_id)
+        sint64_run_id = uint64_to_int64(run_id)
         query = "SELECT * FROM run WHERE run_id = ?;"
         rows = self.query(query, (sint64_run_id,))
         if rows:
             row = rows[0]
             return Run(
-                run_id=convert_sint64_to_uint64(row["run_id"]),
+                run_id=int64_to_uint64(row["run_id"]),
                 fab_id=row["fab_id"],
                 fab_version=row["fab_version"],
                 fab_hash=row["fab_hash"],
@@ -857,13 +852,13 @@ class SqliteLinkState(LinkState, SqliteMixin):  # pylint: disable=R0904
         self._check_and_tag_inactive_run(run_ids=run_ids)
 
         # Convert the uint64 value to sint64 for SQLite
-        sint64_run_ids = (convert_uint64_to_sint64(run_id) for run_id in set(run_ids))
+        sint64_run_ids = (uint64_to_int64(run_id) for run_id in set(run_ids))
         query = f"SELECT * FROM run WHERE run_id IN ({','.join(['?'] * len(run_ids))});"
         rows = self.query(query, tuple(sint64_run_ids))
 
         return {
             # Restore uint64 run IDs
-            convert_sint64_to_uint64(row["run_id"]): RunStatus(
+            int64_to_uint64(row["run_id"]): RunStatus(
                 status=determine_run_status(row),
                 sub_status=row["sub_status"],
                 details=row["details"],
@@ -877,7 +872,7 @@ class SqliteLinkState(LinkState, SqliteMixin):  # pylint: disable=R0904
         self._check_and_tag_inactive_run(run_ids={run_id})
 
         # Convert the uint64 value to sint64 for SQLite
-        sint64_run_id = convert_uint64_to_sint64(run_id)
+        sint64_run_id = uint64_to_int64(run_id)
         query = "SELECT * FROM run WHERE run_id = ?;"
         rows = self.query(query, (sint64_run_id,))
 
@@ -943,7 +938,7 @@ class SqliteLinkState(LinkState, SqliteMixin):  # pylint: disable=R0904
             new_status.details,
             active_until,
             heartbeat_interval,
-            convert_uint64_to_sint64(run_id),
+            uint64_to_int64(run_id),
         )
         self.query(query % timestamp_fld, data)
         return True
@@ -956,14 +951,14 @@ class SqliteLinkState(LinkState, SqliteMixin):  # pylint: disable=R0904
         query = "SELECT * FROM run WHERE starting_at = '' LIMIT 1;"
         rows = self.query(query)
         if rows:
-            pending_run_id = convert_sint64_to_uint64(rows[0]["run_id"])
+            pending_run_id = int64_to_uint64(rows[0]["run_id"])
 
         return pending_run_id
 
     def get_federation_options(self, run_id: int) -> Optional[ConfigRecord]:
         """Retrieve the federation options for the specified `run_id`."""
         # Convert the uint64 value to sint64 for SQLite
-        sint64_run_id = convert_uint64_to_sint64(run_id)
+        sint64_run_id = uint64_to_int64(run_id)
         query = "SELECT federation_options FROM run WHERE run_id = ?;"
         rows = self.query(query, (sint64_run_id,))
 
@@ -988,7 +983,7 @@ class SqliteLinkState(LinkState, SqliteMixin):  # pylint: disable=R0904
         if self.conn is None:
             raise AttributeError("LinkState not initialized")
 
-        sint64_node_id = convert_uint64_to_sint64(node_id)
+        sint64_node_id = uint64_to_int64(node_id)
 
         with self.conn:
             # Check if node exists and not deleted
@@ -1030,7 +1025,7 @@ class SqliteLinkState(LinkState, SqliteMixin):  # pylint: disable=R0904
         self._check_and_tag_inactive_run(run_ids={run_id})
 
         # Search for the run
-        sint_run_id = convert_uint64_to_sint64(run_id)
+        sint_run_id = uint64_to_int64(run_id)
         query = "SELECT * FROM run WHERE run_id = ?;"
         rows = self.query(query, (sint_run_id,))
 
@@ -1060,7 +1055,7 @@ class SqliteLinkState(LinkState, SqliteMixin):  # pylint: disable=R0904
         """Get the context for the specified `run_id`."""
         # Retrieve context if any
         query = "SELECT context FROM context WHERE run_id = ?;"
-        rows = self.query(query, (convert_uint64_to_sint64(run_id),))
+        rows = self.query(query, (uint64_to_int64(run_id),))
         context = context_from_bytes(rows[0]["context"]) if rows else None
         return context
 
@@ -1068,7 +1063,7 @@ class SqliteLinkState(LinkState, SqliteMixin):  # pylint: disable=R0904
         """Set the context for the specified `run_id`."""
         # Convert context to bytes
         context_bytes = context_to_bytes(context)
-        sint_run_id = convert_uint64_to_sint64(run_id)
+        sint_run_id = uint64_to_int64(run_id)
 
         # Check if any existing Context assigned to the run_id
         query = "SELECT COUNT(*) FROM context WHERE run_id = ?;"
@@ -1087,7 +1082,7 @@ class SqliteLinkState(LinkState, SqliteMixin):  # pylint: disable=R0904
     def add_serverapp_log(self, run_id: int, log_message: str) -> None:
         """Add a log entry to the ServerApp logs for the specified `run_id`."""
         # Convert the uint64 value to sint64 for SQLite
-        sint64_run_id = convert_uint64_to_sint64(run_id)
+        sint64_run_id = uint64_to_int64(run_id)
 
         # Store log
         try:
@@ -1103,7 +1098,7 @@ class SqliteLinkState(LinkState, SqliteMixin):  # pylint: disable=R0904
     ) -> tuple[str, float]:
         """Get the ServerApp logs for the specified `run_id`."""
         # Convert the uint64 value to sint64 for SQLite
-        sint64_run_id = convert_uint64_to_sint64(run_id)
+        sint64_run_id = uint64_to_int64(run_id)
 
         # Check if the run_id exists
         query = "SELECT run_id FROM run WHERE run_id = ?;"
@@ -1153,7 +1148,7 @@ class SqliteLinkState(LinkState, SqliteMixin):  # pylint: disable=R0904
         """Create a token for the given run ID."""
         token = secrets.token_hex(FLWR_APP_TOKEN_LENGTH)  # Generate a random token
         query = "INSERT INTO token_store (run_id, token) VALUES (:run_id, :token);"
-        data = {"run_id": convert_uint64_to_sint64(run_id), "token": token}
+        data = {"run_id": uint64_to_int64(run_id), "token": token}
         try:
             self.query(query, data)
         except sqlite3.IntegrityError:
@@ -1163,7 +1158,7 @@ class SqliteLinkState(LinkState, SqliteMixin):  # pylint: disable=R0904
     def verify_token(self, run_id: int, token: str) -> bool:
         """Verify a token for the given run ID."""
         query = "SELECT token FROM token_store WHERE run_id = :run_id;"
-        data = {"run_id": convert_uint64_to_sint64(run_id)}
+        data = {"run_id": uint64_to_int64(run_id)}
         rows = self.query(query, data)
         if not rows:
             return False
@@ -1172,7 +1167,7 @@ class SqliteLinkState(LinkState, SqliteMixin):  # pylint: disable=R0904
     def delete_token(self, run_id: int) -> None:
         """Delete the token for the given run ID."""
         query = "DELETE FROM token_store WHERE run_id = :run_id;"
-        data = {"run_id": convert_uint64_to_sint64(run_id)}
+        data = {"run_id": uint64_to_int64(run_id)}
         self.query(query, data)
 
     def get_run_id_by_token(self, token: str) -> Optional[int]:
@@ -1182,7 +1177,7 @@ class SqliteLinkState(LinkState, SqliteMixin):  # pylint: disable=R0904
         rows = self.query(query, data)
         if not rows:
             return None
-        return convert_sint64_to_uint64(rows[0]["run_id"])
+        return int64_to_uint64(rows[0]["run_id"])
 
 
 def message_to_dict(message: Message) -> dict[str, Any]:
@@ -1237,5 +1232,5 @@ def determine_run_status(row: dict[str, Any]) -> str:
                 return Status.RUNNING
             return Status.STARTING
         return Status.PENDING
-    run_id = convert_sint64_to_uint64(row["run_id"])
+    run_id = int64_to_uint64(row["run_id"])
     raise sqlite3.IntegrityError(f"The run {run_id} does not have a valid status.")

--- a/framework/py/flwr/server/superlink/linkstate/utils.py
+++ b/framework/py/flwr/server/superlink/linkstate/utils.py
@@ -33,6 +33,7 @@ from flwr.common.typing import RunStatus
 # pylint: disable=E0611
 from flwr.proto.message_pb2 import Context as ProtoContext
 from flwr.proto.recorddict_pb2 import ConfigRecord as ProtoConfigRecord
+from flwr.supercore.utils import int64_to_uint64, uint64_to_int64
 
 # pylint: enable=E0611
 VALID_RUN_STATUS_TRANSITIONS = {
@@ -76,58 +77,6 @@ def generate_rand_int_from_bytes(
     return num
 
 
-def convert_uint64_to_sint64(u: int) -> int:
-    """Convert a uint64 value to a sint64 value with the same bit sequence.
-
-    Parameters
-    ----------
-    u : int
-        The unsigned 64-bit integer to convert.
-
-    Returns
-    -------
-    int
-        The signed 64-bit integer equivalent.
-
-        The signed 64-bit integer will have the same bit pattern as the
-        unsigned 64-bit integer but may have a different decimal value.
-
-        For numbers within the range [0, `sint64` max value], the decimal
-        value remains the same. However, for numbers greater than the `sint64`
-        max value, the decimal value will differ due to the wraparound caused
-        by the sign bit.
-    """
-    if u >= (1 << 63):
-        return u - (1 << 64)
-    return u
-
-
-def convert_sint64_to_uint64(s: int) -> int:
-    """Convert a sint64 value to a uint64 value with the same bit sequence.
-
-    Parameters
-    ----------
-    s : int
-        The signed 64-bit integer to convert.
-
-    Returns
-    -------
-    int
-        The unsigned 64-bit integer equivalent.
-
-        The unsigned 64-bit integer will have the same bit pattern as the
-        signed 64-bit integer but may have a different decimal value.
-
-        For negative `sint64` values, the conversion adds 2^64 to the
-        signed value to obtain the equivalent `uint64` value. For non-negative
-        `sint64` values, the decimal value remains unchanged in the `uint64`
-        representation.
-    """
-    if s < 0:
-        return s + (1 << 64)
-    return s
-
-
 def convert_uint64_values_in_dict_to_sint64(
     data_dict: dict[str, int], keys: list[str]
 ) -> None:
@@ -142,7 +91,7 @@ def convert_uint64_values_in_dict_to_sint64(
     """
     for key in keys:
         if key in data_dict:
-            data_dict[key] = convert_uint64_to_sint64(data_dict[key])
+            data_dict[key] = uint64_to_int64(data_dict[key])
 
 
 def convert_sint64_values_in_dict_to_uint64(
@@ -159,7 +108,7 @@ def convert_sint64_values_in_dict_to_uint64(
     """
     for key in keys:
         if key in data_dict:
-            data_dict[key] = convert_sint64_to_uint64(data_dict[key])
+            data_dict[key] = int64_to_uint64(data_dict[key])
 
 
 def context_to_bytes(context: Context) -> bytes:

--- a/framework/py/flwr/server/superlink/linkstate/utils_test.py
+++ b/framework/py/flwr/server/superlink/linkstate/utils_test.py
@@ -20,9 +20,7 @@ import unittest
 from parameterized import parameterized
 
 from .utils import (
-    convert_sint64_to_uint64,
     convert_sint64_values_in_dict_to_uint64,
-    convert_uint64_to_sint64,
     convert_uint64_values_in_dict_to_sint64,
     generate_rand_int_from_bytes,
 )
@@ -30,62 +28,6 @@ from .utils import (
 
 class UtilsTest(unittest.TestCase):
     """Test utils code."""
-
-    @parameterized.expand(  # type: ignore
-        [
-            # Test values within the positive range of sint64 (below 2^63)
-            (0, 0),  # Minimum positive value
-            (1, 1),  # 1 remains 1 in both uint64 and sint64
-            (2**62, 2**62),  # Mid-range positive value
-            (2**63 - 1, 2**63 - 1),  # Maximum positive value for sint64
-            # Test values at or above 2^63 (become negative in sint64)
-            (2**63, -(2**63)),  # Minimum negative value for sint64
-            (2**63 + 1, -(2**63) + 1),  # Slightly above the boundary
-            (9223372036854775811, -9223372036854775805),  # Some value > sint64 max
-            (2**64 - 1, -1),  # Maximum uint64 value becomes -1 in sint64
-        ]
-    )
-    def test_convert_uint64_to_sint64(self, before: int, after: int) -> None:
-        """Test conversion from uint64 to sint64."""
-        self.assertEqual(convert_uint64_to_sint64(before), after)
-
-    @parameterized.expand(  # type: ignore
-        [
-            # Test values within the negative range of sint64
-            (-(2**63), 2**63),  # Minimum sint64 value becomes 2^63 in uint64
-            (-(2**63) + 1, 2**63 + 1),  # Slightly above the minimum
-            (-9223372036854775805, 9223372036854775811),  # Some value > sint64 max
-            # Test zero-adjacent inputs
-            (-1, 2**64 - 1),  # -1 in sint64 becomes 2^64 - 1 in uint64
-            (0, 0),  # 0 remains 0 in both sint64 and uint64
-            (1, 1),  # 1 remains 1 in both sint64 and uint64
-            # Test values within the positive range of sint64
-            (2**63 - 1, 2**63 - 1),  # Maximum positive value in sint64
-            # Test boundary and maximum uint64 value
-            (2**63, 2**63),  # Exact boundary value for sint64
-            (2**64 - 1, 2**64 - 1),  # Maximum uint64 value, stays the same
-        ]
-    )
-    def test_sint64_to_uint64(self, before: int, after: int) -> None:
-        """Test conversion from sint64 to uint64."""
-        self.assertEqual(convert_sint64_to_uint64(before), after)
-
-    @parameterized.expand(  # type: ignore
-        [
-            (0),
-            (1),
-            (2**62),
-            (2**63 - 1),
-            (2**63),
-            (2**63 + 1),
-            (9223372036854775811),
-            (2**64 - 1),
-        ]
-    )
-    def test_uint64_to_sint64_to_uint64(self, expected: int) -> None:
-        """Test conversion from sint64 to uint64."""
-        actual = convert_sint64_to_uint64(convert_uint64_to_sint64(expected))
-        self.assertEqual(expected, actual)
 
     @parameterized.expand(  # type: ignore
         [

--- a/framework/py/flwr/supercore/utils.py
+++ b/framework/py/flwr/supercore/utils.py
@@ -30,3 +30,23 @@ def mask_string(value: str, head: int = 4, tail: int = 4) -> str:
     if len(value) <= head + tail:
         return value
     return f"{value[:head]}...{value[-tail:]}"
+
+
+def uint64_to_int64(unsigned: int) -> int:
+    """Convert a uint64 integer to a sint64 with the same bit pattern.
+
+    For values >= 2^63, wraps around by subtracting 2^64.
+    """
+    if unsigned >= (1 << 63):
+        return unsigned - (1 << 64)
+    return unsigned
+
+
+def int64_to_uint64(signed: int) -> int:
+    """Convert a sint64 integer to a uint64 with the same bit pattern.
+
+    For negative values, wraps around by adding 2^64.
+    """
+    if signed < 0:
+        return signed + (1 << 64)
+    return signed

--- a/framework/py/flwr/supercore/utils_test.py
+++ b/framework/py/flwr/supercore/utils_test.py
@@ -15,7 +15,9 @@
 """Tests for utility functions for the infrastructure."""
 
 
-from .utils import mask_string
+from parameterized import parameterized
+
+from .utils import int64_to_uint64, mask_string, uint64_to_int64
 
 
 def test_mask_string() -> None:
@@ -27,3 +29,62 @@ def test_mask_string() -> None:
     assert mask_string("") == ""
     assert mask_string("1234567890", head=2, tail=3) == "12...890"
     assert mask_string("1234567890", head=5, tail=4) == "12345...7890"
+
+
+@parameterized.expand(  # type: ignore
+    [
+        # Test values within the positive range of sint64 (below 2^63)
+        (0, 0),  # Minimum positive value
+        (1, 1),  # 1 remains 1 in both uint64 and sint64
+        (2**62, 2**62),  # Mid-range positive value
+        (2**63 - 1, 2**63 - 1),  # Maximum positive value for sint64
+        # Test values at or above 2^63 (become negative in sint64)
+        (2**63, -(2**63)),  # Minimum negative value for sint64
+        (2**63 + 1, -(2**63) + 1),  # Slightly above the boundary
+        (9223372036854775811, -9223372036854775805),  # Some value > sint64 max
+        (2**64 - 1, -1),  # Maximum uint64 value becomes -1 in sint64
+    ]
+)
+def test_convert_uint64_to_sint64(before: int, after: int) -> None:
+    """Test conversion from uint64 to sint64."""
+    assert uint64_to_int64(before) == after
+
+
+@parameterized.expand(  # type: ignore
+    [
+        # Test values within the negative range of sint64
+        (-(2**63), 2**63),  # Minimum sint64 value becomes 2^63 in uint64
+        (-(2**63) + 1, 2**63 + 1),  # Slightly above the minimum
+        (-9223372036854775805, 9223372036854775811),  # Some value > sint64 max
+        # Test zero-adjacent inputs
+        (-1, 2**64 - 1),  # -1 in sint64 becomes 2^64 - 1 in uint64
+        (0, 0),  # 0 remains 0 in both sint64 and uint64
+        (1, 1),  # 1 remains 1 in both sint64 and uint64
+        # Test values within the positive range of sint64
+        (2**63 - 1, 2**63 - 1),  # Maximum positive value in sint64
+        # Test boundary and maximum uint64 value
+        (2**63, 2**63),  # Exact boundary value for sint64
+        (2**64 - 1, 2**64 - 1),  # Maximum uint64 value, stays the same
+    ]
+)
+def test_sint64_to_uint64(before: int, after: int) -> None:
+    """Test conversion from sint64 to uint64."""
+    assert int64_to_uint64(before) == after
+
+
+@parameterized.expand(  # type: ignore
+    [
+        (0),
+        (1),
+        (2**62),
+        (2**63 - 1),
+        (2**63),
+        (2**63 + 1),
+        (9223372036854775811),
+        (2**64 - 1),
+    ]
+)
+def test_uint64_to_sint64_to_uint64(expected: int) -> None:
+    """Test conversion from sint64 to uint64."""
+    actual = int64_to_uint64(uint64_to_int64(expected))
+    assert actual == expected


### PR DESCRIPTION
Also simplifies the function names and docstrings... It was a bit wild, not really easy to maintain or understand.