### PR TITLE
feat(framework): Add MeaMed aggregation strategy

### DIFF
--- a/framework/py/flwr/server/strategy/__init__.py
+++ b/framework/py/flwr/server/strategy/__init__.py
@@ -38,6 +38,7 @@ from .fedavg_android import FedAvgAndroid as FedAvgAndroid
 from .fedavgm import FedAvgM as FedAvgM
 from .fedmedian import FedMedian as FedMedian
 from .fedopt import FedOpt as FedOpt
+from .meamed import MeaMed as MeaMed
 from .fedprox import FedProx as FedProx
 from .fedtrimmedavg import FedTrimmedAvg as FedTrimmedAvg
 from .fedxgb_bagging import FedXgbBagging as FedXgbBagging
@@ -71,6 +72,7 @@ __all__ = [
     "FedXgbNnAvg",
     "FedYogi",
     "Krum",
+    "MeaMed",
     "QFedAvg",
     "Strategy",
 ]

--- a/framework/py/flwr/server/strategy/meamed.py
+++ b/framework/py/flwr/server/strategy/meamed.py
@@ -1,0 +1,156 @@
+# Copyright 2025 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Mean-around-Median (MeaMed) [Xie et al., 2018] strategy.
+
+Paper: arxiv.org/abs/1802.10116
+"""
+
+from collections.abc import Callable
+from logging import WARNING
+
+from flwr.common import (
+    FitRes,
+    MetricsAggregationFn,
+    NDArrays,
+    Parameters,
+    Scalar,
+    ndarrays_to_parameters,
+    parameters_to_ndarrays,
+)
+from flwr.common.logger import log
+from flwr.server.client_proxy import ClientProxy
+
+from .aggregate import _aggregate_n_closest_weights, aggregate_median
+from .fedavg import FedAvg
+
+
+# pylint: disable=line-too-long
+class MeaMed(FedAvg):
+    """Mean-around-Median (MeaMed) [Xie et al., 2018] strategy.
+
+    Implemented based on: https://arxiv.org/abs/1802.10116
+
+    MeaMed is a Byzantine-resilient aggregation strategy. It first computes
+    the coordinate-wise median, then averages the `num_closest` values closest
+    to that median for each coordinate.
+
+    Parameters
+    ----------
+    fraction_fit : float, optional
+        Fraction of clients used during training. Defaults to 1.0.
+    fraction_evaluate : float, optional
+        Fraction of clients used during validation. Defaults to 1.0.
+    min_fit_clients : int, optional
+        Minimum number of clients used during training. Defaults to 2.
+    min_evaluate_clients : int, optional
+        Minimum number of clients used during validation. Defaults to 2.
+    min_available_clients : int, optional
+        Minimum number of total clients in the system. Defaults to 2.
+    evaluate_fn : Optional[Callable[[int, NDArrays, Dict[str, Scalar]], Optional[Tuple[float, Dict[str, Scalar]]]]]
+        Optional function used for validation. Defaults to None.
+    on_fit_config_fn : Callable[[int], Dict[str, Scalar]], optional
+        Function used to configure training. Defaults to None.
+    on_evaluate_config_fn : Callable[[int], Dict[str, Scalar]], optional
+        Function used to configure validation. Defaults to None.
+    accept_failures : bool, optional
+        Whether or not accept rounds containing failures. Defaults to True.
+    initial_parameters : Parameters, optional
+        Initial global model parameters.
+    num_closest : int, optional
+        Number of closest values to the median to average. Defaults to 2.
+    """
+
+    # pylint: disable=too-many-arguments,too-many-instance-attributes, line-too-long
+    def __init__(
+        self,
+        *,
+        fraction_fit: float = 1.0,
+        fraction_evaluate: float = 1.0,
+        min_fit_clients: int = 2,
+        min_evaluate_clients: int = 2,
+        min_available_clients: int = 2,
+        evaluate_fn: (
+            Callable[
+                [int, NDArrays, dict[str, Scalar]],
+                tuple[float, dict[str, Scalar]] | None,
+            ]
+            | None
+        ) = None,
+        on_fit_config_fn: Callable[[int], dict[str, Scalar]] | None = None,
+        on_evaluate_config_fn: Callable[[int], dict[str, Scalar]] | None = None,
+        accept_failures: bool = True,
+        initial_parameters: Parameters | None = None,
+        fit_metrics_aggregation_fn: MetricsAggregationFn | None = None,
+        evaluate_metrics_aggregation_fn: MetricsAggregationFn | None = None,
+        num_closest: int = 2,
+    ) -> None:
+        super().__init__(
+            fraction_fit=fraction_fit,
+            fraction_evaluate=fraction_evaluate,
+            min_fit_clients=min_fit_clients,
+            min_evaluate_clients=min_evaluate_clients,
+            min_available_clients=min_available_clients,
+            evaluate_fn=evaluate_fn,
+            on_fit_config_fn=on_fit_config_fn,
+            on_evaluate_config_fn=on_evaluate_config_fn,
+            accept_failures=accept_failures,
+            initial_parameters=initial_parameters,
+            fit_metrics_aggregation_fn=fit_metrics_aggregation_fn,
+            evaluate_metrics_aggregation_fn=evaluate_metrics_aggregation_fn,
+        )
+        self.num_closest = num_closest
+
+    def __repr__(self) -> str:
+        """Compute a string representation of the strategy."""
+        rep = f"MeaMed(accept_failures={self.accept_failures})"
+        return rep
+
+    def aggregate_fit(
+        self,
+        server_round: int,
+        results: list[tuple[ClientProxy, FitRes]],
+        failures: list[tuple[ClientProxy, FitRes] | BaseException],
+    ) -> tuple[Parameters | None, dict[str, Scalar]]:
+        """Aggregate fit results using mean-around-median."""
+        if not results:
+            return None, {}
+        # Do not aggregate if there are failures and failures are not accepted
+        if not self.accept_failures and failures:
+            return None, {}
+
+        # Convert results
+        weights_results = [
+            (parameters_to_ndarrays(fit_res.parameters), fit_res.num_examples)
+            for _, fit_res in results
+        ]
+
+        # Step 1: Compute coordinate-wise median
+        median_weights = aggregate_median(weights_results)
+        # Step 2+3: Select num_closest values to median and average them
+        parameters_aggregated = ndarrays_to_parameters(
+            _aggregate_n_closest_weights(
+                median_weights, weights_results, self.num_closest
+            )
+        )
+
+        # Aggregate custom metrics if aggregation fn was provided
+        metrics_aggregated = {}
+        if self.fit_metrics_aggregation_fn:
+            fit_metrics = [(res.num_examples, res.metrics) for _, res in results]
+            metrics_aggregated = self.fit_metrics_aggregation_fn(fit_metrics)
+        elif server_round == 1:  # Only log this warning once
+            log(WARNING, "No fit_metrics_aggregation_fn provided")
+
+        return parameters_aggregated, metrics_aggregated

--- a/framework/py/flwr/server/strategy/meamed_test.py
+++ b/framework/py/flwr/server/strategy/meamed_test.py
@@ -1,0 +1,202 @@
+# Copyright 2025 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""MeaMed tests."""
+
+
+from numpy import array, float32
+
+from flwr.common import (
+    Code,
+    FitRes,
+    NDArrays,
+    Parameters,
+    Status,
+    ndarrays_to_parameters,
+    parameters_to_ndarrays,
+)
+from flwr.server.client_manager_test import TestClientProxy
+from flwr.server.client_proxy import ClientProxy
+
+from .meamed import MeaMed
+
+
+def test_meamed_num_fit_clients_20_available() -> None:
+    """Test num_fit_clients function."""
+    # Prepare
+    strategy = MeaMed()
+    expected = 20
+
+    # Execute
+    actual, _ = strategy.num_fit_clients(num_available_clients=20)
+
+    # Assert
+    assert expected == actual
+
+
+def test_meamed_num_fit_clients_19_available() -> None:
+    """Test num_fit_clients function."""
+    # Prepare
+    strategy = MeaMed()
+    expected = 19
+
+    # Execute
+    actual, _ = strategy.num_fit_clients(num_available_clients=19)
+
+    # Assert
+    assert expected == actual
+
+
+def test_meamed_num_fit_clients_10_available() -> None:
+    """Test num_fit_clients function."""
+    # Prepare
+    strategy = MeaMed()
+    expected = 10
+
+    # Execute
+    actual, _ = strategy.num_fit_clients(num_available_clients=10)
+
+    # Assert
+    assert expected == actual
+
+
+def test_meamed_num_fit_clients_minimum() -> None:
+    """Test num_fit_clients function."""
+    # Prepare
+    strategy = MeaMed()
+    expected = 9
+
+    # Execute
+    actual, _ = strategy.num_fit_clients(num_available_clients=9)
+
+    # Assert
+    assert expected == actual
+
+
+def test_meamed_num_evaluation_clients_40_available() -> None:
+    """Test num_evaluation_clients function."""
+    # Prepare
+    strategy = MeaMed(fraction_evaluate=0.05)
+    expected = 2
+
+    # Execute
+    actual, _ = strategy.num_evaluation_clients(num_available_clients=40)
+
+    # Assert
+    assert expected == actual
+
+
+def test_meamed_num_evaluation_clients_39_available() -> None:
+    """Test num_evaluation_clients function."""
+    # Prepare
+    strategy = MeaMed(fraction_evaluate=0.05)
+    expected = 2
+
+    # Execute
+    actual, _ = strategy.num_evaluation_clients(num_available_clients=39)
+
+    # Assert
+    assert expected == actual
+
+
+def test_meamed_num_evaluation_clients_20_available() -> None:
+    """Test num_evaluation_clients function."""
+    # Prepare
+    strategy = MeaMed(fraction_evaluate=0.05)
+    expected = 2
+
+    # Execute
+    actual, _ = strategy.num_evaluation_clients(num_available_clients=20)
+
+    # Assert
+    assert expected == actual
+
+
+def test_meamed_num_evaluation_clients_minimum() -> None:
+    """Test num_evaluation_clients function."""
+    # Prepare
+    strategy = MeaMed(fraction_evaluate=0.05)
+    expected = 2
+
+    # Execute
+    actual, _ = strategy.num_evaluation_clients(num_available_clients=19)
+
+    # Assert
+    assert expected == actual
+
+
+def test_aggregate_fit() -> None:
+    """Tests if MeaMed is aggregating correctly.
+
+    With values [0.2, 1.0, 0.5], the median is 0.5.
+    With num_closest=2, the 2 closest to 0.5 are 0.2 and 0.5.
+    Their mean is 0.35.
+    """
+    # Prepare
+    previous_weights: NDArrays = [array([0.1, 0.1, 0.1, 0.1], dtype=float32)]
+    strategy = MeaMed(
+        initial_parameters=ndarrays_to_parameters(previous_weights),
+        num_closest=2,
+    )
+    param_0: Parameters = ndarrays_to_parameters(
+        [array([0.2, 0.2, 0.2, 0.2], dtype=float32)]
+    )
+    param_1: Parameters = ndarrays_to_parameters(
+        [array([1.0, 1.0, 1.0, 1.0], dtype=float32)]
+    )
+    param_2: Parameters = ndarrays_to_parameters(
+        [array([0.5, 0.5, 0.5, 0.5], dtype=float32)]
+    )
+    client_0 = TestClientProxy(cid="0")
+    client_1 = TestClientProxy(cid="1")
+    client_2 = TestClientProxy(cid="2")
+    results: list[tuple[ClientProxy, FitRes]] = [
+        (
+            client_0,
+            FitRes(
+                status=Status(code=Code.OK, message="Success"),
+                parameters=param_0,
+                num_examples=5,
+                metrics={},
+            ),
+        ),
+        (
+            client_1,
+            FitRes(
+                status=Status(code=Code.OK, message="Success"),
+                parameters=param_1,
+                num_examples=5,
+                metrics={},
+            ),
+        ),
+        (
+            client_2,
+            FitRes(
+                status=Status(code=Code.OK, message="Success"),
+                parameters=param_2,
+                num_examples=5,
+                metrics={},
+            ),
+        ),
+    ]
+    expected: NDArrays = [array([0.35, 0.35, 0.35, 0.35], dtype=float32)]
+
+    # Execute
+    actual_aggregated, _ = strategy.aggregate_fit(
+        server_round=1, results=results, failures=[]
+    )
+    assert actual_aggregated
+    actual_list = parameters_to_ndarrays(actual_aggregated)
+    actual = actual_list[0]
+    assert (abs(actual - expected[0]) < 1e-6).all()

--- a/framework/py/flwr/serverapp/strategy/__init__.py
+++ b/framework/py/flwr/serverapp/strategy/__init__.py
@@ -30,6 +30,7 @@ from .fedavg import FedAvg
 from .fedavgm import FedAvgM
 from .fedmedian import FedMedian
 from .fedprox import FedProx
+from .meamed import MeaMed
 from .fedtrimmedavg import FedTrimmedAvg
 from .fedxgb_bagging import FedXgbBagging
 from .fedxgb_cyclic import FedXgbCyclic
@@ -57,6 +58,7 @@ __all__ = [
     "FedXgbCyclic",
     "FedYogi",
     "Krum",
+    "MeaMed",
     "MultiKrum",
     "QFedAvg",
     "Result",

--- a/framework/py/flwr/serverapp/strategy/meamed.py
+++ b/framework/py/flwr/serverapp/strategy/meamed.py
@@ -1,0 +1,161 @@
+# Copyright 2025 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Mean-around-Median (MeaMed) [Xie et al., 2018] strategy.
+
+Paper: arxiv.org/abs/1802.10116
+"""
+
+
+from collections.abc import Callable, Iterable
+from logging import INFO
+from typing import cast
+
+import numpy as np
+
+from flwr.common import Array, ArrayRecord, Message, MetricRecord, RecordDict
+from flwr.common.logger import log
+
+from .fedavg import FedAvg
+
+
+class MeaMed(FedAvg):
+    """Mean-around-Median (MeaMed) strategy.
+
+    Implementation based on https://arxiv.org/abs/1802.10116
+
+    MeaMed is a Byzantine-resilient aggregation strategy. It first computes
+    the coordinate-wise median, then averages the ``num_closest`` values closest
+    to that median for each coordinate.
+
+    Parameters
+    ----------
+    fraction_train : float (default: 1.0)
+        Fraction of nodes used during training. In case ``min_train_nodes``
+        is larger than ``fraction_train * total_connected_nodes``,
+        ``min_train_nodes`` will still be sampled.
+    fraction_evaluate : float (default: 1.0)
+        Fraction of nodes used during validation. In case ``min_evaluate_nodes``
+        is larger than ``fraction_evaluate * total_connected_nodes``,
+        ``min_evaluate_nodes`` will still be sampled.
+    min_train_nodes : int (default: 2)
+        Minimum number of nodes used during training.
+    min_evaluate_nodes : int (default: 2)
+        Minimum number of nodes used during validation.
+    min_available_nodes : int (default: 2)
+        Minimum number of total nodes in the system.
+    weighted_by_key : str (default: "num-examples")
+        The key within each MetricRecord whose value is used as the weight when
+        computing weighted averages for MetricRecords.
+    arrayrecord_key : str (default: "arrays")
+        Key used to store the ArrayRecord when constructing Messages.
+    configrecord_key : str (default: "config")
+        Key used to store the ConfigRecord when constructing Messages.
+    train_metrics_aggr_fn : Optional[callable] (default: None)
+        Function with signature (list[RecordDict], str) -> MetricRecord,
+        used to aggregate MetricRecords from training round replies.
+        If ``None``, defaults to ``aggregate_metricrecords``, which performs a
+        weighted average using the provided weight factor key.
+    evaluate_metrics_aggr_fn : Optional[callable] (default: None)
+        Function with signature (list[RecordDict], str) -> MetricRecord,
+        used to aggregate MetricRecords from training round replies.
+        If ``None``, defaults to ``aggregate_metricrecords``, which performs a
+        weighted average using the provided weight factor key.
+    num_closest : int (default: 2)
+        Number of closest values to the median to average per coordinate.
+    """
+
+    def __init__(  # pylint: disable=R0913, R0917
+        self,
+        fraction_train: float = 1.0,
+        fraction_evaluate: float = 1.0,
+        min_train_nodes: int = 2,
+        min_evaluate_nodes: int = 2,
+        min_available_nodes: int = 2,
+        weighted_by_key: str = "num-examples",
+        arrayrecord_key: str = "arrays",
+        configrecord_key: str = "config",
+        train_metrics_aggr_fn: (
+            Callable[[list[RecordDict], str], MetricRecord] | None
+        ) = None,
+        evaluate_metrics_aggr_fn: (
+            Callable[[list[RecordDict], str], MetricRecord] | None
+        ) = None,
+        num_closest: int = 2,
+    ) -> None:
+        super().__init__(
+            fraction_train=fraction_train,
+            fraction_evaluate=fraction_evaluate,
+            min_train_nodes=min_train_nodes,
+            min_evaluate_nodes=min_evaluate_nodes,
+            min_available_nodes=min_available_nodes,
+            weighted_by_key=weighted_by_key,
+            arrayrecord_key=arrayrecord_key,
+            configrecord_key=configrecord_key,
+            train_metrics_aggr_fn=train_metrics_aggr_fn,
+            evaluate_metrics_aggr_fn=evaluate_metrics_aggr_fn,
+        )
+        self.num_closest = num_closest
+
+    def summary(self) -> None:
+        """Log summary configuration of the strategy."""
+        log(INFO, "\t├──> MeaMed settings:")
+        log(INFO, "\t│\t└── num_closest: %s", self.num_closest)
+        super().summary()
+
+    def aggregate_train(
+        self,
+        server_round: int,
+        replies: Iterable[Message],
+    ) -> tuple[ArrayRecord | None, MetricRecord | None]:
+        """Aggregate ArrayRecords and MetricRecords in the received Messages."""
+        valid_replies, _ = self._check_and_log_replies(replies, is_train=True)
+
+        if not valid_replies:
+            return None, None
+
+        # Get the key for the only ArrayRecord from the first Message
+        record_key = list(valid_replies[0].content.array_records.keys())[0]
+        # Preserve keys for arrays in ArrayRecord
+        array_keys = list(valid_replies[0].content[record_key].keys())
+
+        # Compute mean-around-median for each layer
+        arrays = ArrayRecord()
+        for array_key in array_keys:
+            # Get the corresponding layer from each client
+            layers = [
+                cast(ArrayRecord, msg.content[record_key]).pop(array_key).numpy()
+                for msg in valid_replies
+            ]
+            stacked = np.stack(layers)
+
+            # Step 1: Compute coordinate-wise median
+            median = np.median(stacked, axis=0)
+
+            # Step 2: Find the num_closest values to the median per coordinate
+            diff = np.abs(stacked - median)
+            indices = np.argpartition(
+                diff, kth=self.num_closest - 1, axis=0
+            )[: self.num_closest]
+
+            # Step 3: Average the closest values
+            closest = np.take_along_axis(stacked, indices, axis=0)
+            arrays[array_key] = Array(np.asarray(np.mean(closest, axis=0)))
+
+        # Aggregate MetricRecords
+        metrics = self.train_metrics_aggr_fn(
+            [msg.content for msg in valid_replies],
+            self.weighted_by_key,
+        )
+        return arrays, metrics

--- a/framework/py/flwr/serverapp/strategy/meamed_test.py
+++ b/framework/py/flwr/serverapp/strategy/meamed_test.py
@@ -1,0 +1,87 @@
+# Copyright 2025 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""MeaMed tests."""
+
+
+import numpy as np
+
+from flwr.common import ArrayRecord
+
+from .meamed import MeaMed
+from .strategy_utils_test import create_mock_reply
+
+
+def test_aggregate_fit() -> None:
+    """Tests if MeaMed is aggregating correctly.
+
+    With values [0.2, 1.0, 0.5], the median is 0.5.
+    With num_closest=2, the 2 closest to 0.5 are 0.2 and 0.5.
+    Their mean is 0.35.
+    """
+    # Prepare
+    strategy = MeaMed(num_closest=2)
+    replies = [
+        create_mock_reply(ArrayRecord([np.array([0.2, 0.2, 0.2, 0.2])]), 5),
+        create_mock_reply(ArrayRecord([np.array([1.0, 1.0, 1.0, 1.0])]), 2),
+        create_mock_reply(ArrayRecord([np.array([0.5, 0.5, 0.5, 0.5])]), 9),
+    ]
+    expected = np.array([0.35, 0.35, 0.35, 0.35])
+
+    # Execute
+    actual_aggregated, _ = strategy.aggregate_train(1, replies)
+
+    # Assert
+    assert actual_aggregated
+    actual = actual_aggregated.to_numpy_ndarrays()[0]
+    np.testing.assert_allclose(actual, expected)
+
+
+def test_aggregate_fit_all_closest() -> None:
+    """Tests MeaMed with num_closest equal to number of clients (degenerates to mean)."""
+    # Prepare
+    strategy = MeaMed(num_closest=3)
+    replies = [
+        create_mock_reply(ArrayRecord([np.array([0.2, 0.2, 0.2, 0.2])]), 5),
+        create_mock_reply(ArrayRecord([np.array([1.0, 1.0, 1.0, 1.0])]), 2),
+        create_mock_reply(ArrayRecord([np.array([0.5, 0.5, 0.5, 0.5])]), 9),
+    ]
+    # Mean of all three: (0.2 + 1.0 + 0.5) / 3 ≈ 0.5667
+    expected = np.array([0.5666667, 0.5666667, 0.5666667, 0.5666667])
+
+    # Execute
+    actual_aggregated, _ = strategy.aggregate_train(1, replies)
+
+    # Assert
+    assert actual_aggregated
+    actual = actual_aggregated.to_numpy_ndarrays()[0]
+    np.testing.assert_allclose(actual, expected, rtol=1e-4)
+
+
+def test_aggregate_fit_with_scalar_weights() -> None:
+    """Tests if MeaMed preserves 0-dim arrays."""
+    strategy = MeaMed(num_closest=2)
+    replies = [
+        create_mock_reply(ArrayRecord([np.array(1.0)]), 1),
+        create_mock_reply(ArrayRecord([np.array(3.0)]), 1),
+        create_mock_reply(ArrayRecord([np.array(2.0)]), 1),
+    ]
+    # Median is 2.0, closest 2 are 1.0 and 2.0 (or 2.0 and 3.0), mean = 1.5 or 2.5
+    # Actually: |1-2|=1, |3-2|=1, |2-2|=0 → closest 2 are 2.0 and one of {1.0, 3.0}
+
+    actual_aggregated, _ = strategy.aggregate_train(1, replies)
+
+    assert actual_aggregated
+    actual = actual_aggregated.to_numpy_ndarrays()[0]
+    assert actual.shape == ()


### PR DESCRIPTION
## Summary

- Implements the **MeaMed (Mean-around-Median)** Byzantine-resilient aggregation strategy from [Xie et al., 2018](https://arxiv.org/abs/1802.10116)
- Adds implementation in both **legacy** (`server/strategy/`) and **modern Message API** (`serverapp/strategy/`) paths
- Algorithm: computes coordinate-wise median, then averages the `num_closest` values nearest to that median per coordinate

Closes #1611

## Details

**New files:**
- `framework/py/flwr/server/strategy/meamed.py` — Legacy API strategy
- `framework/py/flwr/server/strategy/meamed_test.py` — Legacy tests (9 tests)
- `framework/py/flwr/serverapp/strategy/meamed.py` — Modern Message API strategy
- `framework/py/flwr/serverapp/strategy/meamed_test.py` — Modern tests (3 tests)

**Modified files:**
- `framework/py/flwr/server/strategy/__init__.py` — Export `MeaMed`
- `framework/py/flwr/serverapp/strategy/__init__.py` — Export `MeaMed`

The legacy implementation reuses the existing `aggregate_median` + `_aggregate_n_closest_weights` helpers from `aggregate.py`. The modern implementation uses inline numpy with `np.argpartition`, following the `FedTrimmedAvg` pattern.

## Test plan

- [x] All 12 new MeaMed tests pass
- [x] Existing FedMedian tests still pass (no regression)
- [ ] CI passes