### PR TITLE
fix(framework): Fix Windows remote app parsing in `flwr run`

### DIFF
--- a/framework/py/flwr/cli/cli_test.py
+++ b/framework/py/flwr/cli/cli_test.py
@@ -15,8 +15,9 @@
 """Tests for the CLI."""
 
 
+import inspect
 from types import SimpleNamespace
-from typing import Any
+from typing import Annotated, Any, get_args, get_origin
 from unittest.mock import patch
 
 import pytest
@@ -26,6 +27,7 @@ from flwr.supercore.version import package_version
 
 from . import app as app_module
 from .app import app
+from .run.run import run as run_command
 
 runner = CliRunner()
 
@@ -74,6 +76,10 @@ def test_run_command() -> None:
 
 def test_run_command_accepts_remote_app_spec() -> None:
     """Remote app specs should stay as raw strings instead of path-normalized values."""
+    app_annotation = inspect.signature(run_command).parameters["app"].annotation
+    assert get_origin(app_annotation) is Annotated
+    assert get_args(app_annotation)[0] is str
+
     with (
         patch("flwr.cli.app.warn_if_flwr_update_available"),
         patch("flwr.cli.run.run.read_superlink_connection") as mock_read_connection,

--- a/framework/py/flwr/cli/cli_test.py
+++ b/framework/py/flwr/cli/cli_test.py
@@ -15,6 +15,7 @@
 """Tests for the CLI."""
 
 
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import patch
 
@@ -69,6 +70,22 @@ def test_run_command() -> None:
     assert result.exit_code == 0
     assert "Usage:" in result.output
     assert "run" in result.output
+
+
+def test_run_command_accepts_remote_app_spec() -> None:
+    """Remote app specs should stay as raw strings instead of path-normalized values."""
+    with (
+        patch("flwr.cli.app.warn_if_flwr_update_available"),
+        patch("flwr.cli.run.run.read_superlink_connection") as mock_read_connection,
+        patch("flwr.cli.run.run._run_with_control_api") as mock_run_with_control_api,
+    ):
+        mock_read_connection.return_value = SimpleNamespace(federation=None)
+
+        result = runner.invoke(app, ["run", "@flwrlabs/quickstart-numpy"])
+
+    assert result.exit_code == 0
+    assert mock_run_with_control_api.call_args is not None
+    assert mock_run_with_control_api.call_args.args[-1] == "@flwrlabs/quickstart-numpy"
 
 
 def test_build_command() -> None:

--- a/framework/py/flwr/cli/cli_test.py
+++ b/framework/py/flwr/cli/cli_test.py
@@ -15,6 +15,7 @@
 """Tests for the CLI."""
 
 
+import importlib
 import inspect
 from types import SimpleNamespace
 from typing import Annotated, Any, get_args, get_origin
@@ -27,7 +28,9 @@ from flwr.supercore.version import package_version
 
 from . import app as app_module
 from .app import app
-from .run.run import run as run_command
+
+run_module = importlib.import_module("flwr.cli.run.run")
+run_command = run_module.run
 
 runner = CliRunner()
 
@@ -82,8 +85,8 @@ def test_run_command_accepts_remote_app_spec() -> None:
 
     with (
         patch("flwr.cli.app.warn_if_flwr_update_available"),
-        patch("flwr.cli.run.run.read_superlink_connection") as mock_read_connection,
-        patch("flwr.cli.run.run._run_with_control_api") as mock_run_with_control_api,
+        patch.object(run_module, "read_superlink_connection") as mock_read_connection,
+        patch.object(run_module, "_run_with_control_api") as mock_run_with_control_api,
     ):
         mock_read_connection.return_value = SimpleNamespace(federation=None)
 

--- a/framework/py/flwr/cli/run/run.py
+++ b/framework/py/flwr/cli/run/run.py
@@ -129,8 +129,9 @@ def run(
 
             config, warnings = load_and_validate(app_path / FAB_CONFIG_FILE)
             if warnings:
+                warning_path = app_path / FAB_CONFIG_FILE
                 typer.secho(
-                    f"Flower App configuration warnings in '{app_path / FAB_CONFIG_FILE}':\n"
+                    f"Flower App configuration warnings in '{warning_path}':\n"
                     + "\n".join([f"- {line}" for line in warnings]),
                     fg=typer.colors.YELLOW,
                     bold=True,

--- a/framework/py/flwr/cli/run/run.py
+++ b/framework/py/flwr/cli/run/run.py
@@ -56,7 +56,10 @@ CONN_REFRESH_PERIOD = 60  # Connection refresh period for log streaming (seconds
 def run(
     app: Annotated[
         str,
-        typer.Argument(help="Path of the Flower App to run."),
+        typer.Argument(
+            help="Path of the Flower App to run, or a remote app spec "
+            "like '@account_name/app_name'."
+        ),
     ] = ".",
     superlink: Annotated[
         str | None,

--- a/framework/py/flwr/cli/run/run.py
+++ b/framework/py/flwr/cli/run/run.py
@@ -55,9 +55,9 @@ CONN_REFRESH_PERIOD = 60  # Connection refresh period for log streaming (seconds
 # pylint: disable-next=too-many-locals, too-many-branches, R0913, R0917
 def run(
     app: Annotated[
-        Path,
+        str,
         typer.Argument(help="Path of the Flower App to run."),
-    ] = Path("."),
+    ] = ".",
     superlink: Annotated[
         str | None,
         typer.Argument(help="Name of the SuperLink connection."),
@@ -104,38 +104,40 @@ def run(
 ) -> None:
     """Run Flower App."""
     with cli_output_handler(output_format=output_format) as is_json:
-        # Migrate legacy usage if any
-        migrate(str(app), [], ignore_legacy_usage=True)
-
         # Read superlink connection configuration
         superlink_connection = read_superlink_connection(superlink)
 
         # Determine if app is remote
         app_spec = None
         config: dict[str, Any] = {}
-        if (app_str := str(app)).startswith("@"):
+        if app.startswith("@"):
             # Validate app version and ID format
             try:
-                _ = parse_app_spec(app_str)
+                _ = parse_app_spec(app)
             except ValueError as e:
                 raise click.ClickException(str(e)) from e
 
-            app_spec = app_str
+            app_path = Path(".")
+            app_spec = app
 
         # Validate TOML configuration for local app
         else:
-            app = app.expanduser().resolve()  # Resolve path to absolute
-            config, warnings = load_and_validate(app / FAB_CONFIG_FILE)
+            app_path = Path(app).expanduser().resolve()  # Resolve path to absolute
+
+            # Migrate legacy usage if any
+            migrate(str(app_path), [], ignore_legacy_usage=True)
+
+            config, warnings = load_and_validate(app_path / FAB_CONFIG_FILE)
             if warnings:
                 typer.secho(
-                    f"Flower App configuration warnings in '{app / FAB_CONFIG_FILE}':\n"
+                    f"Flower App configuration warnings in '{app_path / FAB_CONFIG_FILE}':\n"
                     + "\n".join([f"- {line}" for line in warnings]),
                     fg=typer.colors.YELLOW,
                     bold=True,
                 )
 
         _run_with_control_api(
-            app,
+            app_path,
             config,
             federation,
             superlink_connection,

--- a/framework/py/flwr/cli/run/run.py
+++ b/framework/py/flwr/cli/run/run.py
@@ -104,9 +104,6 @@ def run(
 ) -> None:
     """Run Flower App."""
     with cli_output_handler(output_format=output_format) as is_json:
-        # Read superlink connection configuration
-        superlink_connection = read_superlink_connection(superlink)
-
         # Determine if app is remote
         app_spec = None
         config: dict[str, Any] = {}
@@ -135,6 +132,9 @@ def run(
                     fg=typer.colors.YELLOW,
                     bold=True,
                 )
+
+        # Read superlink connection configuration
+        superlink_connection = read_superlink_connection(superlink)
 
         _run_with_control_api(
             app_path,


### PR DESCRIPTION
This prevents `flwr run @account/app` from being treated as a Windows path before validation.