### PR TITLE
fix(framework): Guard startup migrations on Postgres

### DIFF
--- a/framework/py/flwr/supercore/state/alembic/utils.py
+++ b/framework/py/flwr/supercore/state/alembic/utils.py
@@ -14,14 +14,14 @@
 # ==============================================================================
 """Helpers for running and validating Alembic migrations."""
 
-
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from logging import INFO
 from pathlib import Path
 
 from alembic import command
 from alembic.config import Config
-from sqlalchemy import MetaData, create_engine, inspect, pool
+from sqlalchemy import MetaData, create_engine, inspect, pool, text
 from sqlalchemy.engine import Engine
 
 from flwr.common.exit import ExitCode, flwr_exit
@@ -43,6 +43,8 @@ ALEMBIC_DIR = Path(__file__).resolve().parent
 ALEMBIC_VERSION_TABLE = "alembic_version"
 FLWR_STATE_BASELINE_REVISION = "8e65d8ae60b0"  # Never change this
 FLWR_STATE_LATEST_REVISIONS = "heads"
+_POSTGRESQL_MIGRATION_LOCK_NAMESPACE = 0x466C5752  # "FlWR"
+_POSTGRESQL_MIGRATION_LOCK_ID = 0x4D494752  # "MIGR"
 
 
 def register_metadata_provider(provider: MetadataProvider) -> None:
@@ -120,6 +122,12 @@ def get_combined_metadata() -> MetaData:
 
 
 def run_migrations(engine: Engine) -> None:
+    """Run pending Alembic migrations under the configured database guard."""
+    with _migration_guard(engine):
+        _run_migrations(engine)
+
+
+def _run_migrations(engine: Engine) -> None:
     """Run pending Alembic migrations, handling pre-Alembic legacy databases.
 
     Expected scenarios:
@@ -168,6 +176,35 @@ def run_migrations(engine: Engine) -> None:
     stamp_existing_database(engine, FLWR_STATE_BASELINE_REVISION)
     command.upgrade(config, FLWR_STATE_LATEST_REVISIONS)
     log(INFO, "Flower state database stamped and upgraded successfully!")
+
+
+@contextmanager
+def _migration_guard(engine: Engine) -> Iterator[None]:
+    """Guard schema migrations for backends that need cross-process serialization."""
+    if engine.dialect.name != "postgresql":
+        yield
+        return
+
+    lock_params = {
+        "namespace": _POSTGRESQL_MIGRATION_LOCK_NAMESPACE,
+        "lock_id": _POSTGRESQL_MIGRATION_LOCK_ID,
+    }
+
+    with engine.connect() as connection:
+        lock_connection = connection.execution_options(isolation_level="AUTOCOMMIT")
+        log(INFO, "Acquiring PostgreSQL advisory lock for Flower state migrations.")
+        lock_connection.execute(
+            text("SELECT pg_advisory_lock(:namespace, :lock_id)"),
+            lock_params,
+        )
+        try:
+            yield
+        finally:
+            lock_connection.execute(
+                text("SELECT pg_advisory_unlock(:namespace, :lock_id)"),
+                lock_params,
+            )
+            log(INFO, "Released PostgreSQL advisory lock for Flower state migrations.")
 
 
 def build_alembic_config(engine: Engine) -> Config:

--- a/framework/py/flwr/supercore/state/alembic/utils_test.py
+++ b/framework/py/flwr/supercore/state/alembic/utils_test.py
@@ -14,14 +14,13 @@
 # ==============================================================================
 """Tests for Alembic migration helpers."""
 
-
 import unittest
 from collections.abc import Sequence
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from types import SimpleNamespace
 from typing import Any, cast
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from alembic import command
 from alembic.autogenerate import compare_metadata
@@ -175,6 +174,80 @@ class TestAlembicRun(unittest.TestCase):
             self.assertFalse(check_migrations_pending(engine))
         finally:
             engine.dispose()
+
+    @patch("flwr.supercore.state.alembic.utils._run_migrations")
+    def test_run_migrations_uses_postgresql_advisory_lock(
+        self, mock_run_migrations: MagicMock
+    ) -> None:
+        """Ensure PostgreSQL migrations are serialized with an advisory lock."""
+        events: list[str] = []
+        engine = MagicMock()
+        engine.dialect.name = "postgresql"
+        connection = MagicMock()
+        connection.execution_options.return_value = connection
+        engine.connect.return_value.__enter__.return_value = connection
+
+        def execute(statement: object, _params: object) -> None:
+            sql = str(statement)
+            if "pg_advisory_lock" in sql:
+                events.append("lock")
+            if "pg_advisory_unlock" in sql:
+                events.append("unlock")
+
+        def run(_engine: Engine) -> None:
+            events.append("migrate")
+
+        connection.execute.side_effect = execute
+        mock_run_migrations.side_effect = run
+
+        run_migrations(engine)
+
+        self.assertEqual(events, ["lock", "migrate", "unlock"])
+        connection.execution_options.assert_called_once_with(
+            isolation_level="AUTOCOMMIT"
+        )
+        mock_run_migrations.assert_called_once_with(engine)
+
+    @patch("flwr.supercore.state.alembic.utils._run_migrations")
+    def test_run_migrations_releases_postgresql_advisory_lock_on_error(
+        self, mock_run_migrations: MagicMock
+    ) -> None:
+        """Ensure PostgreSQL advisory locks are released when migrations fail."""
+        events: list[str] = []
+        engine = MagicMock()
+        engine.dialect.name = "postgresql"
+        connection = MagicMock()
+        connection.execution_options.return_value = connection
+        engine.connect.return_value.__enter__.return_value = connection
+
+        def execute(statement: object, _params: object) -> None:
+            sql = str(statement)
+            if "pg_advisory_lock" in sql:
+                events.append("lock")
+            if "pg_advisory_unlock" in sql:
+                events.append("unlock")
+
+        connection.execute.side_effect = execute
+        mock_run_migrations.side_effect = RuntimeError("migration failed")
+
+        with self.assertRaisesRegex(RuntimeError, "migration failed"):
+            run_migrations(engine)
+
+        self.assertEqual(events, ["lock", "unlock"])
+        mock_run_migrations.assert_called_once_with(engine)
+
+    @patch("flwr.supercore.state.alembic.utils._run_migrations")
+    def test_run_migrations_does_not_lock_non_postgresql_backends(
+        self, mock_run_migrations: MagicMock
+    ) -> None:
+        """Ensure non-PostgreSQL backends keep the existing migration behavior."""
+        engine = MagicMock()
+        engine.dialect.name = "sqlite"
+
+        run_migrations(engine)
+
+        engine.connect.assert_not_called()
+        mock_run_migrations.assert_called_once_with(engine)
 
     def test_migrated_schema_matches_metadata(self) -> None:
         """Verify that migrations match current SQLAlchemy metadata."""


### PR DESCRIPTION
## Issue

Multiple SuperLink replicas can start against the same shared Postgres database and all try to run Alembic state migrations at the same time. That can make startup contend on schema inspection or DDL even though only one process should mutate the schema.

Affected boundary: Flower state Alembic startup migrations used by `LinkState`, `CoreState`, and `ObjectStore` initialization.

## Proposal

This PR wraps `run_migrations` in a backend-specific migration guard:

- PostgreSQL acquires a blocking `pg_advisory_lock` before any Alembic inspection, stamping, or upgrade work.
- The advisory lock is released in `finally`, including when migration execution fails.
- SQLite and in-memory startup paths keep the existing behavior and do not acquire a guard.

No schema migration, data backfill, or user-facing config change is included.

## Validation

- `uv run --python=3.11 python -m pytest -q py/flwr/supercore/state/alembic/utils_test.py py/flwr/supercore/sql_mixin_test.py`
- `uv run --python=3.11 python -m ruff check py/flwr/supercore/state/alembic/utils.py py/flwr/supercore/state/alembic/utils_test.py`
- `uv run --python=3.11 python -m ruff format --check py/flwr/supercore/state/alembic/utils.py py/flwr/supercore/state/alembic/utils_test.py`