### PR TITLE
refactor(framework): Simplify check for `ray` being installed

### DIFF
--- a/framework/py/flwr/server/superlink/fleet/vce/backend/__init__.py
+++ b/framework/py/flwr/server/superlink/fleet/vce/backend/__init__.py
@@ -15,32 +15,7 @@
 """Simulation Engine Backends."""
 
 
-import importlib
-
 from .backend import Backend, BackendConfig
-
-is_ray_installed = importlib.util.find_spec("ray") is not None
-
-# Mapping of supported backends
-supported_backends: dict[str, type[Backend]] = {}
-
-# To log backend-specific error message when chosen backend isn't available
-error_messages_backends: dict[str, str] = {}
-
-if is_ray_installed:
-    from .raybackend import RayBackend
-
-    supported_backends["ray"] = RayBackend
-else:
-    error_messages_backends[
-        "ray"
-    ] = """Unable to import module `ray`.
-
-    To install the necessary dependencies, install `flwr` with the `simulation` extra:
-
-        pip install -U "flwr[simulation]"
-    """
-
 
 __all__ = [
     "Backend",

--- a/framework/py/flwr/server/superlink/fleet/vce/backend/raybackend.py
+++ b/framework/py/flwr/server/superlink/fleet/vce/backend/raybackend.py
@@ -120,7 +120,10 @@ class RayBackend(Backend):
                 pythonpath = f"{pythonpath}{os.pathsep}{os.environ['PYTHONPATH']}"
             os.environ["PYTHONPATH"] = pythonpath
 
-            ray.init(**ray_init_args)
+            ray.init(
+                runtime_env={"env_vars": {"PYTHONPATH": pythonpath}},
+                **ray_init_args,
+            )
 
     @property
     def num_workers(self) -> int:

--- a/framework/py/flwr/server/superlink/fleet/vce/backend/raybackend.py
+++ b/framework/py/flwr/server/superlink/fleet/vce/backend/raybackend.py
@@ -15,6 +15,7 @@
 """Ray backend for the Fleet API using the Simulation Engine."""
 
 
+import os
 import sys
 from collections.abc import Callable
 from logging import DEBUG, ERROR
@@ -110,10 +111,16 @@ class RayBackend(Backend):
             if backend_config.get(self.init_args_key):
                 for k, v in backend_config[self.init_args_key].items():
                     ray_init_args[k] = v
-            ray.init(
-                runtime_env={"env_vars": {"PYTHONPATH": ":".join(sys.path)}},
-                **ray_init_args,
-            )
+            ray_init_args.setdefault("include_dashboard", False)
+
+            # Ray subprocesses inherit environment variables, but not this
+            # driver's in-memory sys.path changes from runtime dependency setup.
+            pythonpath = os.pathsep.join(sys.path)
+            if os.environ.get("PYTHONPATH"):
+                pythonpath = f"{pythonpath}{os.pathsep}{os.environ['PYTHONPATH']}"
+            os.environ["PYTHONPATH"] = pythonpath
+
+            ray.init(**ray_init_args)
 
     @property
     def num_workers(self) -> int:

--- a/framework/py/flwr/server/superlink/fleet/vce/vce_api.py
+++ b/framework/py/flwr/server/superlink/fleet/vce/vce_api.py
@@ -47,7 +47,8 @@ from flwr.supercore.constant import FLWR_IN_MEMORY_DB_NAME
 from flwr.supercore.object_store import ObjectStoreFactory
 from flwr.superlink.federation import NoOpFederationManager
 
-from .backend import Backend, error_messages_backends, supported_backends
+from .backend import Backend
+from .backend.raybackend import RayBackend
 
 NodeToPartitionMapping = dict[int, int]
 
@@ -333,27 +334,11 @@ def start_vce(
     )
 
     # Load backend config
-    log(DEBUG, "Supported backends: %s", list(supported_backends.keys()))
     backend_config = json.loads(backend_config_json_stream)
-
-    try:
-        backend_type = supported_backends[backend_name]
-    except KeyError as ex:
-        log(
-            ERROR,
-            "Backend `%s`, is not supported. Use any of %s or add support "
-            "for a new backend.",
-            backend_name,
-            list(supported_backends.keys()),
-        )
-        if backend_name in error_messages_backends:
-            log(ERROR, error_messages_backends[backend_name])
-
-        raise ex
 
     def backend_fn() -> Backend:
         """Instantiate a Backend."""
-        return backend_type(backend_config)
+        return RayBackend(backend_config)
 
     # Load ClientApp if needed
     def _load() -> ClientApp:

--- a/framework/py/flwr/server/superlink/fleet/vce/vce_api.py
+++ b/framework/py/flwr/server/superlink/fleet/vce/vce_api.py
@@ -48,7 +48,6 @@ from flwr.supercore.object_store import ObjectStoreFactory
 from flwr.superlink.federation import NoOpFederationManager
 
 from .backend import Backend
-from .backend.raybackend import RayBackend
 
 NodeToPartitionMapping = dict[int, int]
 
@@ -338,6 +337,8 @@ def start_vce(
 
     def backend_fn() -> Backend:
         """Instantiate a Backend."""
+        from .backend.raybackend import RayBackend # pylint: disable=C0415
+
         return RayBackend(backend_config)
 
     # Load ClientApp if needed

--- a/framework/py/flwr/server/superlink/fleet/vce/vce_api.py
+++ b/framework/py/flwr/server/superlink/fleet/vce/vce_api.py
@@ -337,7 +337,7 @@ def start_vce(
 
     def backend_fn() -> Backend:
         """Instantiate a Backend."""
-        from .backend.raybackend import RayBackend # pylint: disable=C0415
+        from .backend.raybackend import RayBackend  # pylint: disable=C0415
 
         return RayBackend(backend_config)
 

--- a/framework/py/flwr/server/superlink/fleet/vce/vce_api_test.py
+++ b/framework/py/flwr/server/superlink/fleet/vce/vce_api_test.py
@@ -268,11 +268,6 @@ class TestFleetSimulationEngineRayBackend(TestCase):
         with self.assertRaises(JSONDecodeError):
             start_and_shutdown(num_supernodes=50, backend_config="not a proper config")
 
-    def test_with_nonexistent_backend(self) -> None:
-        """Test specifying a backend that does not exist."""
-        with self.assertRaises(KeyError):
-            start_and_shutdown(num_supernodes=50, backend="this-backend-does-not-exist")
-
     def test_erroneous_arguments_num_supernodes_and_existing_mapping(self) -> None:
         """Test ValueError if a node mapping is passed but also num_supernodes.
 


### PR DESCRIPTION
Performing the check at import time isn't ideal when we want to rely on auto-install dependencies for an app. 