### PR TITLE
ci(framework): Improve CI job name formatting

### DIFF
--- a/.github/workflows/framework-e2e.yml
+++ b/.github/workflows/framework-e2e.yml
@@ -273,7 +273,7 @@ jobs:
             "FedAvgM",
             "FedAdam",
             "FedAdagrad",
-            "FedYogi",
+            "FedYogi"
           ]
 
     name: Strategy / ${{ matrix.strat }}

--- a/.github/workflows/framework-e2e.yml
+++ b/.github/workflows/framework-e2e.yml
@@ -4,11 +4,11 @@ on:
   push:
     branches:
       - main
-      - 'release/framework-*'
+      - "release/framework-*"
   pull_request:
     branches:
       - main
-      - 'release/framework-*'
+      - "release/framework-*"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.event.pull_request.number || github.ref }}
@@ -88,12 +88,7 @@ jobs:
         exclude:
           - connection: insecure
             authentication: client-auth
-    name: |
-      Control API / 
-      Python ${{ matrix.python-version }} /
-      ${{ matrix.connection }} / 
-      ${{ matrix.authentication }} / 
-      ${{ matrix.engine }} 
+    name: Control API / Python ${{ matrix.python-version }} / ${{ matrix.connection }} /  ${{ matrix.authentication }} /  ${{ matrix.engine }}
     defaults:
       run:
         working-directory: framework/e2e/${{ matrix.directory }}
@@ -104,7 +99,7 @@ jobs:
         uses: ./.github/actions/bootstrap
         with:
           python-version: ${{ matrix.python-version }}
-          poetry-skip: 'true'
+          poetry-skip: "true"
       - name: Install Flower from repo
         if: ${{ needs.changes.outputs.framework == 'true' && (github.repository != 'flwrlabs/flower' || github.event.pull_request.head.repo.fork || github.actor == 'dependabot[bot]') }}
         working-directory: ./framework
@@ -128,7 +123,7 @@ jobs:
           Run Control API test / 
           ${{ matrix.connection }} / 
           ${{ matrix.authentication }} / 
-          ${{ matrix.engine }} 
+          ${{ matrix.engine }}
         if: ${{ needs.changes.outputs.framework == 'true' }}
         working-directory: framework/e2e/${{ matrix.directory }}
         run: ./../test_control_api.sh "${{ matrix.connection }}" "${{ matrix.authentication}}" "${{ matrix.engine }}"
@@ -204,11 +199,11 @@ jobs:
         if: ${{ needs.changes.outputs.framework == 'true' }}
         uses: actions/setup-python@v6
         with:
-          python-version: '3.10'
+          python-version: "3.10"
       - name: Install build tools
         if: ${{ needs.changes.outputs.framework == 'true' }}
         run: |
-            python -m pip install -U pip==26.0.1
+          python -m pip install -U pip==26.0.1
         shell: bash
       # Using approach described here for Python location caching:
       # https://blog.allenai.org/python-caching-in-github-actions-e9452698e98d
@@ -269,7 +264,17 @@ jobs:
     needs: [changes, wheel]
     strategy:
       matrix:
-        strat: ["FedMedian", "FedTrimmedAvg", "QFedAvg", "FaultTolerantFedAvg", "FedAvgM", "FedAdam", "FedAdagrad", "FedYogi"]
+        strat:
+          [
+            "FedMedian",
+            "FedTrimmedAvg",
+            "QFedAvg",
+            "FaultTolerantFedAvg",
+            "FedAvgM",
+            "FedAdam",
+            "FedAdagrad",
+            "FedYogi",
+          ]
 
     name: Strategy / ${{ matrix.strat }}
 
@@ -283,7 +288,7 @@ jobs:
         if: ${{ needs.changes.outputs.framework == 'true' }}
         uses: ./.github/actions/bootstrap
         with:
-          poetry-skip: 'true'
+          poetry-skip: "true"
       - name: Install dependencies
         if: ${{ needs.changes.outputs.framework == 'true' }}
         run: |
@@ -359,14 +364,13 @@ jobs:
             exit 1
           fi
 
-
   pull-app:
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     needs: [changes, wheel]
     env:
-      ACCOUNT: 'flwrlabs'
-      APP_NAME: 'numpy-ci'
+      ACCOUNT: "flwrlabs"
+      APP_NAME: "numpy-ci"
 
     name: flwr new @
 
@@ -411,12 +415,7 @@ jobs:
       matrix:
         framework: ["numpy"]
         python-version: ["3.10", "3.11", "3.12", "3.13"]
-
-    name: |
-      Build & Install /
-      Python ${{ matrix.python-version }} /
-      ${{ matrix.framework }}
-
+    name: Build & Install / Python ${{ matrix.python-version }} / ${{ matrix.framework }}
     steps:
       - uses: actions/checkout@v5
       - name: Bootstrap
@@ -424,7 +423,7 @@ jobs:
         uses: ./.github/actions/bootstrap
         with:
           python-version: ${{ matrix.python-version }}
-          poetry-skip: 'true'
+          poetry-skip: "true"
       - name: Install Flower from repo
         if: ${{ needs.changes.outputs.framework == 'true' && (github.repository != 'flwrlabs/flower' || github.event.pull_request.head.repo.fork || github.actor == 'dependabot[bot]') }}
         run: |
@@ -456,12 +455,7 @@ jobs:
         connection: [insecure]
         engine: [deployment-engine, simulation-engine]
         authentication: [no-auth]
-    name: |
-      NumPy ${{ matrix.numpy-version }} / 
-      Python ${{ matrix.python-version }} /
-      ${{ matrix.connection }} / 
-      ${{ matrix.authentication }} / 
-      ${{ matrix.engine }} 
+    name: NumPy ${{ matrix.numpy-version }} / Python ${{ matrix.python-version }} / ${{ matrix.connection }} / ${{ matrix.authentication }} / ${{ matrix.engine }}
     defaults:
       run:
         working-directory: framework/e2e/${{ matrix.directory }}
@@ -472,7 +466,7 @@ jobs:
         uses: ./.github/actions/bootstrap
         with:
           python-version: ${{ matrix.python-version }}
-          poetry-skip: 'true'
+          poetry-skip: "true"
       - name: Install Flower from repo
         if: ${{ needs.changes.outputs.framework == 'true' && (github.repository != 'flwrlabs/flower' || github.event.pull_request.head.repo.fork || github.actor == 'dependabot[bot]') }}
         working-directory: ./framework
@@ -496,7 +490,7 @@ jobs:
           Run Flower - NumPy 1.26 test / 
           ${{ matrix.connection }} / 
           ${{ matrix.authentication }} / 
-          ${{ matrix.engine }} 
+          ${{ matrix.engine }}
         if: ${{ needs.changes.outputs.framework == 'true' }}
         working-directory: framework/e2e/${{ matrix.directory }}
         run: ./../test_control_api.sh "${{ matrix.connection }}" "${{ matrix.authentication}}" "${{ matrix.engine }}"
@@ -507,7 +501,7 @@ jobs:
       PYTHONIOENCODING: utf-8
     timeout-minutes: 10
     needs: [changes, wheel]
-  
+
     name: Windows compatibility test
 
     steps:
@@ -516,7 +510,7 @@ jobs:
         if: ${{ needs.changes.outputs.framework == 'true' }}
         uses: actions/setup-python@v6
         with:
-          python-version: '3.10'
+          python-version: "3.10"
       - name: Install build tools
         if: ${{ needs.changes.outputs.framework == 'true' }}
         run: python -m pip install -U pip==26.0.1
@@ -541,11 +535,7 @@ jobs:
         python-version: ["3.10"]
 
     if: ${{ needs.changes.outputs.framework == 'true' }}
-
-    name: |
-      ServerApp/run heartbeat test with ${{ matrix.engine }} runtime /
-      Python ${{ matrix.python-version }}
-
+    name: ServerApp/run heartbeat test with ${{ matrix.engine }} runtime / Python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v5
       - name: Set up Python

--- a/.github/workflows/framework-e2e.yml
+++ b/.github/workflows/framework-e2e.yml
@@ -88,7 +88,7 @@ jobs:
         exclude:
           - connection: insecure
             authentication: client-auth
-    name: Control API / Python ${{ matrix.python-version }} / ${{ matrix.connection }} /  ${{ matrix.authentication }} /  ${{ matrix.engine }}
+    name: Control API / Python ${{ matrix.python-version }} / ${{ matrix.connection }} / ${{ matrix.authentication }} / ${{ matrix.engine }}
     defaults:
       run:
         working-directory: framework/e2e/${{ matrix.directory }}
@@ -120,9 +120,9 @@ jobs:
             python -m pip install "${WHEEL_URL}"
           fi
       - name: >
-          Run Control API test / 
-          ${{ matrix.connection }} / 
-          ${{ matrix.authentication }} / 
+          Run Control API test /
+          ${{ matrix.connection }} /
+          ${{ matrix.authentication }} /
           ${{ matrix.engine }}
         if: ${{ needs.changes.outputs.framework == 'true' }}
         working-directory: framework/e2e/${{ matrix.directory }}
@@ -487,9 +487,9 @@ jobs:
             python -m pip install "${WHEEL_URL}" "numpy>=${{ matrix.numpy-version }},<2.0"
           fi
       - name: >
-          Run Flower - NumPy 1.26 test / 
-          ${{ matrix.connection }} / 
-          ${{ matrix.authentication }} / 
+          Run Flower - NumPy 1.26 test /
+          ${{ matrix.connection }} /
+          ${{ matrix.authentication }} /
           ${{ matrix.engine }}
         if: ${{ needs.changes.outputs.framework == 'true' }}
         working-directory: framework/e2e/${{ matrix.directory }}


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/flwrlabs/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

This change improves the listing of CI jobs locally with [`act`](https://github.com/nektos/act) without impacting how CI jobs are displayed in the GitHub actions view.

<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

### Checklist

- [ ] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [ ] Address LLM-reviewer comments, if applicable (e.g., GitHub Copilot)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.ai/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
