### PR TITLE
refactor(framework): Remove `.create_task` overrides in `LinkState` and `NodeState`

### DIFF
--- a/framework/py/flwr/server/superlink/linkstate/in_memory_linkstate.py
+++ b/framework/py/flwr/server/superlink/linkstate/in_memory_linkstate.py
@@ -100,29 +100,6 @@ class InMemoryLinkState(LinkState, InMemoryCoreState):  # pylint: disable=R0902,
         """Get the FederationManager instance."""
         return self._federation_manager
 
-    def create_task(  # pylint: disable=too-many-arguments,too-many-positional-arguments
-        self,
-        task_type: str,
-        run_id: int,
-        fab_hash: str | None = None,
-        model_ref: str | None = None,
-        connector_ref: str | None = None,
-    ) -> int | None:
-        """Create a task."""
-        with self.lock:
-            if run_id not in self.run_ids:
-                raise RuntimeError(
-                    f"Run {run_id} not found. create_task requires an existing run."
-                )
-
-            return super().create_task(
-                task_type=task_type,
-                run_id=run_id,
-                fab_hash=fab_hash,
-                model_ref=model_ref,
-                connector_ref=connector_ref,
-            )
-
     def _get_run(self, run_id: int) -> Run:
         """Return run metadata with lifecycle fields from its primary task."""
         run = self.run_ids[run_id].run

--- a/framework/py/flwr/server/superlink/linkstate/linkstate_test.py
+++ b/framework/py/flwr/server/superlink/linkstate/linkstate_test.py
@@ -176,16 +176,6 @@ class StateTest(CoreStateTest):
         self.assertEqual(tasks[0].type, TaskType.SERVER_APP)
         self.assertEqual(run.primary_task_id, tasks[0].task_id)
 
-    def test_create_task_rejects_missing_run(self) -> None:
-        """Creating a task for an unknown run should fail."""
-        state = self.state_factory()
-
-        with self.assertRaisesRegex(
-            RuntimeError,
-            "Run 42 not found. create_task requires an existing run.",
-        ):
-            state.create_task(task_type="flwr-model", run_id=42)
-
     def test_get_run_info_without_filters_returns_all_runs(self) -> None:
         """Test get_run_info returns all runs when no filter is provided."""
         # Prepare

--- a/framework/py/flwr/server/superlink/linkstate/sql_linkstate.py
+++ b/framework/py/flwr/server/superlink/linkstate/sql_linkstate.py
@@ -116,33 +116,6 @@ class SqlLinkState(LinkState, SqlCoreState):  # pylint: disable=R0904
         """Return the FederationManager instance."""
         return self._federation_manager
 
-    def create_task(  # pylint: disable=too-many-arguments,too-many-positional-arguments
-        self,
-        task_type: str,
-        run_id: int,
-        fab_hash: str | None = None,
-        model_ref: str | None = None,
-        connector_ref: str | None = None,
-    ) -> int | None:
-        """Create a task."""
-        with self.session():
-            if not self.query(
-                "SELECT run_id FROM run WHERE run_id = :run_id",
-                {"run_id": uint64_to_int64(run_id)},
-            ):
-                raise RuntimeError(
-                    f"Run {run_id} not found. create_task requires an existing run."
-                )
-
-            task_id = super().create_task(
-                task_type=task_type,
-                run_id=run_id,
-                fab_hash=fab_hash,
-                model_ref=model_ref,
-                connector_ref=connector_ref,
-            )
-            return task_id
-
     def store_message_ins(self, message: Message) -> str | None:
         """Store one Message."""
         # Validate message


### PR DESCRIPTION
The `run_id` is retrieved from authenticated task identity and there's no need to double check run ID in the `.create_task` methods. Removed the overrides to simplify the structure and make `LinkState` and `NodeState` more unified.