### PR TITLE
ci(intelligence:skip): Update Intelligence TS CI setup

### DIFF
--- a/.github/workflows/intelligence-docs.yml
+++ b/.github/workflows/intelligence-docs.yml
@@ -48,12 +48,12 @@ jobs:
       - name: Bootstrap
         uses: ./.github/actions/bootstrap
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: "22.14.0"
       - name: Install pnpm
         run: |
-          npm install -g pnpm
+          npm install -g pnpm@10.25.0
       - name: Install Flower Intelligence
         run: |
           cd intelligence/ts

--- a/.github/workflows/intelligence-release.yml
+++ b/.github/workflows/intelligence-release.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: '22.14.0'
           registry-url: https://registry.npmjs.org
@@ -37,13 +37,13 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: '22.14.0'
           registry-url: https://registry.npmjs.org
 
       - name: Install pnpm
-        run: npm install -g pnpm
+        run: npm install -g pnpm@10.25.0
 
       - name: Install dependencies
         working-directory: intelligence/ts

--- a/.github/workflows/intelligence-ts.yml
+++ b/.github/workflows/intelligence-ts.yml
@@ -30,12 +30,12 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: '22.14.0'
 
       - name: Install pnpm
-        run: npm install -g pnpm
+        run: npm install -g pnpm@10.25.0
 
       - name: Install dependencies
         working-directory: intelligence/ts
@@ -53,12 +53,12 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: '22.14.0'
 
       - name: Install pnpm
-        run: npm install -g pnpm
+        run: npm install -g pnpm@10.25.0
 
       - name: Install dependencies
         working-directory: intelligence/ts
@@ -87,12 +87,12 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: '22.14.0'
 
       - name: Install pnpm
-        run: npm install -g pnpm
+        run: npm install -g pnpm@10.25.0
 
       - name: Install dependencies
         working-directory: intelligence/ts
@@ -110,12 +110,12 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: '22.14.0'
 
       - name: Install pnpm
-        run: npm install -g pnpm
+        run: npm install -g pnpm@10.25.0
 
       - name: Install dependencies
         working-directory: intelligence/ts
@@ -148,12 +148,12 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: '22.14.0'
 
       - name: Install pnpm
-        run: npm install -g pnpm
+        run: npm install -g pnpm@10.25.0
 
       - name: Install dependencies
         working-directory: intelligence/ts
@@ -184,12 +184,12 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
-          node-version: '20.11.0'
+          node-version: '22.14.0'
 
       - name: Install pnpm
-        run: npm install -g pnpm
+        run: npm install -g pnpm@10.25.0
 
       - name: Install dependencies
         working-directory: intelligence/ts
@@ -208,13 +208,13 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: '22.14.0'
           registry-url: https://registry.npmjs.org
 
       - name: Install pnpm
-        run: npm install -g pnpm
+        run: npm install -g pnpm@10.25.0
 
       - name: Install dependencies
         working-directory: intelligence/ts

--- a/intelligence/docs/source/contributor-how-to-build-from-source.rst
+++ b/intelligence/docs/source/contributor-how-to-build-from-source.rst
@@ -20,14 +20,14 @@ You can install ``pnpm`` globally using npm. Open your terminal and run:
 
 .. code-block:: bash
 
-    npm install -g pnpm
+    npm install -g pnpm@10.25.0
 
 Alternatively, if you are using Corepack (bundled with recent Node.js versions), enable
 pnpm with:
 
 .. code-block:: bash
 
-    corepack enable pnpm
+    corepack prepare pnpm@10.25.0 --activate
 
 *********************
  Setting up the repo

--- a/intelligence/ts/package.json
+++ b/intelligence/ts/package.json
@@ -19,6 +19,7 @@
   },
   "author": "The Flower Authors <hello@flower.ai>",
   "version": "0.2.6",
+  "packageManager": "pnpm@10.25.0",
   "type": "module",
   "main": "./dist/flowerintelligence.cjs.js",
   "module": "./dist/flowerintelligence.es.js",

--- a/intelligence/ts/package.json
+++ b/intelligence/ts/package.json
@@ -20,6 +20,14 @@
   "author": "The Flower Authors <hello@flower.ai>",
   "version": "0.2.6",
   "packageManager": "pnpm@10.25.0",
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild",
+      "onnxruntime-node",
+      "protobufjs",
+      "sharp"
+    ]
+  },
   "type": "module",
   "main": "./dist/flowerintelligence.cjs.js",
   "module": "./dist/flowerintelligence.es.js",

--- a/intelligence/ts/src/engines/remoteEngine.test.ts
+++ b/intelligence/ts/src/engines/remoteEngine.test.ts
@@ -13,17 +13,33 @@
 // limitations under the License.
 // =============================================================================
 
-import { assert, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, assert, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { CryptographyHandler } from './remoteEngine/cryptoHandler';
 import { getTimestamp } from './remoteEngine/cryptoUtils';
 import { KeyManager } from './remoteEngine/keyManager';
 import { NetworkService } from './remoteEngine/networkService';
 
-const API_KEY = process.env.FI_API_KEY ?? '';
-const REMOTE_URL = process.env.FI_DEV_REMOTE_URL ?? '';
+const API_KEY = process.env.FI_API_KEY ?? 'test-api-key';
+const REMOTE_URL = process.env.FI_DEV_REMOTE_URL ?? 'https://example.test';
 const STRING_TIMESTAMP = '2025-03-06T13:19:47.353034';
 const INT_TIMESTAMP = 1741267187353;
+const EXPIRES_AT = '2099-01-01T00:00:00.000000';
+
+let serverPublicKeyBase64 = '';
+
+async function exportTestServerPublicKey(): Promise<string> {
+  const keyPair = await crypto.subtle.generateKey(
+    {
+      name: 'ECDH',
+      namedCurve: 'P-384',
+    },
+    true,
+    ['deriveBits']
+  );
+  const exportedKey = await crypto.subtle.exportKey('spki', keyPair.publicKey);
+  return btoa(String.fromCharCode(...new Uint8Array(exportedKey)));
+}
 
 vi.mock('./constants', () => ({
   DEFAULT_MODEL: 'meta/llama3.2-1b/instruct-fp16',
@@ -32,6 +48,37 @@ vi.mock('./constants', () => ({
   SDK: 'TS',
   ALLOWED_ROLES: ['system', 'assistant', 'user'],
 }));
+
+beforeAll(async () => {
+  serverPublicKeyBase64 = await exportTestServerPublicKey();
+});
+
+beforeEach(() => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn((input: URL | RequestInfo) => {
+      const url =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+      if (url.endsWith('/v1/encryption/public-key')) {
+        return new Response(
+          JSON.stringify({ expires_at: EXPIRES_AT, encryption_id: 'test-encryption-id' }),
+          { status: 200 }
+        );
+      }
+      if (url.endsWith('/v1/encryption/server-public-key')) {
+        return new Response(
+          JSON.stringify({ expires_at: EXPIRES_AT, public_key_base64: serverPublicKeyBase64 }),
+          { status: 200 }
+        );
+      }
+      return new Response('', { status: 404, statusText: 'Not Found' });
+    })
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 describe('CryptographyHandler', () => {
   let cryptographyHandler: CryptographyHandler;

--- a/intelligence/ts/src/flowerintelligence.test.ts
+++ b/intelligence/ts/src/flowerintelligence.test.ts
@@ -17,10 +17,17 @@ import { vi } from 'vitest';
 
 vi.mock('./constants', () => ({
   DEFAULT_MODEL: 'meta/llama3.2-1b/instruct-fp16',
-  REMOTE_URL: process.env.FI_DEV_REMOTE_URL,
+  REMOTE_URL: process.env.FI_DEV_REMOTE_URL ?? 'https://example.test',
   VERSION: '0.2.6',
   SDK: 'TS',
   ALLOWED_ROLES: ['system', 'assistant', 'user'],
+}));
+
+vi.mock('./engines/common/model', () => ({
+  getEngineModelConfig: async () => ({
+    ok: true,
+    value: { name: 'hf-internal-testing/tiny-random-gpt2', vram: 0 },
+  }),
 }));
 
 import { describe, expect, it, beforeEach, assert } from 'vitest';
@@ -33,9 +40,28 @@ describe('FlowerIntelligence', () => {
   let fi: FlowerIntelligence;
 
   beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.spyOn(RemoteEngine.prototype, 'chat').mockImplementation(
+      async (_messages, _model, _temperature, _topP, maxCompletionTokens, responseFormat) => {
+        const content: string = responseFormat
+          ? JSON.stringify({ brand: 'Toyota', model: 'Supra', car_type: 'Coupe' })
+          : maxCompletionTokens
+            ? 'Short reply'
+            : 'Hello from the remote engine.';
+
+        return {
+          ok: true,
+          message: {
+            role: 'assistant',
+            content,
+          },
+        };
+      }
+    );
+
     fi = new FlowerIntelligence();
     fi.remoteHandoff = true;
-    fi.apiKey = process.env.FI_API_KEY ?? '';
+    fi.apiKey = process.env.FI_API_KEY ?? 'test-api-key';
   });
 
   describe('getEngine', () => {


### PR DESCRIPTION
## Summary

Update Intelligence TypeScript CI setup consistently:

- update Intelligence workflows to `actions/setup-node@v6`
- install `pnpm@10.25.0` instead of floating latest
- standardize the TypeScript docs workflow/job on Node `22.14.0`
- add `packageManager: pnpm@10.25.0` to `intelligence/ts/package.json`
- approve pnpm 10 dependency build scripts needed by the TypeScript SDK
- pin the pnpm version in the Intelligence build-from-source docs
- mock remote service/model-config calls in Intelligence TS unit tests so CI does not depend on dev-service availability or runner free memory

## Why

This isolates the Intelligence TypeScript tooling setup fix from PR #6693 and avoids CI drift from floating pnpm releases. The unit-test mocks keep the `Intelligence TS` workflow deterministic; the workflow still keeps the separate demo/e2e job for live remote-service coverage.

## Validation

- Parsed `.github/workflows/intelligence-*.yml` as YAML locally.
- Parsed `intelligence/ts/package.json` as JSON locally.
- Verified no remaining unpinned `npm install -g pnpm`, `actions/setup-node@v3`, or `corepack enable pnpm` usage in Intelligence workflows/docs.
- Ran `pnpm install --frozen-lockfile` in `intelligence/ts`.
- Ran `pnpm build` in `intelligence/ts`.
- Ran `pnpm test` in `intelligence/ts`.
- Ran `pnpm lint:check` in `intelligence/ts`.
- Ran `pnpm format:check` in `intelligence/ts`.
- Ran `PYTHONPATH=dev python -m devtool.check_pr_title 'ci(intelligence:skip): Update Intelligence TS CI setup'`.

Note: `uv run --no-sync docstrfmt --check ../intelligence/docs/source/contributor-how-to-build-from-source.rst` could not run locally because the unsynced `dev` environment does not currently have `docstrfmt` installed; CI covers this check.