### PR TITLE
feat(framework): Validate Python version range during app publish

### DIFF
--- a/framework/py/flwr/cli/app_cmd/publish.py
+++ b/framework/py/flwr/cli/app_cmd/publish.py
@@ -20,6 +20,8 @@ from pathlib import Path
 from typing import IO, Annotated, Any, cast
 
 import click
+from packaging.specifiers import InvalidSpecifier, SpecifierSet
+from packaging.version import InvalidVersion, Version
 import requests
 import typer
 from requests import Response
@@ -46,6 +48,10 @@ from ..utils import (
     load_cli_auth_plugin_from_connection,
     validate_project_name,
 )
+
+PYTHON_VERSION_MIN = Version("3.10")
+PYTHON_VERSION_MAX = Version("3.14")
+PYTHON_VERSION_NEXT = Version("3.15")
 
 
 # pylint: disable=too-many-locals
@@ -77,6 +83,7 @@ def publish(
     config, _ = load_and_validate(app / FAB_CONFIG_FILE, check_module=False)
     _validate_app_name(app.name, "Flower App directory name")
     _validate_description(config["project"].get("description", ""))
+    _validate_requires_python(config)
 
     # Collect & validate app files
     file_paths = _collect_file_paths(app)
@@ -132,6 +139,64 @@ def _validate_app_name(name: str, target: str) -> None:
         validate_project_name(name, target)
     except ValueError as err:
         raise click.ClickException(str(err)) from None
+
+
+def _validate_requires_python(config: dict[str, Any]) -> None:
+    """Validate [project].requires-python for Flower Hub publishing."""
+    requires_python = config["project"].get("requires-python")
+    if not isinstance(requires_python, str) or requires_python.strip() == "":
+        raise click.ClickException(
+            "Missing or invalid [project].requires-python. "
+            'Please set it to a range within ">=3.10,<=3.14".'
+        )
+
+    try:
+        specifier_set = SpecifierSet(requires_python)
+    except InvalidSpecifier as err:
+        raise click.ClickException(
+            "Invalid [project].requires-python: expected a valid Python version "
+            'specifier within ">=3.10,<=3.14".'
+        ) from err
+
+    lower_bounds: list[Version] = []
+    upper_bounds: list[Version] = []
+    for specifier in specifier_set:
+        try:
+            version = Version(specifier.version)
+        except InvalidVersion as err:
+            raise click.ClickException(
+                "Invalid [project].requires-python: expected valid Python versions "
+                'within ">=3.10,<=3.14".'
+            ) from err
+
+        if specifier.operator in {">=", ">", "==", "==="}:
+            lower_bounds.append(version)
+        if specifier.operator in {"<=", "<", "==", "==="}:
+            upper_bounds.append(version)
+
+    if not lower_bounds or max(lower_bounds) < PYTHON_VERSION_MIN:
+        raise click.ClickException(
+            "Invalid [project].requires-python: publishing requires a lower bound "
+            'of ">=3.10" or higher.'
+        )
+
+    if not upper_bounds:
+        raise click.ClickException(
+            "Invalid [project].requires-python: publishing requires an upper bound "
+            'of "<=3.14" or "<3.15".'
+        )
+
+    if not any(
+        specifier.operator == "<"
+        and Version(specifier.version) == PYTHON_VERSION_NEXT
+        or specifier.operator in {"<=", "==", "==="}
+        and Version(specifier.version) <= PYTHON_VERSION_MAX
+        for specifier in specifier_set
+    ):
+        raise click.ClickException(
+            "Invalid [project].requires-python: publishing requires an upper bound "
+            'of "<=3.14" or "<3.15".'
+        )
 
 
 def _detect_mime(path: Path) -> str:

--- a/framework/py/flwr/cli/app_cmd/publish.py
+++ b/framework/py/flwr/cli/app_cmd/publish.py
@@ -52,6 +52,9 @@ from ..utils import (
 PYTHON_VERSION_MIN = Version("3.10")
 PYTHON_VERSION_MAX = Version("3.14")
 PYTHON_VERSION_NEXT = Version("3.15")
+PYTHON_VERSION_RANGE = f">={PYTHON_VERSION_MIN},<={PYTHON_VERSION_MAX}"
+PYTHON_VERSION_UPPER_BOUND = f"<={PYTHON_VERSION_MAX}"
+PYTHON_VERSION_ALT_UPPER_BOUND = f"<{PYTHON_VERSION_NEXT}"
 
 
 # pylint: disable=too-many-locals
@@ -147,7 +150,7 @@ def _validate_requires_python(config: dict[str, Any]) -> None:
     if not isinstance(requires_python, str) or requires_python.strip() == "":
         raise click.ClickException(
             "Missing or invalid [project].requires-python. "
-            'Please set it to a range within ">=3.10,<=3.14".'
+            f'Please set it to a range within "{PYTHON_VERSION_RANGE}".'
         )
 
     try:
@@ -155,7 +158,7 @@ def _validate_requires_python(config: dict[str, Any]) -> None:
     except InvalidSpecifier as err:
         raise click.ClickException(
             "Invalid [project].requires-python: expected a valid Python version "
-            'specifier within ">=3.10,<=3.14".'
+            f'specifier within "{PYTHON_VERSION_RANGE}".'
         ) from err
 
     lower_bounds: list[Version] = []
@@ -166,7 +169,7 @@ def _validate_requires_python(config: dict[str, Any]) -> None:
         except InvalidVersion as err:
             raise click.ClickException(
                 "Invalid [project].requires-python: expected valid Python versions "
-                'within ">=3.10,<=3.14".'
+                f'within "{PYTHON_VERSION_RANGE}".'
             ) from err
 
         if specifier.operator in {">=", ">", "==", "==="}:
@@ -177,13 +180,14 @@ def _validate_requires_python(config: dict[str, Any]) -> None:
     if not lower_bounds or max(lower_bounds) < PYTHON_VERSION_MIN:
         raise click.ClickException(
             "Invalid [project].requires-python: publishing requires a lower bound "
-            'of ">=3.10" or higher.'
+            f'of ">={PYTHON_VERSION_MIN}" or higher.'
         )
 
     if not upper_bounds:
         raise click.ClickException(
             "Invalid [project].requires-python: publishing requires an upper bound "
-            'of "<=3.14" or "<3.15".'
+            f'of "{PYTHON_VERSION_UPPER_BOUND}" or '
+            f'"{PYTHON_VERSION_ALT_UPPER_BOUND}".'
         )
 
     if not any(
@@ -195,7 +199,8 @@ def _validate_requires_python(config: dict[str, Any]) -> None:
     ):
         raise click.ClickException(
             "Invalid [project].requires-python: publishing requires an upper bound "
-            'of "<=3.14" or "<3.15".'
+            f'of "{PYTHON_VERSION_UPPER_BOUND}" or '
+            f'"{PYTHON_VERSION_ALT_UPPER_BOUND}".'
         )
 
 

--- a/framework/py/flwr/cli/app_cmd/publish.py
+++ b/framework/py/flwr/cli/app_cmd/publish.py
@@ -20,10 +20,10 @@ from pathlib import Path
 from typing import IO, Annotated, Any, cast
 
 import click
-from packaging.specifiers import InvalidSpecifier, SpecifierSet
-from packaging.version import InvalidVersion, Version
 import requests
 import typer
+from packaging.specifiers import InvalidSpecifier, SpecifierSet
+from packaging.version import InvalidVersion, Version
 from requests import Response
 
 from flwr.cli.config_utils import load_and_validate

--- a/framework/py/flwr/cli/app_cmd/publish_test.py
+++ b/framework/py/flwr/cli/app_cmd/publish_test.py
@@ -35,6 +35,7 @@ from .publish import (
     _validate_app_name,
     _validate_description,
     _validate_files,
+    _validate_requires_python,
 )
 
 TEXT_EXT = ".py"
@@ -261,6 +262,42 @@ def test_validate_description_empty_raises() -> None:
 def test_validate_description_valid() -> None:
     """Test valid description passes validation."""
     _validate_description("A simple Flower federated learning app.")
+
+
+@pytest.mark.parametrize(
+    "requires_python",
+    [">=3.10,<=3.14", ">=3.10,<3.15", ">=3.11,<=3.14", "==3.12"],
+)
+def test_validate_requires_python_accepts_supported_ranges(
+    requires_python: str,
+) -> None:
+    """Test supported Python version ranges pass validation."""
+    _validate_requires_python({"project": {"requires-python": requires_python}})
+
+
+@pytest.mark.parametrize(
+    ("requires_python", "match"),
+    [
+        (None, "Missing or invalid"),
+        ("", "Missing or invalid"),
+        (">=3.9,<=3.14", "lower bound"),
+        (">=3.10,<4.0", "upper bound"),
+        (">=3.10", "upper bound"),
+        (">=3.10,<=3.15", "upper bound"),
+        ("not-a-specifier", "valid Python version specifier"),
+    ],
+)
+def test_validate_requires_python_rejects_unsupported_ranges(
+    requires_python: str | None,
+    match: str,
+) -> None:
+    """Test unsupported Python version ranges fail validation."""
+    project = {}
+    if requires_python is not None:
+        project["requires-python"] = requires_python
+
+    with pytest.raises(click.ClickException, match=match):
+        _validate_requires_python({"project": project})
 
 
 @pytest.mark.parametrize("value", ["app-numpy33", "App-NumPy33"])


### PR DESCRIPTION
This PR adds a publish time validation for `[project].requires-python` in `pyproject.toml` to ensure Flower Hub apps declare support within Python >=3.10,<=3.13 (the current supported versions).