### PR TITLE
feat(framework): Ensure graceful exit of `flwr-*` processes upon run being stopped by user

### DIFF
--- a/framework/py/flwr/common/logger.py
+++ b/framework/py/flwr/common/logger.py
@@ -441,7 +441,7 @@ def stop_log_uploader(
 ) -> None:
     """Stop the log uploader thread."""
     log_queue.put(None)
-    log_uploader.join()
+    log_uploader.join(timeout=0)
 
 
 def _remove_emojis(text: str) -> str:

--- a/framework/py/flwr/common/logger.py
+++ b/framework/py/flwr/common/logger.py
@@ -436,12 +436,9 @@ def start_log_uploader(
     return thread
 
 
-def stop_log_uploader(
-    log_queue: Queue[str | None], log_uploader: threading.Thread
-) -> None:
+def stop_log_uploader(log_queue: Queue[str | None]) -> None:
     """Stop the log uploader thread."""
     log_queue.put(None)
-    log_uploader.join(timeout=0)
 
 
 def _remove_emojis(text: str) -> str:

--- a/framework/py/flwr/common/retry_invoker.py
+++ b/framework/py/flwr/common/retry_invoker.py
@@ -16,7 +16,9 @@
 
 
 import itertools
+import os
 import random
+import signal
 import threading
 import time
 from collections.abc import Callable, Generator, Iterable
@@ -33,6 +35,7 @@ from flwr.common.typing import RunNotRunningException
 from flwr.proto.clientappio_pb2_grpc import ClientAppIoStub
 from flwr.proto.fleet_pb2_grpc import FleetStub
 from flwr.proto.serverappio_pb2_grpc import ServerAppIoStub
+from flwr.supercore.constant import FORCE_EXIT_TIMEOUT_SECONDS
 
 
 def exponential(
@@ -352,6 +355,14 @@ def make_simple_grpc_retry_invoker() -> RetryInvoker:
     def _should_giveup_fn(e: Exception) -> bool:
         if e.code() == grpc.StatusCode.PERMISSION_DENIED:  # type: ignore
             raise RunNotRunningException
+        if e.code() == grpc.StatusCode.UNAUTHENTICATED:  # type: ignore
+            # Authentication failures should trigger shutdown rather than retrying
+            # This can occur, for example, when the user runs `flwr stop`
+            # Note: On Windows, `os.kill` terminates the process abruptly, not ideal
+            # Note: `signal.raise_signal` is not effective in `flwr-simulation`
+            os.kill(os.getpid(), signal.SIGINT)
+            time.sleep(FORCE_EXIT_TIMEOUT_SECONDS + 1)
+            return False
         if e.code() == grpc.StatusCode.UNAVAILABLE:  # type: ignore
             # Check if this is an SSL handshake failure - these should fail fast
             details = str(e.details() if hasattr(e, "details") else "").lower()

--- a/framework/py/flwr/server/serverapp/app.py
+++ b/framework/py/flwr/server/serverapp/app.py
@@ -159,7 +159,7 @@ def run_serverapp(  # pylint: disable=R0913, R0914, R0915, R0917, W0212
 
         # Stop log uploader for this run and upload final logs
         if log_uploader:
-            stop_log_uploader(log_queue, log_uploader)
+            stop_log_uploader(log_queue)
 
         # Update run status
         if run and run_status and grid:

--- a/framework/py/flwr/simulation/app.py
+++ b/framework/py/flwr/simulation/app.py
@@ -187,29 +187,21 @@ def run_simulation_process(  # pylint: disable=R0913, R0914, R0915, R0917, W0212
 
     def on_exit() -> None:
         # Stop heartbeat sender
-        print("\n onexit starts!!")
         if heartbeat_sender and heartbeat_sender.is_running:
-            print("Stopping heartbeat sender...")
             heartbeat_sender.stop()
-            print("\n onexit stops heartbeat sender!!")
-    
+
         # Stop log uploader for this run and upload final logs
         if log_uploader:
-            print("Stopping log uploader and uploading final logs...")
-            stop_log_uploader(log_queue, log_uploader)
-            print("Stopped log uploader and uploaded final logs.")
+            stop_log_uploader(log_queue)
 
         # Update run status
-        print("Updating run status to FINISHED...")
         if run and run_status:
             run_status_proto = run_status_to_proto(run_status)
             conn._stub.UpdateRunStatus(
                 UpdateRunStatusRequest(run_id=run.run_id, run_status=run_status_proto)
             )
 
-        print("Cleaning up app runtime environment...")
         cleanup_app_runtime_environment(runtime_env_dir)
-        print("Cleanup of app runtime environment completed.")
 
     register_signal_handlers(
         event_type=EventType.FLWR_SIMULATION_RUN_LEAVE,

--- a/framework/py/flwr/simulation/app.py
+++ b/framework/py/flwr/simulation/app.py
@@ -187,21 +187,29 @@ def run_simulation_process(  # pylint: disable=R0913, R0914, R0915, R0917, W0212
 
     def on_exit() -> None:
         # Stop heartbeat sender
+        print("\n onexit starts!!")
         if heartbeat_sender and heartbeat_sender.is_running:
+            print("Stopping heartbeat sender...")
             heartbeat_sender.stop()
-
+            print("\n onexit stops heartbeat sender!!")
+    
         # Stop log uploader for this run and upload final logs
         if log_uploader:
+            print("Stopping log uploader and uploading final logs...")
             stop_log_uploader(log_queue, log_uploader)
+            print("Stopped log uploader and uploaded final logs.")
 
         # Update run status
+        print("Updating run status to FINISHED...")
         if run and run_status:
             run_status_proto = run_status_to_proto(run_status)
             conn._stub.UpdateRunStatus(
                 UpdateRunStatusRequest(run_id=run.run_id, run_status=run_status_proto)
             )
 
+        print("Cleaning up app runtime environment...")
         cleanup_app_runtime_environment(runtime_env_dir)
+        print("Cleanup of app runtime environment completed.")
 
     register_signal_handlers(
         event_type=EventType.FLWR_SIMULATION_RUN_LEAVE,

--- a/framework/py/flwr/simulation/run_simulation.py
+++ b/framework/py/flwr/simulation/run_simulation.py
@@ -335,7 +335,6 @@ def _main_loop(
             },
         )
         if serverapp_th:
-            serverapp_th.join(timeout=5)
             if server_app_thread_has_exception.is_set():
                 raise RuntimeError("Exception in ServerApp thread")
 

--- a/framework/py/flwr/supercore/heartbeat.py
+++ b/framework/py/flwr/supercore/heartbeat.py
@@ -153,6 +153,7 @@ def make_app_heartbeat_fn_grpc(
 
         # Raise SIGINT to trigger graceful shutdown if heartbeat failed
         if not res.success:
+            # Never reach here due to token authentication unless race conditions occur
             signal.raise_signal(signal.SIGINT)
         return True
 

--- a/framework/py/flwr/supercore/superexec/plugin/serverapp_exec_plugin.py
+++ b/framework/py/flwr/supercore/superexec/plugin/serverapp_exec_plugin.py
@@ -33,12 +33,12 @@ class ServerAppExecPlugin(BaseExecPlugin):
 
     appio_api_address_arg = "--serverappio-api-address"
 
-    # def get_popen_kwargs(self) -> dict[str, Any]:
-    #     """Isolate ServerApp stdio from the parent SuperLink process streams."""
-    #     return {
-    #         "stdout": subprocess.DEVNULL,
-    #         "stderr": subprocess.DEVNULL,
-    #     }
+    def get_popen_kwargs(self) -> dict[str, Any]:
+        """Isolate ServerApp stdio from the parent SuperLink process streams."""
+        return {
+            "stdout": subprocess.DEVNULL,
+            "stderr": subprocess.DEVNULL,
+        }
 
     def launch_app(self, token: str, run_id: int) -> None:
         """Launch the application associated with a given run ID and token."""

--- a/framework/py/flwr/supercore/superexec/plugin/serverapp_exec_plugin.py
+++ b/framework/py/flwr/supercore/superexec/plugin/serverapp_exec_plugin.py
@@ -33,12 +33,12 @@ class ServerAppExecPlugin(BaseExecPlugin):
 
     appio_api_address_arg = "--serverappio-api-address"
 
-    def get_popen_kwargs(self) -> dict[str, Any]:
-        """Isolate ServerApp stdio from the parent SuperLink process streams."""
-        return {
-            "stdout": subprocess.DEVNULL,
-            "stderr": subprocess.DEVNULL,
-        }
+    # def get_popen_kwargs(self) -> dict[str, Any]:
+    #     """Isolate ServerApp stdio from the parent SuperLink process streams."""
+    #     return {
+    #         "stdout": subprocess.DEVNULL,
+    #         "stderr": subprocess.DEVNULL,
+    #     }
 
     def launch_app(self, token: str, run_id: int) -> None:
         """Launch the application associated with a given run ID and token."""


### PR DESCRIPTION
### Summary
- Translates `UNAUTHENTICATED` gRPC error into `SIGINT` signal
- Uses `os.kill` instead of cross-platform friendly `signal.raise_signal`, as the latter is not effective in `flwr-simulation`

### Root cause
After introducing token auth, once a run is stopped by user, unauthenticated grpc error will be raised. We used to rely on the response of heartbeat request to trigger the exit, but now we will get unauthenticated error instead of a response.