### PR TITLE
fix(examples): Remove non-routable host address

### DIFF
--- a/examples/flower-authentication/certificate.conf
+++ b/examples/flower-authentication/certificate.conf
@@ -18,4 +18,3 @@ subjectAltName = @alt_names
 DNS.1 = localhost
 IP.1 = ::1
 IP.2 = 127.0.0.1
-IP.3 = 0.0.0.0


### PR DESCRIPTION
`0.0.0.0` is not a routable host address. Certificates should contain concrete listener IPs only.