### PR TITLE
feat(framework): Add LaunchResult to Executor Protocol

### DIFF
--- a/framework/py/flwr/supercore/superexec/executor/__init__.py
+++ b/framework/py/flwr/supercore/superexec/executor/__init__.py
@@ -16,11 +16,13 @@
 
 from .factory import get_executor
 from .subprocess_executor import SubprocessExecutor
-from .types import ExecutionSpec, Executor
+from .types import ExecutionSpec, Executor, LaunchResult, LaunchResultStatus
 
 __all__ = [
     "ExecutionSpec",
     "Executor",
+    "LaunchResult",
+    "LaunchResultStatus",
     "SubprocessExecutor",
     "get_executor",
 ]

--- a/framework/py/flwr/supercore/superexec/executor/subprocess_executor.py
+++ b/framework/py/flwr/supercore/superexec/executor/subprocess_executor.py
@@ -39,7 +39,13 @@ class SubprocessExecutor:
                 spec.token,
             ]
         except KeyError:
-            return LaunchResult.failed(f"Unsupported task type: {spec.task_type}")
+            supported_task_types = ", ".join(
+                task_type.value for task_type in TASK_TYPE_TO_COMMAND
+            )
+            return LaunchResult.failed(
+                f"Unsupported task type: {spec.task_type.value}. "
+                f"Supported task types: {supported_task_types}"
+            )
 
         if spec.insecure:
             args.append("--insecure")

--- a/framework/py/flwr/supercore/superexec/executor/subprocess_executor.py
+++ b/framework/py/flwr/supercore/superexec/executor/subprocess_executor.py
@@ -30,22 +30,13 @@ class SubprocessExecutor:
 
     def launch(self, spec: ExecutionSpec) -> LaunchResult:
         """Start the TaskExecutor process described by the execution spec."""
-        try:
-            args = [
-                TASK_TYPE_TO_COMMAND[spec.task_type],
-                TASK_TYPE_TO_APPIO_API_ADDRESS_ARG[spec.task_type],
-                spec.appio_api_address,
-                "--token",
-                spec.token,
-            ]
-        except KeyError:
-            supported_task_types = ", ".join(
-                task_type.value for task_type in TASK_TYPE_TO_COMMAND
-            )
-            return LaunchResult.failed(
-                f"Unsupported task type: {spec.task_type.value}. "
-                f"Supported task types: {supported_task_types}"
-            )
+        args = [
+            TASK_TYPE_TO_COMMAND[spec.task_type],
+            TASK_TYPE_TO_APPIO_API_ADDRESS_ARG[spec.task_type],
+            spec.appio_api_address,
+            "--token",
+            spec.token,
+        ]
 
         if spec.insecure:
             args.append("--insecure")
@@ -58,17 +49,14 @@ class SubprocessExecutor:
         if spec.runtime_dependency_install:
             args.append("--allow-runtime-dependency-installation")
 
-        try:
-            if spec.suppress_output:
-                subprocess.Popen(  # pylint: disable=consider-using-with
-                    args,
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.DEVNULL,
-                )
-                return LaunchResult.accepted()
+        if spec.suppress_output:
+            subprocess.Popen(  # pylint: disable=consider-using-with
+                args,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            return LaunchResult.accepted()
 
-            subprocess.Popen(args)  # pylint: disable=consider-using-with
-        except OSError as exc:
-            return LaunchResult.failed(f"Failed to start TaskExecutor: {exc}")
+        subprocess.Popen(args)  # pylint: disable=consider-using-with
 
         return LaunchResult.accepted()

--- a/framework/py/flwr/supercore/superexec/executor/subprocess_executor.py
+++ b/framework/py/flwr/supercore/superexec/executor/subprocess_executor.py
@@ -22,21 +22,24 @@ from flwr.supercore.constant import (
     TASK_TYPE_TO_COMMAND,
 )
 
-from .types import ExecutionSpec
+from .types import ExecutionSpec, LaunchResult
 
 
 class SubprocessExecutor:
     """Run TaskExecutor processes as local subprocesses."""
 
-    def launch(self, spec: ExecutionSpec) -> None:
+    def launch(self, spec: ExecutionSpec) -> LaunchResult:
         """Start the TaskExecutor process described by the execution spec."""
-        args = [
-            TASK_TYPE_TO_COMMAND[spec.task_type],
-            TASK_TYPE_TO_APPIO_API_ADDRESS_ARG[spec.task_type],
-            spec.appio_api_address,
-            "--token",
-            spec.token,
-        ]
+        try:
+            args = [
+                TASK_TYPE_TO_COMMAND[spec.task_type],
+                TASK_TYPE_TO_APPIO_API_ADDRESS_ARG[spec.task_type],
+                spec.appio_api_address,
+                "--token",
+                spec.token,
+            ]
+        except KeyError:
+            return LaunchResult.failed(f"Unsupported task type: {spec.task_type}")
 
         if spec.insecure:
             args.append("--insecure")
@@ -49,12 +52,17 @@ class SubprocessExecutor:
         if spec.runtime_dependency_install:
             args.append("--allow-runtime-dependency-installation")
 
-        if spec.suppress_output:
-            subprocess.Popen(  # pylint: disable=consider-using-with
-                args,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-            )
-            return
+        try:
+            if spec.suppress_output:
+                subprocess.Popen(  # pylint: disable=consider-using-with
+                    args,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
+                return LaunchResult.accepted()
 
-        subprocess.Popen(args)  # pylint: disable=consider-using-with
+            subprocess.Popen(args)  # pylint: disable=consider-using-with
+        except OSError as exc:
+            return LaunchResult.failed(f"Failed to start TaskExecutor: {exc}")
+
+        return LaunchResult.accepted()

--- a/framework/py/flwr/supercore/superexec/executor/subprocess_executor_test.py
+++ b/framework/py/flwr/supercore/superexec/executor/subprocess_executor_test.py
@@ -19,6 +19,8 @@ import subprocess
 from typing import Any
 from unittest.mock import Mock, patch
 
+import pytest
+
 from flwr.supercore.constant import TaskType
 
 from .subprocess_executor import SubprocessExecutor
@@ -152,22 +154,17 @@ def test_launch_does_not_suppress_output_by_default() -> None:
     assert "stderr" not in popen_mock.call_args.kwargs
 
 
-def test_launch_returns_failed_when_subprocess_cannot_start() -> None:
-    """Test subprocess executor returns failed when Popen raises."""
+def test_launch_raises_when_subprocess_cannot_start() -> None:
+    """Test subprocess executor preserves Popen failure semantics."""
     with patch.object(subprocess, "Popen", side_effect=OSError("missing binary")):
-        result = SubprocessExecutor().launch(_execution_spec())
-
-    assert result.status == LaunchResultStatus.FAILED
-    assert result.message == "Failed to start TaskExecutor: missing binary"
+        with pytest.raises(OSError, match="missing binary"):
+            SubprocessExecutor().launch(_execution_spec())
 
 
-def test_launch_returns_failed_for_unsupported_task_type() -> None:
-    """Test subprocess executor returns failed for unsupported task types."""
+def test_launch_raises_for_unsupported_task_type() -> None:
+    """Test subprocess executor preserves unsupported task type failures."""
     with patch.object(subprocess, "Popen") as popen_mock:
-        result = SubprocessExecutor().launch(
-            _execution_spec(task_type=TaskType.AGENT_APP)
-        )
+        with pytest.raises(KeyError):
+            SubprocessExecutor().launch(_execution_spec(task_type=TaskType.AGENT_APP))
 
     popen_mock.assert_not_called()
-    assert result.status == LaunchResultStatus.FAILED
-    assert result.message == f"Unsupported task type: {TaskType.AGENT_APP}"

--- a/framework/py/flwr/supercore/superexec/executor/subprocess_executor_test.py
+++ b/framework/py/flwr/supercore/superexec/executor/subprocess_executor_test.py
@@ -22,7 +22,7 @@ from unittest.mock import Mock, patch
 from flwr.supercore.constant import TaskType
 
 from .subprocess_executor import SubprocessExecutor
-from .types import ExecutionSpec
+from .types import ExecutionSpec, LaunchResultStatus
 
 
 def _execution_spec(**overrides: Any) -> ExecutionSpec:
@@ -43,7 +43,7 @@ def _execution_spec(**overrides: Any) -> ExecutionSpec:
 def test_launch_renders_insecure_clientapp_args() -> None:
     """Test subprocess executor renders insecure ClientApp args."""
     with patch.object(subprocess, "Popen") as popen_mock:
-        SubprocessExecutor().launch(_execution_spec())
+        result = SubprocessExecutor().launch(_execution_spec())
 
     popen_mock.assert_called_once_with(
         [
@@ -55,6 +55,8 @@ def test_launch_renders_insecure_clientapp_args() -> None:
             "--insecure",
         ]
     )
+    assert result.status == LaunchResultStatus.ACCEPTED
+    assert result.message is None
 
 
 def test_launch_renders_root_certificates_args() -> None:
@@ -100,7 +102,7 @@ def test_launch_renders_parent_pid_flag() -> None:
 def test_launch_suppresses_output_when_requested() -> None:
     """Test subprocess executor suppresses output when requested."""
     with patch.object(subprocess, "Popen") as popen_mock:
-        SubprocessExecutor().launch(
+        result = SubprocessExecutor().launch(
             _execution_spec(
                 task_type=TaskType.SERVER_APP,
                 suppress_output=True,
@@ -119,6 +121,7 @@ def test_launch_suppresses_output_when_requested() -> None:
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
     )
+    assert result.status == LaunchResultStatus.ACCEPTED
 
 
 def test_launch_renders_simulation_args() -> None:
@@ -147,3 +150,24 @@ def test_launch_does_not_suppress_output_by_default() -> None:
 
     assert "stdout" not in popen_mock.call_args.kwargs
     assert "stderr" not in popen_mock.call_args.kwargs
+
+
+def test_launch_returns_failed_when_subprocess_cannot_start() -> None:
+    """Test subprocess executor returns failed when Popen raises."""
+    with patch.object(subprocess, "Popen", side_effect=OSError("missing binary")):
+        result = SubprocessExecutor().launch(_execution_spec())
+
+    assert result.status == LaunchResultStatus.FAILED
+    assert result.message == "Failed to start TaskExecutor: missing binary"
+
+
+def test_launch_returns_failed_for_unsupported_task_type() -> None:
+    """Test subprocess executor returns failed for unsupported task types."""
+    with patch.object(subprocess, "Popen") as popen_mock:
+        result = SubprocessExecutor().launch(
+            _execution_spec(task_type=TaskType.AGENT_APP)
+        )
+
+    popen_mock.assert_not_called()
+    assert result.status == LaunchResultStatus.FAILED
+    assert result.message == f"Unsupported task type: {TaskType.AGENT_APP}"

--- a/framework/py/flwr/supercore/superexec/executor/types.py
+++ b/framework/py/flwr/supercore/superexec/executor/types.py
@@ -15,6 +15,7 @@
 """Executor types for SuperExec TaskExecutor processes."""
 
 from dataclasses import dataclass
+from enum import StrEnum
 from typing import Protocol
 
 from flwr.supercore.constant import TaskType
@@ -34,12 +35,49 @@ class ExecutionSpec:  # pylint: disable=too-many-instance-attributes
     suppress_output: bool
 
 
+class LaunchResultStatus(StrEnum):
+    """Immediate outcome of an executor launch attempt."""
+
+    ACCEPTED = "accepted"
+    CAPACITY_REJECTED = "capacity_rejected"
+    FAILED = "failed"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class LaunchResult:
+    """Structured result returned by an executor launch attempt."""
+
+    status: LaunchResultStatus
+    message: str | None = None
+
+    @classmethod
+    def accepted(cls) -> "LaunchResult":
+        """Return a result for a launch accepted by the backend."""
+        return cls(status=LaunchResultStatus.ACCEPTED)
+
+    @classmethod
+    def capacity_rejected(cls, message: str | None = None) -> "LaunchResult":
+        """Return a result for capacity rejection after launch was attempted."""
+        return cls(status=LaunchResultStatus.CAPACITY_REJECTED, message=message)
+
+    @classmethod
+    def failed(cls, message: str | None = None) -> "LaunchResult":
+        """Return a result for a known launch failure."""
+        return cls(status=LaunchResultStatus.FAILED, message=message)
+
+    @classmethod
+    def unknown(cls, message: str | None = None) -> "LaunchResult":
+        """Return a result for an ambiguous launch outcome."""
+        return cls(status=LaunchResultStatus.UNKNOWN, message=message)
+
+
 class Executor(Protocol):
     """SuperExec component that starts TaskExecutor processes from an ExecutionSpec.
 
-    An executor only starts processes; it does not wait, monitor, terminate,
-    reconcile, or report task status.
+    An executor only starts processes and reports the immediate launch outcome;
+    it does not wait, monitor, terminate, reconcile, or report task status.
     """
 
-    def launch(self, spec: ExecutionSpec) -> None:
+    def launch(self, spec: ExecutionSpec) -> LaunchResult:
         """Start the TaskExecutor process described by the execution spec."""


### PR DESCRIPTION
## Issue

`Executor.launch` currently returns `None`, so SuperExec has no structured way to distinguish an accepted launch from an immediate launch failure.

### Related issues/PRs

Follow-up to token-file support for TaskExecutors.

## Proposal

### Explanation

Add `LaunchResult` and `LaunchResultStatus`, update the `Executor.launch` protocol to return `LaunchResult`, and make `SubprocessExecutor` return `accepted` or `failed` for immediate launch outcomes.

### Checklist

- [x] Implement proposed change
- [x] Write tests
- [x] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [x] Address LLM-reviewer comments, if applicable (e.g., GitHub Copilot)
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?