### PR TITLE
feat(framework): Add K8s Executor Capacity Wait

### DIFF
--- a/framework/py/flwr/supercore/superexec/executor/kubernetes_executor.py
+++ b/framework/py/flwr/supercore/superexec/executor/kubernetes_executor.py
@@ -434,9 +434,9 @@ def _label_selector(labels: dict[str, str]) -> str:
 def _pod_items(pod_list: object) -> list[object]:
     """Return Pod items from a Kubernetes list response."""
     items = _object_field(pod_list, "items")
-    if items is None:
-        return []
-    return list(items)
+    if isinstance(items, Sequence) and not isinstance(items, str):
+        return list(items)
+    return []
 
 
 def _is_active_pod(pod: object) -> bool:

--- a/framework/py/flwr/supercore/superexec/executor/kubernetes_executor.py
+++ b/framework/py/flwr/supercore/superexec/executor/kubernetes_executor.py
@@ -161,7 +161,17 @@ class KubernetesExecutor:
 
         last_log_at: float | None = None
         while True:
-            active_pod_count = self._active_pod_count()
+            try:
+                active_pod_count = self._active_pod_count()
+            except Exception:  # pylint: disable=broad-exception-caught
+                log(
+                    WARNING,
+                    "Kubernetes capacity check failed; proceeding without waiting. "
+                    "selector=%s",
+                    _capacity_label_selector(self._config),
+                    exc_info=True,
+                )
+                return
             if active_pod_count < self._config.active_pod_budget:
                 return
 

--- a/framework/py/flwr/supercore/superexec/executor/kubernetes_executor.py
+++ b/framework/py/flwr/supercore/superexec/executor/kubernetes_executor.py
@@ -37,6 +37,12 @@ APPIO_ROOT_CERTIFICATES_FILE_PATH = f"{APPIO_CREDENTIALS_MOUNT_PATH}/ca.crt"
 LAUNCH_ATTEMPT_LABEL = "flower.ai/launch-attempt"
 
 
+class KubernetesPodList(Protocol):
+    """Subset of Kubernetes PodList used by capacity checks."""
+
+    items: Sequence[object]
+
+
 class KubernetesClient(Protocol):
     """Subset of Kubernetes CoreV1Api used by the executor."""
 
@@ -49,7 +55,9 @@ class KubernetesClient(Protocol):
     def delete_namespaced_secret(self, name: str, namespace: str) -> object:
         """Delete a Kubernetes Secret from the selected namespace."""
 
-    def list_namespaced_pod(self, namespace: str, label_selector: str) -> object:
+    def list_namespaced_pod(
+        self, namespace: str, label_selector: str
+    ) -> KubernetesPodList:
         """List Kubernetes Pods in the selected namespace."""
 
 
@@ -431,7 +439,7 @@ def _label_selector(labels: dict[str, str]) -> str:
     return ",".join(f"{key}={value}" for key, value in sorted(labels.items()))
 
 
-def _pod_items(pod_list: object) -> list[object]:
+def _pod_items(pod_list: KubernetesPodList | Mapping[str, object]) -> list[object]:
     """Return Pod items from a Kubernetes list response."""
     items = _object_field(pod_list, "items")
     if isinstance(items, Sequence) and not isinstance(items, str):

--- a/framework/py/flwr/supercore/superexec/executor/kubernetes_executor.py
+++ b/framework/py/flwr/supercore/superexec/executor/kubernetes_executor.py
@@ -14,9 +14,10 @@
 # ==============================================================================
 """Kubernetes executor for SuperExec TaskExecutor processes."""
 
-from collections.abc import Mapping, Sequence
+import time
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
-from logging import WARNING
+from logging import INFO, WARNING
 from pathlib import Path
 from typing import Protocol, cast
 from uuid import uuid4
@@ -47,6 +48,9 @@ class KubernetesClient(Protocol):
 
     def delete_namespaced_secret(self, name: str, namespace: str) -> object:
         """Delete a Kubernetes Secret from the selected namespace."""
+
+    def list_namespaced_pod(self, namespace: str, label_selector: str) -> object:
+        """List Kubernetes Pods in the selected namespace."""
 
 
 @dataclass(frozen=True)
@@ -106,6 +110,11 @@ class KubernetesExecutorConfig:  # pylint: disable=too-many-instance-attributes
     container_security_context: JSONObject | None = None
     # Optional Pod field only; service account policy/RBAC is decided elsewhere.
     service_account_name: str | None = None
+    active_pod_budget: int | None = None
+    capacity_poll_interval: float = 1.0
+    capacity_log_interval: float | None = None
+    sleep: Callable[[float], None] = time.sleep
+    monotonic: Callable[[], float] = time.monotonic
 
     def __post_init__(self) -> None:
         """Validate required object-building inputs."""
@@ -120,6 +129,17 @@ class KubernetesExecutorConfig:  # pylint: disable=too-many-instance-attributes
         _validate_optional_string("Priority class name", self.priority_class_name)
         if self.labels is not None:
             _validate_labels(self.labels)
+        if self.active_pod_budget is not None:
+            if self.active_pod_budget <= 0:
+                raise ValueError("Active Pod budget must be positive.")
+            if self.resource_pool is None:
+                raise ValueError(
+                    "Resource pool must be configured when active Pod budget is set."
+                )
+        if self.capacity_poll_interval <= 0:
+            raise ValueError("Capacity poll interval must be positive.")
+        if self.capacity_log_interval is not None and self.capacity_log_interval <= 0:
+            raise ValueError("Capacity log interval must be positive.")
 
 
 class KubernetesExecutor:
@@ -135,10 +155,33 @@ class KubernetesExecutor:
         self._config = config
 
     def wait_for_capacity(self) -> None:
-        """Return immediately.
+        """Wait until the configured resource pool is below its active Pod budget."""
+        if self._config.active_pod_budget is None:
+            return
 
-        Kubernetes capacity checks are not implemented yet.
-        """
+        last_log_at: float | None = None
+        while True:
+            active_pod_count = self._active_pod_count()
+            if active_pod_count < self._config.active_pod_budget:
+                return
+
+            if self._config.capacity_log_interval is not None:
+                now = self._config.monotonic()
+                if (
+                    last_log_at is None
+                    or now - last_log_at >= self._config.capacity_log_interval
+                ):
+                    log(
+                        INFO,
+                        "Waiting for Kubernetes TaskExecutor capacity: "
+                        "%s active Pods, budget %s, selector %s",
+                        active_pod_count,
+                        self._config.active_pod_budget,
+                        _capacity_label_selector(self._config),
+                    )
+                    last_log_at = now
+
+            self._config.sleep(self._config.capacity_poll_interval)
 
     def launch(self, spec: ExecutionSpec) -> LaunchResult:
         """Submit the TaskExecutor Pod and credential Secret."""
@@ -167,6 +210,14 @@ class KubernetesExecutor:
             return result
 
         return LaunchResult.accepted()
+
+    def _active_pod_count(self) -> int:
+        """Return the active TaskExecutor Pod count for the configured pool."""
+        pod_list = self._client.list_namespaced_pod(
+            self._config.namespace,
+            label_selector=_capacity_label_selector(self._config),
+        )
+        return sum(1 for pod in _pod_items(pod_list) if _is_active_pod(pod))
 
 
 def _build_appio_credentials_secret(
@@ -345,6 +396,57 @@ def _labels(
     if config.labels is not None:
         labels.update(config.labels)
     return labels
+
+
+def _capacity_label_selector(config: KubernetesExecutorConfig) -> str:
+    """Return the label selector used for resource-pool capacity checks."""
+    return _label_selector(_capacity_labels(config))
+
+
+def _capacity_labels(config: KubernetesExecutorConfig) -> dict[str, str]:
+    """Return labels identifying the constrained TaskExecutor pool."""
+    labels = {
+        "app.kubernetes.io/name": "flower",
+        "app.kubernetes.io/component": "taskexecutor",
+    }
+    if config.resource_pool is not None:
+        labels["flower.ai/resource-pool"] = config.resource_pool
+    if config.labels is not None:
+        labels.update(config.labels)
+    return labels
+
+
+def _label_selector(labels: dict[str, str]) -> str:
+    """Return a Kubernetes equality label selector."""
+    return ",".join(f"{key}={value}" for key, value in sorted(labels.items()))
+
+
+def _pod_items(pod_list: object) -> list[object]:
+    """Return Pod items from a Kubernetes list response."""
+    items = _object_field(pod_list, "items")
+    if items is None:
+        return []
+    return list(items)
+
+
+def _is_active_pod(pod: object) -> bool:
+    """Return true if a Pod counts against best-effort launch capacity."""
+    metadata = _object_field(pod, "metadata")
+    deletion_timestamp = _object_field(metadata, "deletion_timestamp")
+    if deletion_timestamp is None:
+        deletion_timestamp = _object_field(metadata, "deletionTimestamp")
+    if deletion_timestamp is not None:
+        return True
+
+    status = _object_field(pod, "status")
+    return _object_field(status, "phase") in {"Pending", "Running"}
+
+
+def _object_field(value: object, field_name: str) -> object | None:
+    """Return a field from a Kubernetes dict or model object."""
+    if isinstance(value, dict):
+        return value.get(field_name)
+    return getattr(value, field_name, None)
 
 
 def _validate_labels(labels: dict[str, str]) -> None:

--- a/framework/py/flwr/supercore/superexec/executor/kubernetes_executor.py
+++ b/framework/py/flwr/supercore/superexec/executor/kubernetes_executor.py
@@ -449,7 +449,7 @@ def _is_active_pod(pod: object) -> bool:
         return True
 
     status = _object_field(pod, "status")
-    return _object_field(status, "phase") in {"Pending", "Running"}
+    return _object_field(status, "phase") not in {"Succeeded", "Failed"}
 
 
 def _object_field(value: object, field_name: str) -> object | None:

--- a/framework/py/flwr/supercore/superexec/executor/kubernetes_executor_test.py
+++ b/framework/py/flwr/supercore/superexec/executor/kubernetes_executor_test.py
@@ -457,10 +457,22 @@ def test_config_rejects_capacity_budget_without_resource_pool() -> None:
         _executor_config(active_pod_budget=10)
 
 
+def test_config_rejects_non_positive_active_pod_budget() -> None:
+    """Test active Pod budget must be positive when configured."""
+    with pytest.raises(ValueError, match="Active Pod budget must be positive"):
+        _executor_config(active_pod_budget=0)
+
+
 def test_config_rejects_invalid_capacity_poll_interval() -> None:
     """Test capacity poll interval must be positive."""
     with pytest.raises(ValueError, match="Capacity poll interval must be positive"):
         _executor_config(capacity_poll_interval=0)
+
+
+def test_config_rejects_invalid_capacity_log_interval() -> None:
+    """Test capacity log interval must be positive when provided."""
+    with pytest.raises(ValueError, match="Capacity log interval must be positive"):
+        _executor_config(capacity_log_interval=0)
 
 
 def test_wait_for_capacity_returns_below_budget_without_sleeping() -> None:

--- a/framework/py/flwr/supercore/superexec/executor/kubernetes_executor_test.py
+++ b/framework/py/flwr/supercore/superexec/executor/kubernetes_executor_test.py
@@ -91,6 +91,13 @@ def _appio_root_certificates(
     return _get_appio_root_certificates(spec, config)
 
 
+def _pod(phase: str, deletion_timestamp: str | None = None) -> dict[str, Any]:
+    metadata = {}
+    if deletion_timestamp is not None:
+        metadata["deletionTimestamp"] = deletion_timestamp
+    return {"metadata": metadata, "status": {"phase": phase}}
+
+
 def test_build_appio_credentials_secret_contains_token_and_ca() -> None:
     """Test building the AppIo credential Secret."""
     spec = _execution_spec()
@@ -442,6 +449,110 @@ def test_build_taskexecutor_pod_copies_nested_json_config() -> None:
     assert tolerations[0]["value"] == "true"
     assert pod_resources["requests"]["memory"] == "1Gi"
     assert pod_toleration["key"] == "flower.ai/taskexecutor"
+
+
+def test_config_rejects_capacity_budget_without_resource_pool() -> None:
+    """Test capacity gating requires an explicit resource pool."""
+    with pytest.raises(ValueError, match="Resource pool must be configured"):
+        _executor_config(active_pod_budget=10)
+
+
+def test_config_rejects_invalid_capacity_poll_interval() -> None:
+    """Test capacity poll interval must be positive."""
+    with pytest.raises(ValueError, match="Capacity poll interval must be positive"):
+        _executor_config(capacity_poll_interval=0)
+
+
+def test_wait_for_capacity_returns_below_budget_without_sleeping() -> None:
+    """Test capacity wait returns immediately when the active Pod count fits."""
+    client = Mock()
+    client.list_namespaced_pod.return_value = {"items": [_pod("Running")]}
+    sleep = Mock()
+    config = _executor_config(
+        labels={"flower.ai/team": "platform"},
+        resource_pool="gpu-pool",
+        active_pod_budget=2,
+        capacity_poll_interval=3.0,
+        sleep=sleep,
+    )
+
+    KubernetesExecutor(client=client, config=config).wait_for_capacity()
+
+    client.list_namespaced_pod.assert_called_once_with(
+        "flower-system",
+        label_selector=(
+            "app.kubernetes.io/component=taskexecutor,"
+            "app.kubernetes.io/name=flower,"
+            "flower.ai/resource-pool=gpu-pool,"
+            "flower.ai/team=platform"
+        ),
+    )
+    sleep.assert_not_called()
+
+
+def test_wait_for_capacity_sleeps_and_polls_again_at_budget() -> None:
+    """Test capacity wait sleeps when the active Pod count reaches the budget."""
+    client = Mock()
+    client.list_namespaced_pod.side_effect = [
+        {"items": [_pod("Pending")]},
+        {"items": []},
+    ]
+    sleep = Mock()
+    config = _executor_config(
+        resource_pool="gpu-pool",
+        active_pod_budget=1,
+        capacity_poll_interval=3.0,
+        sleep=sleep,
+    )
+
+    KubernetesExecutor(client=client, config=config).wait_for_capacity()
+
+    assert client.list_namespaced_pod.call_count == 2
+    sleep.assert_called_once_with(3.0)
+
+
+def test_wait_for_capacity_counts_pending_running_and_terminating_pods() -> None:
+    """Test active Pod counting includes phase-active and terminating Pods."""
+    client = Mock()
+    client.list_namespaced_pod.side_effect = [
+        {
+            "items": [
+                _pod("Pending"),
+                _pod("Running"),
+                _pod("Succeeded", deletion_timestamp="2026-05-26T18:30:00Z"),
+                _pod("Failed", deletion_timestamp="2026-05-26T18:31:00Z"),
+            ]
+        },
+        {"items": []},
+    ]
+    sleep = Mock()
+    config = _executor_config(
+        resource_pool="gpu-pool",
+        active_pod_budget=4,
+        sleep=sleep,
+    )
+
+    KubernetesExecutor(client=client, config=config).wait_for_capacity()
+
+    sleep.assert_called_once_with(1.0)
+
+
+def test_wait_for_capacity_ignores_terminal_pods_not_terminating() -> None:
+    """Test Succeeded and Failed Pods do not count when they are not terminating."""
+    client = Mock()
+    client.list_namespaced_pod.return_value = {
+        "items": [_pod("Succeeded"), _pod("Failed")]
+    }
+    sleep = Mock()
+    config = _executor_config(
+        resource_pool="gpu-pool",
+        active_pod_budget=1,
+        sleep=sleep,
+    )
+
+    KubernetesExecutor(client=client, config=config).wait_for_capacity()
+
+    sleep.assert_not_called()
 
 
 def test_launch_submits_secret_before_pod_and_returns_accepted(


### PR DESCRIPTION
## Issue

### Description

This PR adds the Kubernetes SuperExec executor capacity wait on top of the K8s launch implementation.

### Related issues/PRs

Builds on #7269.

## Proposal

### Explanation

This adds `KubernetesExecutor.wait_for_capacity()` for the configured constrained TaskExecutor resource pool.

The capacity wait lists TaskExecutor Pods in the configured namespace with stable labels, including the configured resource-pool identity and extra executor labels. It blocks while the active Pod count is at or above the configured budget, then returns once the pool can accept one more best-effort launch.

The active count includes Pending Pods, Running Pods, and terminating Pods. Terminal Succeeded and Failed Pods are ignored unless they are still terminating. The wait is intentionally best effort and does not reserve scheduler capacity.

The PR also adds executor config for the active Pod budget, poll interval, optional log interval, and deterministic sleep/time injection for tests. It does not add `CapacityProfile`, cleanup, scheduler simulation, production Helm/Kapitan wiring, or AppIo/CoreState task-status changes.

### Checklist

- [x] Implement proposed change
- [x] Write tests
- [x] Update [documentation](https://flower.ai/docs/writing-documentation.html) (not needed; no user-facing docs changed)
- [x] Address LLM-reviewer comments, if applicable (e.g., GitHub Copilot)
- [x] Make CI checks pass
- [x] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)
