### PR TITLE
refactor(examples): Mark the old quickstart-pytorch example as deprecated to avoid confusion

### DIFF
--- a/examples/quickstart-pytorch-deprecated/README.md
+++ b/examples/quickstart-pytorch-deprecated/README.md
@@ -1,10 +1,10 @@
 ---
-tags: [quickstart, vision, fds]
+tags: [quickstart, vision, fds, deprecated]
 dataset: [CIFAR-10]
 framework: [torch, torchvision]
 ---
 
-# Federated Learning with PyTorch and Flower (Quickstart Example)
+# [Deprecated] Federated Learning with PyTorch and Flower (Quickstart Example)
 
 > [!CAUTION]
 > This example uses a deprecated API for Flower. Use instead the [quickstart-pytorch](../quickstart-pytorch/) which makes use of the Message API.


### PR DESCRIPTION
### Now
<img width="746" height="149" alt="Screenshot 2026-01-05 at 14 28 01" src="https://github.com/user-attachments/assets/7d34f5f8-9a39-469e-9132-1fe9d5866dbb" />
- Added `[Deprecated]` prefix
- Added `deprecated` tag

### Before
<img width="921" height="142" alt="image" src="https://github.com/user-attachments/assets/acc31c4b-29b1-4df3-83d7-2beb83387913" />
