### PR TITLE
ci(framework): Fix fastai E2E test

### DIFF
--- a/framework/e2e/e2e-fastai/pyproject.toml
+++ b/framework/e2e/e2e-fastai/pyproject.toml
@@ -10,10 +10,10 @@ license = "Apache-2.0"
 dependencies = [
     "flwr[simulation] @ {root:parent:parent:uri}",
     "fastai>=2.7.12,<3.0.0",
+    "fastprogress==1.0.5",
     "torch>=2.1.0,<3.0.0",
     "spacy==3.8.7",
     "numpy<2.0.0",
-    "ipython>=8.0",
 ]
 
 [tool.hatch.build.targets.wheel]


### PR DESCRIPTION
Thanks @chongshenng for identifying the issue. We need to pin the `fastprogess` version to avoid this known bug in the latest versions.

Fixing the following issue:

```shell
  python -c "from fastai.vision.all import untar_data, URLs
  untar_data(URLs.MNIST)
  "
  shell: /usr/bin/bash -e {0}
  env:
    FLWR_TELEMETRY_ENABLED: 0
    ARTIFACT_BUCKET: artifact.flower.ai
    pythonLocation: /opt/hostedtoolcache/Python/3.10.19/x64
    PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.10.19/x64/lib/pkgconfig
    Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.10.19/x64
    Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.10.19/x64
    Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.10.19/x64
    LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.10.19/x64/lib
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/opt/hostedtoolcache/Python/3.10.19/x64/lib/python3.10/site-packages/fastai/vision/all.py", line 1, in <module>
    from . import models
  File "/opt/hostedtoolcache/Python/3.10.19/x64/lib/python3.10/site-packages/fastai/vision/models/__init__.py", line 1, in <module>
    from . import xresnet
  File "/opt/hostedtoolcache/Python/3.10.19/x64/lib/python3.10/site-packages/fastai/vision/models/xresnet.py", line 7, in <module>
    from ...torch_basics import *
  File "/opt/hostedtoolcache/Python/3.10.19/x64/lib/python3.10/site-packages/fastai/torch_basics.py", line 9, in <module>
    from .imports import *
  File "/opt/hostedtoolcache/Python/3.10.19/x64/lib/python3.10/site-packages/fastai/imports.py", line 34, in <module>
    from fastprogress.fastprogress import progress_bar,master_bar
  File "/opt/hostedtoolcache/Python/3.10.19/x64/lib/python3.10/site-packages/fastprogress/__init__.py", line 2, in <module>
    from .fastprogress import master_bar, progress_bar, force_console_behavior
  File "/opt/hostedtoolcache/Python/3.10.19/x64/lib/python3.10/site-packages/fastprogress/fastprogress.py", line 17, in <module>
    from IPython.display import display,HTML,Markdown
ModuleNotFoundError: No module named 'IPython'
Error: Process completed with exit code 1.
```

It's blocking https://github.com/adap/flower/pull/6326