### PR TITLE
fix(framework): Make task-to-task message delivery crash-safe

### DIFF
--- a/framework/py/flwr/server/superlink/fleet/grpc_rere/fleet_servicer_test.py
+++ b/framework/py/flwr/server/superlink/fleet/grpc_rere/fleet_servicer_test.py
@@ -738,13 +738,14 @@ class TestFleetServicer(unittest.TestCase):  # pylint: disable=R0902, R0904
         run_id = self._create_dummy_run()
 
         # Prepare: Create a message
-        msg_proto = create_res_message(
+        msg_proto = create_ins_message(
             src_node_id=SUPERLINK_NODE_ID, dst_node_id=node_id, run_id=run_id
         )
         message = message_from_proto(msg_proto)
         # pylint: disable-next=E1137
         message.content["test_config"] = ConfigRecord({"a": 123, "b": [4, 5, 6]})
         message.metadata.__dict__["_message_id"] = message.object_id
+        assert self.state.store_message_ins(message)
 
         # Prepare: Store message in ObjectStore
         all_objects = get_all_nested_objects(message)

--- a/framework/py/flwr/server/superlink/fleet/message_handler/message_handler.py
+++ b/framework/py/flwr/server/superlink/fleet/message_handler/message_handler.py
@@ -360,12 +360,29 @@ def confirm_message_received(
     if abort_msg:
         raise InvalidRunStatusException(abort_msg)
 
-    state.acknowledge_message(request.message_object_id)
+    reply_to_message_id = _try_get_reply_to_message_id(
+        store.get(request.message_object_id)
+    )
+    acknowledged = state.acknowledge_message(
+        request.message_object_id, request.run_id, reply_to_message_id
+    )
 
     # Delete the message object
-    store.delete(request.message_object_id)
+    if acknowledged:
+        store.delete(request.message_object_id)
 
     return ConfirmMessageReceivedResponse()
+
+
+def _try_get_reply_to_message_id(object_content: bytes | None) -> str | None:
+    """Return reply_to_message_id for stored Message objects without children."""
+    if object_content is None:
+        return None
+    try:
+        message = Message.inflate(object_content)
+    except (ValueError, UnexpectedObjectContentError):
+        return None
+    return message.metadata.reply_to_message_id or None
 
 
 def _validate_heartbeat_interval(interval: float) -> None:

--- a/framework/py/flwr/server/superlink/fleet/message_handler/message_handler_test.py
+++ b/framework/py/flwr/server/superlink/fleet/message_handler/message_handler_test.py
@@ -26,10 +26,13 @@ from flwr.proto.fleet_pb2 import (  # pylint: disable=E0611
     PullMessagesRequest,
     PushMessagesRequest,
 )
-from flwr.proto.message_pb2 import ObjectTree  # pylint: disable=E0611
+from flwr.proto.message_pb2 import (  # pylint: disable=E0611
+    ConfirmMessageReceivedRequest,
+    ObjectTree,
+)
 from flwr.proto.node_pb2 import Node  # pylint: disable=E0611
 
-from .message_handler import pull_messages, push_messages
+from .message_handler import confirm_message_received, pull_messages, push_messages
 
 
 def test_pull_messages() -> None:
@@ -159,3 +162,19 @@ def test_push_messages_cleans_up_failed_message_objects() -> None:
     store.delete.assert_called_once_with("object-id")
     store.delete_objects_in_run.assert_not_called()
     assert not response.objects_to_push
+
+
+def test_confirm_message_received_keeps_object_when_not_acknowledged() -> None:
+    """Test confirm_message_received keeps object after rejected acknowledgement."""
+    request = ConfirmMessageReceivedRequest(run_id=123, message_object_id="msg-id")
+    state = MagicMock()
+    state.get_run_status.return_value = {
+        123: RunStatus(status=Status.RUNNING, sub_status="", details="")
+    }
+    state.acknowledge_message.return_value = False
+    store = MagicMock()
+
+    confirm_message_received(request=request, state=state, store=store)
+
+    state.acknowledge_message.assert_called_once_with("msg-id", 123, None)
+    store.delete.assert_not_called()

--- a/framework/py/flwr/server/superlink/linkstate/in_memory_linkstate.py
+++ b/framework/py/flwr/server/superlink/linkstate/in_memory_linkstate.py
@@ -388,26 +388,50 @@ class InMemoryLinkState(LinkState, InMemoryCoreState):  # pylint: disable=R0902,
                     del self.message_ins_store[message_id]
                     self.acknowledged_message_ins_ids.discard(message_id)
                 # Delete Message replies
-                if message_id in self.message_ins_id_to_message_res_id:
-                    message_res_id = self.message_ins_id_to_message_res_id.pop(
-                        message_id
-                    )
-                    del self.message_res_store[message_res_id]
+                self.message_ins_id_to_message_res_id.pop(message_id, None)
+                for msg_res_id, msg_res in list(self.message_res_store.items()):
+                    if msg_res.metadata.reply_to_message_id == message_id:
+                        self.message_res_store.pop(msg_res_id, None)
 
-    def acknowledge_message(self, message_id: str) -> None:
+    def acknowledge_message(
+        self, message_id: str, run_id: int, reply_to_message_id: str | None = None
+    ) -> bool:
         """Mark a delivered Message as durably received."""
         with self.lock:
             for msg_ins_id, msg_res_id in list(
                 self.message_ins_id_to_message_res_id.items()
             ):
-                if msg_res_id == message_id:
+                msg_res = self.message_res_store.get(msg_res_id)
+                if (
+                    msg_res_id == message_id
+                    and msg_res
+                    and msg_res.metadata.run_id == run_id
+                ):
                     self.message_ins_store.pop(msg_ins_id, None)
                     self.acknowledged_message_ins_ids.discard(msg_ins_id)
                     self.message_ins_id_to_message_res_id.pop(msg_ins_id, None)
-                    self.message_res_store.pop(msg_res_id, None)
-                    return
-            if message_id in self.message_ins_store:
+                    for stored_msg_res_id, stored_msg_res in list(
+                        self.message_res_store.items()
+                    ):
+                        if stored_msg_res.metadata.reply_to_message_id == msg_ins_id:
+                            self.message_res_store.pop(stored_msg_res_id, None)
+                    return True
+            if reply_to_message_id:
+                msg_ins = self.message_ins_store.get(reply_to_message_id)
+                if msg_ins and msg_ins.metadata.run_id == run_id:
+                    self.message_ins_store.pop(reply_to_message_id, None)
+                    self.acknowledged_message_ins_ids.discard(reply_to_message_id)
+                    self.message_ins_id_to_message_res_id.pop(reply_to_message_id, None)
+                    for msg_res_id, msg_res in list(self.message_res_store.items()):
+                        if msg_res.metadata.reply_to_message_id == reply_to_message_id:
+                            self.message_res_store.pop(msg_res_id, None)
+                    return True
+                return False
+            msg_ins = self.message_ins_store.get(message_id)
+            if msg_ins and msg_ins.metadata.run_id == run_id:
                 self.acknowledged_message_ins_ids.add(message_id)
+                return True
+            return False
 
     def get_message_ids_from_run_id(self, run_id: int) -> set[str]:
         """Get all instruction Message IDs for the given run_id."""

--- a/framework/py/flwr/server/superlink/linkstate/linkstate.py
+++ b/framework/py/flwr/server/superlink/linkstate/linkstate.py
@@ -132,7 +132,9 @@ class LinkState(CoreState):  # pylint: disable=R0904
         """
 
     @abc.abstractmethod
-    def acknowledge_message(self, message_id: str) -> None:
+    def acknowledge_message(
+        self, message_id: str, run_id: int, reply_to_message_id: str | None = None
+    ) -> bool:
         """Mark a delivered Message as durably received."""
 
     @abc.abstractmethod

--- a/framework/py/flwr/server/superlink/linkstate/linkstate_test.py
+++ b/framework/py/flwr/server/superlink/linkstate/linkstate_test.py
@@ -675,6 +675,39 @@ class StateTest(CoreStateTest):
         assert state.num_message_ins() == 0
         assert state.num_message_res() == 0
 
+    def test_acknowledge_message_removes_duplicate_replies(self) -> None:
+        """Test acknowledgement removes all replies for the instruction."""
+        # Prepare
+        state = self.state_factory()
+        node_id = create_dummy_node(state)
+        run_id = create_dummy_run(state)
+        msg_id = state.store_message_ins(
+            create_ins_message_obj(
+                src_node_id=SUPERLINK_NODE_ID,
+                dst_node_id=node_id,
+                run_id=run_id,
+            )
+        )
+        assert msg_id
+        msg_ins = state.get_message_ins(node_id=node_id, limit=1)[0]
+
+        msg_res_id = ""
+        for _ in range(2):
+            msg_res = Message(RecordDict(), reply_to=msg_ins)
+            msg_res.metadata.__dict__["_message_id"] = str(uuid4())
+            stored_msg_res_id = state.store_message_res(msg_res)
+            assert stored_msg_res_id
+            msg_res_id = stored_msg_res_id
+        assert state.num_message_ins() == 1
+        assert state.num_message_res() == 2
+
+        # Execute
+        assert state.acknowledge_message(msg_res_id, run_id)
+
+        # Assert
+        assert state.num_message_ins() == 0
+        assert state.num_message_res() == 0
+
     def test_get_message_ids_from_run_id(self) -> None:
         """Test get_message_ids_from_run_id."""
         # Prepare
@@ -2250,7 +2283,7 @@ class SqlFileBasedTest(SqlInMemoryStateTest):
         )
         assert len(state.get_message_ins(node_id=node_id, limit=1)) == 1
 
-        state.acknowledge_message(msg_id)
+        state.acknowledge_message(msg_id, run_id)
         state.query(
             """
             UPDATE message_ins
@@ -2296,16 +2329,17 @@ class SqlFileBasedTest(SqlInMemoryStateTest):
         )
         assert len(state.get_message_res({msg_id})) == 1
 
-        state.acknowledge_message(res_id)
+        state.acknowledge_message(res_id, run_id)
         assert state.num_message_ins() == 0
         assert state.num_message_res() == 0
 
-    def test_get_message_res_handles_duplicate_replies(self) -> None:
-        """Ensure duplicate replies for one instruction do not crash polling."""
+    def test_acknowledge_message_is_scoped_to_run_id(self) -> None:
+        """Ensure a mismatched run cannot acknowledge delivered Messages."""
         # Prepare
         state = self.state_factory()
         node_id = create_dummy_node(state)
         run_id = create_dummy_run(state)
+        other_run_id = create_dummy_run(state)
         msg_id = state.store_message_ins(
             create_ins_message_obj(
                 src_node_id=SUPERLINK_NODE_ID,
@@ -2316,17 +2350,56 @@ class SqlFileBasedTest(SqlInMemoryStateTest):
         assert msg_id
         pulled_ins = state.get_message_ins(node_id=node_id, limit=1)[0]
 
-        for _ in range(2):
-            msg_res = Message(RecordDict(), reply_to=pulled_ins)
-            msg_res.metadata.__dict__["_message_id"] = str(uuid4())
-            assert state.store_message_res(msg_res)
+        msg_res = Message(RecordDict(), reply_to=pulled_ins)
+        msg_res.metadata.__dict__["_message_id"] = str(uuid4())
+        res_id = state.store_message_res(msg_res)
+        assert res_id
+
+        # Execute and assert
+        state.acknowledge_message(res_id, other_run_id)
+        assert state.num_message_ins() == 1
+        assert state.num_message_res() == 1
+
+        state.acknowledge_message(res_id, run_id)
+        assert state.num_message_ins() == 0
+        assert state.num_message_res() == 0
+
+    def test_acknowledge_generated_error_reply_deletes_instruction(self) -> None:
+        """Ensure confirming a generated error reply completes cleanup."""
+        # Prepare
+        state = self.state_factory()
+        node_id = create_dummy_node(state)
+        run_id = create_dummy_run(state)
+        assert state.deactivate_node(node_id)
+        msg_id = state.store_message_ins(
+            create_ins_message_obj(
+                src_node_id=SUPERLINK_NODE_ID,
+                dst_node_id=node_id,
+                run_id=run_id,
+            )
+        )
+        assert msg_id
 
         # Execute
         replies = state.get_message_res({msg_id})
+        assert len(replies) == 1
+        assert replies[0].has_error()
+        other_run_id = create_dummy_run(state)
+        state.acknowledge_message(
+            replies[0].object_id,
+            other_run_id,
+            replies[0].metadata.reply_to_message_id,
+        )
+        assert state.num_message_ins() == 1
+        assert state.num_message_res() == 0
+
+        state.acknowledge_message(
+            replies[0].object_id, run_id, replies[0].metadata.reply_to_message_id
+        )
 
         # Assert
-        assert len(replies) == 1
-        assert replies[0].metadata.reply_to_message_id == msg_id
+        assert state.num_message_ins() == 0
+        assert state.num_message_res() == 0
 
     # pylint: disable-next=too-many-locals
     def test_get_message_ins_distributes_available_work_under_contention(self) -> None:

--- a/framework/py/flwr/server/superlink/linkstate/sql_linkstate.py
+++ b/framework/py/flwr/server/superlink/linkstate/sql_linkstate.py
@@ -600,38 +600,94 @@ class SqlLinkState(LinkState, SqlCoreState):  # pylint: disable=R0904
             self.query(query_1, params)
             self.query(query_2, params)
 
-    def acknowledge_message(self, message_id: str) -> None:
+    def acknowledge_message(
+        self, message_id: str, run_id: int, reply_to_message_id: str | None = None
+    ) -> bool:
         """Mark a delivered Message as durably received."""
+        sint64_run_id = uint64_to_int64(run_id)
         with self.session():
             rows = self.query(
                 """
                 SELECT reply_to_message_id
                 FROM message_res
-                WHERE message_id = :message_id
+                WHERE message_id = :message_id AND run_id = :run_id
                 """,
-                {"message_id": message_id},
+                {"message_id": message_id, "run_id": sint64_run_id},
             )
             if rows:
                 msg_ins_id = rows[0]["reply_to_message_id"]
                 self.query(
-                    "DELETE FROM message_ins WHERE message_id = :message_id",
-                    {"message_id": msg_ins_id},
+                    """
+                    DELETE FROM message_ins
+                    WHERE message_id = :message_id AND run_id = :run_id
+                    """,
+                    {"message_id": msg_ins_id, "run_id": sint64_run_id},
                 )
                 self.query(
                     "DELETE FROM message_res "
-                    "WHERE reply_to_message_id = :reply_to_message_id",
-                    {"reply_to_message_id": msg_ins_id},
+                    "WHERE reply_to_message_id = :reply_to_message_id "
+                    "AND run_id = :run_id",
+                    {"reply_to_message_id": msg_ins_id, "run_id": sint64_run_id},
                 )
-                return
+                return True
+
+            if reply_to_message_id:
+                rows = self.query(
+                    """
+                    SELECT message_id
+                    FROM message_ins
+                    WHERE message_id = :message_id AND run_id = :run_id
+                    """,
+                    {"message_id": reply_to_message_id, "run_id": sint64_run_id},
+                )
+                if not rows:
+                    return False
+                self.query(
+                    """
+                    DELETE FROM message_ins
+                    WHERE message_id = :message_id AND run_id = :run_id
+                    """,
+                    {"message_id": reply_to_message_id, "run_id": sint64_run_id},
+                )
+                self.query(
+                    "DELETE FROM message_res "
+                    "WHERE reply_to_message_id = :reply_to_message_id "
+                    "AND run_id = :run_id",
+                    {
+                        "reply_to_message_id": reply_to_message_id,
+                        "run_id": sint64_run_id,
+                    },
+                )
+                return True
+
+            rows = self.query(
+                """
+                SELECT message_id
+                FROM message_ins
+                WHERE message_id = :message_id
+                AND run_id = :run_id
+                AND acknowledged_at = ''
+                """,
+                {"message_id": message_id, "run_id": sint64_run_id},
+            )
+            if not rows:
+                return False
 
             self.query(
                 """
                 UPDATE message_ins
                 SET acknowledged_at = :acknowledged_at
-                WHERE message_id = :message_id AND acknowledged_at = ''
+                WHERE message_id = :message_id
+                AND run_id = :run_id
+                AND acknowledged_at = ''
                 """,
-                {"message_id": message_id, "acknowledged_at": now().isoformat()},
+                {
+                    "message_id": message_id,
+                    "run_id": sint64_run_id,
+                    "acknowledged_at": now().isoformat(),
+                },
             )
+            return True
 
     def get_message_ids_from_run_id(self, run_id: int) -> set[str]:
         """Get all instruction Message IDs for the given run_id."""

--- a/framework/py/flwr/server/superlink/serverappio/serverappio_servicer.py
+++ b/framework/py/flwr/server/superlink/serverappio/serverappio_servicer.py
@@ -290,15 +290,9 @@ class ServerAppIoServicer(AppIoServicer, serverappio_pb2_grpc.ServerAppIoService
         # Init state and store
         state = self.state_factory.state()
 
-        # Store Simulation Runtime usage metrics before finishing the primary task.
-        # This ensures that usage is captured even if the task fails to finish properly.
-        if request.bytes_sent or request.bytes_recv:
-            state.store_traffic(
-                run_id=run_id,
-                bytes_sent=request.bytes_sent,
-                bytes_recv=request.bytes_recv,
-            )
-        if request.clientapp_runtime:
+        # Store Simulation Runtime usage before finishing the primary task.
+        # This ensures usage is captured even if the task fails to finish properly.
+        if request.HasField("clientapp_runtime"):
             state.add_clientapp_runtime(run_id, request.clientapp_runtime)
 
         # Finish the task
@@ -383,12 +377,29 @@ class ServerAppIoServicer(AppIoServicer, serverappio_pb2_grpc.ServerAppIoService
         state = self.state_factory.state()
         store = self.objectstore_factory.store()
 
-        _ = _get_authenticated_serverapp_run_id(context)
+        run_id = _get_authenticated_serverapp_run_id(context)
 
-        state.acknowledge_message(request.message_object_id)
-        store.delete(request.message_object_id)
+        reply_to_message_id = _try_get_reply_to_message_id(
+            store.get(request.message_object_id)
+        )
+        acknowledged = state.acknowledge_message(
+            request.message_object_id, run_id, reply_to_message_id
+        )
+        if acknowledged:
+            store.delete(request.message_object_id)
 
         return ConfirmMessageReceivedResponse()
+
+
+def _try_get_reply_to_message_id(object_content: bytes | None) -> str | None:
+    """Return reply_to_message_id for stored Message objects without children."""
+    if object_content is None:
+        return None
+    try:
+        message = Message.inflate(object_content)
+    except (ValueError, UnexpectedObjectContentError):
+        return None
+    return message.metadata.reply_to_message_id or None
 
 
 def _get_authenticated_serverapp_run_id(context: grpc.ServicerContext) -> int:

--- a/framework/py/flwr/server/superlink/serverappio/serverappio_servicer_test.py
+++ b/framework/py/flwr/server/superlink/serverappio/serverappio_servicer_test.py
@@ -27,7 +27,7 @@ from unittest.mock import Mock, patch
 import grpc
 from parameterized import parameterized
 
-from flwr.common import ConfigRecord, Context, Error, Message, RecordDict
+from flwr.common import ConfigRecord, Context, Message, RecordDict
 from flwr.common.constant import (
     SERVERAPPIO_API_DEFAULT_SERVER_ADDRESS,
     SUPERLINK_NODE_ID,
@@ -442,14 +442,12 @@ class TestServerAppIoServicer(unittest.TestCase):  # pylint: disable=R0902, R090
         assert task.type == TaskType.MODEL
         assert task.model_ref == "models/abc"
 
-    def test_push_task_output_stores_simulation_metrics(self) -> None:
-        """PushTaskOutput should persist Simulation Runtime usage metrics."""
+    def test_push_task_output_stores_simulation_runtime(self) -> None:
+        """PushTaskOutput should persist Simulation Runtime usage."""
         # Prepare
         request = PushTaskOutputRequest(
             sub_status="completed",
             details="",
-            bytes_sent=123,
-            bytes_recv=456,
             clientapp_runtime=7.89,
         )
 
@@ -460,8 +458,6 @@ class TestServerAppIoServicer(unittest.TestCase):  # pylint: disable=R0902, R090
         assert isinstance(response, PushTaskOutputResponse)
         assert grpc.StatusCode.OK == call.code()
         run = self.state.get_run_info(run_ids=[self._auth_run_id])[0]
-        assert run.bytes_sent == 123
-        assert run.bytes_recv == 456
         assert run.clientapp_runtime == 7.89
 
     def test_get_node(self) -> None:
@@ -538,70 +534,6 @@ class TestServerAppIoServicer(unittest.TestCase):  # pylint: disable=R0902, R090
             # Ins message was deleted
             assert self.state.num_message_ins() == 0
 
-    @parameterized.expand(
-        [
-            # Reply with Message
-            (RecordDict(), None),
-            # Reply with Error
-            (None, Error(code=0)),
-        ]
-    )  # type: ignore
-    def test_confirm_message_received_deletes_messages_in_linkstate(
-        self, content: RecordDict | None, error: Error | None
-    ) -> None:
-        """Test `ConfirmMessageReceived` deletes messages from LinkState."""
-        # Prepare
-        run_id = self._auth_run_id
-
-        # Push Messages and reply
-        message_ins = message_from_proto(
-            create_ins_message(
-                src_node_id=SUPERLINK_NODE_ID, dst_node_id=self.node_id, run_id=run_id
-            )
-        )
-        # pylint: disable-next=W0212
-        message_ins.metadata._message_id = message_ins.object_id  # type: ignore
-
-        msg_id = self.state.store_message_ins(message=message_ins)
-        msg_ = self.state.get_message_ins(node_id=self.node_id, limit=1)[0]
-
-        if content is not None:
-            reply_msg = Message(content, reply_to=msg_)
-        else:
-            assert error is not None
-            reply_msg = Message(error, reply_to=msg_)
-
-        # pylint: disable-next=W0212
-        reply_msg.metadata._message_id = reply_msg.object_id  # type: ignore
-
-        self.state.store_message_res(message=reply_msg)
-        # Register response in ObjectStore (so pulling message request can be completed)
-        self.store.preregister(run_id, get_object_tree(reply_msg))
-        request = PullAppMessagesRequest(message_ids=[str(msg_id)])
-
-        # Execute
-        response, call = self._pull_messages.with_call(request=request)
-
-        # Assert
-        assert isinstance(response, PullAppMessagesResponse)
-        assert grpc.StatusCode.OK == call.code()
-        assert self.state.num_message_ins() == 1
-        assert self.state.num_message_res() == 1
-
-        confirm_request = ConfirmMessageReceivedRequest(
-            node=Node(node_id=self.node_id),
-            run_id=run_id,
-            message_object_id=reply_msg.object_id,
-        )
-        response, call = self._confirm_message_received.with_call(
-            request=confirm_request
-        )
-
-        assert isinstance(response, ConfirmMessageReceivedResponse)
-        assert grpc.StatusCode.OK == call.code()
-        assert self.state.num_message_ins() == 0
-        assert self.state.num_message_res() == 0
-
     def test_pull_message_from_expired_message_error(self) -> None:
         """Test that the servicer correctly handles the registration in the ObjectStore
         of an Error message created by the LinkState due to an expired TTL."""
@@ -640,6 +572,42 @@ class TestServerAppIoServicer(unittest.TestCase):  # pylint: disable=R0902, R090
             ]
             # expected a single object id (that of the error message)
             assert list(object_ids_in_response) == [msg_res.object_id]
+
+    def test_confirm_generated_error_reply_deletes_message_in_linkstate(self) -> None:
+        """Test `ConfirmMessageReceived` cleans up generated error replies."""
+        # Prepare
+        run_id = self._auth_run_id
+        assert self.state.deactivate_node(self.node_id)
+        message_ins = message_from_proto(
+            create_ins_message(
+                src_node_id=SUPERLINK_NODE_ID, dst_node_id=self.node_id, run_id=run_id
+            )
+        )
+        msg_id = self.state.store_message_ins(message=message_ins)
+
+        request = PullAppMessagesRequest(message_ids=[str(msg_id)])
+        response, call = self._pull_messages.with_call(request=request)
+        assert isinstance(response, PullAppMessagesResponse)
+        assert grpc.StatusCode.OK == call.code()
+        msg_res = message_from_proto(response.messages_list[0])
+        assert msg_res.has_error()
+        assert self.state.num_message_ins() == 1
+
+        # Execute
+        confirm_request = ConfirmMessageReceivedRequest(
+            node=Node(node_id=self.node_id),
+            run_id=run_id,
+            message_object_id=msg_res.object_id,
+        )
+        response, call = self._confirm_message_received.with_call(
+            request=confirm_request
+        )
+
+        # Assert
+        assert isinstance(response, ConfirmMessageReceivedResponse)
+        assert grpc.StatusCode.OK == call.code()
+        assert self.state.num_message_ins() == 0
+        assert self.state.num_message_res() == 0
 
     def test_push_object_succesful(self) -> None:
         """Test `PushObject`."""
@@ -762,14 +730,19 @@ class TestServerAppIoServicer(unittest.TestCase):  # pylint: disable=R0902, R090
     def test_confirm_message_received_successful(self) -> None:
         """Test `ConfirmMessageReceived` success."""
         # Prepare
-        run_id = self._create_dummy_run()
+        run_id = self._auth_run_id
         proto = create_ins_message(
             src_node_id=SUPERLINK_NODE_ID, dst_node_id=self.node_id, run_id=run_id
         )
         message_ins = message_from_proto(proto)
+        assert self.state.store_message_ins(message_ins)
+        message_ins = self.state.get_message_ins(node_id=self.node_id, limit=1)[0]
         message_res = Message(
             RecordDict({"cfg": ConfigRecord({"key": "value"})}), reply_to=message_ins
         )
+        # pylint: disable-next=W0212
+        message_res.metadata._message_id = message_res.object_id  # type: ignore
+        assert self.state.store_message_res(message_res)
 
         # Prepare: Save reply message in ObjectStore
         all_objects = get_all_nested_objects(message_res)
@@ -779,6 +752,8 @@ class TestServerAppIoServicer(unittest.TestCase):  # pylint: disable=R0902, R090
 
         # Assert: All objects are stored in the ObjectStore
         assert len(self.store) == len(all_objects)
+        assert self.state.num_message_ins() == 1
+        assert self.state.num_message_res() == 1
 
         # Execute: Confirm message received
         request = ConfirmMessageReceivedRequest(
@@ -794,6 +769,8 @@ class TestServerAppIoServicer(unittest.TestCase):  # pylint: disable=R0902, R090
 
         # Assert: Message is removed from LinkState
         assert len(self.store) == 0
+        assert self.state.num_message_ins() == 0
+        assert self.state.num_message_res() == 0
 
     def test_run_status_transitions(self) -> None:
         """Test `PullTaskInput` activates a claimed task and marks the run running."""


### PR DESCRIPTION
## Review setup

This PR is stacked on #7244 for review purposes only. #7244 contains the shared LinkState delivery-lease foundation; this PR shows only the task-to-task acknowledgement hardening on top of it.

After #7244 merges, this PR should be rebased back onto `main`.

## Issue

Task-to-task confirmations could delete ObjectStore payloads even when LinkState did not actually acknowledge the message. A stale or misrouted confirmation could therefore remove another run's payload while leaving LinkState rows behind, breaking later redelivery.

Generated error replies also needed to complete cleanup through the original instruction, and duplicate in-memory replies could leave orphaned reply messages behind.

## Fix

- Make message acknowledgements run-scoped and return whether cleanup happened.
- Delete ObjectStore payloads only after a successful LinkState acknowledgement.
- Allow generated error replies to acknowledge the original instruction via `reply_to_message_id`.
- Remove all duplicate in-memory replies for an acknowledged instruction.

## Validation

- Added/updated LinkState, Fleet, and ServerAppIo tests for the task-to-task acknowledgement paths.
- Focused pytest, Ruff, and Black checks pass locally.
