### PR TITLE
feat(framework): Allow fetching retrieved messages in `NodeState`

### DIFF
--- a/framework/py/flwr/supernode/nodestate/in_memory_nodestate.py
+++ b/framework/py/flwr/supernode/nodestate/in_memory_nodestate.py
@@ -79,6 +79,7 @@ class InMemoryNodeState(NodeState):  # pylint: disable=too-many-instance-attribu
         *,
         run_ids: Sequence[int] | None = None,
         is_reply: bool | None = None,
+        is_retrieved: bool | None = False,
         limit: int | None = None,
     ) -> Sequence[Message]:
         """Retrieve messages based on the specified filters."""
@@ -90,9 +91,10 @@ class InMemoryNodeState(NodeState):  # pylint: disable=too-many-instance-attribu
                 entry = self.msg_store[object_id]
                 message = entry.message
 
-                # Skip messages that have already been retrieved
-                if entry.is_retrieved:
-                    continue
+                # Filter by retrieved status if specified
+                if is_retrieved is not None:
+                    if entry.is_retrieved != is_retrieved:
+                        continue
 
                 # Skip messages whose run_id doesn't match the filter
                 if run_ids is not None:

--- a/framework/py/flwr/supernode/nodestate/nodestate.py
+++ b/framework/py/flwr/supernode/nodestate/nodestate.py
@@ -55,6 +55,7 @@ class NodeState(CoreState):
         *,
         run_ids: Sequence[int] | None = None,
         is_reply: bool | None = None,
+        is_retrieved: bool | None = False,
         limit: int | None = None,
     ) -> Sequence[Message]:
         """Retrieve messages based on the specified filters.
@@ -70,6 +71,9 @@ class NodeState(CoreState):
         is_reply : Optional[bool] (default: None)
             If True, filter for reply messages; if False, filter for non-reply
             (instruction) messages.
+        is_retrieved : Optional[bool] (default: False)
+            If True, retrieve only messages that have already been retrieved.
+            If False, retrieve only messages that have not yet been retrieved.
         limit : Optional[int] (default: None)
             Maximum number of messages to return. If None, no limit is applied.
 
@@ -77,11 +81,6 @@ class NodeState(CoreState):
         -------
         Sequence[Message]
             A sequence of messages matching the specified filters.
-
-        Notes
-        -----
-        **IMPORTANT:** Retrieved messages will **NOT** be returned again by subsequent
-        calls to this method, even if the filters match them.
         """
 
     @abstractmethod


### PR DESCRIPTION
This will be used internally to fetch all retrieved messages for a given run and insert error messages when the ClientApp heartbeat is missing.