### PR TITLE
fix(framework): Preserve PushMessages upload hints

### DIFF
--- a/framework/py/flwr/server/superlink/serverappio/serverappio_servicer.py
+++ b/framework/py/flwr/server/superlink/serverappio/serverappio_servicer.py
@@ -67,7 +67,6 @@ from flwr.supercore.inflatable.inflatable_object import (
     UnexpectedObjectContentError,
     get_all_nested_objects,
     get_object_tree,
-    iterate_object_tree,
     no_object_id_recompute,
 )
 from flwr.supercore.interceptors import get_authenticated_task
@@ -145,7 +144,7 @@ class ServerAppIoServicer(AppIoServicer, serverappio_pb2_grpc.ServerAppIoService
                 detail="`Message.metadata` has mismatched `run_id`",
             )
             # Store objects
-            objects_to_push |= set(store.preregister(run_id, object_tree))
+            message_objects_to_push = set(store.preregister(run_id, object_tree))
             # Store message
             message_id: str | None = state.store_message_ins(message=message)
             # This is temporary. We should consider a more robust cleanup
@@ -156,8 +155,8 @@ class ServerAppIoServicer(AppIoServicer, serverappio_pb2_grpc.ServerAppIoService
                 and state.get_run_status({run_id})[run_id].status == Status.FINISHED
             ):
                 store.delete(object_tree.object_id)
-                for tree_node in iterate_object_tree(object_tree):
-                    objects_to_push.discard(tree_node.object_id)
+            else:
+                objects_to_push |= message_objects_to_push
             message_ids.append(message_id)
 
         return PushAppMessagesResponse(

--- a/framework/py/flwr/server/superlink/serverappio/serverappio_servicer_test.py
+++ b/framework/py/flwr/server/superlink/serverappio/serverappio_servicer_test.py
@@ -473,6 +473,58 @@ class TestServerAppIoServicer(unittest.TestCase):  # pylint: disable=R0902, R090
         assert isinstance(response, GetNodesResponse)
         assert grpc.StatusCode.OK == call.code()
 
+    def test_push_messages_keeps_shared_upload_hint_after_rejection(self) -> None:
+        """PushMessages should keep accepted-message upload hints."""
+        # Prepare
+        run_id = self._auth_run_id
+        message_1 = create_ins_message(
+            src_node_id=SUPERLINK_NODE_ID, dst_node_id=self.node_id, run_id=run_id
+        )
+        message_2 = create_ins_message(
+            src_node_id=SUPERLINK_NODE_ID, dst_node_id=self.node_id, run_id=run_id
+        )
+        shared_child_id = hashlib.sha256(b"shared-child").hexdigest()
+        object_tree_1 = ObjectTree(
+            object_id=message_1.metadata.message_id,
+            children=[ObjectTree(object_id=shared_child_id)],
+        )
+        object_tree_2 = ObjectTree(
+            object_id=message_2.metadata.message_id,
+            children=[ObjectTree(object_id=shared_child_id)],
+        )
+        request = PushAppMessagesRequest(
+            messages_list=[message_1, message_2],
+            message_object_trees=[object_tree_1, object_tree_2],
+        )
+        original_store_message_ins = self.state.store_message_ins
+        primary_task_id = self._primary_task_id(run_id)
+        call_count = 0
+
+        def store_message_ins_and_finish_run(message: Message) -> str | None:
+            nonlocal call_count
+            call_count += 1
+            message_id = original_store_message_ins(message)
+            if call_count == 1:
+                assert self.state.finish_task(primary_task_id, "", "")
+            return message_id
+
+        # Execute
+        with patch.object(
+            self.state,
+            "store_message_ins",
+            side_effect=store_message_ins_and_finish_run,
+        ):
+            response, call = self._push_messages.with_call(request=request)
+
+        # Assert
+        assert isinstance(response, PushAppMessagesResponse)
+        assert grpc.StatusCode.OK == call.code()
+        assert list(response.message_ids) == [message_1.metadata.message_id, ""]
+        assert set(response.objects_to_push) == {
+            message_1.metadata.message_id,
+            shared_child_id,
+        }
+
     @parameterized.expand(
         [
             # The normal case:


### PR DESCRIPTION
## Issue

### Description

`ServerAppIo.PushMessages` built one batch-wide `objects_to_push` set before knowing whether each message was accepted. If an earlier message was accepted and a later message was rejected because the run finished concurrently, rejection cleanup could remove upload hints for object IDs shared with the accepted message.

This matters for HA SuperLink deployments because an accepted message can remain in LinkState while the response no longer asks the ServerApp to upload all objects needed by that message.

## Proposal

### Explanation

This PR tracks upload hints per message and only adds them to the response after the message write is accepted. If a later batch item is rejected during run-finished cleanup, its cleanup no longer removes hints needed by earlier accepted messages.

### Checklist

- [x] Implement proposed change
- [x] Write tests
- [x] Run focused ServerAppIo tests
