### PR TITLE
fix(*:skip): Delay inspection for unary-stream calls for runtime version check

### DIFF
--- a/framework/py/flwr/supercore/interceptors/runtime_version_interceptor.py
+++ b/framework/py/flwr/supercore/interceptors/runtime_version_interceptor.py
@@ -78,6 +78,7 @@ class RuntimeVersionClientInterceptor(
         continuation: Callable[[Any, Any], Any],
         client_call_details: grpc.ClientCallDetails,
         request: GrpcMessage,
+        inspect_errors_immediately: bool,
     ) -> grpc.Call:
         """Add runtime version metadata and inspect RPC completion metadata."""
         details = client_call_details._replace(
@@ -100,7 +101,7 @@ class RuntimeVersionClientInterceptor(
             raise
 
         incompat_error_handled = False
-        if isinstance(call, grpc.RpcError):
+        if inspect_errors_immediately and isinstance(call, grpc.RpcError):
             if exit_message := self._get_incompat_exit_message(call):
                 incompat_error_handled = True
                 flwr_exit(ExitCode.RUNTIME_VERSION_INCOMPATIBLE, exit_message)
@@ -127,7 +128,12 @@ class RuntimeVersionClientInterceptor(
         request: GrpcMessage,
     ) -> grpc.Call:
         """Add the runtime version metadata headers for unary-unary RPCs."""
-        return self._intercept_call(continuation, client_call_details, request)
+        return self._intercept_call(
+            continuation,
+            client_call_details,
+            request,
+            inspect_errors_immediately=True,
+        )
 
     def intercept_unary_stream(
         self,
@@ -136,7 +142,12 @@ class RuntimeVersionClientInterceptor(
         request: GrpcMessage,
     ) -> grpc.Call:
         """Add the runtime version metadata headers for unary-stream RPCs."""
-        return self._intercept_call(continuation, client_call_details, request)
+        return self._intercept_call(
+            continuation,
+            client_call_details,
+            request,
+            inspect_errors_immediately=False,
+        )
 
 
 class RuntimeVersionServerInterceptor(grpc.ServerInterceptor):  # type: ignore[misc]

--- a/framework/py/flwr/supercore/interceptors/runtime_version_interceptor_test.py
+++ b/framework/py/flwr/supercore/interceptors/runtime_version_interceptor_test.py
@@ -593,22 +593,3 @@ class TestRuntimeVersionClientInterceptorUnaryStream(TestCase):
             ExitCode.RUNTIME_VERSION_INCOMPATIBLE,
             "Runtime version compatibility check failed.\nruntime mismatch",
         )
-
-    def test_active_rpc_error_stream_is_not_inspected_before_completion(self) -> None:
-        """Active unary-stream RpcError calls should not be inspected eagerly."""
-        rpc_error = _make_runtime_rpc_error()
-        rpc_error.add_callback.return_value = True
-
-        with patch(
-            "flwr.supercore.interceptors.runtime_version_interceptor.flwr_exit"
-        ) as flwr_exit_mock:
-            response = self.interceptor.intercept_unary_stream(
-                continuation=lambda _details, _request: rpc_error,
-                client_call_details=_make_call_details("/flwr.proto.Fleet/PullTaskIns"),
-                request=GetNodesRequest(),
-            )
-
-        self.assertIs(response, rpc_error)
-        rpc_error.add_callback.assert_called_once()
-        rpc_error.details.assert_not_called()
-        flwr_exit_mock.assert_not_called()

--- a/framework/py/flwr/supercore/interceptors/runtime_version_interceptor_test.py
+++ b/framework/py/flwr/supercore/interceptors/runtime_version_interceptor_test.py
@@ -535,3 +535,22 @@ class TestRuntimeVersionClientInterceptorUnaryStream(TestCase):
             ExitCode.RUNTIME_VERSION_INCOMPATIBLE,
             "Runtime version compatibility check failed.\nruntime mismatch",
         )
+
+    def test_active_rpc_error_stream_is_not_inspected_before_completion(self) -> None:
+        """Active unary-stream RpcError calls should not be inspected eagerly."""
+        rpc_error = _make_runtime_rpc_error()
+        rpc_error.add_callback.return_value = True
+
+        with patch(
+            "flwr.supercore.interceptors.runtime_version_interceptor.flwr_exit"
+        ) as flwr_exit_mock:
+            response = self.interceptor.intercept_unary_stream(
+                continuation=lambda _details, _request: rpc_error,
+                client_call_details=_make_call_details("/flwr.proto.Fleet/PullTaskIns"),
+                request=GetNodesRequest(),
+            )
+
+        self.assertIs(response, rpc_error)
+        rpc_error.add_callback.assert_called_once()
+        rpc_error.details.assert_not_called()
+        flwr_exit_mock.assert_not_called()


### PR DESCRIPTION
## Description

`flwr run --stream` can hang because the runtime-version interceptor calls `details()` immediately on active unary-stream RPCs like `StreamLogs`, which can block until the stream ends.

## Proposal

Only inspect returned `grpc.RpcError` objects immediately for unary-unary calls. For unary-stream calls, defer inspection until completion, preserving incompatibility handling without blocking log streaming.