### PR TITLE
feat(framework): Disable process dumping for SuperExec on Linux

### DIFF
--- a/framework/py/flwr/supercore/cli/flower_superexec.py
+++ b/framework/py/flwr/supercore/cli/flower_superexec.py
@@ -42,11 +42,14 @@ from flwr.supercore.superexec.plugin import (
 )
 from flwr.supercore.superexec.run_superexec import run_superexec
 from flwr.supercore.update_check import warn_if_flwr_update_available
+from flwr.supercore.utils import disable_process_dumping
 from flwr.supercore.version import package_version
 
 
 def flower_superexec() -> None:
     """Run `flower-superexec` command."""
+    disable_process_dumping(strict=False)
+
     warn_if_flwr_update_available(process_name="flower-superexec")
     args = _parse_args().parse_args()
 

--- a/framework/py/flwr/supercore/cli/flower_superexec.py
+++ b/framework/py/flwr/supercore/cli/flower_superexec.py
@@ -49,7 +49,6 @@ from flwr.supercore.version import package_version
 def flower_superexec() -> None:
     """Run `flower-superexec` command."""
     disable_process_dumping(strict=False)
-
     warn_if_flwr_update_available(process_name="flower-superexec")
     args = _parse_args().parse_args()
 

--- a/framework/py/flwr/supercore/utils.py
+++ b/framework/py/flwr/supercore/utils.py
@@ -15,22 +15,27 @@
 """Utility functions for the infrastructure."""
 
 
+import ctypes
 import json
 import os
 import re
+import sys
 from collections.abc import Sequence
+from logging import WARN
 from pathlib import Path
 from typing import Any, TypeVar
 
 import requests
 
 from flwr.common.constant import FLWR_DIR, FLWR_HOME
+from flwr.common.logger import log
 from flwr.proto.federation_config_pb2 import SimulationConfig  # pylint: disable=E0611
 from flwr.supercore.version import package_version as flwr_version
 
 from .constant import APP_ID_PATTERN, APP_VERSION_PATTERN, MAX_NAME_LENGTH
 
 T = TypeVar("T", str, bytes)
+PR_SET_DUMPABLE = 4  # from /usr/include/linux/prctl.h
 
 
 def mask_string(value: str, head: int = 4, tail: int = 4) -> str:
@@ -373,3 +378,25 @@ def get_metadata_bytes(
 ) -> bytes | None:
     """Return exactly one non-empty bytes metadata value for `key`."""
     return _get_metadata_typed(metadata, key, bytes)
+
+
+def disable_process_dumping(strict: bool) -> None:
+    """Disable process dumping (core dumps + ptrace) on Linux."""
+    if not sys.platform.startswith("linux"):
+        return  # No-op on non-Linux systems
+
+    try:
+        libc = ctypes.CDLL(None)
+
+        # Define argument and return types for prctl
+        libc.prctl.argtypes = [ctypes.c_int, ctypes.c_ulong]
+        libc.prctl.restype = ctypes.c_int
+
+        result = libc.prctl(PR_SET_DUMPABLE, 0)
+        if result != 0:
+            raise OSError("prctl(PR_SET_DUMPABLE, 0) failed")
+
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        if strict:
+            raise RuntimeError(f"Failed to disable process dumping: {e!r}") from e
+        log(WARN, "Failed to disable process dumping: %s", e)


### PR DESCRIPTION
Verified by running `strace -p <pid>` on WSL. The command can be attached to `flower-superlink` but not `flower-superexec`.