### PR TITLE
fix(framework): Prevent heartbeats reviving deleted nodes

### DIFF
--- a/framework/py/flwr/server/superlink/linkstate/linkstate_test.py
+++ b/framework/py/flwr/server/superlink/linkstate/linkstate_test.py
@@ -2224,6 +2224,45 @@ class SqlFileBasedTest(SqlInMemoryStateTest):
             # Assert
             assert sum(len(res) for res in results if res is not None) == 1
 
+    def test_acknowledge_node_heartbeat_does_not_revive_deleted_node(self) -> None:
+        """Ensure a heartbeat cannot move an unregistered node back online."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Prepare
+            db_path = self._shared_sql_database(tmpdir)
+            states = self._create_shared_sql_states(db_path)
+            heartbeat_state = states[0]
+            delete_state = states[1]
+            node_id = create_dummy_node(heartbeat_state, activate=False)
+            original_query = heartbeat_state.query
+            did_delete = False
+
+            def delete_before_heartbeat_update(
+                query: str, data: Any = None
+            ) -> list[dict[str, Any]]:
+                nonlocal did_delete
+                normalized_query = " ".join(query.split())
+                if not did_delete and normalized_query.startswith(
+                    "UPDATE node SET online_until"
+                ):
+                    did_delete = True
+                    delete_state.delete_node("mock_flwr_aid", node_id)
+                return original_query(query, data)
+
+            heartbeat_state.query = (  # type: ignore[method-assign]
+                delete_before_heartbeat_update
+            )
+
+            # Execute
+            acknowledged = heartbeat_state.acknowledge_node_heartbeat(
+                node_id, heartbeat_interval=30
+            )
+
+            # Assert
+            assert did_delete
+            assert not acknowledged
+            node = heartbeat_state.get_node_info(node_ids=[node_id])[0]
+            assert node.status == NodeStatus.UNREGISTERED
+
     # pylint: disable-next=too-many-locals
     def test_get_message_ins_distributes_available_work_under_contention(self) -> None:
         """Ensure two replicas can each claim work when two Messages are available."""

--- a/framework/py/flwr/server/superlink/linkstate/sql_linkstate.py
+++ b/framework/py/flwr/server/superlink/linkstate/sql_linkstate.py
@@ -1176,39 +1176,31 @@ class SqlLinkState(LinkState, SqlCoreState):  # pylint: disable=R0904
         """
         sint64_node_id = uint64_to_int64(node_id)
 
-        # Check if the node exists and is not unregistered
-        query = """
-            SELECT status FROM node WHERE node_id = :node_id AND status != :unregistered
-        """
-        rows = self.query(
-            query, {"node_id": sint64_node_id, "unregistered": NodeStatus.UNREGISTERED}
-        )
-        if not rows:
-            return False
-
-        # Construct query and params
         current_dt = now()
-        query = (
-            "UPDATE node SET online_until = :online_until, "
-            "heartbeat_interval = :heartbeat_interval"
-        )
+        query = """
+            UPDATE node
+            SET online_until = :online_until,
+                heartbeat_interval = :heartbeat_interval,
+                last_activated_at = CASE
+                    WHEN status != :online THEN :last_activated_at
+                    ELSE last_activated_at
+                END,
+                status = :online
+            WHERE node_id = :node_id AND status != :unregistered
+            RETURNING node_id
+        """
         params: dict[str, Any] = {
             "online_until": current_dt.timestamp()
             + HEARTBEAT_PATIENCE * heartbeat_interval,
             "heartbeat_interval": heartbeat_interval,
+            "last_activated_at": current_dt.isoformat(),
+            "online": NodeStatus.ONLINE,
+            "node_id": sint64_node_id,
+            "unregistered": NodeStatus.UNREGISTERED,
         }
 
-        # Set timestamp if the status changes
-        if rows[0]["status"] != NodeStatus.ONLINE:
-            query += ", status = :online, last_activated_at = :last_activated_at"
-            params["online"] = NodeStatus.ONLINE
-            params["last_activated_at"] = current_dt.isoformat()
-
-        # Execute the query, refreshing `online_until` and `heartbeat_interval`
-        query += " WHERE node_id = :node_id"
-        params["node_id"] = sint64_node_id
-        self.query(query, params)
-        return True
+        rows = self.query(query, params)
+        return len(rows) > 0
 
     def get_serverapp_context(self, run_id: int) -> Context | None:
         """Get the context for the specified `run_id`."""


### PR DESCRIPTION
## What
Make SqlLinkState.acknowledge_node_heartbeat a single conditional write. The heartbeat now updates the node only when the row still exists and is not UNREGISTERED, and returns False if a concurrent delete_node already made the node terminal.

## Why
The previous SQL path read node status first, then updated by node_id only. In a multi-SuperLink deployment, a heartbeat could read a registered/offline node, another replica could unregister it, and the heartbeat could then set it back to online from stale state.