### PR TITLE
fix(framework): Fix flower-tutorial dir structure in flower-docs

### DIFF
--- a/framework/docs/source/tutorial-series-get-started-with-flower-pytorch.rst
+++ b/framework/docs/source/tutorial-series-get-started-with-flower-pytorch.rst
@@ -96,7 +96,6 @@ It should have the following structure:
 .. code-block:: shell
 
     flower-tutorial
-    ├── README.md
     ├── flower_tutorial
     │   ├── __init__.py
     │   ├── client_app.py   # Defines your ClientApp


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/adap/flower/blob/main/CONTRIBUTING.md
-->

## Issue; 
Mention of READ.md twice for flower-tutorial directory in docs

### Description

In Get started with Flower segment of [Flower docs](https://flower.ai/docs/framework/tutorial-series-get-started-with-flower-pytorch.html), flower-tutorial directory, README.md is mentioned twice.

### Related issues

Fixes #6253 

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

### Checklist

- [x] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.ai/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->