### PR TITLE
ci(*:skip): Use HF CIFAR-10 for PyTorch e2e datasets

### DIFF
--- a/.github/workflows/framework-e2e.yml
+++ b/.github/workflows/framework-e2e.yml
@@ -163,8 +163,8 @@ jobs:
           - directory: e2e-tensorflow
             e2e: e2e_tensorflow
             dataset: |
-              import tensorflow as tf
-              tf.keras.datasets.cifar10.load_data()
+              from datasets import load_dataset
+              load_dataset('uoft-cs/cifar10')
 
           - directory: e2e-opacus
             e2e: e2e_opacus

--- a/.github/workflows/framework-e2e.yml
+++ b/.github/workflows/framework-e2e.yml
@@ -158,6 +158,7 @@ jobs:
             e2e: e2e_pytorch
             dataset: |
               from torchvision.datasets import CIFAR10
+              CIFAR10.url = 'https://huggingface.co/datasets/VerisimilitudeX/cifar10/resolve/main/cifar-10-python.tar.gz'
               CIFAR10('./data', download=True)
 
           - directory: e2e-tensorflow
@@ -170,6 +171,7 @@ jobs:
             e2e: e2e_opacus
             dataset: |
               from torchvision.datasets import CIFAR10
+              CIFAR10.url = 'https://huggingface.co/datasets/VerisimilitudeX/cifar10/resolve/main/cifar-10-python.tar.gz'
               CIFAR10('./data', download=True)
 
           - directory: e2e-pytorch-lightning

--- a/.github/workflows/framework-e2e.yml
+++ b/.github/workflows/framework-e2e.yml
@@ -157,9 +157,8 @@ jobs:
           - directory: e2e-pytorch
             e2e: e2e_pytorch
             dataset: |
-              from torchvision.datasets import CIFAR10
-              CIFAR10.url = 'https://huggingface.co/datasets/VerisimilitudeX/cifar10/resolve/main/cifar-10-python.tar.gz'
-              CIFAR10('./data', download=True)
+              from datasets import load_dataset
+              load_dataset('uoft-cs/cifar10')
 
           - directory: e2e-tensorflow
             e2e: e2e_tensorflow
@@ -170,9 +169,8 @@ jobs:
           - directory: e2e-opacus
             e2e: e2e_opacus
             dataset: |
-              from torchvision.datasets import CIFAR10
-              CIFAR10.url = 'https://huggingface.co/datasets/VerisimilitudeX/cifar10/resolve/main/cifar-10-python.tar.gz'
-              CIFAR10('./data', download=True)
+              from datasets import load_dataset
+              load_dataset('uoft-cs/cifar10')
 
           - directory: e2e-pytorch-lightning
             e2e: e2e_pytorch_lightning

--- a/framework/e2e/e2e-opacus/e2e_opacus/client_app.py
+++ b/framework/e2e/e2e-opacus/e2e_opacus/client_app.py
@@ -13,6 +13,11 @@ from flwr.app import Context
 from flwr.client import NumPyClient, start_client
 from flwr.clientapp import ClientApp
 
+CIFAR10.url = (
+    "https://huggingface.co/datasets/VerisimilitudeX/cifar10/resolve/main/"
+    "cifar-10-python.tar.gz"
+)
+
 # Define parameters.
 PARAMS = {
     "batch_size": 32,

--- a/framework/e2e/e2e-opacus/e2e_opacus/client_app.py
+++ b/framework/e2e/e2e-opacus/e2e_opacus/client_app.py
@@ -5,18 +5,13 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 import torchvision.transforms as transforms
+from datasets import load_dataset
 from opacus import PrivacyEngine
 from torch.utils.data import DataLoader
-from torchvision.datasets import CIFAR10
 
 from flwr.app import Context
 from flwr.client import NumPyClient, start_client
 from flwr.clientapp import ClientApp
-
-CIFAR10.url = (
-    "https://huggingface.co/datasets/VerisimilitudeX/cifar10/resolve/main/"
-    "cifar-10-python.tar.gz"
-)
 
 # Define parameters.
 PARAMS = {
@@ -31,6 +26,21 @@ PRIVACY_PARAMS = {
     "max_grad_norm": 1.2,
 }
 DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+
+
+class Cifar10Dataset(torch.utils.data.Dataset):
+    """CIFAR-10 dataset loaded from Hugging Face."""
+
+    def __init__(self, split, transform):
+        self.dataset = load_dataset("uoft-cs/cifar10", split=split)
+        self.transform = transform
+
+    def __len__(self):
+        return len(self.dataset)
+
+    def __getitem__(self, idx):
+        item = self.dataset[idx]
+        return self.transform(item["img"]), item["label"]
 
 
 # Define model used for training.
@@ -85,7 +95,7 @@ def load_data():
     transform = transforms.Compose(
         [transforms.ToTensor(), transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))]
     )
-    data = CIFAR10("./../data", train=True, download=True, transform=transform)
+    data = Cifar10Dataset("train", transform=transform)
     split = math.floor(len(data) * 0.01 * PARAMS["train_split"])
     trainset = torch.utils.data.Subset(data, list(range(0, split)))
     testset = torch.utils.data.Subset(

--- a/framework/e2e/e2e-opacus/pyproject.toml
+++ b/framework/e2e/e2e-opacus/pyproject.toml
@@ -8,6 +8,7 @@ version = "1.0.0"
 description = "Opacus E2E testing"
 license = "Apache-2.0"
 dependencies = [
+    "datasets>=4.0.0,<5.0.0",
     "flwr[simulation] @ {root:parent:parent:uri}",
     "opacus>=1.4.0,<2.0.0",
     "torch>=1.13.1,<3.0.0",

--- a/framework/e2e/e2e-pytorch/e2e_pytorch/client_app.py
+++ b/framework/e2e/e2e-pytorch/e2e_pytorch/client_app.py
@@ -5,19 +5,14 @@ from datetime import datetime
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from datasets import load_dataset
 from torch.utils.data import DataLoader, Subset
-from torchvision.datasets import CIFAR10
 from torchvision.transforms import Compose, Normalize, ToTensor
 from tqdm import tqdm
 
 from flwr.app import ConfigRecord, Context, RecordDict
 from flwr.client import NumPyClient, start_client
 from flwr.clientapp import ClientApp
-
-CIFAR10.url = (
-    "https://huggingface.co/datasets/VerisimilitudeX/cifar10/resolve/main/"
-    "cifar-10-python.tar.gz"
-)
 
 # #############################################################################
 # 1. Regular PyTorch pipeline: nn.Module, train, test, and DataLoader
@@ -27,6 +22,21 @@ warnings.filterwarnings("ignore", category=UserWarning)
 DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
 SUBSET_SIZE = 1000
 STATE_VAR = "timestamp"
+
+
+class Cifar10Dataset(torch.utils.data.Dataset):
+    """CIFAR-10 dataset loaded from Hugging Face."""
+
+    def __init__(self, split, transform):
+        self.dataset = load_dataset("uoft-cs/cifar10", split=split)
+        self.transform = transform
+
+    def __len__(self):
+        return len(self.dataset)
+
+    def __getitem__(self, idx):
+        item = self.dataset[idx]
+        return self.transform(item["img"]), item["label"]
 
 
 class Net(nn.Module):
@@ -78,8 +88,8 @@ def test(net, testloader):
 def load_data():
     """Load CIFAR-10 (training and test set)."""
     trf = Compose([ToTensor(), Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))])
-    trainset = CIFAR10("./../data", train=True, download=True, transform=trf)
-    testset = CIFAR10("./../data", train=False, download=True, transform=trf)
+    trainset = Cifar10Dataset("train", transform=trf)
+    testset = Cifar10Dataset("test", transform=trf)
     trainset = Subset(trainset, range(SUBSET_SIZE))
     testset = Subset(testset, range(10))
     return DataLoader(trainset, batch_size=32, shuffle=True), DataLoader(testset)

--- a/framework/e2e/e2e-pytorch/e2e_pytorch/client_app.py
+++ b/framework/e2e/e2e-pytorch/e2e_pytorch/client_app.py
@@ -14,6 +14,11 @@ from flwr.app import ConfigRecord, Context, RecordDict
 from flwr.client import NumPyClient, start_client
 from flwr.clientapp import ClientApp
 
+CIFAR10.url = (
+    "https://huggingface.co/datasets/VerisimilitudeX/cifar10/resolve/main/"
+    "cifar-10-python.tar.gz"
+)
+
 # #############################################################################
 # 1. Regular PyTorch pipeline: nn.Module, train, test, and DataLoader
 # #############################################################################

--- a/framework/e2e/e2e-pytorch/pyproject.toml
+++ b/framework/e2e/e2e-pytorch/pyproject.toml
@@ -8,6 +8,7 @@ version = "1.0.0"
 description = "PyTorch Federated Learning E2E test with Flower"
 license = "Apache-2.0"
 dependencies = [
+    "datasets>=4.0.0,<5.0.0",
     "flwr[simulation] @ {root:parent:parent:uri}",
     "torch>=2.5.0,<3.0.0",
     "torchvision>=0.20.1,<0.21.0",

--- a/framework/e2e/e2e-tensorflow/e2e_tensorflow/client_app.py
+++ b/framework/e2e/e2e-tensorflow/e2e_tensorflow/client_app.py
@@ -1,6 +1,8 @@
 import os
 
+import numpy as np
 import tensorflow as tf
+from datasets import load_dataset
 
 from flwr.app import Context
 from flwr.client import NumPyClient, start_client
@@ -14,13 +16,21 @@ TEST_SUBSET_SIZE = 10
 os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"
 
 
-# Load CIFAR-10 using built-in Keras loader
-(x_train, y_train), (x_test, y_test) = tf.keras.datasets.cifar10.load_data()
+def load_cifar10():
+    trainset = load_dataset("uoft-cs/cifar10", split=f"train[:{TRAIN_SUBSET_SIZE}]")
+    testset = load_dataset("uoft-cs/cifar10", split=f"test[:{TEST_SUBSET_SIZE}]")
+    x_train = np.array([item["img"] for item in trainset])
+    y_train = np.array([item["label"] for item in trainset])
+    x_test = np.array([item["img"] for item in testset])
+    y_test = np.array([item["label"] for item in testset])
+    return (x_train, y_train), (x_test, y_test)
+
+
+# Load CIFAR-10 from Hugging Face
+(x_train, y_train), (x_test, y_test) = load_cifar10()
 
 x_train = x_train.astype("float32") / 255.0
 x_test = x_test.astype("float32") / 255.0
-x_train, y_train = x_train[:TRAIN_SUBSET_SIZE], y_train[:TRAIN_SUBSET_SIZE]
-x_test, y_test = x_test[:TEST_SUBSET_SIZE], y_test[:TEST_SUBSET_SIZE]
 
 ds_train = (
     tf.data.Dataset.from_tensor_slices((x_train, y_train))

--- a/framework/e2e/e2e-tensorflow/pyproject.toml
+++ b/framework/e2e/e2e-tensorflow/pyproject.toml
@@ -8,6 +8,7 @@ version = "1.0.0"
 description = "Keras Federated Learning E2E test with Flower"
 license = "Apache-2.0"
 dependencies = [
+    "datasets>=4.0.0,<5.0.0",
     "flwr[simulation] @ {root:parent:parent:uri}",
     "tensorflow-cpu>=2.18.0",
     "Pillow>=11.2.1",


### PR DESCRIPTION
This PR Switch PyTorch and Opacus e2e tests to load CIFAR-10 from Hugging Face `uoft-cs/cifar10` to avoid CI failures from the unavailable source.