### PR TITLE
ci(framework): Use new environment variable for PyPI publishing

### DIFF
--- a/.github/workflows/framework-release-nightly.yml
+++ b/.github/workflows/framework-release-nightly.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Release nightly
         id: release
         env:
-          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+          PYPI_REPOSITORY_PASSWORD: ${{ secrets.PYPI_REPOSITORY_PASSWORD }}
         working-directory: framework
         run: |
           RESULT=$(./dev/publish-nightly.sh)

--- a/datasets/dev/publish.sh
+++ b/datasets/dev/publish.sh
@@ -17,14 +17,8 @@
 
 set -euo pipefail
 
-missing=0
-for var in PYPI_REPOSITORY_PASSWORD; do
-  if [[ -z "${!var:-}" ]]; then
-    echo "Missing required configuration: ${var}" >&2
-    missing=1
-  fi
-done
-if [[ "${missing}" -ne 0 ]]; then
+if [[ -z "${PYPI_REPOSITORY_PASSWORD:-}" ]]; then
+  echo "Missing required configuration: PYPI_REPOSITORY_PASSWORD" >&2
   exit 1
 fi
 

--- a/datasets/dev/publish.sh
+++ b/datasets/dev/publish.sh
@@ -18,4 +18,4 @@
 set -e
 cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"/../
 
-uv publish --token "${PYPI_TOKEN}"
+uv publish --token "${PYPI_REPOSITORY_PASSWORD}"

--- a/datasets/dev/publish.sh
+++ b/datasets/dev/publish.sh
@@ -15,7 +15,19 @@
 # limitations under the License.
 # ==============================================================================
 
-set -e
+set -euo pipefail
+
+missing=0
+for var in PYPI_REPOSITORY_PASSWORD; do
+  if [[ -z "${!var:-}" ]]; then
+    echo "Missing required configuration: ${var}" >&2
+    missing=1
+  fi
+done
+if [[ "${missing}" -ne 0 ]]; then
+  exit 1
+fi
+
 cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"/../
 
 uv publish --token "${PYPI_REPOSITORY_PASSWORD}"

--- a/framework/dev/publish-nightly.sh
+++ b/framework/dev/publish-nightly.sh
@@ -17,14 +17,8 @@
 
 set -euo pipefail
 
-missing=0
-for var in PYPI_REPOSITORY_PASSWORD; do
-    if [[ -z "${!var:-}" ]]; then
-        echo "Missing required configuration: ${var}" >&2
-        missing=1
-    fi
-done
-if [[ "${missing}" -ne 0 ]]; then
+if [[ -z "${PYPI_REPOSITORY_PASSWORD:-}" ]]; then
+    echo "Missing required configuration: PYPI_REPOSITORY_PASSWORD" >&2
     exit 1
 fi
 

--- a/framework/dev/publish-nightly.sh
+++ b/framework/dev/publish-nightly.sh
@@ -15,7 +15,19 @@
 # limitations under the License.
 # ==============================================================================
 
-set -e
+set -euo pipefail
+
+missing=0
+for var in PYPI_REPOSITORY_PASSWORD; do
+    if [[ -z "${!var:-}" ]]; then
+        echo "Missing required configuration: ${var}" >&2
+        missing=1
+    fi
+done
+if [[ "${missing}" -ne 0 ]]; then
+    exit 1
+fi
+
 cd "$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"/../
 
 # This script will build and publish a nightly release of Flower under the condition

--- a/framework/dev/publish-nightly.sh
+++ b/framework/dev/publish-nightly.sh
@@ -29,7 +29,7 @@ if [[ $(git log --since="24 hours ago" --pretty=oneline) ]]; then
     sed -i -E "s/^name = \"(.+)\"/name = \"\1-nightly\"/" pyproject.toml
     sed -i -E "s/^version = \"(.+)\"/version = \"\1.dev$(date '+%Y%m%d')\"/" pyproject.toml
     python -m poetry build
-    python -m poetry publish -u __token__ -p $PYPI_TOKEN
+    python -m poetry publish -u __token__ -p "${PYPI_REPOSITORY_PASSWORD}"
 else
     echo "There were no commits in the last 24 hours."
 fi


### PR DESCRIPTION
## Summary

- Replace the old `PYPI_TOKEN` secret/env usage with `PYPI_REPOSITORY_PASSWORD` in PyPI publish paths.
- Keep the nightly framework workflow aligned with the existing stable release secret name.
- Update the dataset publish helper to use the same repository password env var.

This intentionally excludes the local act workflow/profile changes from the other workstream.

## Validation

- `rg -n -i "pypi[_-]?token|PYPI_TOKEN" .` returned no matches in the isolated PR worktree.
- `bash -n framework/dev/publish-nightly.sh datasets/dev/publish.sh`
- `git diff --check`