### PR TITLE
fix(framework): Prefer task tokens in AppIo auth and enforce run binding

### DIFF
--- a/framework/py/flwr/supercore/interceptors/__init__.py
+++ b/framework/py/flwr/supercore/interceptors/__init__.py
@@ -22,6 +22,7 @@ from .appio_token_interceptor import (
     AppIoTokenServerInterceptor,
     create_clientappio_token_auth_server_interceptor,
     create_serverappio_token_auth_server_interceptor,
+    get_authenticated_task,
 )
 from .runtime_version_interceptor import (
     RuntimeVersionClientInterceptor,
@@ -49,4 +50,5 @@ __all__ = [
     "create_serverappio_runtime_version_server_interceptor",
     "create_serverappio_superexec_auth_server_interceptor",
     "create_serverappio_token_auth_server_interceptor",
+    "get_authenticated_task",
 ]

--- a/framework/py/flwr/supercore/interceptors/appio_token_interceptor.py
+++ b/framework/py/flwr/supercore/interceptors/appio_token_interceptor.py
@@ -17,26 +17,37 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Mapping, Sequence
+from contextvars import ContextVar
 from typing import Any, NoReturn, Protocol, cast
 
 import grpc
 from google.protobuf.message import Message as GrpcMessage
 
+from flwr.proto.task_pb2 import Task  # pylint: disable=E0611
 from flwr.supercore.auth import (
     CLIENTAPPIO_METHOD_AUTH_POLICY,
     SERVERAPPIO_METHOD_AUTH_POLICY,
     MethodTokenPolicy,
 )
-from flwr.supercore.utils import get_metadata_str
+from flwr.supercore.utils import find_metadata_keys, get_metadata_str
 
 APP_TOKEN_HEADER = "flwr-app-token"
 AUTHENTICATION_FAILED_MESSAGE = "Authentication failed."
 RUN_BINDING_FAILED_MESSAGE = "Token is not valid for requested run."
+_current_task: ContextVar[Task | None] = ContextVar("current_task", default=None)
 
 
 class _TokenState(Protocol):
     """State methods required by token auth."""
+
+    def get_task_id_by_token(self, token: str) -> int | None:
+        """Return the task ID associated with the task token, if valid."""
+
+    def get_tasks(
+        self, *, task_ids: Sequence[int] | None = None
+    ) -> Sequence[Task]:
+        """Retrieve tasks matching the given task IDs."""
 
     def get_run_id_by_token(self, token: str) -> int | None:
         """Return the run id associated with token, if it exists."""
@@ -79,10 +90,13 @@ class AppIoTokenClientInterceptor(grpc.UnaryUnaryClientInterceptor):  # type: ig
         client_call_details: grpc.ClientCallDetails,
         request: GrpcMessage,
     ) -> grpc.Call:
-        """Add/replace the App token metadata on outbound unary requests."""
-        metadata = list(client_call_details.metadata or [])
-        metadata = [(key, value) for key, value in metadata if key != APP_TOKEN_HEADER]
-        metadata.append((APP_TOKEN_HEADER, self._token))
+        """Add the App token metadata on outbound unary requests."""
+        metadata = tuple(client_call_details.metadata or ())
+        if find_metadata_keys(metadata, (APP_TOKEN_HEADER,)):
+            raise RuntimeError(
+                f"{APP_TOKEN_HEADER} already present in outbound metadata."
+            )
+        metadata += ((APP_TOKEN_HEADER, self._token),)
         details = client_call_details._replace(metadata=metadata)
         return continuation(details, request)
 
@@ -137,17 +151,23 @@ class AppIoTokenServerInterceptor(grpc.ServerInterceptor):  # type: ignore
                 _abort_auth_denied(context)
 
             state = self._state_provider()
-            run_id = state.get_run_id_by_token(token)
 
-            # Validate both token->run lookup and run->token mapping.
+            # Prefer task tokens. Legacy run tokens are kept temporarily for older
+            # callers until all AppIo request-token RPCs have been removed.
+            task = _get_task_by_token(state, token)
+            if task is not None:
+                _validate_request_run_id(request, task.run_id, context)
+                ctx_token = _current_task.set(task)
+                try:
+                    return unary_handler(request, context)
+                finally:
+                    _current_task.reset(ctx_token)
+
+            run_id = state.get_run_id_by_token(token)
             if run_id is None or not state.verify_token(run_id, token):
                 _abort_auth_denied(context)
 
-            # Validate request.run_id matches the run_id associated with the token
-            request_run_id: int | None = _get_request_run_id(request)
-            if request_run_id is not None and request_run_id != run_id:
-                _abort_run_denied(context)
-
+            _validate_request_run_id(request, run_id, context)
             return unary_handler(request, context)
 
         return grpc.unary_unary_rpc_method_handler(
@@ -155,6 +175,44 @@ class AppIoTokenServerInterceptor(grpc.ServerInterceptor):  # type: ignore
             request_deserializer=method_handler.request_deserializer,
             response_serializer=method_handler.response_serializer,
         )
+
+
+def _get_task_by_token(state: _TokenState, token: str) -> Task | None:
+    """Return the task associated with the task token, if available."""
+    get_task_by_token = getattr(state, "get_task_by_token", None)
+    if callable(get_task_by_token):
+        return cast(Task | None, get_task_by_token(token))
+
+    task_id = state.get_task_id_by_token(token)
+    if task_id is None:
+        return None
+
+    tasks = state.get_tasks(task_ids=[task_id])
+    return tasks[0] if tasks else None
+
+
+def _validate_request_run_id(
+    request: GrpcMessage, authenticated_run_id: int, context: grpc.ServicerContext
+) -> None:
+    """Abort if request.run_id conflicts with the authenticated run ID."""
+    request_run_id = _get_request_run_id(request)
+    if request_run_id is not None and request_run_id != authenticated_run_id:
+        _abort_run_denied(context)
+
+
+def get_authenticated_task() -> Task:
+    """Return the task identity authenticated for the current RPC.
+
+    The task is available only while handling an RPC authenticated with an AppIo
+    task token.
+    """
+    ret = _current_task.get()
+    if ret is None:
+        raise RuntimeError(
+            "No authenticated task in the current RPC context. "
+            "This function must be called from a task-token-authenticated RPC handler."
+        )
+    return ret
 
 
 def create_serverappio_token_auth_server_interceptor(

--- a/framework/py/flwr/supercore/interceptors/appio_token_interceptor_test.py
+++ b/framework/py/flwr/supercore/interceptors/appio_token_interceptor_test.py
@@ -32,6 +32,7 @@ from flwr.proto.appio_pb2 import (  # pylint: disable=E0611
 from flwr.proto.clientappio_pb2_grpc import ClientAppIoServicer
 from flwr.proto.message_pb2 import PushObjectRequest  # pylint: disable=E0611
 from flwr.proto.serverappio_pb2 import GetNodesRequest  # pylint: disable=E0611
+from flwr.proto.task_pb2 import Task  # pylint: disable=E0611
 from flwr.proto.serverappio_pb2_grpc import ServerAppIoServicer
 from flwr.supercore.auth import (
     CLIENTAPPIO_METHOD_AUTH_POLICY,
@@ -66,8 +67,28 @@ class _HandlerCallDetails:
 
 
 class _TokenState:
-    def __init__(self, token_to_run_id: dict[str, int]) -> None:
+    def __init__(
+        self,
+        token_to_run_id: dict[str, int],
+        token_to_task: dict[str, Task] | None = None,
+    ) -> None:
         self._token_to_run_id = token_to_run_id
+        self._token_to_task = token_to_task or {}
+
+    def get_task_id_by_token(self, token: str) -> int | None:
+        """Return the task ID for a task token, if present."""
+        task = self._token_to_task.get(token)
+        return task.task_id if task is not None else None
+
+    def get_tasks(self, *, task_ids: list[int] | None = None) -> list[Task]:
+        """Return tasks matching the task IDs."""
+        if task_ids is None:
+            return list(self._token_to_task.values())
+        return [
+            task
+            for task in self._token_to_task.values()
+            if task.task_id in task_ids
+        ]
 
     def get_run_id_by_token(self, token: str) -> int | None:
         """Return the run id for a token, if present."""
@@ -97,13 +118,13 @@ def _make_non_unary_handler() -> grpc.RpcMethodHandler:
 class TestAppIoTokenClientInterceptor(TestCase):
     """Unit tests for AppIoTokenClientInterceptor."""
 
-    def test_attach_and_replace_app_token_header(self) -> None:
-        """The interceptor should enforce a single App token header."""
+    def test_attach_app_token_header(self) -> None:
+        """The interceptor should attach App token metadata."""
         interceptor = AppIoTokenClientInterceptor(token="new-token")
         details = _ClientCallDetails(
             method="/flwr.proto.ServerAppIo/GetNodes",
             timeout=None,
-            metadata=(("x-test", "value"), (APP_TOKEN_HEADER, "old-token")),
+            metadata=(("x-test", "value"),),
             credentials=None,
             wait_for_ready=None,
             compression=None,
@@ -131,14 +152,35 @@ class TestAppIoTokenClientInterceptor(TestCase):
             [(APP_TOKEN_HEADER, "new-token")],
         )
 
+    def test_raise_if_app_token_header_already_present(self) -> None:
+        """The interceptor should reject duplicate App token metadata."""
+        interceptor = AppIoTokenClientInterceptor(token="new-token")
+        details = _ClientCallDetails(
+            method="/flwr.proto.ServerAppIo/GetNodes",
+            timeout=None,
+            metadata=(("x-test", "value"), (APP_TOKEN_HEADER, "old-token")),
+            credentials=None,
+            wait_for_ready=None,
+            compression=None,
+        )
+
+        with self.assertRaises(RuntimeError):
+            interceptor.intercept_unary_unary(
+                continuation=Mock(),
+                client_call_details=details,
+                request=GetNodesRequest(run_id=1),
+            )
+
 
 class TestAppIoTokenServerInterceptor(TestCase):
     """Unit tests for AppIoTokenServerInterceptor."""
 
     def _new_interceptor(
-        self, token_to_run_id: dict[str, int]
+        self,
+        token_to_run_id: dict[str, int],
+        token_to_task: dict[str, Task] | None = None,
     ) -> AppIoTokenServerInterceptor:
-        state = _TokenState(token_to_run_id)
+        state = _TokenState(token_to_run_id, token_to_task)
         return create_serverappio_token_auth_server_interceptor(lambda: state)
 
     @staticmethod
@@ -233,6 +275,54 @@ class TestAppIoTokenServerInterceptor(TestCase):
         # cross-run use is expected.
         response = cast(str, intercepted.unary_unary(GetNodesRequest(run_id=7), Mock()))
         self.assertEqual(response, "ok")
+
+    def test_valid_task_token_passes_for_matching_run(self) -> None:
+        """Protected methods should pass with a task token for the request run."""
+        task = Task(task_id=123, run_id=7)
+        interceptor = self._new_interceptor(
+            token_to_run_id={}, token_to_task={"task-token": task}
+        )
+        method = self._find_serverappio_method(requires_token=True)
+        if method is None:
+            self.skipTest("No token-required ServerAppIo method found in policy table.")
+
+        intercepted = interceptor.intercept_service(
+            lambda _: _make_unary_handler(),
+            _HandlerCallDetails(
+                method,
+                invocation_metadata=((APP_TOKEN_HEADER, "task-token"),),
+            ),
+        )
+
+        response = cast(str, intercepted.unary_unary(GetNodesRequest(run_id=7), Mock()))
+        self.assertEqual(response, "ok")
+
+    def test_task_token_run_id_mismatch_denied_for_protected_method(self) -> None:
+        """Protected methods should deny task tokens for a different run."""
+        task = Task(task_id=123, run_id=7)
+        interceptor = self._new_interceptor(
+            token_to_run_id={}, token_to_task={"task-token": task}
+        )
+        method = self._find_serverappio_method(requires_token=True)
+        if method is None:
+            self.skipTest("No token-required ServerAppIo method found in policy table.")
+        context = Mock()
+        context.abort.side_effect = grpc.RpcError()
+
+        intercepted = interceptor.intercept_service(
+            lambda _: _make_unary_handler(),
+            _HandlerCallDetails(
+                method,
+                invocation_metadata=((APP_TOKEN_HEADER, "task-token"),),
+            ),
+        )
+
+        with self.assertRaises(grpc.RpcError):
+            intercepted.unary_unary(GetNodesRequest(run_id=8), context)
+        context.abort.assert_called_once_with(
+            grpc.StatusCode.PERMISSION_DENIED,
+            RUN_BINDING_FAILED_MESSAGE,
+        )
 
     def test_run_id_mismatch_denied_for_protected_method(self) -> None:
         """Protected methods should deny token use against a different run."""


### PR DESCRIPTION
### Motivation

- Ensure AppIo auth prefers task-token authentication while keeping the legacy run-token fallback for older callers.
- Prevent cross-run usage of tokens by strictly validating `request.run_id` against the authenticated task/run.
- Make the authenticated task available to RPC handlers and avoid silently replacing duplicate outbound token metadata.

### Description

- Updated server interceptor to first resolve a task via a task-token (supporting both `get_task_by_token` and `get_task_id_by_token`+`get_tasks` fallbacks) and, if found, authenticate the RPC as that task; otherwise fall back to the legacy `get_run_id_by_token` path.
- Centralized request run-id validation in `_validate_request_run_id` and abort with permission denied when a cross-run mismatch is detected.
- Exposed the authenticated task to handlers using a `ContextVar` and added `get_authenticated_task()` to the interceptors package and `__all__` exports.
- Changed the client interceptor to reject duplicate outbound `flwr-app-token` metadata instead of silently replacing it.
- Added compatibility and unit tests for task-token handling, run binding mismatch, and duplicate outbound token metadata, and updated `interceptors/__init__.py` to export the new helper.

### Testing

- Ran linter: `cd framework && python -m ruff check py/flwr/supercore/interceptors/appio_token_interceptor.py py/flwr/supercore/interceptors/appio_token_interceptor_test.py py/flwr/supercore/interceptors/__init__.py` (passed).
- Ran unit tests: `cd framework && PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest py/flwr/supercore/interceptors/appio_token_interceptor_test.py` (all tests passed).
- Verified syntax: `cd framework && python -m py_compile py/flwr/supercore/interceptors/appio_token_interceptor.py py/flwr/supercore/interceptors/appio_token_interceptor_test.py py/flwr/supercore/interceptors/__init__.py` (passed).
- Note: attempting the project `uv run --no-sync --python=3.10.19 ...` was blocked by the environment when downloading the referenced Python build through the proxy, so the `uv`-driven run could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ffa21f46bc832ba4f666c4fd2566d4)