### PR TITLE
ci(framework): Allow configurable Python publish repositories

### DIFF
--- a/.github/workflows/framework-release-nightly.yml
+++ b/.github/workflows/framework-release-nightly.yml
@@ -40,6 +40,9 @@ jobs:
         id: release
         env:
           PYPI_REPOSITORY_PASSWORD: ${{ secrets.PYPI_REPOSITORY_PASSWORD }}
+          PYPI_REPOSITORY_URL: ${{ vars.PYPI_REPOSITORY_URL }}
+          PYPI_REPOSITORY_NAME: ${{ vars.PYPI_REPOSITORY_NAME }}
+          PYPI_REPOSITORY_USERNAME: ${{ vars.PYPI_REPOSITORY_USERNAME }}
         working-directory: framework
         run: |
           RESULT=$(./dev/publish-nightly.sh)

--- a/.github/workflows/framework-release.yml
+++ b/.github/workflows/framework-release.yml
@@ -22,6 +22,10 @@ on:
         description: "Docker image namespace. Defaults to vars.DOCKER_IMAGE_NAMESPACE."
         required: false
         default: ""
+      pypi-repository-url:
+        description: "Python package repository URL. Defaults to PyPI."
+        required: false
+        default: ""
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -59,6 +63,8 @@ jobs:
         env:
           PACKAGE_VERSION: ${{ inputs.package-version }}
           PYPI_REPOSITORY_USERNAME: ${{ vars.PYPI_REPOSITORY_USERNAME }}
+          PYPI_REPOSITORY_URL: ${{ inputs.pypi-repository-url || vars.PYPI_REPOSITORY_URL }}
+          PYPI_REPOSITORY_NAME: ${{ vars.PYPI_REPOSITORY_NAME }}
         run: ./framework/dev/release/publish-wheel.sh
 
   prepare-docker-build-matrix:

--- a/framework/dev/publish-nightly.sh
+++ b/framework/dev/publish-nightly.sh
@@ -15,27 +15,44 @@
 # limitations under the License.
 # ==============================================================================
 
+# Fail as soon as a command errors, an unset variable is used, or a pipeline fails.
 set -euo pipefail
 
+# The password/token is required. The username is optional because token-based
+# repositories commonly use "__token__", which this script provides by default.
 if [[ -z "${PYPI_REPOSITORY_PASSWORD:-}" ]]; then
     echo "Missing required configuration: PYPI_REPOSITORY_PASSWORD" >&2
     exit 1
 fi
 
+# Move from framework/dev to framework so Poetry can find pyproject.toml.
 cd "$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"/../
 
-# This script will build and publish a nightly release of Flower under the condition
-# that at least one commit was made in the last 24 hours.
-# It will rename the package name in the pyproject.toml to from "flwr" to "flwr-nightly".
-# The version name in the pyproject.toml will be appended with "-dev" and the current date.
-# The result will be a release on PyPi of the package "flwr-nightly" of version e.g.
-# "0.1.1.dev20200716" as seen at https://pypi.org/project/flwr-nightly/
-
+# Nightlies are only published if there was repository activity in the last 24
+# hours. The CI checkout is disposable, so it is safe to rewrite pyproject.toml
+# before building: "flwr" becomes "flwr-nightly" and the current date is appended
+# to the version, for example "1.2.3.dev20260514".
 if [[ $(git log --since="24 hours ago" --pretty=oneline) ]]; then
     sed -i -E "s/^name = \"(.+)\"/name = \"\1-nightly\"/" pyproject.toml
     sed -i -E "s/^version = \"(.+)\"/version = \"\1.dev$(date '+%Y%m%d')\"/" pyproject.toml
+
+    # Build both publishable Python artifacts from the rewritten metadata.
     python -m poetry build
-    python -m poetry publish -u __token__ -p "${PYPI_REPOSITORY_PASSWORD}"
+
+    # Store publish options in an array so usernames, passwords, and URLs are
+    # passed to Poetry as separate arguments even if they contain shell metacharacters.
+    publish_args=(-u "${PYPI_REPOSITORY_USERNAME:-__token__}" -p "${PYPI_REPOSITORY_PASSWORD}")
+    if [[ -n "${PYPI_REPOSITORY_URL:-}" ]]; then
+        # When a repository URL is configured, register it with Poetry and
+        # publish there instead of using Poetry's default PyPI endpoint.
+        repository_name="${PYPI_REPOSITORY_NAME:-act}"
+        python -m poetry config "repositories.${repository_name}" "${PYPI_REPOSITORY_URL}"
+        publish_args=(-r "${repository_name}" "${publish_args[@]}")
+    fi
+
+    # Poetry only builds when --build is passed, so this publishes the artifacts
+    # from the explicit build step above instead of rebuilding them.
+    python -m poetry publish --dist-dir dist "${publish_args[@]}"
 else
     echo "There were no commits in the last 24 hours."
 fi

--- a/framework/dev/release/publish-wheel.sh
+++ b/framework/dev/release/publish-wheel.sh
@@ -15,8 +15,10 @@
 # limitations under the License.
 # ==============================================================================
 
+# Fail as soon as a command errors, an unset variable is used, or a pipeline fails.
 set -euo pipefail
 
+# Check all required configuration up front so CI prints every missing value in one run.
 missing=0
 for var in PYPI_REPOSITORY_USERNAME PYPI_REPOSITORY_PASSWORD; do
   if [[ -z "${!var:-}" ]]; then
@@ -24,10 +26,14 @@ for var in PYPI_REPOSITORY_USERNAME PYPI_REPOSITORY_PASSWORD; do
     missing=1
   fi
 done
+
 if [[ "${missing}" -ne 0 ]]; then
   exit 1
 fi
 
+# Resolve the release version. In tests, PACKAGE_VERSION can be set directly. In
+# release CI, tags look like "framework-1.2.3" and need the "framework-" prefix
+# removed. Local/manual runs fall back to the version from pyproject.toml.
 if [[ -n "${PACKAGE_VERSION:-}" ]]; then
   tag_name="${PACKAGE_VERSION}"
 elif [[ "${GITHUB_REF_NAME:-}" == framework-* ]]; then
@@ -36,7 +42,11 @@ else
   tag_name=$(cd framework && python -m poetry version --short)
 fi
 
+# Make the resolved version available to later GitHub Actions steps.
 echo "flwr-version=${tag_name}" >> "${GITHUB_OUTPUT}"
+
+# The release artifacts are built elsewhere. This job downloads the wheel and
+# source distribution for the resolved version, then publishes those exact files.
 wheel_name="flwr-${tag_name}-py3-none-any.whl"
 tar_name="flwr-${tag_name}.tar.gz"
 wheel_url="https://artifact.flower.ai/py/release/v${tag_name}/${wheel_name}"
@@ -46,4 +56,18 @@ mkdir -p framework/dist
 curl --fail --location --silent --show-error "${wheel_url}" --output "framework/dist/${wheel_name}"
 curl --fail --location --silent --show-error "${tar_url}" --output "framework/dist/${tar_name}"
 
-(cd framework && python -m poetry publish -u "${PYPI_REPOSITORY_USERNAME}" -p "${PYPI_REPOSITORY_PASSWORD}")
+# Store publish options in an array so usernames, passwords, and URLs are passed
+# to Poetry as separate arguments even if they contain special shell characters.
+publish_args=(-u "${PYPI_REPOSITORY_USERNAME}" -p "${PYPI_REPOSITORY_PASSWORD}")
+if [[ -n "${PYPI_REPOSITORY_URL:-}" ]]; then
+  # When a repository URL is configured, register it with Poetry and publish
+  # there instead of using Poetry's default PyPI endpoint.
+  repository_name="${PYPI_REPOSITORY_NAME:-act}"
+  (cd framework && python -m poetry config "repositories.${repository_name}" "${PYPI_REPOSITORY_URL}")
+  publish_args=(-r "${repository_name}" "${publish_args[@]}")
+fi
+
+# Run Poetry from the framework directory because pyproject.toml lives there.
+# Poetry only builds when --build is passed, so this publishes the downloaded
+# artifacts from dist instead of rebuilding them.
+(cd framework && python -m poetry publish --dist-dir dist "${publish_args[@]}")


### PR DESCRIPTION
## Summary

Adds an explicit way for framework release and nightly publish jobs to publish Python packages to a non-default Poetry repository when requested.

By default, behavior remains unchanged: if `PYPI_REPOSITORY_URL` is unset, the scripts still call `poetry publish` against Poetry's default repository configuration.

## Reasoning

The local `act` smoke-test harness can validate workflow wiring with dry-runs, but real publish-job validation needs disposable external targets. Docker publishing already supports alternate registries through workflow inputs and repository variables. Python package publishing did not: both release scripts published to Poetry's default package repository.

That meant a local or manual test had only two choices:

- use `--dryrun`, which validates wiring but not the actual package upload path, or
- run against the default package repository, which is not safe for disposable validation.

This PR adds a small opt-in path for TestPyPI/devpi/staging package registries while keeping production behavior stable.

## Changes

- Adds optional `pypi-repository-url` workflow dispatch input for framework releases.
- Passes `PYPI_REPOSITORY_URL`, `PYPI_REPOSITORY_NAME`, and `PYPI_REPOSITORY_USERNAME` into release/nightly scripts from repository variables.
- Configures a named Poetry repository only when `PYPI_REPOSITORY_URL` is set.
- Keeps the existing default publish behavior when no repository URL override is configured.

## Validation

- `bash -n framework/dev/release/publish-wheel.sh framework/dev/publish-nightly.sh`

No real package publish was run.