### PR TITLE
refactor(framework): Introduce select lock clause hook

### DIFF
--- a/framework/py/flwr/server/superlink/linkstate/linkstate_test.py
+++ b/framework/py/flwr/server/superlink/linkstate/linkstate_test.py
@@ -1972,6 +1972,26 @@ class SqlInMemoryStateTest(StateTest, unittest.TestCase):
         self.assertIn("ORDER BY created_at, message_id", captured[0])
         self.assertNotIn("rowid", captured[0])
 
+    def test_message_ins_claim_can_append_select_lock_clause(self) -> None:
+        """Message claiming can append a subclass-provided row-locking clause."""
+        state = self.state_factory()
+        captured: list[str] = []
+
+        # pylint: disable-next=unused-argument
+        def fake_query(query: str, data: Any = None) -> list[dict[str, Any]]:
+            captured.append(query)
+            return []
+
+        state.query = fake_query  # type: ignore[method-assign]
+        state._claim_message_ins_rows(1, 3)  # pylint: disable=protected-access
+        self.assertNotIn("FOR TEST LOCK", captured[0])
+
+        state._claim_message_ins_select_lock_clause = (  # pylint: disable=protected-access
+            "FOR TEST LOCK"
+        )
+        state._claim_message_ins_rows(1, 3)  # pylint: disable=protected-access
+        self.assertIn("FOR TEST LOCK", captured[1])
+
     def test_token_expiry_does_not_overwrite_finished_completed_run(self) -> None:
         """Ensure token cleanup doesn't mutate terminal COMPLETED status."""
         # Prepare

--- a/framework/py/flwr/server/superlink/linkstate/linkstate_test.py
+++ b/framework/py/flwr/server/superlink/linkstate/linkstate_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 """Tests all LinkState implemenations have to conform to."""
+
 # pylint: disable=invalid-name, too-many-lines, R0904, R0913
 
 
@@ -1974,23 +1975,28 @@ class SqlInMemoryStateTest(StateTest, unittest.TestCase):
 
     def test_message_ins_claim_can_append_select_lock_clause(self) -> None:
         """Message claiming can append a subclass-provided row-locking clause."""
+        # Prepare
         state = self.state_factory()
-        captured: list[str] = []
+        last_query = ""
 
         # pylint: disable-next=unused-argument
         def fake_query(query: str, data: Any = None) -> list[dict[str, Any]]:
-            captured.append(query)
+            nonlocal last_query
+            last_query = query
             return []
 
         state.query = fake_query  # type: ignore[method-assign]
-        state._claim_message_ins_rows(1, 3)  # pylint: disable=protected-access
-        self.assertNotIn("FOR TEST LOCK", captured[0])
 
+        # Execute & assert - without lock clause
+        state._claim_message_ins_rows(1, 3)  # pylint: disable=protected-access
+        self.assertNotIn("FOR TEST LOCK", last_query)
+
+        # Execute & assert - with lock clause
         state._claim_message_ins_select_lock_clause = (  # pylint: disable=protected-access
             "FOR TEST LOCK"
         )
         state._claim_message_ins_rows(1, 3)  # pylint: disable=protected-access
-        self.assertIn("FOR TEST LOCK", captured[1])
+        self.assertIn("FOR TEST LOCK", last_query)
 
     def test_token_expiry_does_not_overwrite_finished_completed_run(self) -> None:
         """Ensure token cleanup doesn't mutate terminal COMPLETED status."""

--- a/framework/py/flwr/server/superlink/linkstate/linkstate_test.py
+++ b/framework/py/flwr/server/superlink/linkstate/linkstate_test.py
@@ -29,7 +29,7 @@ from abc import abstractmethod
 from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
 from typing import Any
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, PropertyMock, patch
 from uuid import uuid4
 
 from parameterized import parameterized
@@ -1991,10 +1991,13 @@ class SqlInMemoryStateTest(StateTest, unittest.TestCase):
         self.assertNotIn("FOR TEST LOCK", last_query)
 
         # Execute & assert - with lock clause
-        state._claim_message_ins_select_lock_clause = (  # pylint: disable=protected-access
-            "FOR TEST LOCK"
-        )
-        state._claim_message_ins_rows(1, 3)  # pylint: disable=protected-access
+        with patch.object(
+            type(state),
+            "select_lock_sql",
+            new_callable=PropertyMock,
+            return_value="FOR TEST LOCK",
+        ):
+            state._claim_message_ins_rows(1, 3)  # pylint: disable=protected-access
         self.assertIn("FOR TEST LOCK", last_query)
 
     def test_token_expiry_does_not_overwrite_finished_completed_run(self) -> None:

--- a/framework/py/flwr/server/superlink/linkstate/linkstate_test.py
+++ b/framework/py/flwr/server/superlink/linkstate/linkstate_test.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 """Tests all LinkState implemenations have to conform to."""
-
 # pylint: disable=invalid-name, too-many-lines, R0904, R0913
 
 

--- a/framework/py/flwr/server/superlink/linkstate/sql_linkstate.py
+++ b/framework/py/flwr/server/superlink/linkstate/sql_linkstate.py
@@ -84,7 +84,10 @@ PRIMARY_TASK_STATUS_CONDITIONS = {
 class SqlLinkState(LinkState, SqlCoreState):  # pylint: disable=R0904
     """SQLAlchemy-based LinkState implementation."""
 
-    _claim_message_ins_select_lock_clause = ""
+    @property
+    def select_lock_sql(self) -> str:
+        """Return the SQL clause for row-locking, which is overridable by subclasses."""
+        return ""
 
     def __init__(
         self,
@@ -329,23 +332,18 @@ class SqlLinkState(LinkState, SqlCoreState):  # pylint: disable=R0904
         candidate_cte = ""
         condition = common_condition
         if limit is not None:
-            # Optional clause for backends that support row-locking while selecting
-            # candidates. Keep it before LIMIT so locked rows are skipped before
-            # limiting the result set.
-            select_lock_sql = (
-                f" {self._claim_message_ins_select_lock_clause}"
-                if self._claim_message_ins_select_lock_clause
-                else ""
-            )
             # Materialize limited candidates before updating. Some backends can
             # otherwise re-evaluate same-table subqueries while UPDATE scans rows.
+            # `self.select_lock_sql` is an optional clause for backends that support
+            # row-locking while selecting candidates. Keep it before LIMIT so locked
+            # rows are skipped before limiting the result set.
             candidate_cte = f"""
                 WITH candidate_message_ins AS (
                     SELECT message_id
                     FROM message_ins
                     WHERE {common_condition}
                     ORDER BY created_at, message_id
-                    {select_lock_sql}
+                    {self.select_lock_sql}
                     LIMIT :limit
                 )
             """

--- a/framework/py/flwr/server/superlink/linkstate/sql_linkstate.py
+++ b/framework/py/flwr/server/superlink/linkstate/sql_linkstate.py
@@ -328,10 +328,10 @@ class SqlLinkState(LinkState, SqlCoreState):  # pylint: disable=R0904
         """
         condition = common_condition
         if limit is not None:
-            select_lock_clause = self._claim_message_ins_select_lock_clause
+            # Optional clause appended to the limited candidate SELECT.
             select_lock_sql = (
-                f"\n                    {select_lock_clause}"
-                if select_lock_clause
+                f" {self._claim_message_ins_select_lock_clause}"
+                if self._claim_message_ins_select_lock_clause
                 else ""
             )
             condition = f"""

--- a/framework/py/flwr/server/superlink/linkstate/sql_linkstate.py
+++ b/framework/py/flwr/server/superlink/linkstate/sql_linkstate.py
@@ -84,6 +84,8 @@ PRIMARY_TASK_STATUS_CONDITIONS = {
 class SqlLinkState(LinkState, SqlCoreState):  # pylint: disable=R0904
     """SQLAlchemy-based LinkState implementation."""
 
+    _claim_message_ins_select_lock_clause = ""
+
     def __init__(
         self,
         database_path: str,
@@ -326,13 +328,19 @@ class SqlLinkState(LinkState, SqlCoreState):  # pylint: disable=R0904
         """
         condition = common_condition
         if limit is not None:
+            select_lock_clause = self._claim_message_ins_select_lock_clause
+            select_lock_sql = (
+                f"\n                    {select_lock_clause}"
+                if select_lock_clause
+                else ""
+            )
             condition = f"""
                 message_id IN (
                     SELECT message_id
                     FROM message_ins
                     WHERE {common_condition}
                     ORDER BY created_at, message_id
-                    LIMIT :limit
+                    LIMIT :limit{select_lock_sql}
                 )
                 AND delivered_at = ''
             """

--- a/framework/py/flwr/server/superlink/linkstate/sql_linkstate.py
+++ b/framework/py/flwr/server/superlink/linkstate/sql_linkstate.py
@@ -326,27 +326,39 @@ class SqlLinkState(LinkState, SqlCoreState):  # pylint: disable=R0904
             AND delivered_at = ''
             AND (created_at + ttl) > :current
         """
+        candidate_cte = ""
         condition = common_condition
         if limit is not None:
-            # Optional clause appended to the limited candidate SELECT.
+            # Optional clause for backends that support row-locking while selecting
+            # candidates. Keep it before LIMIT so locked rows are skipped before
+            # limiting the result set.
             select_lock_sql = (
                 f" {self._claim_message_ins_select_lock_clause}"
                 if self._claim_message_ins_select_lock_clause
                 else ""
             )
-            condition = f"""
-                message_id IN (
+            # Materialize limited candidates before updating. Some backends can
+            # otherwise re-evaluate same-table subqueries while UPDATE scans rows.
+            candidate_cte = f"""
+                WITH candidate_message_ins AS (
                     SELECT message_id
                     FROM message_ins
                     WHERE {common_condition}
                     ORDER BY created_at, message_id
-                    LIMIT :limit{select_lock_sql}
+                    {select_lock_sql}
+                    LIMIT :limit
+                )
+            """
+            condition = """
+                message_id IN (
+                    SELECT message_id FROM candidate_message_ins
                 )
                 AND delivered_at = ''
             """
             params["limit"] = limit
 
         query = f"""
+            {candidate_cte}
             UPDATE message_ins
             SET delivered_at = :delivered_at
             WHERE {condition}


### PR DESCRIPTION
### Description

Limited message claiming can update more rows than intended when the `UPDATE` uses a same-table subquery with `LIMIT`.

### Proposal

Use a Common Table Expression (CTE) to select the limited candidate rows first, then update only those rows. This makes the candidate set stable before the `UPDATE` runs.
