### PR TITLE
feat(framework): Add k3d probe image smoke for Kubernetes executor

### DIFF
--- a/framework/dev/kubernetes_executor_k3d_probe/Dockerfile
+++ b/framework/dev/kubernetes_executor_k3d_probe/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2026 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+FROM python:3.11-slim
+
+COPY probe_taskexecutor.py /usr/local/bin/probe_taskexecutor.py
+
+RUN chmod +x /usr/local/bin/probe_taskexecutor.py \
+    && ln -s /usr/local/bin/probe_taskexecutor.py /usr/local/bin/flwr-serverapp \
+    && ln -s /usr/local/bin/probe_taskexecutor.py /usr/local/bin/flwr-clientapp \
+    && ln -s /usr/local/bin/probe_taskexecutor.py /usr/local/bin/flwr-simulation

--- a/framework/dev/kubernetes_executor_k3d_probe/probe_taskexecutor.py
+++ b/framework/dev/kubernetes_executor_k3d_probe/probe_taskexecutor.py
@@ -1,0 +1,129 @@
+#!/usr/local/bin/python
+# Copyright 2026 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Dev-only KubernetesExecutor probe TaskExecutor command."""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+APPIO_TOKEN_FILE_PATH = "/run/flwr/appio/token"
+APPIO_ROOT_CERTIFICATES_FILE_PATH = "/run/flwr/appio/ca.crt"
+SMOKE_TOKEN_PATTERN = re.compile(r"^smoke-token-[0-9a-f]{32}-[0-9]+$")
+COMMAND_TO_ADDRESS_ARG = {
+    "flwr-serverapp": "--serverappio-api-address",
+    "flwr-clientapp": "--clientappio-api-address",
+    "flwr-simulation": "--serverappio-api-address",
+}
+
+
+class ProbeFailure(RuntimeError):
+    """Raised when the probe command surface is not rendered as expected."""
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Validate the mounted Secret and rendered TaskExecutor argv."""
+    if argv is None:
+        argv = sys.argv
+
+    try:
+        _run_probe(argv)
+    except ProbeFailure as exc:
+        print(f"probe failed: {exc}", file=sys.stderr)
+        return 1
+    print("probe passed: mounted credentials and rendered argv were valid")
+    return 0
+
+
+def _run_probe(argv: list[str]) -> None:
+    """Run the probe checks."""
+    command = os.path.basename(argv[0])
+    args = argv[1:]
+    address_arg = COMMAND_TO_ADDRESS_ARG.get(command)
+    if address_arg is None:
+        raise ProbeFailure(f"unsupported command {command!r}")
+
+    appio_address = _required_arg_value(args, address_arg)
+    if not appio_address.strip():
+        raise ProbeFailure(f"{address_arg} value must not be empty")
+    print(f"probe: verified {address_arg}")
+
+    token_path = _required_arg_value(args, "--token-file")
+    if token_path != APPIO_TOKEN_FILE_PATH:
+        raise ProbeFailure(
+            f"--token-file must point at {APPIO_TOKEN_FILE_PATH}, got {token_path!r}"
+        )
+    _verify_token_file(Path(token_path))
+    print("probe: verified mounted token file")
+
+    _verify_tls_args(args)
+
+
+def _required_arg_value(args: list[str], flag: str) -> str:
+    """Return the value following a required argv flag."""
+    try:
+        index = args.index(flag)
+    except ValueError as exc:
+        raise ProbeFailure(f"missing required argument {flag}") from exc
+    value_index = index + 1
+    if value_index >= len(args):
+        raise ProbeFailure(f"missing value for {flag}")
+    value = args[value_index]
+    if value.startswith("--"):
+        raise ProbeFailure(f"missing value for {flag}")
+    return value
+
+
+def _verify_token_file(token_path: Path) -> None:
+    """Verify token file existence and smoke-token shape without printing it."""
+    if not token_path.is_file():
+        raise ProbeFailure(f"token file does not exist at {token_path}")
+    token = token_path.read_text(encoding="utf-8").strip()
+    if not SMOKE_TOKEN_PATTERN.fullmatch(token):
+        raise ProbeFailure("token file content did not match smoke token pattern")
+
+
+def _verify_tls_args(args: list[str]) -> None:
+    """Verify AppIo TLS mode arguments are internally consistent."""
+    has_insecure = "--insecure" in args
+    has_root_certificates = "--root-certificates" in args
+    if has_insecure and has_root_certificates:
+        raise ProbeFailure(
+            "--insecure and --root-certificates must not both be rendered"
+        )
+    if has_insecure:
+        print("probe: verified insecure AppIo flag")
+        return
+    if has_root_certificates:
+        root_certificates_path = _required_arg_value(args, "--root-certificates")
+        if root_certificates_path != APPIO_ROOT_CERTIFICATES_FILE_PATH:
+            raise ProbeFailure(
+                "--root-certificates must point at "
+                f"{APPIO_ROOT_CERTIFICATES_FILE_PATH}, got {root_certificates_path!r}"
+            )
+        if not Path(root_certificates_path).is_file():
+            raise ProbeFailure(
+                f"root certificates file does not exist at {root_certificates_path}"
+            )
+        print("probe: verified root certificates file")
+        return
+    raise ProbeFailure("expected either --insecure or --root-certificates")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/framework/dev/kubernetes_executor_k3d_probe/probe_taskexecutor.py
+++ b/framework/dev/kubernetes_executor_k3d_probe/probe_taskexecutor.py
@@ -21,6 +21,9 @@ import os
 import re
 import sys
 from pathlib import Path
+from typing import Any
+
+import _ssl
 
 APPIO_TOKEN_FILE_PATH = "/run/flwr/appio/token"
 APPIO_ROOT_CERTIFICATES_FILE_PATH = "/run/flwr/appio/ca.crt"
@@ -120,9 +123,43 @@ def _verify_tls_args(args: list[str]) -> None:
             raise ProbeFailure(
                 f"root certificates file does not exist at {root_certificates_path}"
             )
-        print("probe: verified root certificates file")
+        common_name = _verify_root_certificate(Path(root_certificates_path))
+        print(f"probe: verified root certificate commonName={common_name}")
         return
     raise ProbeFailure("expected either --insecure or --root-certificates")
+
+
+def _verify_root_certificate(root_certificates_path: Path) -> str:
+    """Verify root certificates file is parseable and return its common name."""
+    try:
+        decoded = _ssl._test_decode_cert(str(root_certificates_path))
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        raise ProbeFailure("root certificates file is not a valid certificate") from exc
+
+    common_name = _certificate_common_name(decoded)
+    if common_name is None:
+        raise ProbeFailure("root certificate subject does not include commonName")
+    return common_name
+
+
+def _certificate_common_name(decoded_certificate: dict[str, Any]) -> str | None:
+    """Return the commonName from a decoded certificate subject."""
+    subject = decoded_certificate.get("subject")
+    if not isinstance(subject, tuple):
+        return None
+    for relative_distinguished_name in subject:
+        if not isinstance(relative_distinguished_name, tuple):
+            continue
+        for attribute in relative_distinguished_name:
+            if (
+                isinstance(attribute, tuple)
+                and len(attribute) == 2
+                and attribute[0] == "commonName"
+            ):
+                value = attribute[1]
+                if isinstance(value, str) and value.strip():
+                    return value
+    return None
 
 
 if __name__ == "__main__":

--- a/framework/dev/kubernetes_executor_k3d_smoke.py
+++ b/framework/dev/kubernetes_executor_k3d_smoke.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import argparse
+import ast
 import os
 import shlex
 import shutil
@@ -27,6 +28,7 @@ import time
 import uuid
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
 from flwr.supercore.constant import TaskType
@@ -44,10 +46,13 @@ DEFAULT_CLUSTER_NAME = "flwr-k8s-executor-smoke"
 DEFAULT_NAMESPACE = "flwr-k8s-executor-smoke"
 DEFAULT_IMAGE = "ghcr.io/flwrlabs/taskexecutor:dev"
 DEFAULT_IMAGE_PULL_POLICY = "Never"
+DEFAULT_PROBE_IMAGE = "flwr-kubernetes-executor-k3d-probe:dev"
 DEFAULT_APPIO_API_ADDRESS = "127.0.0.1:9092"
 DEFAULT_ACTIVE_POD_BUDGET = 1
 DEFAULT_CAPACITY_TIMEOUT = 30.0
 DEFAULT_CAPACITY_POLL_INTERVAL = 0.25
+DEFAULT_POD_SUCCEEDED_TIMEOUT = 60.0
+DEFAULT_POD_SUCCEEDED_POLL_INTERVAL = 0.5
 DIAGNOSTIC_POD_STATUS_TIMEOUT = 3.0
 DIAGNOSTIC_POD_STATUS_POLL = 0.50
 LOCAL_RESOURCE_POOL = "local-k3d-smoke"
@@ -77,6 +82,11 @@ class SmokeConfig:
     capacity_poll_interval: float
     keep_resources: bool
     delete_cluster: bool
+    probe_image: bool = False
+    probe_image_tag: str = DEFAULT_PROBE_IMAGE
+    require_pod_succeeded: bool = False
+    pod_succeeded_timeout: float = DEFAULT_POD_SUCCEEDED_TIMEOUT
+    pod_succeeded_poll_interval: float = DEFAULT_POD_SUCCEEDED_POLL_INTERVAL
 
 
 class CoreV1ApiAdapter:
@@ -126,10 +136,20 @@ def _print_run_overview(config: SmokeConfig) -> None:
     _print_detail("namespace", config.namespace)
     _print_detail("image", config.image)
     _print_detail("image pull policy", config.image_pull_policy)
+    _print_detail("probe image mode", str(config.probe_image))
+    if config.probe_image:
+        _print_detail("probe image tag", config.probe_image_tag)
     _print_detail("AppIo API address", config.appio_api_address)
     _print_detail("active Pod budget", str(config.active_pod_budget))
     _print_detail("capacity timeout", f"{config.capacity_timeout}s")
     _print_detail("capacity poll interval", f"{config.capacity_poll_interval}s")
+    _print_detail("require Pod succeeded", str(config.require_pod_succeeded))
+    if config.require_pod_succeeded:
+        _print_detail("Pod succeeded timeout", f"{config.pod_succeeded_timeout}s")
+        _print_detail(
+            "Pod succeeded poll interval",
+            f"{config.pod_succeeded_poll_interval}s",
+        )
     _print_detail("keep resources", str(config.keep_resources))
     _print_detail("delete cluster", str(config.delete_cluster))
 
@@ -271,10 +291,11 @@ def _print_started_container_logs(
             print(f"  WARN: could not read logs for `{container_name}`: {exc}")
             continue
 
-        if not str(logs).strip():
+        logs_text = _command_output_text(logs)
+        if not logs_text.strip():
             print("  (empty)")
             continue
-        for line in str(logs).strip().splitlines():
+        for line in logs_text.strip().splitlines():
             print(f"  {line}")
 
 
@@ -283,6 +304,21 @@ def _print_command_output(label: str, output: str) -> None:
     print(f"{label}:")
     for line in output.strip().splitlines():
         print(f"  {line}")
+
+
+def _command_output_text(output: object) -> str:
+    """Return command or log output as printable text."""
+    if isinstance(output, bytes):
+        return output.decode("utf-8", errors="replace")
+    text = str(output)
+    if text.startswith(("b'", 'b"')):
+        try:
+            literal = ast.literal_eval(text)
+        except (SyntaxError, ValueError):
+            return text
+        if isinstance(literal, bytes):
+            return literal.decode("utf-8", errors="replace")
+    return text
 
 
 def _format_command(command: Sequence[str]) -> str:
@@ -319,6 +355,21 @@ def parse_args(argv: Sequence[str] | None = None) -> SmokeConfig:
         ),
     )
     parser.add_argument(
+        "--probe-image",
+        action="store_true",
+        default=_env_bool("PROBE_IMAGE", False),
+        help=(
+            "Build and import the dev-only probe image into k3d, use it as "
+            "the TaskExecutor image with imagePullPolicy=Never, and require "
+            "the executor-created Pod to reach Succeeded."
+        ),
+    )
+    parser.add_argument(
+        "--probe-image-tag",
+        default=_env("PROBE_IMAGE_TAG", DEFAULT_PROBE_IMAGE),
+        help="Local Docker image tag used when --probe-image is enabled.",
+    )
+    parser.add_argument(
         "--appio-api-address",
         default=_env("APPIO_API_ADDRESS", DEFAULT_APPIO_API_ADDRESS),
         help="AppIo API address passed into the rendered TaskExecutor Pod.",
@@ -342,6 +393,29 @@ def parse_args(argv: Sequence[str] | None = None) -> SmokeConfig:
         help="Capacity polling interval used by the executor.",
     )
     parser.add_argument(
+        "--require-pod-succeeded",
+        action="store_true",
+        default=_env_bool("REQUIRE_POD_SUCCEEDED", False),
+        help=(
+            "Require smoke Pods selected by the run label to reach Succeeded "
+            "within the bounded Pod completion timeout."
+        ),
+    )
+    parser.add_argument(
+        "--pod-succeeded-timeout",
+        type=float,
+        default=_env_float("POD_SUCCEEDED_TIMEOUT", DEFAULT_POD_SUCCEEDED_TIMEOUT),
+        help="Harness-level timeout for the required Pod Succeeded proof.",
+    )
+    parser.add_argument(
+        "--pod-succeeded-poll-interval",
+        type=float,
+        default=_env_float(
+            "POD_SUCCEEDED_POLL_INTERVAL", DEFAULT_POD_SUCCEEDED_POLL_INTERVAL
+        ),
+        help="Polling interval used while waiting for smoke Pods to succeed.",
+    )
+    parser.add_argument(
         "--keep-resources",
         action="store_true",
         default=_env_bool("KEEP_RESOURCES", False),
@@ -354,18 +428,27 @@ def parse_args(argv: Sequence[str] | None = None) -> SmokeConfig:
         help="Delete the k3d cluster at the end only if this harness created it.",
     )
     args = parser.parse_args(argv)
+    image = args.probe_image_tag if args.probe_image else args.image
+    image_pull_policy = (
+        DEFAULT_IMAGE_PULL_POLICY if args.probe_image else args.image_pull_policy
+    )
 
     return SmokeConfig(
         cluster_name=args.cluster_name,
         namespace=args.namespace,
-        image=args.image,
-        image_pull_policy=args.image_pull_policy,
+        image=image,
+        image_pull_policy=image_pull_policy,
         appio_api_address=args.appio_api_address,
         active_pod_budget=args.active_pod_budget,
         capacity_timeout=args.capacity_timeout,
         capacity_poll_interval=args.capacity_poll_interval,
         keep_resources=args.keep_resources,
         delete_cluster=args.delete_cluster,
+        probe_image=args.probe_image,
+        probe_image_tag=args.probe_image_tag,
+        require_pod_succeeded=args.require_pod_succeeded or args.probe_image,
+        pod_succeeded_timeout=args.pod_succeeded_timeout,
+        pod_succeeded_poll_interval=args.pod_succeeded_poll_interval,
     )
 
 
@@ -399,6 +482,8 @@ def run_smoke(config: SmokeConfig) -> None:
     cleanup_completed = False
     cluster_created = ensure_k3d_cluster(config.cluster_name)
     try:
+        prepare_probe_image(config)
+
         _print_section("Load kubeconfig and create Kubernetes API client")
         print(
             "Loading kubeconfig for the current context selected by "
@@ -455,6 +540,15 @@ def run_smoke(config: SmokeConfig) -> None:
             "OK: capacity selector found at least the configured active Pod "
             f"budget ({len(pods)} of {config.active_pod_budget})."
         )
+        if config.require_pod_succeeded:
+            pods = wait_for_pods_succeeded(
+                api,
+                config.namespace,
+                selector,
+                expected_count=config.active_pod_budget,
+                timeout=config.pod_succeeded_timeout,
+                poll_interval=config.pod_succeeded_poll_interval,
+            )
         report_pod_lifecycle_diagnostics(api, config.namespace, pods)
 
         if config.keep_resources:
@@ -467,6 +561,18 @@ def run_smoke(config: SmokeConfig) -> None:
                 "Inspect preserved resources with: "
                 f"kubectl get pods,secrets -n {config.namespace} -l '{selector}'"
             )
+        elif config.require_pod_succeeded:
+            _print_section("Skip active-capacity wait proof")
+            print(
+                "Skipping wait_for_capacity() blocking proof because the probe "
+                "mode requires the smoke Pod to complete first. Terminal Pods "
+                "do not count against active capacity."
+            )
+            cleanup_labeled_objects(api, config.namespace, selector)
+            wait_for_no_labeled_objects(
+                api, config.namespace, selector, timeout=config.capacity_timeout
+            )
+            cleanup_completed = True
         else:
             prove_wait_for_capacity_blocks_and_unblocks(
                 executor=executor,
@@ -508,6 +614,7 @@ def validate_smoke_config(config: SmokeConfig) -> None:
         ("Namespace", config.namespace),
         ("TaskExecutor image", config.image),
         ("Image pull policy", config.image_pull_policy),
+        ("Probe image tag", config.probe_image_tag),
         ("AppIo API address", config.appio_api_address),
     ):
         if not value.strip():
@@ -518,8 +625,19 @@ def validate_smoke_config(config: SmokeConfig) -> None:
         raise SmokeFailure("Capacity timeout must be positive.")
     if config.capacity_poll_interval <= 0:
         raise SmokeFailure("Capacity poll interval must be positive.")
+    if config.pod_succeeded_timeout <= 0:
+        raise SmokeFailure("Pod succeeded timeout must be positive.")
+    if config.pod_succeeded_poll_interval <= 0:
+        raise SmokeFailure("Pod succeeded poll interval must be positive.")
     if config.keep_resources and config.delete_cluster:
         raise SmokeFailure("--keep-resources cannot be combined with --delete-cluster.")
+    if config.probe_image and config.image != config.probe_image_tag:
+        raise SmokeFailure(
+            "Probe image mode must use the probe image tag as the "
+            "TaskExecutor image."
+        )
+    if config.probe_image and config.image_pull_policy != DEFAULT_IMAGE_PULL_POLICY:
+        raise SmokeFailure("Probe image mode requires imagePullPolicy=Never.")
 
 
 def ensure_k3d_cluster(cluster_name: str) -> bool:
@@ -546,6 +664,51 @@ def ensure_k3d_cluster(cluster_name: str) -> bool:
     )
     print(f"OK: kubeconfig now points at k3d cluster `{cluster_name}`.")
     return cluster_created
+
+
+def prepare_probe_image(config: SmokeConfig) -> None:
+    """Build and import the dev-only probe image when probe mode is enabled."""
+    if not config.probe_image:
+        return
+
+    _print_section("Build and import controlled probe image")
+    probe_dir = _probe_image_dir()
+    print(
+        "Building the dev-only probe image locally. The image exposes the "
+        "TaskExecutor command names expected by KubernetesExecutor and exits "
+        "successfully only after validating mounted credentials and rendered "
+        "arguments."
+    )
+    _print_detail("probe image directory", str(probe_dir))
+    _print_detail("probe image tag", config.probe_image_tag)
+    _run_command(
+        [
+            "docker",
+            "build",
+            "--tag",
+            config.probe_image_tag,
+            str(probe_dir),
+        ]
+    )
+    print(
+        f"Importing `{config.probe_image_tag}` into k3d cluster "
+        f"`{config.cluster_name}`."
+    )
+    _run_command(
+        [
+            "k3d",
+            "image",
+            "import",
+            config.probe_image_tag,
+            "--cluster",
+            config.cluster_name,
+        ]
+    )
+
+
+def _probe_image_dir() -> Path:
+    """Return the dev-only probe image build directory."""
+    return Path(__file__).resolve().parent / "kubernetes_executor_k3d_probe"
 
 
 def ensure_namespace(api: Any, namespace: str) -> None:
@@ -695,6 +858,72 @@ def report_pod_lifecycle_diagnostics(
         _print_container_statuses(container_statuses)
         _print_pod_events(api, namespace, name)
         _print_started_container_logs(api, namespace, name, container_statuses)
+
+
+def wait_for_pods_succeeded(
+    api: Any,
+    namespace: str,
+    label_selector: str,
+    *,
+    expected_count: int,
+    timeout: float,
+    poll_interval: float,
+) -> list[Any]:
+    """Wait until all smoke Pods selected by the run label reach Succeeded."""
+    _print_section("Require smoke Pods to reach Succeeded")
+    print(
+        "Probe mode requires the executor-created Pod to start and complete. "
+        "The probe container validates the mounted token file and rendered "
+        "TaskExecutor arguments without printing token contents."
+    )
+    _print_detail("namespace", namespace)
+    _print_detail("label selector", label_selector)
+    _print_detail("expected Pod count", str(expected_count))
+    _print_detail("timeout", f"{timeout}s")
+
+    deadline = time.monotonic() + timeout
+    last_summary: str | None = None
+    pods: list[Any] = []
+    while time.monotonic() < deadline:
+        pods = _list_items(
+            api.list_namespaced_pod(namespace=namespace, label_selector=label_selector)
+        )
+        summary = _pod_phase_summary(pods)
+        if summary != last_summary:
+            print(f"Current selected Pods: {summary}")
+            last_summary = summary
+
+        if len(pods) >= expected_count and all(
+            _object_phase(pod) == "Succeeded" for pod in pods
+        ):
+            print("OK: all selected smoke Pods reached Succeeded.")
+            return pods
+
+        failed = [pod for pod in pods if _object_phase(pod) == "Failed"]
+        if failed:
+            report_pod_lifecycle_diagnostics(api, namespace, pods)
+            failed_names = ", ".join(_object_name(pod) or "<unknown>" for pod in failed)
+            raise SmokeFailure(f"Smoke Pod(s) failed before Succeeded: {failed_names}.")
+
+        time.sleep(poll_interval)
+
+    report_pod_lifecycle_diagnostics(api, namespace, pods)
+    raise SmokeFailure(
+        "Smoke Pod(s) did not reach Succeeded before timeout. Inspect with: "
+        f"kubectl get pods -n {namespace} -l '{label_selector}'"
+    )
+
+
+def _pod_phase_summary(pods: Sequence[Any]) -> str:
+    """Return a compact Pod phase summary for completion polling output."""
+    if not pods:
+        return "0 Pod(s)"
+    values = []
+    for pod in pods:
+        name = _object_name(pod) or "<unknown>"
+        phase = _object_phase(pod) or "<unknown>"
+        values.append(f"{name}:{phase}")
+    return ", ".join(values)
 
 
 def _refresh_pods_for_lifecycle_diagnostics(

--- a/framework/dev/kubernetes_executor_k3d_smoke.py
+++ b/framework/dev/kubernetes_executor_k3d_smoke.py
@@ -47,6 +47,27 @@ DEFAULT_NAMESPACE = "flwr-k8s-executor-smoke"
 DEFAULT_IMAGE = "ghcr.io/flwrlabs/taskexecutor:dev"
 DEFAULT_IMAGE_PULL_POLICY = "Never"
 DEFAULT_PROBE_IMAGE = "flwr-kubernetes-executor-k3d-probe:dev"
+PROBE_ROOT_CERTIFICATE_COMMON_NAME = "flwr-k8s-executor-smoke-ca"
+PROBE_ROOT_CERTIFICATE = """-----BEGIN CERTIFICATE-----
+MIIDKzCCAhOgAwIBAgIUYtO398ah/BPXfS9K+brpsqbASW4wDQYJKoZIhvcNAQEL
+BQAwJTEjMCEGA1UEAwwaZmx3ci1rOHMtZXhlY3V0b3Itc21va2UtY2EwHhcNMjYw
+NjAyMjAzNzU1WhcNMzYwNTMwMjAzNzU1WjAlMSMwIQYDVQQDDBpmbHdyLWs4cy1l
+eGVjdXRvci1zbW9rZS1jYTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB
+ALYGcPOoD1Gz/mBIVU+SL6C8+1I7d0dq20txhbhqaV4kftxv+2Wxw/dUjrurjDQe
+/97/BKLXgBNwUam26CeFcwnsMyqWFXGCnNNfLToMop1bMUAev06PScPaRJ0RnjIF
+4+Ov5cAVNPkFxR+Nw6ayOpkwjSXTIiqD7fug+wqxEKJRfg/QEc4zFa2V6zaQFOJa
+vb0WGUFm7MzPa+32tEbH1pN6VW5wAT0JghLVx5FRA2cpH8sCieov8L7IVXM5aMu9
+upcne7FQ99sSErER9sEjqFNK7byTP9xZIIjGT4Ep4DqWzORphwwEEzC4BrvTzLJm
+HgskFwljSadTOg/dZu/wXo0CAwEAAaNTMFEwHQYDVR0OBBYEFNB+hF1kkiZ2RraA
+/yN44RPK3v+RMB8GA1UdIwQYMBaAFNB+hF1kkiZ2RraA/yN44RPK3v+RMA8GA1Ud
+EwEB/wQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBABgKx51NWCvPFHN0eGyfZ+Yo
+3a85eBT9xPhnmBViffZcRb9OOlaz9+5mFTpQqVH+E7SLuB44gyWiHw4DSNj3cidh
+vW2+dhHxfi/1zAnP32fHM8CKd8qYooX1nCK+yXwePNX0k/Fl5AdjmHbVn5M71ivx
+Qd2OwBmMat8bHy3nKML7zU3T2kkycfrUxxfxXVjnBWHjGHZs9jaecoL3nid8Iy3C
+SFu6f/R8MZ63Y8fw8Wx+CEo7OZC8mm+/Fcx9dvB+TsjW+xDkHTUcjBdKhMPQ791b
+4D1rmzythc7HsGmlE2RiXxZY5VTk02cxASo31+zWia4erpwGY3yWcZFe62Tjw6k=
+-----END CERTIFICATE-----
+"""
 DEFAULT_APPIO_API_ADDRESS = "127.0.0.1:9092"
 DEFAULT_ACTIVE_POD_BUDGET = 1
 DEFAULT_CAPACITY_TIMEOUT = 30.0
@@ -139,6 +160,10 @@ def _print_run_overview(config: SmokeConfig) -> None:
     _print_detail("probe image mode", str(config.probe_image))
     if config.probe_image:
         _print_detail("probe image tag", config.probe_image_tag)
+        _print_detail(
+            "probe root certificate commonName",
+            PROBE_ROOT_CERTIFICATE_COMMON_NAME,
+        )
     _print_detail("AppIo API address", config.appio_api_address)
     _print_detail("active Pod budget", str(config.active_pod_budget))
     _print_detail("capacity timeout", f"{config.capacity_timeout}s")
@@ -510,6 +535,11 @@ def run_smoke(config: SmokeConfig) -> None:
         _print_detail("TaskExecutor image", config.image)
         _print_detail("image pull policy", config.image_pull_policy)
         _print_detail("AppIo API address", config.appio_api_address)
+        if config.probe_image:
+            _print_detail(
+                "AppIo root certificate commonName",
+                PROBE_ROOT_CERTIFICATE_COMMON_NAME,
+            )
         _print_detail("active Pod budget", str(config.active_pod_budget))
         _print_detail("capacity poll interval", f"{config.capacity_poll_interval}s")
         print(
@@ -736,6 +766,9 @@ def build_executor_config(config: SmokeConfig, run_id: str) -> KubernetesExecuto
     return KubernetesExecutorConfig(
         namespace=config.namespace,
         image=config.image,
+        appio_root_certificates=(
+            PROBE_ROOT_CERTIFICATE if config.probe_image else None
+        ),
         image_pull_policy=config.image_pull_policy,
         resource_pool=LOCAL_RESOURCE_POOL,
         labels={RUN_LABEL_KEY: run_id},
@@ -764,7 +797,7 @@ def build_execution_spec(
         task_type=TaskType.SERVER_APP,
         appio_api_address=config.appio_api_address,
         token=f"smoke-token-{run_id}-{task_offset}",
-        insecure=True,
+        insecure=not config.probe_image,
         root_certificates_path=None,
         runtime_dependency_install=False,
         parent_pid=None,
@@ -797,6 +830,11 @@ def launch_smoke_pods(
         _print_detail("task id", str(spec.task_id))
         _print_detail("AppIo API address", spec.appio_api_address)
         _print_detail("insecure AppIo", str(spec.insecure))
+        if not spec.insecure:
+            _print_detail(
+                "root certificates",
+                f"mounted dev certificate CN={PROBE_ROOT_CERTIFICATE_COMMON_NAME}",
+            )
         _print_detail(
             "runtime dependency install", str(spec.runtime_dependency_install)
         )

--- a/framework/dev/kubernetes_executor_k3d_smoke_test.py
+++ b/framework/dev/kubernetes_executor_k3d_smoke_test.py
@@ -100,6 +100,71 @@ def test_probe_taskexecutor_validates_mounted_token_and_insecure_args(
     )
 
 
+def test_probe_taskexecutor_validates_root_certificate_common_name(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    """Test the probe parses the mounted root certificate and emits the CN."""
+    token_path = tmp_path / "token"
+    token_path.write_text(
+        "smoke-token-0123456789abcdef0123456789abcdef-0", encoding="utf-8"
+    )
+    root_certificates_path = tmp_path / "ca.crt"
+    root_certificates_path.write_text(smoke.PROBE_ROOT_CERTIFICATE, encoding="utf-8")
+    monkeypatch.setattr(probe, "APPIO_TOKEN_FILE_PATH", str(token_path))
+    monkeypatch.setattr(
+        probe, "APPIO_ROOT_CERTIFICATES_FILE_PATH", str(root_certificates_path)
+    )
+
+    probe._run_probe(
+        [
+            "flwr-serverapp",
+            "--serverappio-api-address",
+            "appio:9092",
+            "--token-file",
+            str(token_path),
+            "--root-certificates",
+            str(root_certificates_path),
+        ]
+    )
+
+    output = capsys.readouterr().out
+    assert (
+        "probe: verified root certificate "
+        f"commonName={smoke.PROBE_ROOT_CERTIFICATE_COMMON_NAME}"
+    ) in output
+
+
+def test_probe_taskexecutor_rejects_invalid_root_certificate(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+) -> None:
+    """Test the probe rejects a mounted root certificate that is not parseable."""
+    token_path = tmp_path / "token"
+    token_path.write_text(
+        "smoke-token-0123456789abcdef0123456789abcdef-0", encoding="utf-8"
+    )
+    root_certificates_path = tmp_path / "ca.crt"
+    root_certificates_path.write_text("not a cert", encoding="utf-8")
+    monkeypatch.setattr(probe, "APPIO_TOKEN_FILE_PATH", str(token_path))
+    monkeypatch.setattr(
+        probe, "APPIO_ROOT_CERTIFICATES_FILE_PATH", str(root_certificates_path)
+    )
+
+    with pytest.raises(probe.ProbeFailure, match="not a valid certificate"):
+        probe._run_probe(
+            [
+                "flwr-serverapp",
+                "--serverappio-api-address",
+                "appio:9092",
+                "--token-file",
+                str(token_path),
+                "--root-certificates",
+                str(root_certificates_path),
+            ]
+        )
+
+
 def test_core_v1_api_adapter_forwards_executor_calls() -> None:
     """Test CoreV1Api calls are adapted to the executor client protocol."""
     api = Mock()
@@ -166,6 +231,32 @@ def test_build_execution_spec_uses_unique_task_ids_and_tokens() -> None:
     assert first.task_id > 0
     assert second.task_id == first.task_id + 1
     assert first.token != second.token
+    assert first.insecure is True
+
+
+def test_probe_mode_mounts_dev_root_certificate_and_uses_secure_spec() -> None:
+    """Test probe mode exercises the root-certificates TaskExecutor path."""
+    config = smoke.SmokeConfig(
+        cluster_name="cluster",
+        namespace="namespace",
+        image=smoke.DEFAULT_PROBE_IMAGE,
+        image_pull_policy="Never",
+        appio_api_address="appio:9092",
+        active_pod_budget=1,
+        capacity_timeout=5.0,
+        capacity_poll_interval=0.1,
+        keep_resources=False,
+        delete_cluster=False,
+        probe_image=True,
+    )
+    run_id = "0123456789abcdef0123456789abcdef"
+
+    executor_config = smoke.build_executor_config(config, run_id)
+    spec = smoke.build_execution_spec(config, run_id)
+
+    assert executor_config.appio_root_certificates == smoke.PROBE_ROOT_CERTIFICATE
+    assert spec.insecure is False
+    assert spec.root_certificates_path is None
 
 
 def test_pod_lifecycle_diagnostics_reports_waiting_pod_without_logs(

--- a/framework/dev/kubernetes_executor_k3d_smoke_test.py
+++ b/framework/dev/kubernetes_executor_k3d_smoke_test.py
@@ -20,6 +20,7 @@ import threading
 from typing import Any
 from unittest.mock import Mock, call
 
+import kubernetes_executor_k3d_probe.probe_taskexecutor as probe
 import kubernetes_executor_k3d_smoke as smoke
 import pytest
 
@@ -54,6 +55,49 @@ def test_parse_args_uses_environment_defaults(monkeypatch: pytest.MonkeyPatch) -
     assert config.capacity_poll_interval == 0.1
     assert config.keep_resources is True
     assert config.delete_cluster is True
+
+
+def test_parse_args_probe_image_forces_local_image_and_completion() -> None:
+    """Test probe image mode selects the controlled image and strict Pod wait."""
+    config = smoke.parse_args(["--probe-image"])
+
+    assert config.probe_image is True
+    assert config.image == smoke.DEFAULT_PROBE_IMAGE
+    assert config.image_pull_policy == "Never"
+    assert config.require_pod_succeeded is True
+
+
+def test_parse_args_can_require_pod_succeeded_without_building_probe() -> None:
+    """Test strict Pod completion can be requested for a caller-provided image."""
+    config = smoke.parse_args(
+        ["--require-pod-succeeded", "--image", "example/taskexecutor:local"]
+    )
+
+    assert config.probe_image is False
+    assert config.image == "example/taskexecutor:local"
+    assert config.require_pod_succeeded is True
+
+
+def test_probe_taskexecutor_validates_mounted_token_and_insecure_args(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+) -> None:
+    """Test the probe command accepts executor-rendered insecure args."""
+    token_path = tmp_path / "token"
+    token_path.write_text(
+        "smoke-token-0123456789abcdef0123456789abcdef-0", encoding="utf-8"
+    )
+    monkeypatch.setattr(probe, "APPIO_TOKEN_FILE_PATH", str(token_path))
+
+    probe._run_probe(
+        [
+            "flwr-serverapp",
+            "--serverappio-api-address",
+            "appio:9092",
+            "--token-file",
+            str(token_path),
+            "--insecure",
+        ]
+    )
 
 
 def test_core_v1_api_adapter_forwards_executor_calls() -> None:
@@ -195,7 +239,7 @@ def test_pod_lifecycle_diagnostics_reads_started_container_logs(
     """Test lifecycle diagnostics read logs for a started container."""
     api = Mock()
     api.list_namespaced_event.return_value = {"items": []}
-    api.read_namespaced_pod_log.return_value = "hello from taskexecutor\n"
+    api.read_namespaced_pod_log.return_value = b"hello from taskexecutor\n"
     pod = {
         "metadata": {"name": "pod-a"},
         "status": {
@@ -228,6 +272,13 @@ def test_pod_lifecycle_diagnostics_reads_started_container_logs(
         namespace="namespace",
         container="taskexecutor",
         tail_lines=80,
+    )
+
+
+def test_command_output_text_decodes_bytes_literal_string() -> None:
+    """Test Kubernetes log byte-literal strings print as normal text."""
+    assert smoke._command_output_text("b'hello from taskexecutor\\n'") == (
+        "hello from taskexecutor\n"
     )
 
 
@@ -267,6 +318,68 @@ def test_validate_smoke_config_rejects_keep_resources_with_delete_cluster() -> N
 
     with pytest.raises(smoke.SmokeFailure, match="cannot be combined"):
         smoke.validate_smoke_config(config)
+
+
+def test_validate_smoke_config_rejects_probe_mode_without_never_pull() -> None:
+    """Test controlled probe mode keeps imagePullPolicy=Never."""
+    config = smoke.SmokeConfig(
+        cluster_name="cluster",
+        namespace="namespace",
+        image=smoke.DEFAULT_PROBE_IMAGE,
+        image_pull_policy="IfNotPresent",
+        appio_api_address="appio:9092",
+        active_pod_budget=1,
+        capacity_timeout=5.0,
+        capacity_poll_interval=0.1,
+        keep_resources=False,
+        delete_cluster=False,
+        probe_image=True,
+    )
+
+    with pytest.raises(smoke.SmokeFailure, match="imagePullPolicy=Never"):
+        smoke.validate_smoke_config(config)
+
+
+def test_prepare_probe_image_builds_and_imports(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+) -> None:
+    """Test probe mode builds the local image and imports it into k3d."""
+    commands = []
+    monkeypatch.setattr(smoke, "_run_command", commands.append)
+    monkeypatch.setattr(smoke, "_probe_image_dir", lambda: tmp_path)
+    config = smoke.SmokeConfig(
+        cluster_name="cluster",
+        namespace="namespace",
+        image=smoke.DEFAULT_PROBE_IMAGE,
+        image_pull_policy="Never",
+        appio_api_address="appio:9092",
+        active_pod_budget=1,
+        capacity_timeout=5.0,
+        capacity_poll_interval=0.1,
+        keep_resources=False,
+        delete_cluster=False,
+        probe_image=True,
+    )
+
+    smoke.prepare_probe_image(config)
+
+    assert commands == [
+        [
+            "docker",
+            "build",
+            "--tag",
+            smoke.DEFAULT_PROBE_IMAGE,
+            str(tmp_path),
+        ],
+        [
+            "k3d",
+            "image",
+            "import",
+            smoke.DEFAULT_PROBE_IMAGE,
+            "--cluster",
+            "cluster",
+        ],
+    ]
 
 
 def test_cleanup_deletes_only_objects_matching_selector() -> None:
@@ -336,4 +449,49 @@ def test_wait_for_capacity_proof_rejects_immediate_return() -> None:
             cleanup=Mock(),
             timeout=1.0,
             block_check_timeout=0.01,
+        )
+
+
+def test_wait_for_pods_succeeded_returns_when_all_selected_pods_succeed() -> None:
+    """Test strict probe wait returns selected Pods once they reach Succeeded."""
+    api = Mock()
+    pending = {"metadata": {"name": "pod-a"}, "status": {"phase": "Pending"}}
+    succeeded = {"metadata": {"name": "pod-a"}, "status": {"phase": "Succeeded"}}
+    api.list_namespaced_pod.side_effect = [
+        {"items": [pending]},
+        {"items": [succeeded]},
+    ]
+
+    pods = smoke.wait_for_pods_succeeded(
+        api,
+        "namespace",
+        "label=value",
+        expected_count=1,
+        timeout=1.0,
+        poll_interval=0.01,
+    )
+
+    assert pods == [succeeded]
+
+
+def test_wait_for_pods_succeeded_fails_fast_for_failed_pod() -> None:
+    """Test strict probe wait fails when a selected Pod enters Failed."""
+    api = Mock()
+    api.list_namespaced_pod.return_value = {
+        "items": [{"metadata": {"name": "pod-a"}, "status": {"phase": "Failed"}}]
+    }
+    api.list_namespaced_event.return_value = {"items": []}
+    api.read_namespaced_pod.return_value = {
+        "metadata": {"name": "pod-a"},
+        "status": {"phase": "Failed"},
+    }
+
+    with pytest.raises(smoke.SmokeFailure, match="failed before Succeeded"):
+        smoke.wait_for_pods_succeeded(
+            api,
+            "namespace",
+            "label=value",
+            expected_count=1,
+            timeout=1.0,
+            poll_interval=0.01,
         )


### PR DESCRIPTION
## Issue

### Description

This PR adds a controlled k3d probe image smoke on top of the local Kubernetes SuperExec executor k3d harness.

### Related issues/PRs

Builds on #7299.

## Proposal

### Explanation

This extends the optional `framework/dev/` k3d harness with a dev-only probe image mode for `KubernetesExecutor`.

The new `--probe-image` mode builds a tiny local probe image, imports it into the selected k3d cluster, uses it as the TaskExecutor image with `imagePullPolicy=Never`, and requires the executor-created Pod to reach `Succeeded` within a bounded timeout.

The probe image exposes the TaskExecutor command names rendered by the executor and validates the mounted AppIo credential Secret from inside the container. It checks that `/run/flwr/appio/token` exists, verifies the smoke-token shape without printing token contents, and confirms the rendered AppIo address, token-file, and insecure/root-certificate arguments.

The existing default k3d smoke remains an API and capacity proof and does not require the Pod image to exist or the container to start. Fake AppIo, a real TaskExecutor-compatible image, FAB execution, cleanup/sweeper changes, CI defaults, and production deployment wiring remain follow-up work.

### Checklist

- [x] Implement proposed change
- [x] Write tests
- [x] Update [documentation](https://flower.ai/docs/writing-documentation.html) (not needed; optional local dev harness only)
- [x] Address LLM-reviewer comments, if applicable (e.g., GitHub Copilot)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)
