### PR TITLE
fix(framework): Handle SuperExec runtime version error

### DIFF
--- a/framework/py/flwr/supercore/interceptors/runtime_version_interceptor.py
+++ b/framework/py/flwr/supercore/interceptors/runtime_version_interceptor.py
@@ -100,6 +100,7 @@ class RuntimeVersionClientInterceptor(
             self._maybe_exit_on_incompat_error(err)
             raise
 
+        # Avoid duplicate handling when tests mock flwr_exit and execution continues
         incompat_error_handled = False
         if inspect_errors_immediately and isinstance(call, grpc.RpcError):
             if exit_message := self._get_incompat_exit_message(call):

--- a/framework/py/flwr/supercore/interceptors/runtime_version_interceptor.py
+++ b/framework/py/flwr/supercore/interceptors/runtime_version_interceptor.py
@@ -14,6 +14,7 @@
 # ==============================================================================
 """Runtime version metadata interceptors."""
 
+
 from __future__ import annotations
 
 from collections.abc import Callable

--- a/framework/py/flwr/supercore/interceptors/runtime_version_interceptor.py
+++ b/framework/py/flwr/supercore/interceptors/runtime_version_interceptor.py
@@ -78,6 +78,7 @@ class RuntimeVersionClientInterceptor(
         continuation: Callable[[Any, Any], Any],
         client_call_details: grpc.ClientCallDetails,
         request: GrpcMessage,
+        inspect_errors_immediately: bool,
     ) -> grpc.Call:
         """Add runtime version metadata and inspect RPC completion metadata."""
         details = client_call_details._replace(
@@ -100,7 +101,7 @@ class RuntimeVersionClientInterceptor(
             raise
 
         incompat_error_handled = False
-        if isinstance(call, grpc.RpcError):
+        if inspect_errors_immediately and isinstance(call, grpc.RpcError):
             if exit_message := self._get_incompat_exit_message(call):
                 incompat_error_handled = True
                 flwr_exit(ExitCode.RUNTIME_VERSION_INCOMPATIBLE, exit_message)
@@ -127,7 +128,12 @@ class RuntimeVersionClientInterceptor(
         request: GrpcMessage,
     ) -> grpc.Call:
         """Add the runtime version metadata headers for unary-unary RPCs."""
-        return self._intercept_call(continuation, client_call_details, request)
+        return self._intercept_call(
+            continuation,
+            client_call_details,
+            request,
+            inspect_errors_immediately=True,
+        )
 
     def intercept_unary_stream(
         self,
@@ -136,7 +142,12 @@ class RuntimeVersionClientInterceptor(
         request: GrpcMessage,
     ) -> grpc.Call:
         """Add the runtime version metadata headers for unary-stream RPCs."""
-        return self._intercept_call(continuation, client_call_details, request)
+        return self._intercept_call(
+            continuation,
+            client_call_details,
+            request,
+            inspect_errors_immediately=False,
+        )
 
 
 class RuntimeVersionServerInterceptor(grpc.ServerInterceptor):  # type: ignore[misc]

--- a/framework/py/flwr/supercore/interceptors/runtime_version_interceptor.py
+++ b/framework/py/flwr/supercore/interceptors/runtime_version_interceptor.py
@@ -14,7 +14,6 @@
 # ==============================================================================
 """Runtime version metadata interceptors."""
 
-
 from __future__ import annotations
 
 from collections.abc import Callable
@@ -53,7 +52,7 @@ class RuntimeVersionClientInterceptor(
         if incompat_message:
             log(WARN, incompat_message)
 
-    def _maybe_exit_on_incompat_error(self, grpc_error: grpc.RpcError) -> None:
+    def _maybe_exit_on_incompat_error(self, grpc_error: grpc.RpcError) -> bool:
         """Exit on runtime-version rejections encoded as FlowerError JSON."""
         details = grpc_error.details() if hasattr(grpc_error, "details") else None
         flower_error = FlowerError.from_json(details)
@@ -65,6 +64,8 @@ class RuntimeVersionClientInterceptor(
             if flower_error.public_details:
                 exit_message += f"\n{flower_error.public_details}"
             flwr_exit(ExitCode.RUNTIME_VERSION_INCOMPATIBLE, exit_message)
+            return True
+        return False
 
     def _intercept_call(
         self,
@@ -78,15 +79,28 @@ class RuntimeVersionClientInterceptor(
                 client_call_details.metadata
             )
         )
-        call: grpc.Call = continuation(details, request)
 
-        def _handle_completion() -> None:
-            self._maybe_log_incompat_warning(call.trailing_metadata())
+        incompat_error_handled = False
+
+        def _maybe_exit_on_call_error(call: grpc.Call) -> None:
+            nonlocal incompat_error_handled
             # Some successful call objects (e.g., unary-stream) can also be
             # subclasses of grpc.RpcError. Do not treat RpcError alone as failure;
             # _maybe_exit_on_incompat_error checks the actual RPC details.
-            if isinstance(call, grpc.RpcError):
-                self._maybe_exit_on_incompat_error(call)
+            if isinstance(call, grpc.RpcError) and not incompat_error_handled:
+                incompat_error_handled = self._maybe_exit_on_incompat_error(call)
+
+        try:
+            call: grpc.Call = continuation(details, request)
+        except grpc.RpcError as err:
+            self._maybe_exit_on_incompat_error(err)
+            raise
+
+        _maybe_exit_on_call_error(call)
+
+        def _handle_completion() -> None:
+            self._maybe_log_incompat_warning(call.trailing_metadata())
+            _maybe_exit_on_call_error(call)
 
         # NOTE: Some gRPC call objects expose callback registration without
         # implementing it.

--- a/framework/py/flwr/supercore/interceptors/runtime_version_interceptor.py
+++ b/framework/py/flwr/supercore/interceptors/runtime_version_interceptor.py
@@ -53,20 +53,25 @@ class RuntimeVersionClientInterceptor(
         if incompat_message:
             log(WARN, incompat_message)
 
-    def _maybe_exit_on_incompat_error(self, grpc_error: grpc.RpcError) -> bool:
-        """Exit on runtime-version rejections encoded as FlowerError JSON."""
+    def _get_incompat_exit_message(self, grpc_error: grpc.RpcError) -> str | None:
+        """Return the exit message for a runtime-version rejection, if present."""
         details = grpc_error.details() if hasattr(grpc_error, "details") else None
         flower_error = FlowerError.from_json(details)
         if (
-            flower_error is not None
-            and flower_error.code == ApiErrorCode.RUNTIME_VERSION_INCOMPATIBLE
+            flower_error is None
+            or flower_error.code != ApiErrorCode.RUNTIME_VERSION_INCOMPATIBLE
         ):
-            exit_message = flower_error.message
-            if flower_error.public_details:
-                exit_message += f"\n{flower_error.public_details}"
+            return None
+
+        exit_message = flower_error.message
+        if flower_error.public_details:
+            exit_message += f"\n{flower_error.public_details}"
+        return exit_message
+
+    def _maybe_exit_on_incompat_error(self, grpc_error: grpc.RpcError) -> None:
+        """Exit on runtime-version rejections encoded as FlowerError JSON."""
+        if exit_message := self._get_incompat_exit_message(grpc_error):
             flwr_exit(ExitCode.RUNTIME_VERSION_INCOMPATIBLE, exit_message)
-            return True
-        return False
 
     def _intercept_call(
         self,
@@ -81,15 +86,12 @@ class RuntimeVersionClientInterceptor(
             )
         )
 
-        incompat_error_handled = False
-
         def _maybe_exit_on_call_error(call: grpc.Call) -> None:
-            nonlocal incompat_error_handled
             # Some successful call objects (e.g., unary-stream) can also be
             # subclasses of grpc.RpcError. Do not treat RpcError alone as failure;
-            # _maybe_exit_on_incompat_error checks the actual RPC details.
-            if isinstance(call, grpc.RpcError) and not incompat_error_handled:
-                incompat_error_handled = self._maybe_exit_on_incompat_error(call)
+            # _get_incompat_exit_message checks the actual RPC details.
+            if isinstance(call, grpc.RpcError):
+                self._maybe_exit_on_incompat_error(call)
 
         try:
             call: grpc.Call = continuation(details, request)
@@ -97,11 +99,16 @@ class RuntimeVersionClientInterceptor(
             self._maybe_exit_on_incompat_error(err)
             raise
 
-        _maybe_exit_on_call_error(call)
+        incompat_error_handled = False
+        if isinstance(call, grpc.RpcError):
+            if exit_message := self._get_incompat_exit_message(call):
+                flwr_exit(ExitCode.RUNTIME_VERSION_INCOMPATIBLE, exit_message)
+                incompat_error_handled = True
 
         def _handle_completion() -> None:
             self._maybe_log_incompat_warning(call.trailing_metadata())
-            _maybe_exit_on_call_error(call)
+            if not incompat_error_handled:
+                _maybe_exit_on_call_error(call)
 
         # NOTE: Some gRPC call objects expose callback registration without
         # implementing it.

--- a/framework/py/flwr/supercore/interceptors/runtime_version_interceptor.py
+++ b/framework/py/flwr/supercore/interceptors/runtime_version_interceptor.py
@@ -102,8 +102,8 @@ class RuntimeVersionClientInterceptor(
         incompat_error_handled = False
         if isinstance(call, grpc.RpcError):
             if exit_message := self._get_incompat_exit_message(call):
-                flwr_exit(ExitCode.RUNTIME_VERSION_INCOMPATIBLE, exit_message)
                 incompat_error_handled = True
+                flwr_exit(ExitCode.RUNTIME_VERSION_INCOMPATIBLE, exit_message)
 
         def _handle_completion() -> None:
             self._maybe_log_incompat_warning(call.trailing_metadata())

--- a/framework/py/flwr/supercore/interceptors/runtime_version_interceptor_test.py
+++ b/framework/py/flwr/supercore/interceptors/runtime_version_interceptor_test.py
@@ -120,12 +120,14 @@ def _make_stream_call(
     return call
 
 
-def _make_runtime_rpc_error() -> grpc.RpcError:
+def _make_runtime_rpc_error(
+    code: ApiErrorCode = ApiErrorCode.RUNTIME_VERSION_INCOMPATIBLE,
+) -> grpc.RpcError:
     rpc_error = grpc.RpcError()
     rpc_error.trailing_metadata = Mock(return_value=())
     rpc_error.details = Mock(
         return_value=FlowerError(
-            ApiErrorCode.RUNTIME_VERSION_INCOMPATIBLE,
+            code,
             "internal diagnostic message",
             public_details="runtime mismatch",
         ).to_json("Runtime version compatibility check failed.")
@@ -214,6 +216,62 @@ class TestRuntimeVersionClientInterceptor(TestCase):
             ExitCode.RUNTIME_VERSION_INCOMPATIBLE,
             "Runtime version compatibility check failed.\nruntime mismatch",
         )
+
+    def test_log_unary_incompatibility_from_raised_rpc_error(self) -> None:
+        """Raised unary-unary RpcError outcomes should trigger Flower exits."""
+        rpc_error = _make_runtime_rpc_error()
+
+        def continuation(
+            _client_call_details: grpc.ClientCallDetails,
+            _request: GrpcMessage,
+        ) -> grpc.Call:
+            raise rpc_error
+
+        with (
+            patch(
+                "flwr.supercore.interceptors.runtime_version_interceptor.flwr_exit"
+            ) as flwr_exit_mock,
+            self.assertRaises(grpc.RpcError),
+        ):
+            self.interceptor.intercept_unary_unary(
+                continuation=continuation,
+                client_call_details=_make_call_details(
+                    "/flwr.proto.ServerAppIo/GetNodes"
+                ),
+                request=GetNodesRequest(),
+            )
+
+        flwr_exit_mock.assert_called_once_with(
+            ExitCode.RUNTIME_VERSION_INCOMPATIBLE,
+            "Runtime version compatibility check failed.\nruntime mismatch",
+        )
+
+    def test_raised_non_incompatibility_rpc_error_is_reraised(self) -> None:
+        """Raised non-runtime-version RpcError outcomes should pass through."""
+        rpc_error = _make_runtime_rpc_error(ApiErrorCode.ENTITLEMENT_ERROR)
+
+        def continuation(
+            _client_call_details: grpc.ClientCallDetails,
+            _request: GrpcMessage,
+        ) -> grpc.Call:
+            raise rpc_error
+
+        with (
+            patch(
+                "flwr.supercore.interceptors.runtime_version_interceptor.flwr_exit"
+            ) as flwr_exit_mock,
+            self.assertRaises(grpc.RpcError) as exc,
+        ):
+            self.interceptor.intercept_unary_unary(
+                continuation=continuation,
+                client_call_details=_make_call_details(
+                    "/flwr.proto.ServerAppIo/GetNodes"
+                ),
+                request=GetNodesRequest(),
+            )
+
+        self.assertIs(exc.exception, rpc_error)
+        flwr_exit_mock.assert_not_called()
 
 
 class TestRuntimeVersionServerInterceptor(TestCase):


### PR DESCRIPTION
This PR handles runtime version incompatibility errors returned by gRPC client calls before they surface as raw `_InactiveRpcError` tracebacks.
