### PR TITLE
feat(framework): Add `src_task_id` and `dst_task_id` to Message class

### DIFF
--- a/framework/py/flwr/app/metadata.py
+++ b/framework/py/flwr/app/metadata.py
@@ -50,6 +50,10 @@ class Metadata:  # pylint: disable=too-many-instance-attributes
     message_type : str
         A string that encodes the action to be executed on
         the receiving end.
+    src_task_id : Optional[int] (default: None)
+        An identifier for the source task sending this message.
+    dst_task_id : Optional[int] (default: None)
+        An identifier for the destination task receiving this message.
     """
 
     def __init__(  # pylint: disable=too-many-arguments,too-many-positional-arguments
@@ -63,12 +67,16 @@ class Metadata:  # pylint: disable=too-many-instance-attributes
         created_at: float,
         ttl: float,
         message_type: str,
+        src_task_id: int | None = None,
+        dst_task_id: int | None = None,
     ) -> None:
         var_dict = {
             "_run_id": run_id,
             "_message_id": message_id,
             "_src_node_id": src_node_id,
             "_dst_node_id": dst_node_id,
+            "_src_task_id": src_task_id,
+            "_dst_task_id": dst_task_id,
             "_reply_to_message_id": reply_to_message_id,
             "_group_id": group_id,
             "_created_at": created_at,
@@ -107,6 +115,26 @@ class Metadata:  # pylint: disable=too-many-instance-attributes
     def dst_node_id(self, value: int) -> None:
         """Set dst_node_id."""
         self.__dict__["_dst_node_id"] = value
+
+    @property
+    def src_task_id(self) -> int | None:
+        """An identifier for the source task sending this message."""
+        return cast(int | None, self.__dict__["_src_task_id"])
+
+    @src_task_id.setter
+    def src_task_id(self, value: int | None) -> None:
+        """Set src_task_id."""
+        self.__dict__["_src_task_id"] = value
+
+    @property
+    def dst_task_id(self) -> int | None:
+        """An identifier for the destination task receiving this message."""
+        return cast(int | None, self.__dict__["_dst_task_id"])
+
+    @dst_task_id.setter
+    def dst_task_id(self, value: int | None) -> None:
+        """Set dst_task_id."""
+        self.__dict__["_dst_task_id"] = value
 
     @property
     def group_id(self) -> str:

--- a/framework/py/flwr/common/message.py
+++ b/framework/py/flwr/common/message.py
@@ -546,7 +546,7 @@ def _check_arg_types(  # pylint: disable=too-many-arguments, R0917
         and (message_type is None or isinstance(message_type, str))
         and (content is None or isinstance(content, RecordDict))
         and (error is None or isinstance(error, Error))
-        and (ttl is None or isinstance(ttl, (int | float)))
+        and (ttl is None or isinstance(ttl, (int, float)))
         and (group_id is None or isinstance(group_id, str))
         and (src_task_id is None or isinstance(src_task_id, int))
         and (dst_task_id is None or isinstance(dst_task_id, int))

--- a/framework/py/flwr/common/message.py
+++ b/framework/py/flwr/common/message.py
@@ -49,8 +49,9 @@ DEFAULT_TTL = 43200  # This is 12 hours
 MESSAGE_INIT_ERROR_MESSAGE = (
     "Invalid arguments for Message. Expected one of the documented "
     "signatures: Message(content: RecordDict, dst_node_id: int, message_type: str,"
-    " *, [ttl: float, group_id: str]) or Message(content: RecordDict | error: Error,"
-    " *, reply_to: Message, [ttl: float])."
+    " *, [ttl: float, group_id: str, src_task_id: int, dst_task_id: int]) or "
+    "Message(content: RecordDict | error: Error, *, reply_to: Message, "
+    "[ttl: float])."
 )
 
 
@@ -99,6 +100,10 @@ class Message(InflatableObject):
     group_id : Optional[str] (default: None)
         An identifier for grouping messages. In some settings, this is used as
         the FL round.
+    src_task_id : Optional[int] (default: None)
+        An identifier for the source task sending this message.
+    dst_task_id : Optional[int] (default: None)
+        An identifier for the destination task receiving this message.
     reply_to : Optional[Message] (default: None)
         The instruction message to which this message is a reply. This message does
         not retain the original message's content but derives its metadata from it.
@@ -113,6 +118,8 @@ class Message(InflatableObject):
         *,
         ttl: float | None = None,
         group_id: str | None = None,
+        src_task_id: int | None = None,
+        dst_task_id: int | None = None,
     ) -> None: ...
 
     @overload
@@ -134,6 +141,8 @@ class Message(InflatableObject):
         error: Error | None = None,
         ttl: float | None = None,
         group_id: str | None = None,
+        src_task_id: int | None = None,
+        dst_task_id: int | None = None,
         reply_to: Message | None = None,
         metadata: Metadata | None = None,
     ) -> None:
@@ -152,6 +161,8 @@ class Message(InflatableObject):
             error=error,
             ttl=ttl,
             group_id=group_id,
+            src_task_id=src_task_id,
+            dst_task_id=dst_task_id,
             reply_to=reply_to,
             metadata=metadata,
         )
@@ -162,7 +173,15 @@ class Message(InflatableObject):
             # except `content`, `error`, or `content_or_error`
             if any(
                 x is not None
-                for x in [dst_node_id, message_type, ttl, group_id, reply_to]
+                for x in [
+                    dst_node_id,
+                    message_type,
+                    ttl,
+                    group_id,
+                    src_task_id,
+                    dst_task_id,
+                    reply_to,
+                ]
             ):
                 raise MessageInitializationError(
                     f"Invalid arguments for {Message.__qualname__}. "
@@ -193,13 +212,24 @@ class Message(InflatableObject):
                 created_at=now().timestamp(),
                 ttl=ttl or DEFAULT_TTL,
                 message_type=message_type,
+                src_task_id=src_task_id,
+                dst_task_id=dst_task_id,
             )
 
         # Create metadata for a reply message
         else:
             # Check arguments
-            # `dst_node_id`, `message_type` and `group_id` must not be set
-            if any(x is not None for x in [dst_node_id, message_type, group_id]):
+            # `dst_node_id`, `message_type`, `group_id`, and task IDs must not be set
+            if any(
+                x is not None
+                for x in [
+                    dst_node_id,
+                    message_type,
+                    group_id,
+                    src_task_id,
+                    dst_task_id,
+                ]
+            ):
                 raise MessageInitializationError()
 
             # Set metadata
@@ -214,6 +244,8 @@ class Message(InflatableObject):
                 created_at=current,
                 ttl=_limit_reply_ttl(current, ttl, reply_to),
                 message_type=reply_to.metadata.message_type,
+                src_task_id=reply_to.metadata.dst_task_id,
+                dst_task_id=reply_to.metadata.src_task_id,
             )
 
         metadata.delivered_at = ""  # Backward compatibility
@@ -501,6 +533,8 @@ def _check_arg_types(  # pylint: disable=too-many-arguments, R0917
     error: Error | None = None,
     ttl: float | None = None,
     group_id: str | None = None,
+    src_task_id: int | None = None,
+    dst_task_id: int | None = None,
     reply_to: Message | None = None,
     metadata: Metadata | None = None,
 ) -> None:
@@ -513,6 +547,8 @@ def _check_arg_types(  # pylint: disable=too-many-arguments, R0917
         and (error is None or isinstance(error, Error))
         and (ttl is None or isinstance(ttl, (int | float)))
         and (group_id is None or isinstance(group_id, str))
+        and (src_task_id is None or isinstance(src_task_id, int))
+        and (dst_task_id is None or isinstance(dst_task_id, int))
         and (reply_to is None or isinstance(reply_to, Message))
         and (metadata is None or isinstance(metadata, Metadata))
     ):

--- a/framework/py/flwr/common/message.py
+++ b/framework/py/flwr/common/message.py
@@ -49,9 +49,10 @@ DEFAULT_TTL = 43200  # This is 12 hours
 MESSAGE_INIT_ERROR_MESSAGE = (
     "Invalid arguments for Message. Expected one of the documented "
     "signatures: Message(content: RecordDict, dst_node_id: int, message_type: str,"
-    " *, [ttl: float, group_id: str, src_task_id: int, dst_task_id: int]) or "
+    " *, ttl: float | None = None, group_id: str | None = None, "
+    "src_task_id: int | None = None, dst_task_id: int | None = None) or "
     "Message(content: RecordDict | error: Error, *, reply_to: Message, "
-    "[ttl: float])."
+    "ttl: float | None = None)."
 )
 
 

--- a/framework/py/flwr/common/message.py
+++ b/framework/py/flwr/common/message.py
@@ -49,8 +49,7 @@ DEFAULT_TTL = 43200  # This is 12 hours
 MESSAGE_INIT_ERROR_MESSAGE = (
     "Invalid arguments for Message. Expected one of the documented "
     "signatures: Message(content: RecordDict, dst_node_id: int, message_type: str,"
-    " *, ttl: float | None = None, group_id: str | None = None, "
-    "src_task_id: int | None = None, dst_task_id: int | None = None) or "
+    " *, ttl: float | None = None, group_id: str | None = None) or "
     "Message(content: RecordDict | error: Error, *, reply_to: Message, "
     "ttl: float | None = None)."
 )
@@ -101,10 +100,8 @@ class Message(InflatableObject):
     group_id : Optional[str] (default: None)
         An identifier for grouping messages. In some settings, this is used as
         the FL round.
-    src_task_id : Optional[int] (default: None)
-        An identifier for the source task sending this message.
     dst_task_id : Optional[int] (default: None)
-        An identifier for the destination task receiving this message.
+        Experimental. An identifier for the destination task receiving this message.
     reply_to : Optional[Message] (default: None)
         The instruction message to which this message is a reply. This message does
         not retain the original message's content but derives its metadata from it.
@@ -119,7 +116,6 @@ class Message(InflatableObject):
         *,
         ttl: float | None = None,
         group_id: str | None = None,
-        src_task_id: int | None = None,
         dst_task_id: int | None = None,
     ) -> None: ...
 
@@ -142,7 +138,6 @@ class Message(InflatableObject):
         error: Error | None = None,
         ttl: float | None = None,
         group_id: str | None = None,
-        src_task_id: int | None = None,
         dst_task_id: int | None = None,
         reply_to: Message | None = None,
         metadata: Metadata | None = None,
@@ -162,7 +157,6 @@ class Message(InflatableObject):
             error=error,
             ttl=ttl,
             group_id=group_id,
-            src_task_id=src_task_id,
             dst_task_id=dst_task_id,
             reply_to=reply_to,
             metadata=metadata,
@@ -179,7 +173,6 @@ class Message(InflatableObject):
                     message_type,
                     ttl,
                     group_id,
-                    src_task_id,
                     dst_task_id,
                     reply_to,
                 ]
@@ -213,21 +206,20 @@ class Message(InflatableObject):
                 created_at=now().timestamp(),
                 ttl=ttl or DEFAULT_TTL,
                 message_type=message_type,
-                src_task_id=src_task_id,
                 dst_task_id=dst_task_id,
             )
 
         # Create metadata for a reply message
         else:
             # Check arguments
-            # `dst_node_id`, `message_type`, `group_id`, and task IDs must not be set
+            # `dst_node_id`, `message_type`, `group_id`, and `dst_task_id` must not
+            # be set
             if any(
                 x is not None
                 for x in [
                     dst_node_id,
                     message_type,
                     group_id,
-                    src_task_id,
                     dst_task_id,
                 ]
             ):
@@ -534,7 +526,6 @@ def _check_arg_types(  # pylint: disable=too-many-arguments, R0917
     error: Error | None = None,
     ttl: float | None = None,
     group_id: str | None = None,
-    src_task_id: int | None = None,
     dst_task_id: int | None = None,
     reply_to: Message | None = None,
     metadata: Metadata | None = None,
@@ -548,7 +539,6 @@ def _check_arg_types(  # pylint: disable=too-many-arguments, R0917
         and (error is None or isinstance(error, Error))
         and (ttl is None or isinstance(ttl, (int, float)))
         and (group_id is None or isinstance(group_id, str))
-        and (src_task_id is None or isinstance(src_task_id, int))
         and (dst_task_id is None or isinstance(dst_task_id, int))
         and (reply_to is None or isinstance(reply_to, Message))
         and (metadata is None or isinstance(metadata, Metadata))

--- a/framework/py/flwr/common/message_test.py
+++ b/framework/py/flwr/common/message_test.py
@@ -286,20 +286,37 @@ def test_create_ins_message_success(
     assert msg.metadata.reply_to_message_id == ""  # Should be unset
 
 
-def test_create_ins_message_with_task_ids_success() -> None:
-    """Test creating an instruction message with source and destination task IDs."""
+def test_create_ins_message_with_dst_task_id_success() -> None:
+    """Test creating an instruction message with a destination task ID."""
     # Execute
     msg = Message(
         content=RecordDict(),
         dst_node_id=123,
         message_type="query",
-        src_task_id=456,
         dst_task_id=789,
     )
 
     # Assert
-    assert msg.metadata.src_task_id == 456
+    assert msg.metadata.src_task_id is None
     assert msg.metadata.dst_task_id == 789
+
+
+def test_create_ins_message_with_src_task_id_failure() -> None:
+    """Test that source task ID is not exposed in the constructor."""
+    # Execute
+    with pytest.raises(TypeError, match="src_task_id"):
+        Message(RecordDict(), 123, "query", src_task_id=456)  # type: ignore
+
+
+def test_create_ins_message_failure_excludes_task_ids_from_error() -> None:
+    """Test that task IDs are not included in the generic constructor error."""
+    # Execute
+    with pytest.raises(MessageInitializationError) as exc:
+        Message(RecordDict(), 123)
+
+    # Assert
+    assert "src_task_id" not in str(exc.value)
+    assert "dst_task_id" not in str(exc.value)
 
 
 @pytest.mark.parametrize(
@@ -368,7 +385,6 @@ def test_create_reply_message_success(
         ((RecordDict(), 123, "query"), {"ttl": "wrong type"}),
         ((RecordDict(), 123, "query"), {"group_id": 123}),
         ((RecordDict(), 123, "query"), {"group_id": 123.0}),
-        ((RecordDict(), 123, "query"), {"src_task_id": "wrong type"}),
         ((RecordDict(), 123, "query"), {"dst_task_id": "wrong type"}),
     ],
 )
@@ -399,7 +415,6 @@ def test_create_ins_message_failure(args: Any, kwargs: dict[str, Any]) -> None:
         ((Error(0),), {"message_type": "query"}),
         ((RecordDict(),), {"group_id": "group_xyz"}),
         ((Error(0),), {"group_id": "group_xyz"}),
-        ((RecordDict(),), {"src_task_id": 123}),
         ((Error(0),), {"dst_task_id": 456}),
         # Use invalid arg types
         (("wrong type",), {}),

--- a/framework/py/flwr/common/message_test.py
+++ b/framework/py/flwr/common/message_test.py
@@ -312,7 +312,7 @@ def test_create_ins_message_failure_excludes_task_ids_from_error() -> None:
     """Test that task IDs are not included in the generic constructor error."""
     # Execute
     with pytest.raises(MessageInitializationError) as exc:
-        Message(RecordDict(), 123)
+        Message(RecordDict(), 123)  # type: ignore[call-overload]
 
     # Assert
     assert "src_task_id" not in str(exc.value)

--- a/framework/py/flwr/common/message_test.py
+++ b/framework/py/flwr/common/message_test.py
@@ -179,6 +179,8 @@ def test_create_reply(
                 "message_id": "msg_456",
                 "src_node_id": 1,
                 "dst_node_id": 2,
+                "src_task_id": None,
+                "dst_task_id": None,
                 "reply_to_message_id": "reply_789",
                 "group_id": "group_xyz",
                 "created_at": 1234567890.0,
@@ -279,7 +281,25 @@ def test_create_ins_message_success(
     assert msg.metadata.run_id == 0  # Should be unset
     assert msg.metadata.message_id == ""  # Should be unset
     assert msg.metadata.src_node_id == 0  # Should be unset
+    assert msg.metadata.src_task_id is None
+    assert msg.metadata.dst_task_id is None
     assert msg.metadata.reply_to_message_id == ""  # Should be unset
+
+
+def test_create_ins_message_with_task_ids_success() -> None:
+    """Test creating an instruction message with source and destination task IDs."""
+    # Execute
+    msg = Message(
+        content=RecordDict(),
+        dst_node_id=123,
+        message_type="query",
+        src_task_id=456,
+        dst_task_id=789,
+    )
+
+    # Assert
+    assert msg.metadata.src_task_id == 456
+    assert msg.metadata.dst_task_id == 789
 
 
 @pytest.mark.parametrize(
@@ -292,6 +312,8 @@ def test_create_reply_message_success(
     """Test creating a reply message."""
     # Prepare
     msg = make_message(content=RecordDict(), metadata=RecordMaker(1).metadata())
+    msg.metadata.src_task_id = 123
+    msg.metadata.dst_task_id = 456
     current_time = msg.metadata.created_at
 
     # Execute
@@ -301,6 +323,8 @@ def test_create_reply_message_success(
     assert reply.metadata.run_id == msg.metadata.run_id
     assert reply.metadata.src_node_id == msg.metadata.dst_node_id
     assert reply.metadata.dst_node_id == msg.metadata.src_node_id
+    assert reply.metadata.src_task_id == msg.metadata.dst_task_id
+    assert reply.metadata.dst_task_id == msg.metadata.src_task_id
     assert reply.metadata.reply_to_message_id == msg.metadata.message_id
     assert reply.metadata.group_id == msg.metadata.group_id
     assert current_time < reply.metadata.created_at < now().timestamp()
@@ -344,6 +368,8 @@ def test_create_reply_message_success(
         ((RecordDict(), 123, "query"), {"ttl": "wrong type"}),
         ((RecordDict(), 123, "query"), {"group_id": 123}),
         ((RecordDict(), 123, "query"), {"group_id": 123.0}),
+        ((RecordDict(), 123, "query"), {"src_task_id": "wrong type"}),
+        ((RecordDict(), 123, "query"), {"dst_task_id": "wrong type"}),
     ],
 )
 def test_create_ins_message_failure(args: Any, kwargs: dict[str, Any]) -> None:
@@ -373,6 +399,8 @@ def test_create_ins_message_failure(args: Any, kwargs: dict[str, Any]) -> None:
         ((Error(0),), {"message_type": "query"}),
         ((RecordDict(),), {"group_id": "group_xyz"}),
         ((Error(0),), {"group_id": "group_xyz"}),
+        ((RecordDict(),), {"src_task_id": 123}),
+        ((Error(0),), {"dst_task_id": 456}),
         # Use invalid arg types
         (("wrong type",), {}),
         ((123,), {}),

--- a/framework/py/flwr/common/message_test.py
+++ b/framework/py/flwr/common/message_test.py
@@ -305,7 +305,9 @@ def test_create_ins_message_with_src_task_id_failure() -> None:
     """Test that source task ID is not exposed in the constructor."""
     # Execute
     with pytest.raises(TypeError, match="src_task_id"):
-        Message(RecordDict(), 123, "query", src_task_id=456)  # type: ignore
+        Message(  # type: ignore[call-overload]  # pylint: disable=E1123
+            RecordDict(), 123, "query", src_task_id=456
+        )
 
 
 def test_create_ins_message_failure_excludes_task_ids_from_error() -> None:

--- a/framework/py/flwr/common/message_test.py
+++ b/framework/py/flwr/common/message_test.py
@@ -301,26 +301,6 @@ def test_create_ins_message_with_dst_task_id_success() -> None:
     assert msg.metadata.dst_task_id == 789
 
 
-def test_create_ins_message_with_src_task_id_failure() -> None:
-    """Test that source task ID is not exposed in the constructor."""
-    # Execute
-    with pytest.raises(TypeError, match="src_task_id"):
-        Message(  # type: ignore[call-overload]  # pylint: disable=E1123
-            RecordDict(), 123, "query", src_task_id=456
-        )
-
-
-def test_create_ins_message_failure_excludes_task_ids_from_error() -> None:
-    """Test that task IDs are not included in the generic constructor error."""
-    # Execute
-    with pytest.raises(MessageInitializationError) as exc:
-        Message(RecordDict(), 123)  # type: ignore[call-overload]
-
-    # Assert
-    assert "src_task_id" not in str(exc.value)
-    assert "dst_task_id" not in str(exc.value)
-
-
 @pytest.mark.parametrize(
     "content_or_error,ttl",
     product([RecordDict(), Error(0)], [None, 10.0, 20]),

--- a/framework/py/flwr/common/serde_test.py
+++ b/framework/py/flwr/common/serde_test.py
@@ -448,6 +448,47 @@ def test_message_serialization_deserialization(
     assert original.metadata == deserialized.metadata
 
 
+def test_message_serialization_preserves_optional_task_ids() -> None:
+    """Test serialization and deserialization of optional Message task IDs."""
+    # Prepare
+    maker = RecordMaker(state=2)
+    metadata = maker.metadata()
+    metadata.src_task_id = 123
+    metadata.dst_task_id = 456
+    original = make_message(metadata=metadata, content=maker.recorddict(1, 1, 1))
+
+    # Execute
+    proto = message_to_proto(original)
+    deserialized = message_from_proto(proto)
+
+    # Assert
+    assert proto.metadata.HasField("src_task_id")
+    assert proto.metadata.HasField("dst_task_id")
+    assert deserialized.metadata.src_task_id == 123
+    assert deserialized.metadata.dst_task_id == 456
+    assert original.metadata == deserialized.metadata
+
+
+def test_message_serialization_preserves_absent_task_ids() -> None:
+    """Test absent optional Message task IDs remain absent after serialization."""
+    # Prepare
+    maker = RecordMaker(state=2)
+    original = make_message(
+        metadata=maker.metadata(), content=maker.recorddict(1, 1, 1)
+    )
+
+    # Execute
+    proto = message_to_proto(original)
+    deserialized = message_from_proto(proto)
+
+    # Assert
+    assert not proto.metadata.HasField("src_task_id")
+    assert not proto.metadata.HasField("dst_task_id")
+    assert deserialized.metadata.src_task_id is None
+    assert deserialized.metadata.dst_task_id is None
+    assert original.metadata == deserialized.metadata
+
+
 def test_context_serialization_deserialization() -> None:
     """Test serialization and deserialization of Context."""
     # Prepare

--- a/framework/py/flwr/common/serde_test.py
+++ b/framework/py/flwr/common/serde_test.py
@@ -448,47 +448,6 @@ def test_message_serialization_deserialization(
     assert original.metadata == deserialized.metadata
 
 
-def test_message_serialization_preserves_optional_task_ids() -> None:
-    """Test serialization and deserialization of optional Message task IDs."""
-    # Prepare
-    maker = RecordMaker(state=2)
-    metadata = maker.metadata()
-    metadata.src_task_id = 123
-    metadata.dst_task_id = 456
-    original = make_message(metadata=metadata, content=maker.recorddict(1, 1, 1))
-
-    # Execute
-    proto = message_to_proto(original)
-    deserialized = message_from_proto(proto)
-
-    # Assert
-    assert proto.metadata.HasField("src_task_id")
-    assert proto.metadata.HasField("dst_task_id")
-    assert deserialized.metadata.src_task_id == 123
-    assert deserialized.metadata.dst_task_id == 456
-    assert original.metadata == deserialized.metadata
-
-
-def test_message_serialization_preserves_absent_task_ids() -> None:
-    """Test absent optional Message task IDs remain absent after serialization."""
-    # Prepare
-    maker = RecordMaker(state=2)
-    original = make_message(
-        metadata=maker.metadata(), content=maker.recorddict(1, 1, 1)
-    )
-
-    # Execute
-    proto = message_to_proto(original)
-    deserialized = message_from_proto(proto)
-
-    # Assert
-    assert not proto.metadata.HasField("src_task_id")
-    assert not proto.metadata.HasField("dst_task_id")
-    assert deserialized.metadata.src_task_id is None
-    assert deserialized.metadata.dst_task_id is None
-    assert original.metadata == deserialized.metadata
-
-
 def test_context_serialization_deserialization() -> None:
     """Test serialization and deserialization of Context."""
     # Prepare

--- a/framework/py/flwr/common/serde_utils.py
+++ b/framework/py/flwr/common/serde_utils.py
@@ -156,6 +156,10 @@ def metadata_to_proto(metadata: Metadata) -> ProtoMetadata:
         message_type=metadata.message_type,
         created_at=metadata.created_at,
     )
+    if metadata.src_task_id is not None:
+        proto.src_task_id = metadata.src_task_id
+    if metadata.dst_task_id is not None:
+        proto.dst_task_id = metadata.dst_task_id
     return proto
 
 
@@ -171,5 +175,15 @@ def metadata_from_proto(metadata_proto: ProtoMetadata) -> Metadata:
         created_at=metadata_proto.created_at,
         ttl=metadata_proto.ttl,
         message_type=metadata_proto.message_type,
+        src_task_id=(
+            metadata_proto.src_task_id
+            if metadata_proto.HasField("src_task_id")
+            else None
+        ),
+        dst_task_id=(
+            metadata_proto.dst_task_id
+            if metadata_proto.HasField("dst_task_id")
+            else None
+        ),
     )
     return metadata

--- a/framework/py/flwr/server/superlink/linkstate/utils.py
+++ b/framework/py/flwr/server/superlink/linkstate/utils.py
@@ -138,6 +138,8 @@ def create_message_error_unavailable_res_message(
         message_type=ins_metadata.message_type,
         created_at=current_time,
         ttl=ttl,
+        src_task_id=ins_metadata.dst_task_id,
+        dst_task_id=ins_metadata.src_task_id,
     )
 
     msg = make_message(

--- a/framework/py/flwr/supercore/corestate/utils.py
+++ b/framework/py/flwr/supercore/corestate/utils.py
@@ -18,6 +18,12 @@
 from datetime import datetime
 from os import urandom
 
+from flwr.common import Message
+from flwr.common.constant import SUPERLINK_NODE_ID
+from flwr.supercore.date import now
+
+_MIN_VALID_MESSAGE_CREATED_AT = 1740700800.0
+
 
 def generate_rand_int_from_bytes(
     num_bytes: int, exclude: set[int] | None = None
@@ -49,3 +55,72 @@ def timestamp_to_iso(value: datetime | str | None) -> str:
         return datetime.fromisoformat(value).isoformat()
     except ValueError:
         return value
+
+
+def validate_task_message(message: Message) -> list[str]:
+    """Validate a task Message."""
+    validation_errors = []
+    metadata = message.metadata
+
+    if metadata.message_id == "":
+        validation_errors.append("empty `metadata.message_id`")
+
+    if not metadata.run_id:
+        validation_errors.append("`metadata.run_id` is not set.")
+
+    if metadata.src_task_id is None:
+        validation_errors.append("`metadata.src_task_id` is not set.")
+
+    if metadata.dst_task_id is None:
+        validation_errors.append("`metadata.dst_task_id` is not set.")
+
+    if (
+        metadata.src_task_id is not None
+        and metadata.dst_task_id is not None
+        and metadata.src_task_id == metadata.dst_task_id
+    ):
+        validation_errors.append(
+            "`metadata.src_task_id` and `metadata.dst_task_id` must be different."
+        )
+
+    # Temporary: task messages are routed through SuperLink until task-to-task
+    # communication is supported in SuperNodes.
+    if metadata.src_node_id != SUPERLINK_NODE_ID:
+        validation_errors.append(
+            f"`metadata.src_node_id` is not {SUPERLINK_NODE_ID} (SuperLink node ID)"
+        )
+
+    if metadata.dst_node_id != SUPERLINK_NODE_ID:
+        validation_errors.append(
+            f"`metadata.dst_node_id` is not {SUPERLINK_NODE_ID} (SuperLink node ID)"
+        )
+
+    created_at_is_valid = isinstance(metadata.created_at, (int, float))
+    if not created_at_is_valid:
+        validation_errors.append(
+            "`metadata.created_at` must be a float that records the unix timestamp "
+            "in seconds when the message was created."
+        )
+    elif metadata.created_at < _MIN_VALID_MESSAGE_CREATED_AT:
+        validation_errors.append(
+            "`metadata.created_at` must be a float that records the unix timestamp "
+            "in seconds when the message was created."
+        )
+
+    ttl_is_valid = isinstance(metadata.ttl, (int, float)) and metadata.ttl > 0
+    if not ttl_is_valid:
+        validation_errors.append("`metadata.ttl` must be higher than zero")
+    elif (
+        created_at_is_valid and metadata.created_at + metadata.ttl <= now().timestamp()
+    ):
+        validation_errors.append("Message TTL has expired")
+
+    if metadata.message_type == "":
+        validation_errors.append("`metadata.message_type` MUST be set")
+
+    if not message.has_content() != message.has_error():
+        validation_errors.append(
+            "Either message `content` or `error` MUST be set (but not both)"
+        )
+
+    return validation_errors

--- a/framework/py/flwr/supercore/corestate/utils.py
+++ b/framework/py/flwr/supercore/corestate/utils.py
@@ -66,20 +66,10 @@ def validate_task_message(message: Message) -> list[str]:  # pylint: disable=R09
     if metadata.message_id == "":
         validation_errors.append("empty `metadata.message_id`")
 
-    if not metadata.run_id:
-        validation_errors.append("`metadata.run_id` is not set.")
-
-    if metadata.src_task_id is None:
-        validation_errors.append("`metadata.src_task_id` is not set.")
-
     if metadata.dst_task_id is None:
         validation_errors.append("`metadata.dst_task_id` is not set.")
 
-    if (
-        metadata.src_task_id is not None
-        and metadata.dst_task_id is not None
-        and metadata.src_task_id == metadata.dst_task_id
-    ):
+    if metadata.src_task_id == metadata.dst_task_id:
         validation_errors.append(
             "`metadata.src_task_id` and `metadata.dst_task_id` must be different."
         )
@@ -95,13 +85,7 @@ def validate_task_message(message: Message) -> list[str]:  # pylint: disable=R09
             f"`metadata.dst_node_id` is not {SUPERLINK_NODE_ID} (SuperLink node ID)"
         )
 
-    created_at_is_valid = isinstance(metadata.created_at, (int, float))
-    if not created_at_is_valid:
-        validation_errors.append(
-            "`metadata.created_at` must be a float that records the unix timestamp "
-            "in seconds when the message was created."
-        )
-    elif metadata.created_at < _MIN_VALID_MESSAGE_CREATED_AT:
+    if metadata.created_at < _MIN_VALID_MESSAGE_CREATED_AT:
         validation_errors.append(
             "`metadata.created_at` must be a float that records the unix timestamp "
             "in seconds when the message was created."
@@ -110,9 +94,7 @@ def validate_task_message(message: Message) -> list[str]:  # pylint: disable=R09
     ttl_is_valid = isinstance(metadata.ttl, (int, float)) and metadata.ttl > 0
     if not ttl_is_valid:
         validation_errors.append("`metadata.ttl` must be higher than zero")
-    elif (
-        created_at_is_valid and metadata.created_at + metadata.ttl <= now().timestamp()
-    ):
+    elif metadata.created_at + metadata.ttl <= now().timestamp():
         validation_errors.append("Message TTL has expired")
 
     if metadata.message_type == "":

--- a/framework/py/flwr/supercore/corestate/utils.py
+++ b/framework/py/flwr/supercore/corestate/utils.py
@@ -57,7 +57,7 @@ def timestamp_to_iso(value: datetime | str | None) -> str:
         return value
 
 
-def validate_task_message(message: Message) -> list[str]:
+def validate_task_message(message: Message) -> list[str]:  # pylint: disable=R0912
     """Validate a task Message."""
     validation_errors = []
     metadata = message.metadata

--- a/framework/py/flwr/supercore/corestate/utils.py
+++ b/framework/py/flwr/supercore/corestate/utils.py
@@ -22,6 +22,7 @@ from flwr.common import Message
 from flwr.common.constant import SUPERLINK_NODE_ID
 from flwr.supercore.date import now
 
+# unix timestamp of 28 February 2025 00h:00m:00s UTC
 _MIN_VALID_MESSAGE_CREATED_AT = 1740700800.0
 
 
@@ -83,8 +84,7 @@ def validate_task_message(message: Message) -> list[str]:  # pylint: disable=R09
             "`metadata.src_task_id` and `metadata.dst_task_id` must be different."
         )
 
-    # Temporary: task messages are routed through SuperLink until task-to-task
-    # communication is supported in SuperNodes.
+    # Temporary: task messages are only supported in SuperLink for now.
     if metadata.src_node_id != SUPERLINK_NODE_ID:
         validation_errors.append(
             f"`metadata.src_node_id` is not {SUPERLINK_NODE_ID} (SuperLink node ID)"

--- a/framework/py/flwr/supercore/corestate/utils.py
+++ b/framework/py/flwr/supercore/corestate/utils.py
@@ -91,8 +91,7 @@ def validate_task_message(message: Message) -> list[str]:  # pylint: disable=R09
             "in seconds when the message was created."
         )
 
-    ttl_is_valid = isinstance(metadata.ttl, (int, float)) and metadata.ttl > 0
-    if not ttl_is_valid:
+    if metadata.ttl <= 0:
         validation_errors.append("`metadata.ttl` must be higher than zero")
     elif metadata.created_at + metadata.ttl <= now().timestamp():
         validation_errors.append("Message TTL has expired")

--- a/framework/py/flwr/supercore/corestate/utils.py
+++ b/framework/py/flwr/supercore/corestate/utils.py
@@ -99,7 +99,7 @@ def validate_task_message(message: Message) -> list[str]:  # pylint: disable=R09
     if metadata.message_type == "":
         validation_errors.append("`metadata.message_type` MUST be set")
 
-    if not message.has_content() != message.has_error():
+    if message.has_content() == message.has_error():
         validation_errors.append(
             "Either message `content` or `error` MUST be set (but not both)"
         )

--- a/framework/py/flwr/supercore/corestate/utils_test.py
+++ b/framework/py/flwr/supercore/corestate/utils_test.py
@@ -26,7 +26,7 @@ from .utils import generate_rand_int_from_bytes, validate_task_message
 
 def _create_task_message(  # pylint: disable=too-many-arguments
     *,
-    message_id: str | None = None,
+    message_id: str = "message-id",
     run_id: int = 1,
     src_node_id: int = SUPERLINK_NODE_ID,
     dst_node_id: int = SUPERLINK_NODE_ID,

--- a/framework/py/flwr/supercore/corestate/utils_test.py
+++ b/framework/py/flwr/supercore/corestate/utils_test.py
@@ -24,7 +24,7 @@ from flwr.common.message import make_message
 from .utils import generate_rand_int_from_bytes, validate_task_message
 
 
-def _create_task_message(
+def _create_task_message(  # pylint: disable=too-many-arguments
     *,
     message_id: str = "message-id",
     run_id: int = 1,

--- a/framework/py/flwr/supercore/corestate/utils_test.py
+++ b/framework/py/flwr/supercore/corestate/utils_test.py
@@ -17,7 +17,50 @@
 
 import unittest
 
-from .utils import generate_rand_int_from_bytes
+from flwr.common import Error, Message, Metadata, RecordDict, now
+from flwr.common.constant import SUPERLINK_NODE_ID
+from flwr.common.message import make_message
+
+from .utils import generate_rand_int_from_bytes, validate_task_message
+
+
+def _create_task_message(
+    *,
+    message_id: str = "message-id",
+    run_id: int = 1,
+    src_node_id: int = SUPERLINK_NODE_ID,
+    dst_node_id: int = SUPERLINK_NODE_ID,
+    src_task_id: int | None = 1,
+    dst_task_id: int | None = 2,
+    created_at: float | None = None,
+    ttl: float = 60.0,
+    message_type: str = "train",
+    has_error: bool = False,
+) -> Message:
+    """Create a task Message for testing."""
+    metadata = Metadata(
+        run_id=run_id,
+        message_id=message_id,
+        src_node_id=src_node_id,
+        dst_node_id=dst_node_id,
+        reply_to_message_id="",
+        group_id="",
+        created_at=created_at if created_at is not None else now().timestamp(),
+        ttl=ttl,
+        message_type="train",
+        src_task_id=src_task_id,
+        dst_task_id=dst_task_id,
+    )
+    metadata.__dict__["_message_type"] = message_type
+
+    if has_error:
+        return make_message(metadata=metadata, error=Error(0))
+    return make_message(metadata=metadata, content=RecordDict())
+
+
+def _assert_has_error(errors: list[str], expected: str) -> None:
+    """Assert that an expected validation error fragment exists."""
+    assert any(expected in error for error in errors)
 
 
 class UtilsTest(unittest.TestCase):
@@ -29,3 +72,103 @@ class UtilsTest(unittest.TestCase):
             with self.subTest(num_bytes=num_bytes):
                 rand_int = generate_rand_int_from_bytes(num_bytes)
                 self.assertGreaterEqual(rand_int, 0)
+
+    def test_validate_task_message_accepts_valid_message(self) -> None:
+        """Test that a valid task message passes validation."""
+        for has_error in [False, True]:
+            with self.subTest(has_error=has_error):
+                message = _create_task_message(has_error=has_error)
+
+                self.assertEqual(validate_task_message(message), [])
+
+    def test_validate_task_message_rejects_missing_message_id(self) -> None:
+        """Test that message_id must be set."""
+        message = _create_task_message(message_id="")
+
+        errors = validate_task_message(message)
+
+        _assert_has_error(errors, "metadata.message_id")
+
+    def test_validate_task_message_rejects_missing_run_id(self) -> None:
+        """Test that run_id must be set."""
+        message = _create_task_message(run_id=0)
+
+        errors = validate_task_message(message)
+
+        _assert_has_error(errors, "metadata.run_id")
+
+    def test_validate_task_message_rejects_missing_task_ids(self) -> None:
+        """Test that source and destination task IDs must be set."""
+        message = _create_task_message(src_task_id=None, dst_task_id=None)
+
+        errors = validate_task_message(message)
+
+        _assert_has_error(errors, "metadata.src_task_id")
+        _assert_has_error(errors, "metadata.dst_task_id")
+
+    def test_validate_task_message_rejects_same_task_ids(self) -> None:
+        """Test that source and destination task IDs must differ."""
+        message = _create_task_message(src_task_id=1, dst_task_id=1)
+
+        errors = validate_task_message(message)
+
+        _assert_has_error(errors, "must be different")
+
+    def test_validate_task_message_rejects_non_superlink_node_ids(self) -> None:
+        """Test that task messages currently route through SuperLink."""
+        message = _create_task_message(src_node_id=123, dst_node_id=456)
+
+        errors = validate_task_message(message)
+
+        _assert_has_error(errors, "metadata.src_node_id")
+        _assert_has_error(errors, "metadata.dst_node_id")
+
+    def test_validate_task_message_rejects_invalid_created_at(self) -> None:
+        """Test that created_at must be a plausible timestamp."""
+        message = _create_task_message(created_at=0.0)
+
+        errors = validate_task_message(message)
+
+        _assert_has_error(errors, "metadata.created_at")
+
+    def test_validate_task_message_rejects_non_positive_ttl(self) -> None:
+        """Test that ttl must be positive."""
+        message = _create_task_message(ttl=0.0)
+
+        errors = validate_task_message(message)
+
+        _assert_has_error(errors, "metadata.ttl")
+
+    def test_validate_task_message_rejects_expired_ttl(self) -> None:
+        """Test that task messages must not be expired."""
+        message = _create_task_message(created_at=now().timestamp() - 10.0, ttl=1.0)
+
+        errors = validate_task_message(message)
+
+        _assert_has_error(errors, "TTL has expired")
+
+    def test_validate_task_message_rejects_missing_message_type(self) -> None:
+        """Test that message_type must be set."""
+        message = _create_task_message(message_type="")
+
+        errors = validate_task_message(message)
+
+        _assert_has_error(errors, "metadata.message_type")
+
+    def test_validate_task_message_rejects_missing_content_and_error(self) -> None:
+        """Test that either content or error must be set."""
+        message = _create_task_message()
+        message.__dict__["_content"] = None
+
+        errors = validate_task_message(message)
+
+        _assert_has_error(errors, "content` or `error")
+
+    def test_validate_task_message_rejects_content_and_error(self) -> None:
+        """Test that content and error must not both be set."""
+        message = _create_task_message()
+        message.__dict__["_error"] = Error(0)
+
+        errors = validate_task_message(message)
+
+        _assert_has_error(errors, "content` or `error")

--- a/framework/py/flwr/supercore/corestate/utils_test.py
+++ b/framework/py/flwr/supercore/corestate/utils_test.py
@@ -39,7 +39,7 @@ def _create_task_message(  # pylint: disable=too-many-arguments
     """Create a task Message for testing."""
     metadata = Metadata(
         run_id=run_id,
-        message_id=message_id,
+        message_id="",
         src_node_id=src_node_id,
         dst_node_id=dst_node_id,
         reply_to_message_id="",

--- a/framework/py/flwr/supercore/corestate/utils_test.py
+++ b/framework/py/flwr/supercore/corestate/utils_test.py
@@ -56,6 +56,7 @@ def _create_task_message(  # pylint: disable=too-many-arguments
     else:
         msg = make_message(metadata=metadata, content=RecordDict())
     msg.metadata.__dict__["_message_id"] = msg.object_id
+    return msg
 
 
 def _assert_has_error(errors: list[str], expected: str) -> None:

--- a/framework/py/flwr/supercore/corestate/utils_test.py
+++ b/framework/py/flwr/supercore/corestate/utils_test.py
@@ -84,6 +84,7 @@ class UtilsTest(unittest.TestCase):
 
     def test_validate_task_message_rejects_missing_message_id(self) -> None:
         """Test that message_id must be set."""
+        message = _create_task_message()
         message.metadata.__dict__["_message_id"] = ""
 
         errors = validate_task_message(message)
@@ -153,7 +154,8 @@ class UtilsTest(unittest.TestCase):
 
     def test_validate_task_message_rejects_missing_message_type(self) -> None:
         """Test that message_type must be set."""
-        message = _create_task_message(message_type="")
+        message = _create_task_message()
+        message.metadata.__dict__["_message_type"] = ""
 
         errors = validate_task_message(message)
 

--- a/framework/py/flwr/supercore/corestate/utils_test.py
+++ b/framework/py/flwr/supercore/corestate/utils_test.py
@@ -26,7 +26,7 @@ from .utils import generate_rand_int_from_bytes, validate_task_message
 
 def _create_task_message(  # pylint: disable=too-many-arguments
     *,
-    message_id: str = "message-id",
+    message_id: str | None = None,
     run_id: int = 1,
     src_node_id: int = SUPERLINK_NODE_ID,
     dst_node_id: int = SUPERLINK_NODE_ID,

--- a/framework/py/flwr/supercore/corestate/utils_test.py
+++ b/framework/py/flwr/supercore/corestate/utils_test.py
@@ -89,21 +89,24 @@ class UtilsTest(unittest.TestCase):
 
         _assert_has_error(errors, "metadata.message_id")
 
-    def test_validate_task_message_rejects_missing_run_id(self) -> None:
-        """Test that run_id must be set."""
+    def test_validate_task_message_accepts_unset_run_id(self) -> None:
+        """Test that run_id is not required."""
         message = _create_task_message(run_id=0)
 
+        self.assertEqual(validate_task_message(message), [])
+
+    def test_validate_task_message_accepts_missing_src_task_id(self) -> None:
+        """Test that source task ID is not required."""
+        message = _create_task_message(src_task_id=None)
+
+        self.assertEqual(validate_task_message(message), [])
+
+    def test_validate_task_message_rejects_missing_dst_task_id(self) -> None:
+        """Test that destination task ID must be set."""
+        message = _create_task_message(dst_task_id=None)
+
         errors = validate_task_message(message)
 
-        _assert_has_error(errors, "metadata.run_id")
-
-    def test_validate_task_message_rejects_missing_task_ids(self) -> None:
-        """Test that source and destination task IDs must be set."""
-        message = _create_task_message(src_task_id=None, dst_task_id=None)
-
-        errors = validate_task_message(message)
-
-        _assert_has_error(errors, "metadata.src_task_id")
         _assert_has_error(errors, "metadata.dst_task_id")
 
     def test_validate_task_message_rejects_same_task_ids(self) -> None:

--- a/framework/py/flwr/supercore/corestate/utils_test.py
+++ b/framework/py/flwr/supercore/corestate/utils_test.py
@@ -26,7 +26,6 @@ from .utils import generate_rand_int_from_bytes, validate_task_message
 
 def _create_task_message(  # pylint: disable=too-many-arguments
     *,
-    message_id: str = "message-id",
     run_id: int = 1,
     src_node_id: int = SUPERLINK_NODE_ID,
     dst_node_id: int = SUPERLINK_NODE_ID,
@@ -47,15 +46,16 @@ def _create_task_message(  # pylint: disable=too-many-arguments
         group_id="",
         created_at=created_at if created_at is not None else now().timestamp(),
         ttl=ttl,
-        message_type="train",
+        message_type=message_type,
         src_task_id=src_task_id,
         dst_task_id=dst_task_id,
     )
-    metadata.__dict__["_message_type"] = message_type
 
     if has_error:
-        return make_message(metadata=metadata, error=Error(0))
-    return make_message(metadata=metadata, content=RecordDict())
+        msg = make_message(metadata=metadata, error=Error(0))
+    else:
+        msg = make_message(metadata=metadata, content=RecordDict())
+    msg.metadata.__dict__["_message_id"] = msg.object_id
 
 
 def _assert_has_error(errors: list[str], expected: str) -> None:
@@ -83,7 +83,7 @@ class UtilsTest(unittest.TestCase):
 
     def test_validate_task_message_rejects_missing_message_id(self) -> None:
         """Test that message_id must be set."""
-        message = _create_task_message(message_id="")
+        message.metadata.__dict__["_message_id"] = ""
 
         errors = validate_task_message(message)
 


### PR DESCRIPTION
This PR wires the existing Metadata.src_task_id and Metadata.dst_task_id protobuf fields into the Python Message/Metadata model.

  - Adds optional src_task_id and dst_task_id fields to Metadata.
  - Allows instruction Message construction with optional task IDs.
  - Propagates task IDs through reply construction by swapping source and destination task IDs, matching the existing node ID behavior.
  - Updates metadata protobuf serialization/deserialization to preserve optional field presence.
  - Adds focused tests for task ID construction, reply propagation, and serde round trips.