### PR TITLE
ci(framework): Fix nightly binary image namespace rewrite in Docker matrix

### DIFF
--- a/.github/workflows/framework-release-nightly.yml
+++ b/.github/workflows/framework-release-nightly.yml
@@ -38,7 +38,11 @@ jobs:
 
           NAME=$(poetry version | awk {'print $1'})
           VERSION=$(poetry version -s)
-          python dev/build-docker-image-matrix.py --flwr-version "${VERSION}" --matrix nightly --flwr-package "${NAME}" > matrix.json
+          python dev/build-docker-image-matrix.py --flwr-version "${VERSION}" --matrix nightly --flwr-package "${NAME}" > matrix.raw.json
+          python dev/release/resolve-docker-matrix.py \
+            --input matrix.raw.json \
+            --output matrix.json \
+            --docker-image-namespace "${{ vars.DOCKER_IMAGE_NAMESPACE }}"
           echo "matrix=$(cat matrix.json)" >> $GITHUB_OUTPUT
 
   build-docker-base-images:

--- a/.github/workflows/framework-release-nightly.yml
+++ b/.github/workflows/framework-release-nightly.yml
@@ -22,6 +22,20 @@ jobs:
       - name: Bootstrap
         id: bootstrap
         uses: ./.github/actions/bootstrap
+      - name: Validate Docker publishing configuration
+        run: |
+          if [ -z "${{ vars.DOCKER_IMAGE_REGISTRY }}" ]; then
+            echo "Missing required configuration: DOCKER_IMAGE_REGISTRY" >&2
+            exit 1
+          fi
+          if [ -z "${{ vars.DOCKER_IMAGE_REGISTRY_USER }}" ]; then
+            echo "Missing required configuration: DOCKER_IMAGE_REGISTRY_USER" >&2
+            exit 1
+          fi
+          if [ -z "${{ vars.DOCKER_IMAGE_NAMESPACE }}" ]; then
+            echo "Missing required configuration: DOCKER_IMAGE_NAMESPACE" >&2
+            exit 1
+          fi
       - name: Release nightly
         id: release
         env:


### PR DESCRIPTION
## Summary
- route nightly docker matrix through resolve-docker-matrix
- rewrite binary image repositories to DOCKER_IMAGE_NAMESPACE before publish

## Problem
Nightly builds used matrix entries from build-docker-image-matrix directly. Binary entries are emitted as flwr/<image>, so custom namespace publishing could still push nightly binaries to the wrong namespace.

## Changes
- generate matrix.raw.json in nightly workflow
- run framework/dev/release/resolve-docker-matrix.py with --docker-image-namespace "${{ vars.DOCKER_IMAGE_NAMESPACE }}"
- publish using resolved matrix.json

Follow-up to #7086.
