### PR TITLE
feat(framework): Add runtime version check for simulation ServerAppIo

### DIFF
--- a/framework/py/flwr/common/constant.py
+++ b/framework/py/flwr/common/constant.py
@@ -121,6 +121,11 @@ SUPERLINK_NODE_ID = 1
 PARTITION_ID_KEY = "partition-id"
 NUM_PARTITIONS_KEY = "num-partitions"
 
+# Constants for Flower runtime version metadata
+FLWR_PACKAGE_NAME_METADATA_KEY = "flwr-package-name"
+FLWR_PACKAGE_VERSION_METADATA_KEY = "flwr-package-version"
+FLWR_COMPONENT_NAME_METADATA_KEY = "flwr-component-name"
+
 # Constants for keys in `metadata` of `MessageContainer` in `grpc-adapter`
 GRPC_ADAPTER_METADATA_FLOWER_PACKAGE_NAME_KEY = "flower-package-name"
 GRPC_ADAPTER_METADATA_FLOWER_PACKAGE_VERSION_KEY = "flower-package-version"

--- a/framework/py/flwr/common/runtime_version.py
+++ b/framework/py/flwr/common/runtime_version.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Flower Labs GmbH. All Rights Reserved.
+# Copyright 2026 Flower Labs GmbH. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -150,7 +150,9 @@ def read_runtime_version_metadata(
 
 def evaluate_runtime_version_compatibility(
     local_metadata: RuntimeVersionMetadata,
-    peer_metadata: RuntimeVersionMetadata | Mapping[str, str] | Iterable[tuple[str, str]] | None,
+    peer_metadata: (
+        RuntimeVersionMetadata | Mapping[str, str] | Iterable[tuple[str, str]] | None
+    ),
 ) -> CompatibilityResult:
     """Evaluate whether a peer is runtime-compatible with the local component."""
     local_version = parse_flower_version(local_metadata.package_version)
@@ -200,8 +202,7 @@ def evaluate_runtime_version_compatibility(
         return CompatibilityResult(
             status="invalid",
             reason=(
-                "Peer Flower version metadata is invalid: "
-                f"{peer.package_version!r}."
+                "Peer Flower version metadata is invalid: " f"{peer.package_version!r}."
             ),
             local_metadata=local_metadata,
             peer_metadata=peer,

--- a/framework/py/flwr/common/runtime_version.py
+++ b/framework/py/flwr/common/runtime_version.py
@@ -31,6 +31,7 @@ from flwr.supercore.version import package_name, package_version
 
 RuntimeCompatibilityStatus = Literal[
     "missing",
+    "disabled",
     "invalid",
     "compatible",
     "incompatible",
@@ -169,7 +170,7 @@ def evaluate_runtime_version_compatibility(
             reason=metadata_error,
             local_metadata=local_metadata,
             peer_metadata=peer,
-            local_version=local_version,
+            local_version=None,
             peer_version=None,
         )
 
@@ -186,9 +187,10 @@ def evaluate_runtime_version_compatibility(
     local_version = parse_flower_version(local_metadata.package_version)
     if local_version is None:
         return CompatibilityResult(
-            status="invalid",
+            status="disabled",
             reason=(
-                "Local Flower version metadata is invalid: "
+                "Local Flower version metadata cannot be parsed, version checks "
+                "are disabled: "
                 f"{local_metadata.package_version!r}."
             ),
             local_metadata=local_metadata,

--- a/framework/py/flwr/common/runtime_version.py
+++ b/framework/py/flwr/common/runtime_version.py
@@ -38,10 +38,7 @@ RuntimeCompatibilityStatus = Literal[
 ]
 
 _VERSION_PATTERN = re.compile(
-    r"^(?P<major>0|[1-9]\d*)"
-    r"\.(?P<minor>0|[1-9]\d*)"
-    r"\.(?P<patch>0|[1-9]\d*)"
-    r"(?P<suffix>(?:[.\-+][0-9A-Za-z][0-9A-Za-z.\-+]*)?)$"
+    r"^(?P<major>0|[1-9]\d*)" r"\.(?P<minor>0|[1-9]\d*)" r"\.(?P<patch>0|[1-9]\d*)"
 )
 
 
@@ -105,7 +102,7 @@ def runtime_version_metadata_to_dict(
 
 def parse_flower_version(version: str) -> ParsedFlowerVersion | None:
     """Parse a Flower version into its leading `major.minor.patch` tuple."""
-    if not (match := _VERSION_PATTERN.fullmatch(version.strip())):
+    if not (match := _VERSION_PATTERN.match(version.strip())):
         return None
     return ParsedFlowerVersion(
         major=int(match.group("major")),

--- a/framework/py/flwr/common/runtime_version.py
+++ b/framework/py/flwr/common/runtime_version.py
@@ -38,7 +38,7 @@ RuntimeCompatibilityStatus = Literal[
 ]
 
 _VERSION_PATTERN = re.compile(
-    r"^(?P<major>0|[1-9]\d*)" r"\.(?P<minor>0|[1-9]\d*)" r"\.(?P<patch>0|[1-9]\d*)"
+    r"^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)"
 )
 
 
@@ -198,11 +198,10 @@ def evaluate_runtime_version_compatibility(
 
     peer_version = parse_flower_version(peer.package_version)
     if peer_version is None:
+        peer_version_repr = repr(peer.package_version)
         return CompatibilityResult(
             status="invalid",
-            reason=(
-                "Peer Flower version metadata is invalid: " f"{peer.package_version!r}."
-            ),
+            reason=f"Peer Flower version metadata is invalid: {peer_version_repr}.",
             local_metadata=local_metadata,
             peer_metadata=peer,
             local_version=local_version,

--- a/framework/py/flwr/common/runtime_version.py
+++ b/framework/py/flwr/common/runtime_version.py
@@ -155,20 +155,6 @@ def evaluate_runtime_version_compatibility(
     ),
 ) -> CompatibilityResult:
     """Evaluate whether a peer is runtime-compatible with the local component."""
-    local_version = parse_flower_version(local_metadata.package_version)
-    if local_version is None:
-        return CompatibilityResult(
-            status="invalid",
-            reason=(
-                "Local Flower version metadata is invalid: "
-                f"{local_metadata.package_version!r}."
-            ),
-            local_metadata=local_metadata,
-            peer_metadata=None,
-            local_version=None,
-            peer_version=None,
-        )
-
     peer: RuntimeVersionMetadata | None
     metadata_error: str | None
     if isinstance(peer_metadata, RuntimeVersionMetadata):
@@ -193,7 +179,21 @@ def evaluate_runtime_version_compatibility(
             reason=None,
             local_metadata=local_metadata,
             peer_metadata=None,
-            local_version=local_version,
+            local_version=None,
+            peer_version=None,
+        )
+
+    local_version = parse_flower_version(local_metadata.package_version)
+    if local_version is None:
+        return CompatibilityResult(
+            status="invalid",
+            reason=(
+                "Local Flower version metadata is invalid: "
+                f"{local_metadata.package_version!r}."
+            ),
+            local_metadata=local_metadata,
+            peer_metadata=peer,
+            local_version=None,
             peer_version=None,
         )
 

--- a/framework/py/flwr/common/runtime_version.py
+++ b/framework/py/flwr/common/runtime_version.py
@@ -1,0 +1,265 @@
+# Copyright 2025 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Helpers for Flower runtime version metadata and compatibility checks."""
+
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from typing import Literal
+
+from flwr.common.constant import (
+    FLWR_COMPONENT_NAME_METADATA_KEY,
+    FLWR_PACKAGE_NAME_METADATA_KEY,
+    FLWR_PACKAGE_VERSION_METADATA_KEY,
+)
+from flwr.supercore.version import package_name, package_version
+
+RuntimeCompatibilityStatus = Literal[
+    "missing",
+    "invalid",
+    "compatible",
+    "incompatible",
+]
+
+_VERSION_PATTERN = re.compile(
+    r"^(?P<major>0|[1-9]\d*)"
+    r"\.(?P<minor>0|[1-9]\d*)"
+    r"\.(?P<patch>0|[1-9]\d*)"
+    r"(?P<suffix>(?:[.\-+][0-9A-Za-z][0-9A-Za-z.\-+]*)?)$"
+)
+
+
+@dataclass(frozen=True)
+class RuntimeVersionMetadata:
+    """Flower runtime version metadata attached to a caller."""
+
+    package_name: str
+    package_version: str
+    component_name: str
+
+
+@dataclass(frozen=True, order=True)
+class ParsedFlowerVersion:
+    """A parsed `major.minor.patch` Flower version."""
+
+    major: int
+    minor: int
+    patch: int
+
+
+@dataclass(frozen=True)
+class CompatibilityResult:
+    """Compatibility decision for a runtime peer."""
+
+    status: RuntimeCompatibilityStatus
+    reason: str | None
+    local_metadata: RuntimeVersionMetadata
+    peer_metadata: RuntimeVersionMetadata | None
+    local_version: ParsedFlowerVersion | None
+    peer_version: ParsedFlowerVersion | None
+
+
+def build_runtime_version_metadata(
+    component_name: str,
+    *,
+    package_name_value: str = package_name,
+    package_version_value: str = package_version,
+) -> RuntimeVersionMetadata:
+    """Build metadata for the local Flower runtime component."""
+    component_name = component_name.strip()
+    if component_name == "":
+        raise ValueError("`component_name` must be a non-empty string")
+    return RuntimeVersionMetadata(
+        package_name=package_name_value,
+        package_version=package_version_value,
+        component_name=component_name,
+    )
+
+
+def runtime_version_metadata_to_dict(
+    metadata: RuntimeVersionMetadata,
+) -> dict[str, str]:
+    """Serialize runtime version metadata to a string dictionary."""
+    return {
+        FLWR_PACKAGE_NAME_METADATA_KEY: metadata.package_name,
+        FLWR_PACKAGE_VERSION_METADATA_KEY: metadata.package_version,
+        FLWR_COMPONENT_NAME_METADATA_KEY: metadata.component_name,
+    }
+
+
+def parse_flower_version(version: str) -> ParsedFlowerVersion | None:
+    """Parse a Flower version into its leading `major.minor.patch` tuple."""
+    if not (match := _VERSION_PATTERN.fullmatch(version.strip())):
+        return None
+    return ParsedFlowerVersion(
+        major=int(match.group("major")),
+        minor=int(match.group("minor")),
+        patch=int(match.group("patch")),
+    )
+
+
+def read_runtime_version_metadata(
+    metadata: Mapping[str, str] | Iterable[tuple[str, str]] | None,
+) -> tuple[RuntimeVersionMetadata | None, str | None]:
+    """Read Flower runtime metadata from a mapping or metadata item iterable."""
+    metadata_map = _coerce_metadata(metadata)
+    relevant_keys = (
+        FLWR_PACKAGE_NAME_METADATA_KEY,
+        FLWR_PACKAGE_VERSION_METADATA_KEY,
+        FLWR_COMPONENT_NAME_METADATA_KEY,
+    )
+    present_keys = [key for key in relevant_keys if key in metadata_map]
+    if not present_keys:
+        return None, None
+
+    missing_keys = [key for key in relevant_keys if key not in metadata_map]
+    if missing_keys:
+        missing_keys_str = ", ".join(sorted(missing_keys))
+        return None, f"Missing required Flower runtime metadata: {missing_keys_str}."
+
+    values = {key: metadata_map[key].strip() for key in relevant_keys}
+    empty_keys = [key for key, value in values.items() if value == ""]
+    if empty_keys:
+        empty_keys_str = ", ".join(sorted(empty_keys))
+        return None, f"Flower runtime metadata contains empty values: {empty_keys_str}."
+
+    return (
+        RuntimeVersionMetadata(
+            package_name=values[FLWR_PACKAGE_NAME_METADATA_KEY],
+            package_version=values[FLWR_PACKAGE_VERSION_METADATA_KEY],
+            component_name=values[FLWR_COMPONENT_NAME_METADATA_KEY],
+        ),
+        None,
+    )
+
+
+def evaluate_runtime_version_compatibility(
+    local_metadata: RuntimeVersionMetadata,
+    peer_metadata: RuntimeVersionMetadata | Mapping[str, str] | Iterable[tuple[str, str]] | None,
+) -> CompatibilityResult:
+    """Evaluate whether a peer is runtime-compatible with the local component."""
+    local_version = parse_flower_version(local_metadata.package_version)
+    if local_version is None:
+        return CompatibilityResult(
+            status="invalid",
+            reason=(
+                "Local Flower version metadata is invalid: "
+                f"{local_metadata.package_version!r}."
+            ),
+            local_metadata=local_metadata,
+            peer_metadata=None,
+            local_version=None,
+            peer_version=None,
+        )
+
+    peer: RuntimeVersionMetadata | None
+    metadata_error: str | None
+    if isinstance(peer_metadata, RuntimeVersionMetadata):
+        peer = peer_metadata
+        metadata_error = None
+    else:
+        peer, metadata_error = read_runtime_version_metadata(peer_metadata)
+
+    if metadata_error is not None:
+        return CompatibilityResult(
+            status="invalid",
+            reason=metadata_error,
+            local_metadata=local_metadata,
+            peer_metadata=peer,
+            local_version=local_version,
+            peer_version=None,
+        )
+
+    if peer is None:
+        return CompatibilityResult(
+            status="missing",
+            reason=None,
+            local_metadata=local_metadata,
+            peer_metadata=None,
+            local_version=local_version,
+            peer_version=None,
+        )
+
+    peer_version = parse_flower_version(peer.package_version)
+    if peer_version is None:
+        return CompatibilityResult(
+            status="invalid",
+            reason=(
+                "Peer Flower version metadata is invalid: "
+                f"{peer.package_version!r}."
+            ),
+            local_metadata=local_metadata,
+            peer_metadata=peer,
+            local_version=local_version,
+            peer_version=None,
+        )
+
+    if (
+        local_version.major == peer_version.major
+        and local_version.minor == peer_version.minor
+    ):
+        return CompatibilityResult(
+            status="compatible",
+            reason=None,
+            local_metadata=local_metadata,
+            peer_metadata=peer,
+            local_version=local_version,
+            peer_version=peer_version,
+        )
+
+    return CompatibilityResult(
+        status="incompatible",
+        reason=(
+            "Peer Flower version is outside the accepted major.minor release: "
+            f"{peer.package_version!r}."
+        ),
+        local_metadata=local_metadata,
+        peer_metadata=peer,
+        local_version=local_version,
+        peer_version=peer_version,
+    )
+
+
+def format_incompatible_version_message(
+    connection_name: str,
+    local_metadata: RuntimeVersionMetadata,
+    peer_metadata: RuntimeVersionMetadata,
+) -> str:
+    """Format the standard incompatible-version error message."""
+    return (
+        f"Incompatible Flower version for {connection_name}.\n"
+        f"Local {local_metadata.component_name} version "
+        f"{local_metadata.package_version} only accepts peers from the same "
+        f"major.minor release, but received {peer_metadata.component_name} "
+        f"version {peer_metadata.package_version}."
+    )
+
+
+def format_invalid_metadata_message(connection_name: str, detail: str) -> str:
+    """Format a standard invalid-metadata error message."""
+    return f"Invalid Flower version metadata for {connection_name}. {detail}"
+
+
+def _coerce_metadata(
+    metadata: Mapping[str, str] | Iterable[tuple[str, str]] | None,
+) -> dict[str, str]:
+    if metadata is None:
+        return {}
+    if isinstance(metadata, Mapping):
+        return {str(key): str(value) for key, value in metadata.items()}
+    return {str(key): str(value) for key, value in metadata}

--- a/framework/py/flwr/common/runtime_version_test.py
+++ b/framework/py/flwr/common/runtime_version_test.py
@@ -160,9 +160,7 @@ def test_evaluate_runtime_version_compatibility_tolerates_missing_metadata() -> 
     assert result.reason is None
 
 
-def test_evaluate_runtime_version_compatibility_tolerates_missing_metadata_with_unknown_local() -> (
-    None
-):
+def test_missing_metadata_is_tolerated_with_unknown_local_version() -> None:
     """Missing metadata should remain the rollout case in source environments."""
     result = evaluate_runtime_version_compatibility(
         RuntimeVersionMetadata("unknown", "unknown", "superlink"),
@@ -173,9 +171,7 @@ def test_evaluate_runtime_version_compatibility_tolerates_missing_metadata_with_
     assert result.reason is None
 
 
-def test_evaluate_runtime_version_compatibility_disables_checks_for_unknown_local() -> (
-    None
-):
+def test_version_checks_are_disabled_for_unknown_local_version() -> None:
     """Unparseable local versions should not break the receiving API."""
     result = evaluate_runtime_version_compatibility(
         RuntimeVersionMetadata("unknown", "unknown", "superlink"),

--- a/framework/py/flwr/common/runtime_version_test.py
+++ b/framework/py/flwr/common/runtime_version_test.py
@@ -157,7 +157,9 @@ def test_evaluate_runtime_version_compatibility_tolerates_missing_metadata() -> 
     assert result.reason is None
 
 
-def test_evaluate_runtime_version_compatibility_tolerates_missing_metadata_with_unknown_local() -> None:
+def test_evaluate_runtime_version_compatibility_tolerates_missing_metadata_with_unknown_local() -> (
+    None
+):
     """Missing metadata should remain the rollout case in source environments."""
     result = evaluate_runtime_version_compatibility(
         RuntimeVersionMetadata("unknown", "unknown", "superlink"),
@@ -168,7 +170,9 @@ def test_evaluate_runtime_version_compatibility_tolerates_missing_metadata_with_
     assert result.reason is None
 
 
-def test_evaluate_runtime_version_compatibility_disables_checks_for_unknown_local() -> None:
+def test_evaluate_runtime_version_compatibility_disables_checks_for_unknown_local() -> (
+    None
+):
     """Unparseable local versions should not break the receiving API."""
     result = evaluate_runtime_version_compatibility(
         RuntimeVersionMetadata("unknown", "unknown", "superlink"),

--- a/framework/py/flwr/common/runtime_version_test.py
+++ b/framework/py/flwr/common/runtime_version_test.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Flower Labs GmbH. All Rights Reserved.
+# Copyright 2026 Flower Labs GmbH. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -137,7 +137,9 @@ def test_evaluate_runtime_version_compatibility_rejects_different_minor() -> Non
     assert result.status == "incompatible"
     assert result.peer_metadata == peer
     assert (
-        format_incompatible_version_message("SuperNode <-> SuperLink Fleet API", local, peer)
+        format_incompatible_version_message(
+            "SuperNode <-> SuperLink Fleet API", local, peer
+        )
         == "Incompatible Flower version for SuperNode <-> SuperLink Fleet API.\n"
         "Local superlink version 1.29.2 only accepts peers from the same "
         "major.minor release, but received supernode version 1.30.0."

--- a/framework/py/flwr/common/runtime_version_test.py
+++ b/framework/py/flwr/common/runtime_version_test.py
@@ -157,7 +157,7 @@ def test_evaluate_runtime_version_compatibility_tolerates_missing_metadata() -> 
     assert result.reason is None
 
 
-def test_evaluate_runtime_version_compatibility_tolerates_missing_metadata_with_unknown_local_version() -> None:
+def test_evaluate_runtime_version_compatibility_tolerates_missing_metadata_with_unknown_local() -> None:
     """Missing metadata should remain the rollout case in source environments."""
     result = evaluate_runtime_version_compatibility(
         RuntimeVersionMetadata("unknown", "unknown", "superlink"),
@@ -166,6 +166,19 @@ def test_evaluate_runtime_version_compatibility_tolerates_missing_metadata_with_
 
     assert result.status == "missing"
     assert result.reason is None
+
+
+def test_evaluate_runtime_version_compatibility_disables_checks_for_unknown_local() -> None:
+    """Unparseable local versions should not break the receiving API."""
+    result = evaluate_runtime_version_compatibility(
+        RuntimeVersionMetadata("unknown", "unknown", "superlink"),
+        RuntimeVersionMetadata("flwr", "1.29.0", "simulation"),
+    )
+
+    assert result.status == "disabled"
+    assert result.peer_metadata == RuntimeVersionMetadata(
+        "flwr", "1.29.0", "simulation"
+    )
 
 
 def test_evaluate_runtime_version_compatibility_rejects_invalid_peer_version() -> None:

--- a/framework/py/flwr/common/runtime_version_test.py
+++ b/framework/py/flwr/common/runtime_version_test.py
@@ -160,7 +160,9 @@ def test_evaluate_runtime_version_compatibility_tolerates_missing_metadata() -> 
     assert result.reason is None
 
 
-def test_evaluate_runtime_version_compatibility_tolerates_missing_metadata_with_unknown_local() -> None:
+def test_evaluate_runtime_version_compatibility_tolerates_missing_metadata_with_unknown_local() -> (
+    None
+):
     """Missing metadata should remain the rollout case in source environments."""
     result = evaluate_runtime_version_compatibility(
         RuntimeVersionMetadata("unknown", "unknown", "superlink"),
@@ -171,7 +173,9 @@ def test_evaluate_runtime_version_compatibility_tolerates_missing_metadata_with_
     assert result.reason is None
 
 
-def test_evaluate_runtime_version_compatibility_disables_checks_for_unknown_local() -> None:
+def test_evaluate_runtime_version_compatibility_disables_checks_for_unknown_local() -> (
+    None
+):
     """Unparseable local versions should not break the receiving API."""
     result = evaluate_runtime_version_compatibility(
         RuntimeVersionMetadata("unknown", "unknown", "superlink"),

--- a/framework/py/flwr/common/runtime_version_test.py
+++ b/framework/py/flwr/common/runtime_version_test.py
@@ -1,0 +1,178 @@
+# Copyright 2025 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for Flower runtime version metadata helpers."""
+
+
+import pytest
+
+from flwr.common.constant import (
+    FLWR_COMPONENT_NAME_METADATA_KEY,
+    FLWR_PACKAGE_NAME_METADATA_KEY,
+    FLWR_PACKAGE_VERSION_METADATA_KEY,
+)
+
+from .runtime_version import (
+    ParsedFlowerVersion,
+    RuntimeVersionMetadata,
+    build_runtime_version_metadata,
+    evaluate_runtime_version_compatibility,
+    format_incompatible_version_message,
+    format_invalid_metadata_message,
+    parse_flower_version,
+    read_runtime_version_metadata,
+    runtime_version_metadata_to_dict,
+)
+
+
+@pytest.mark.parametrize(
+    ("version", "expected"),
+    [
+        ("1.29.0", ParsedFlowerVersion(1, 29, 0)),
+        ("1.29.7", ParsedFlowerVersion(1, 29, 7)),
+        ("1.29.0.dev12", ParsedFlowerVersion(1, 29, 0)),
+        ("1.29.0-nightly.20260423", ParsedFlowerVersion(1, 29, 0)),
+    ],
+)
+def test_parse_flower_version_accepts_valid_prefixes(
+    version: str, expected: ParsedFlowerVersion
+) -> None:
+    """Leading `major.minor.patch` should be parsed consistently."""
+    assert parse_flower_version(version) == expected
+
+
+@pytest.mark.parametrize("version", ["1.29", "main", "dev", "unknown", "1.29.x"])
+def test_parse_flower_version_rejects_invalid_values(version: str) -> None:
+    """Versions without a parseable leading release tuple should fail."""
+    assert parse_flower_version(version) is None
+
+
+def test_runtime_version_metadata_round_trip() -> None:
+    """Metadata should serialize using the shared key names."""
+    metadata = build_runtime_version_metadata(
+        "supernode",
+        package_name_value="flwr",
+        package_version_value="1.29.0",
+    )
+
+    assert runtime_version_metadata_to_dict(metadata) == {
+        FLWR_PACKAGE_NAME_METADATA_KEY: "flwr",
+        FLWR_PACKAGE_VERSION_METADATA_KEY: "1.29.0",
+        FLWR_COMPONENT_NAME_METADATA_KEY: "supernode",
+    }
+
+
+def test_build_runtime_version_metadata_rejects_empty_component_name() -> None:
+    """Component names must not be empty."""
+    with pytest.raises(ValueError, match="component_name"):
+        build_runtime_version_metadata("")
+
+
+def test_read_runtime_version_metadata_returns_missing_for_absent_keys() -> None:
+    """Absent Flower metadata should be treated as the rollout missing case."""
+    metadata, error = read_runtime_version_metadata({"other-header": "value"})
+
+    assert metadata is None
+    assert error is None
+
+
+def test_read_runtime_version_metadata_rejects_partial_metadata() -> None:
+    """Partial Flower metadata should be rejected as invalid."""
+    metadata, error = read_runtime_version_metadata(
+        {FLWR_PACKAGE_NAME_METADATA_KEY: "flwr"}
+    )
+
+    assert metadata is None
+    assert error is not None
+    assert "Missing required Flower runtime metadata" in error
+
+
+def test_read_runtime_version_metadata_accepts_metadata_item_iterables() -> None:
+    """gRPC metadata-style iterables should be supported directly."""
+    metadata, error = read_runtime_version_metadata(
+        [
+            (FLWR_PACKAGE_NAME_METADATA_KEY, "flwr"),
+            (FLWR_PACKAGE_VERSION_METADATA_KEY, "1.29.0"),
+            (FLWR_COMPONENT_NAME_METADATA_KEY, "cli"),
+        ]
+    )
+
+    assert error is None
+    assert metadata == RuntimeVersionMetadata(
+        package_name="flwr",
+        package_version="1.29.0",
+        component_name="cli",
+    )
+
+
+def test_evaluate_runtime_version_compatibility_accepts_same_major_minor() -> None:
+    """Patch differences are compatible."""
+    result = evaluate_runtime_version_compatibility(
+        RuntimeVersionMetadata("flwr", "1.29.0", "superlink"),
+        RuntimeVersionMetadata("flwr", "1.29.7", "supernode"),
+    )
+
+    assert result.status == "compatible"
+    assert result.peer_version == ParsedFlowerVersion(1, 29, 7)
+
+
+def test_evaluate_runtime_version_compatibility_rejects_different_minor() -> None:
+    """Different minor versions should be incompatible."""
+    peer = RuntimeVersionMetadata("flwr", "1.30.0", "supernode")
+    local = RuntimeVersionMetadata("flwr", "1.29.2", "superlink")
+
+    result = evaluate_runtime_version_compatibility(local, peer)
+
+    assert result.status == "incompatible"
+    assert result.peer_metadata == peer
+    assert (
+        format_incompatible_version_message("SuperNode <-> SuperLink Fleet API", local, peer)
+        == "Incompatible Flower version for SuperNode <-> SuperLink Fleet API.\n"
+        "Local superlink version 1.29.2 only accepts peers from the same "
+        "major.minor release, but received supernode version 1.30.0."
+    )
+
+
+def test_evaluate_runtime_version_compatibility_tolerates_missing_metadata() -> None:
+    """Missing metadata should be surfaced distinctly for rollout handling."""
+    result = evaluate_runtime_version_compatibility(
+        RuntimeVersionMetadata("flwr", "1.29.0", "superlink"),
+        None,
+    )
+
+    assert result.status == "missing"
+    assert result.reason is None
+
+
+def test_evaluate_runtime_version_compatibility_rejects_invalid_peer_version() -> None:
+    """Unparseable peer versions should be classified as invalid metadata."""
+    result = evaluate_runtime_version_compatibility(
+        RuntimeVersionMetadata("flwr", "1.29.0", "superlink"),
+        RuntimeVersionMetadata("flwr", "main", "supernode"),
+    )
+
+    assert result.status == "invalid"
+    assert result.reason == "Peer Flower version metadata is invalid: 'main'."
+
+
+def test_format_invalid_metadata_message() -> None:
+    """Invalid metadata messages should include the connection name."""
+    assert (
+        format_invalid_metadata_message(
+            "CLI <-> SuperLink Control API",
+            "Missing required Flower runtime metadata: flwr-component-name.",
+        )
+        == "Invalid Flower version metadata for CLI <-> SuperLink Control API. "
+        "Missing required Flower runtime metadata: flwr-component-name."
+    )

--- a/framework/py/flwr/common/runtime_version_test.py
+++ b/framework/py/flwr/common/runtime_version_test.py
@@ -43,6 +43,9 @@ from .runtime_version import (
         ("1.29.7", ParsedFlowerVersion(1, 29, 7)),
         ("1.29.0.dev12", ParsedFlowerVersion(1, 29, 0)),
         ("1.29.0-nightly.20260423", ParsedFlowerVersion(1, 29, 0)),
+        ("1.29.0a0", ParsedFlowerVersion(1, 29, 0)),
+        ("1.29.0b1", ParsedFlowerVersion(1, 29, 0)),
+        ("1.29.0rc1", ParsedFlowerVersion(1, 29, 0)),
     ],
 )
 def test_parse_flower_version_accepts_valid_prefixes(

--- a/framework/py/flwr/common/runtime_version_test.py
+++ b/framework/py/flwr/common/runtime_version_test.py
@@ -157,6 +157,17 @@ def test_evaluate_runtime_version_compatibility_tolerates_missing_metadata() -> 
     assert result.reason is None
 
 
+def test_evaluate_runtime_version_compatibility_tolerates_missing_metadata_with_unknown_local_version() -> None:
+    """Missing metadata should remain the rollout case in source environments."""
+    result = evaluate_runtime_version_compatibility(
+        RuntimeVersionMetadata("unknown", "unknown", "superlink"),
+        None,
+    )
+
+    assert result.status == "missing"
+    assert result.reason is None
+
+
 def test_evaluate_runtime_version_compatibility_rejects_invalid_peer_version() -> None:
     """Unparseable peer versions should be classified as invalid metadata."""
     result = evaluate_runtime_version_compatibility(

--- a/framework/py/flwr/common/runtime_version_test.py
+++ b/framework/py/flwr/common/runtime_version_test.py
@@ -102,7 +102,7 @@ def test_read_runtime_version_metadata_rejects_partial_metadata() -> None:
 
 
 def test_read_runtime_version_metadata_accepts_metadata_item_iterables() -> None:
-    """gRPC metadata-style iterables should be supported directly."""
+    """GRPC metadata-style iterables should be supported directly."""
     metadata, error = read_runtime_version_metadata(
         [
             (FLWR_PACKAGE_NAME_METADATA_KEY, "flwr"),
@@ -160,9 +160,7 @@ def test_evaluate_runtime_version_compatibility_tolerates_missing_metadata() -> 
     assert result.reason is None
 
 
-def test_evaluate_runtime_version_compatibility_tolerates_missing_metadata_with_unknown_local() -> (
-    None
-):
+def test_evaluate_runtime_version_compatibility_tolerates_missing_metadata_with_unknown_local() -> None:
     """Missing metadata should remain the rollout case in source environments."""
     result = evaluate_runtime_version_compatibility(
         RuntimeVersionMetadata("unknown", "unknown", "superlink"),
@@ -173,9 +171,7 @@ def test_evaluate_runtime_version_compatibility_tolerates_missing_metadata_with_
     assert result.reason is None
 
 
-def test_evaluate_runtime_version_compatibility_disables_checks_for_unknown_local() -> (
-    None
-):
+def test_evaluate_runtime_version_compatibility_disables_checks_for_unknown_local() -> None:
     """Unparseable local versions should not break the receiving API."""
     result = evaluate_runtime_version_compatibility(
         RuntimeVersionMetadata("unknown", "unknown", "superlink"),

--- a/framework/py/flwr/server/superlink/serverappio/serverappio_grpc.py
+++ b/framework/py/flwr/server/superlink/serverappio/serverappio_grpc.py
@@ -62,7 +62,7 @@ def run_serverappio_api_grpc(  # pylint: disable=R0913,R0917
         create_serverappio_runtime_version_server_interceptor(),
         create_serverappio_token_auth_server_interceptor(
             state_provider=state_factory.state
-        )
+        ),
     ]
     if superexec_auth_secret is not None:
         interceptors.append(

--- a/framework/py/flwr/server/superlink/serverappio/serverappio_grpc.py
+++ b/framework/py/flwr/server/superlink/serverappio/serverappio_grpc.py
@@ -27,9 +27,9 @@ from flwr.proto.serverappio_pb2_grpc import (  # pylint: disable=E0611
 )
 from flwr.server.superlink.linkstate import LinkStateFactory
 from flwr.supercore.interceptors import (
+    create_serverappio_runtime_version_server_interceptor,
     create_serverappio_superexec_auth_server_interceptor,
     create_serverappio_token_auth_server_interceptor,
-    create_serverappio_runtime_version_server_interceptor,
 )
 from flwr.supercore.object_store import ObjectStoreFactory
 

--- a/framework/py/flwr/server/superlink/serverappio/serverappio_grpc.py
+++ b/framework/py/flwr/server/superlink/serverappio/serverappio_grpc.py
@@ -29,6 +29,7 @@ from flwr.server.superlink.linkstate import LinkStateFactory
 from flwr.supercore.interceptors import (
     create_serverappio_superexec_auth_server_interceptor,
     create_serverappio_token_auth_server_interceptor,
+    create_serverappio_runtime_version_server_interceptor,
 )
 from flwr.supercore.object_store import ObjectStoreFactory
 
@@ -58,6 +59,7 @@ def run_serverappio_api_grpc(  # pylint: disable=R0913,R0917
 
     # Create interceptors
     interceptors = [
+        create_serverappio_runtime_version_server_interceptor(),
         create_serverappio_token_auth_server_interceptor(
             state_provider=state_factory.state
         )

--- a/framework/py/flwr/simulation/simulationio_connection.py
+++ b/framework/py/flwr/simulation/simulationio_connection.py
@@ -25,7 +25,10 @@ from flwr.common.grpc import create_channel, on_channel_state_change
 from flwr.common.logger import log
 from flwr.common.retry_invoker import make_simple_grpc_retry_invoker, wrap_stub
 from flwr.proto.serverappio_pb2_grpc import ServerAppIoStub  # pylint: disable=E0611
-from flwr.supercore.interceptors import AppIoTokenClientInterceptor
+from flwr.supercore.interceptors import (
+    AppIoTokenClientInterceptor,
+    RuntimeVersionClientInterceptor,
+)
 
 
 class SimulationIoConnection:
@@ -80,7 +83,10 @@ class SimulationIoConnection:
             server_address=self._addr,
             insecure=(self._cert is None),
             root_certificates=self._cert,
-            interceptors=[AppIoTokenClientInterceptor(token=self._token)],
+            interceptors=[
+                RuntimeVersionClientInterceptor(component_name="simulation"),
+                AppIoTokenClientInterceptor(token=self._token),
+            ],
         )
         self._channel.subscribe(on_channel_state_change)
         self._grpc_stub = ServerAppIoStub(self._channel)

--- a/framework/py/flwr/simulation/simulationio_connection_test.py
+++ b/framework/py/flwr/simulation/simulationio_connection_test.py
@@ -18,7 +18,10 @@
 import unittest
 from unittest.mock import Mock, patch
 
-from flwr.supercore.interceptors import AppIoTokenClientInterceptor
+from flwr.supercore.interceptors import (
+    AppIoTokenClientInterceptor,
+    RuntimeVersionClientInterceptor,
+)
 
 from .simulationio_connection import SimulationIoConnection
 
@@ -29,13 +32,13 @@ class TestSimulationIoConnection(unittest.TestCase):
     @patch("flwr.simulation.simulationio_connection.wrap_stub")
     @patch("flwr.simulation.simulationio_connection.ServerAppIoStub")
     @patch("flwr.simulation.simulationio_connection.create_channel")
-    def test_connect_adds_client_interceptor(
+    def test_connect_adds_client_interceptors(
         self,
         mock_create_channel: Mock,
         _mock_serverappio_stub: Mock,
         _mock_wrap_stub: Mock,
     ) -> None:
-        """`_connect` should pass the token interceptor to create_channel."""
+        """`_connect` should pass version and token interceptors to create_channel."""
         mock_create_channel.return_value = Mock()
         conn = SimulationIoConnection(token="test-token")
 
@@ -45,8 +48,9 @@ class TestSimulationIoConnection(unittest.TestCase):
         interceptors = kwargs["interceptors"]
         self.assertIsNotNone(interceptors)
         assert interceptors is not None
-        self.assertEqual(len(interceptors), 1)
-        self.assertIsInstance(interceptors[0], AppIoTokenClientInterceptor)
+        self.assertEqual(len(interceptors), 2)
+        self.assertIsInstance(interceptors[0], RuntimeVersionClientInterceptor)
+        self.assertIsInstance(interceptors[1], AppIoTokenClientInterceptor)
 
     def test_init_requires_token(self) -> None:
         """`SimulationIoConnection` should require token values."""

--- a/framework/py/flwr/supercore/interceptors/__init__.py
+++ b/framework/py/flwr/supercore/interceptors/__init__.py
@@ -23,6 +23,11 @@ from .appio_token_interceptor import (
     create_clientappio_token_auth_server_interceptor,
     create_serverappio_token_auth_server_interceptor,
 )
+from .runtime_version_interceptor import (
+    RuntimeVersionClientInterceptor,
+    RuntimeVersionServerInterceptor,
+    create_serverappio_runtime_version_server_interceptor,
+)
 from .superexec_auth_interceptor import (
     SuperExecAuthClientInterceptor,
     SuperExecAuthServerInterceptor,
@@ -35,10 +40,13 @@ __all__ = [
     "AUTHENTICATION_FAILED_MESSAGE",
     "AppIoTokenClientInterceptor",
     "AppIoTokenServerInterceptor",
+    "RuntimeVersionClientInterceptor",
+    "RuntimeVersionServerInterceptor",
     "SuperExecAuthClientInterceptor",
     "SuperExecAuthServerInterceptor",
     "create_clientappio_superexec_auth_server_interceptor",
     "create_clientappio_token_auth_server_interceptor",
+    "create_serverappio_runtime_version_server_interceptor",
     "create_serverappio_superexec_auth_server_interceptor",
     "create_serverappio_token_auth_server_interceptor",
 ]

--- a/framework/py/flwr/supercore/interceptors/runtime_version_interceptor.py
+++ b/framework/py/flwr/supercore/interceptors/runtime_version_interceptor.py
@@ -50,9 +50,7 @@ class RuntimeVersionClientInterceptor(grpc.UnaryUnaryClientInterceptor):  # type
         """Add or replace the runtime version metadata headers."""
         metadata = list(client_call_details.metadata or [])
         metadata = [
-            (key, value)
-            for key, value in metadata
-            if key not in self._metadata
+            (key, value) for key, value in metadata if key not in self._metadata
         ]
         metadata.extend(self._metadata.items())
         details = client_call_details._replace(metadata=metadata)

--- a/framework/py/flwr/supercore/interceptors/runtime_version_interceptor.py
+++ b/framework/py/flwr/supercore/interceptors/runtime_version_interceptor.py
@@ -85,7 +85,7 @@ class RuntimeVersionServerInterceptor(grpc.ServerInterceptor):  # type: ignore
             self._local_metadata,
             handler_call_details.invocation_metadata,
         )
-        if compatibility.status == "missing":
+        if compatibility.status in {"missing", "compatible"}:
             return method_handler
 
         unary_handler = cast(

--- a/framework/py/flwr/supercore/interceptors/runtime_version_interceptor.py
+++ b/framework/py/flwr/supercore/interceptors/runtime_version_interceptor.py
@@ -85,7 +85,7 @@ class RuntimeVersionServerInterceptor(grpc.ServerInterceptor):  # type: ignore
             self._local_metadata,
             handler_call_details.invocation_metadata,
         )
-        if compatibility.status in {"missing", "compatible"}:
+        if compatibility.status in {"missing", "disabled", "compatible"}:
             return method_handler
 
         unary_handler = cast(

--- a/framework/py/flwr/supercore/interceptors/runtime_version_interceptor.py
+++ b/framework/py/flwr/supercore/interceptors/runtime_version_interceptor.py
@@ -1,0 +1,145 @@
+# Copyright 2026 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Runtime version metadata interceptors."""
+
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, cast
+
+import grpc
+from google.protobuf.message import Message as GrpcMessage
+
+from flwr.common.runtime_version import (
+    RuntimeVersionMetadata,
+    build_runtime_version_metadata,
+    evaluate_runtime_version_compatibility,
+    format_incompatible_version_message,
+    format_invalid_metadata_message,
+    runtime_version_metadata_to_dict,
+)
+
+
+class RuntimeVersionClientInterceptor(grpc.UnaryUnaryClientInterceptor):  # type: ignore
+    """Attach Flower runtime version metadata to outbound unary RPCs."""
+
+    def __init__(self, component_name: str) -> None:
+        self._metadata = runtime_version_metadata_to_dict(
+            build_runtime_version_metadata(component_name)
+        )
+
+    def intercept_unary_unary(
+        self,
+        continuation: Callable[[Any, Any], Any],
+        client_call_details: grpc.ClientCallDetails,
+        request: GrpcMessage,
+    ) -> grpc.Call:
+        """Add or replace the runtime version metadata headers."""
+        metadata = list(client_call_details.metadata or [])
+        metadata = [
+            (key, value)
+            for key, value in metadata
+            if key not in self._metadata
+        ]
+        metadata.extend(self._metadata.items())
+        details = client_call_details._replace(metadata=metadata)
+        return continuation(details, request)
+
+
+class RuntimeVersionServerInterceptor(grpc.ServerInterceptor):  # type: ignore
+    """Validate Flower runtime version metadata on inbound unary RPCs."""
+
+    def __init__(
+        self,
+        *,
+        connection_name: str,
+        local_metadata: RuntimeVersionMetadata,
+    ) -> None:
+        self._connection_name = connection_name
+        self._local_metadata = local_metadata
+
+    def intercept_service(
+        self,
+        continuation: Callable[[Any], Any],
+        handler_call_details: grpc.HandlerCallDetails,
+    ) -> grpc.RpcMethodHandler:
+        """Reject explicit invalid or incompatible peer metadata before handling."""
+        method_handler = continuation(handler_call_details)
+        if method_handler is None or method_handler.unary_unary is None:
+            return method_handler
+
+        compatibility = evaluate_runtime_version_compatibility(
+            self._local_metadata,
+            handler_call_details.invocation_metadata,
+        )
+        if compatibility.status == "missing":
+            return method_handler
+
+        unary_handler = cast(
+            Callable[[GrpcMessage, grpc.ServicerContext], GrpcMessage],
+            method_handler.unary_unary,
+        )
+
+        def _version_checked_handler(
+            request: GrpcMessage,
+            context: grpc.ServicerContext,
+        ) -> GrpcMessage:
+            if compatibility.status == "invalid":
+                context.abort(
+                    grpc.StatusCode.FAILED_PRECONDITION,
+                    format_invalid_metadata_message(
+                        self._connection_name,
+                        compatibility.reason or "Unknown metadata error.",
+                    ),
+                )
+                raise RuntimeError("Should not reach this point")
+            if compatibility.status == "incompatible":
+                peer_metadata = compatibility.peer_metadata
+                if peer_metadata is None:
+                    context.abort(
+                        grpc.StatusCode.FAILED_PRECONDITION,
+                        format_invalid_metadata_message(
+                            self._connection_name,
+                            "Peer metadata is unavailable for incompatibility check.",
+                        ),
+                    )
+                    raise RuntimeError("Should not reach this point")
+                context.abort(
+                    grpc.StatusCode.FAILED_PRECONDITION,
+                    format_incompatible_version_message(
+                        self._connection_name,
+                        self._local_metadata,
+                        peer_metadata,
+                    ),
+                )
+                raise RuntimeError("Should not reach this point")
+            return unary_handler(request, context)
+
+        return grpc.unary_unary_rpc_method_handler(
+            _version_checked_handler,
+            request_deserializer=method_handler.request_deserializer,
+            response_serializer=method_handler.response_serializer,
+        )
+
+
+def create_serverappio_runtime_version_server_interceptor(
+    connection_name: str = "flwr-simulation <-> SuperLink ServerAppIo API",
+) -> RuntimeVersionServerInterceptor:
+    """Create the default runtime version interceptor for ServerAppIo."""
+    return RuntimeVersionServerInterceptor(
+        connection_name=connection_name,
+        local_metadata=build_runtime_version_metadata("superlink"),
+    )

--- a/framework/py/flwr/supercore/interceptors/runtime_version_interceptor_test.py
+++ b/framework/py/flwr/supercore/interceptors/runtime_version_interceptor_test.py
@@ -99,6 +99,7 @@ class TestRuntimeVersionServerInterceptor(TestCase):
     """Unit tests for RuntimeVersionServerInterceptor."""
 
     def setUp(self) -> None:
+        """Create a baseline interceptor for each test."""
         self.interceptor = RuntimeVersionServerInterceptor(
             connection_name="flwr-simulation <-> SuperLink ServerAppIo API",
             local_metadata=build_runtime_version_metadata(

--- a/framework/py/flwr/supercore/interceptors/runtime_version_interceptor_test.py
+++ b/framework/py/flwr/supercore/interceptors/runtime_version_interceptor_test.py
@@ -1,0 +1,187 @@
+# Copyright 2026 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for runtime version metadata interceptors."""
+
+
+from collections import namedtuple
+from typing import cast
+from unittest import TestCase
+from unittest.mock import Mock
+
+import grpc
+from google.protobuf.message import Message as GrpcMessage
+
+from flwr.common.constant import (
+    FLWR_COMPONENT_NAME_METADATA_KEY,
+    FLWR_PACKAGE_NAME_METADATA_KEY,
+    FLWR_PACKAGE_VERSION_METADATA_KEY,
+)
+from flwr.common.runtime_version import build_runtime_version_metadata
+from flwr.proto.serverappio_pb2 import GetNodesRequest  # pylint: disable=E0611
+from flwr.supercore.interceptors import (
+    RuntimeVersionClientInterceptor,
+    RuntimeVersionServerInterceptor,
+)
+
+_ClientCallDetails = namedtuple(
+    "_ClientCallDetails",
+    ["method", "timeout", "metadata", "credentials", "wait_for_ready", "compression"],
+)
+
+
+class _HandlerCallDetails:
+    def __init__(
+        self,
+        method: str,
+        invocation_metadata: tuple[tuple[str, str | bytes], ...],
+    ) -> None:
+        self.method = method
+        self.invocation_metadata = invocation_metadata
+
+
+def _make_unary_handler() -> grpc.RpcMethodHandler:
+    def _handler(_request: GrpcMessage, _context: grpc.ServicerContext) -> str:
+        return "ok"
+
+    return grpc.unary_unary_rpc_method_handler(_handler)
+
+
+class TestRuntimeVersionClientInterceptor(TestCase):
+    """Unit tests for RuntimeVersionClientInterceptor."""
+
+    def test_attach_runtime_version_headers(self) -> None:
+        """The interceptor should add the shared version metadata keys."""
+        interceptor = RuntimeVersionClientInterceptor(component_name="simulation")
+        details = _ClientCallDetails(
+            method="/flwr.proto.ServerAppIo/GetNodes",
+            timeout=None,
+            metadata=((FLWR_PACKAGE_NAME_METADATA_KEY, "old"), ("x-test", "value")),
+            credentials=None,
+            wait_for_ready=None,
+            compression=None,
+        )
+        captured: dict[str, list[tuple[str, str | bytes]]] = {}
+
+        def continuation(
+            client_call_details: grpc.ClientCallDetails,
+            _request: GrpcMessage,
+        ) -> str:
+            captured["metadata"] = list(client_call_details.metadata or [])
+            return "ok"
+
+        response = interceptor.intercept_unary_unary(
+            continuation=continuation,
+            client_call_details=details,
+            request=GetNodesRequest(run_id=1),
+        )
+
+        self.assertEqual(response, "ok")
+        metadata = dict(captured["metadata"])
+        self.assertEqual(metadata["x-test"], "value")
+        self.assertIn(FLWR_PACKAGE_NAME_METADATA_KEY, metadata)
+        self.assertIn(FLWR_PACKAGE_VERSION_METADATA_KEY, metadata)
+        self.assertEqual(metadata[FLWR_COMPONENT_NAME_METADATA_KEY], "simulation")
+
+
+class TestRuntimeVersionServerInterceptor(TestCase):
+    """Unit tests for RuntimeVersionServerInterceptor."""
+
+    def setUp(self) -> None:
+        self.interceptor = RuntimeVersionServerInterceptor(
+            connection_name="flwr-simulation <-> SuperLink ServerAppIo API",
+            local_metadata=build_runtime_version_metadata(
+                "superlink",
+                package_name_value="flwr",
+                package_version_value="1.29.0",
+            ),
+        )
+
+    def test_missing_metadata_is_tolerated(self) -> None:
+        """Missing runtime metadata should pass during rollout."""
+        intercepted = self.interceptor.intercept_service(
+            lambda _: _make_unary_handler(),
+            _HandlerCallDetails("/flwr.proto.ServerAppIo/GetNodes", ()),
+        )
+
+        response = cast(str, intercepted.unary_unary(GetNodesRequest(run_id=1), Mock()))
+        self.assertEqual(response, "ok")
+
+    def test_invalid_metadata_is_rejected(self) -> None:
+        """Malformed runtime metadata should be rejected."""
+        context = Mock()
+        context.abort.side_effect = grpc.RpcError()
+        intercepted = self.interceptor.intercept_service(
+            lambda _: _make_unary_handler(),
+            _HandlerCallDetails(
+                "/flwr.proto.ServerAppIo/GetNodes",
+                (
+                    (FLWR_PACKAGE_NAME_METADATA_KEY, "flwr"),
+                    (FLWR_PACKAGE_VERSION_METADATA_KEY, "main"),
+                    (FLWR_COMPONENT_NAME_METADATA_KEY, "simulation"),
+                ),
+            ),
+        )
+
+        with self.assertRaises(grpc.RpcError):
+            intercepted.unary_unary(GetNodesRequest(run_id=1), context)
+        context.abort.assert_called_once_with(
+            grpc.StatusCode.FAILED_PRECONDITION,
+            "Invalid Flower version metadata for "
+            "flwr-simulation <-> SuperLink ServerAppIo API. "
+            "Peer Flower version metadata is invalid: 'main'.",
+        )
+
+    def test_incompatible_metadata_is_rejected(self) -> None:
+        """Different major.minor versions should be rejected."""
+        context = Mock()
+        context.abort.side_effect = grpc.RpcError()
+        intercepted = self.interceptor.intercept_service(
+            lambda _: _make_unary_handler(),
+            _HandlerCallDetails(
+                "/flwr.proto.ServerAppIo/GetNodes",
+                (
+                    (FLWR_PACKAGE_NAME_METADATA_KEY, "flwr"),
+                    (FLWR_PACKAGE_VERSION_METADATA_KEY, "1.30.1"),
+                    (FLWR_COMPONENT_NAME_METADATA_KEY, "simulation"),
+                ),
+            ),
+        )
+
+        with self.assertRaises(grpc.RpcError):
+            intercepted.unary_unary(GetNodesRequest(run_id=1), context)
+        context.abort.assert_called_once_with(
+            grpc.StatusCode.FAILED_PRECONDITION,
+            "Incompatible Flower version for "
+            "flwr-simulation <-> SuperLink ServerAppIo API.\n"
+            "Local superlink version 1.29.0 only accepts peers from the same "
+            "major.minor release, but received simulation version 1.30.1.",
+        )
+
+    def test_compatible_metadata_is_accepted(self) -> None:
+        """Same major.minor versions should pass."""
+        intercepted = self.interceptor.intercept_service(
+            lambda _: _make_unary_handler(),
+            _HandlerCallDetails(
+                "/flwr.proto.ServerAppIo/GetNodes",
+                (
+                    (FLWR_PACKAGE_NAME_METADATA_KEY, "flwr"),
+                    (FLWR_PACKAGE_VERSION_METADATA_KEY, "1.29.7"),
+                    (FLWR_COMPONENT_NAME_METADATA_KEY, "simulation"),
+                ),
+            ),
+        )
+
+        response = cast(str, intercepted.unary_unary(GetNodesRequest(run_id=1), Mock()))
+        self.assertEqual(response, "ok")


### PR DESCRIPTION
This PR adds runtime version metadata helpers and enables the first runtime version check for `simulation -> ServerAppIo`.




