### PR TITLE
fix(*:skip): Bump `requests-cache`

### DIFF
--- a/framework/dev/test.sh
+++ b/framework/dev/test.sh
@@ -6,121 +6,121 @@ echo "=== test.sh ==="
 
 
 # Default value (true)
-RUN_FULL_TEST=${1:-true}
-echo "RUN_FULL_TEST: $RUN_FULL_TEST"
+# RUN_FULL_TEST=${1:-true}
+# echo "RUN_FULL_TEST: $RUN_FULL_TEST"
 
-echo "- Start Python checks"
+# echo "- Start Python checks"
 
-echo "- clang-format:  start"
-clang-format --Werror --dry-run proto/flwr/proto/*
-echo "- clang-format:  done"
+# echo "- clang-format:  start"
+# clang-format --Werror --dry-run proto/flwr/proto/*
+# echo "- clang-format:  done"
 
-echo "- isort: start"
-if $RUN_FULL_TEST; then
-    python -m isort \
-        --check-only \
-        --skip py/flwr/proto \
-        --skip-glob "**/.venv/**" \
-        py e2e
-else
-    python -m isort --check-only --skip py/flwr/proto py
-fi
-echo "- isort: done"
+# echo "- isort: start"
+# if $RUN_FULL_TEST; then
+#     python -m isort \
+#         --check-only \
+#         --skip py/flwr/proto \
+#         --skip-glob "**/.venv/**" \
+#         py e2e
+# else
+#     python -m isort --check-only --skip py/flwr/proto py
+# fi
+# echo "- isort: done"
 
-echo "- black: start"
-if $RUN_FULL_TEST; then
-    python -m black \
-        --extend-exclude "py\/flwr\/proto|(^|\/)\.venv\/" \
-        --check py e2e
-else
-    python -m black \
-        --extend-exclude "py\/flwr\/proto" \
-        --check py
-fi
-echo "- black: done"
+# echo "- black: start"
+# if $RUN_FULL_TEST; then
+#     python -m black \
+#         --extend-exclude "py\/flwr\/proto|(^|\/)\.venv\/" \
+#         --check py e2e
+# else
+#     python -m black \
+#         --extend-exclude "py\/flwr\/proto" \
+#         --check py
+# fi
+# echo "- black: done"
 
-echo "- init_py_check: start"
-python -m devtool.init_py_check py/flwr
-echo "- init_py_check: done"
+# echo "- init_py_check: start"
+# python -m devtool.init_py_check py/flwr
+# echo "- init_py_check: done"
 
-echo "- docsig: start"
-docsig py/flwr
-echo "- docsig:  done"
+# echo "- docsig: start"
+# docsig py/flwr
+# echo "- docsig:  done"
 
-echo "- ruff: start"
-python -m ruff check py/flwr --no-respect-gitignore
-echo "- ruff: done"
+# echo "- ruff: start"
+# python -m ruff check py/flwr --no-respect-gitignore
+# echo "- ruff: done"
 
-echo "- mypy: start"
-python -m mypy py
-echo "- mypy: done"
+# echo "- mypy: start"
+# python -m mypy py
+# echo "- mypy: done"
 
-echo "- pylint: start"
-python -m pylint --ignore=py/flwr/proto py/flwr
-echo "- pylint: done"
+# echo "- pylint: start"
+# python -m pylint --ignore=py/flwr/proto py/flwr
+# echo "- pylint: done"
 
-echo "- pytest: start"
-# Ray's uv runtime-env hook can stall under `uv run` during pytest.
-RAY_ENABLE_UV_RUN_RUNTIME_ENV=0 python -m pytest --cov=py/flwr
-echo "- pytest: done"
+# echo "- pytest: start"
+# # Ray's uv runtime-env hook can stall under `uv run` during pytest.
+# RAY_ENABLE_UV_RUN_RUNTIME_ENV=0 python -m pytest --cov=py/flwr
+# echo "- pytest: done"
 
-echo "- All Python checks passed"
+# echo "- All Python checks passed"
 
-echo "- Start Markdown checks"
+# echo "- Start Markdown checks"
 
-if $RUN_FULL_TEST; then
-    echo "- mdformat: start"
-    python -m mdformat --check --number docs/source
-    echo "- mdformat: done"
-fi
+# if $RUN_FULL_TEST; then
+#     echo "- mdformat: start"
+#     python -m mdformat --check --number docs/source
+#     echo "- mdformat: done"
+# fi
 
-echo "- All Markdown checks passed"
+# echo "- All Markdown checks passed"
 
-echo "- Start TOML checks"
+# echo "- Start TOML checks"
 
-echo "- taplo: start"
-taplo fmt --check
-echo "- taplo: done"
+# echo "- taplo: start"
+# taplo fmt --check
+# echo "- taplo: done"
 
-echo "- All TOML checks passed"
+# echo "- All TOML checks passed"
 
-echo "- Start rST checks"
+# echo "- Start rST checks"
 
-if $RUN_FULL_TEST; then
-    echo "- docstrfmt: start"
-    docstrfmt --check docs/source
-    echo "- docstrfmt: done"
-fi
+# if $RUN_FULL_TEST; then
+#     echo "- docstrfmt: start"
+#     docstrfmt --check docs/source
+#     echo "- docstrfmt: done"
+# fi
 
-echo "- All rST checks passed"
+# echo "- All rST checks passed"
 
-echo "- Start SQLAlchemy schema checks"
+# echo "- Start SQLAlchemy schema checks"
 
-# Core schema check
-paracelsus inject py/flwr/supercore/state/schema/README.md dev.get_schema_base:Base \
-  --import-module "flwr.supercore.state.schema.linkstate_tables:*" \
-  --import-module "flwr.supercore.state.schema.corestate_tables:*" \
-  --import-module "flwr.supercore.state.schema.objectstore_tables:*" \
-  --layout elk \
-  --check
+# # Core schema check
+# paracelsus inject py/flwr/supercore/state/schema/README.md dev.get_schema_base:Base \
+#   --import-module "flwr.supercore.state.schema.linkstate_tables:*" \
+#   --import-module "flwr.supercore.state.schema.corestate_tables:*" \
+#   --import-module "flwr.supercore.state.schema.objectstore_tables:*" \
+#   --layout elk \
+#   --check
 
-# EE schema check (if available)
-if python -c "import flwr.ee.state.alembic.tables" 2>/dev/null; then
-  paracelsus inject py/flwr/ee/state/schema/README.md dev.get_schema_base:EEBase \
-    --import-module "flwr.ee.state.alembic.tables:*" \
-    --layout elk \
-    --check
-fi
+# # EE schema check (if available)
+# if python -c "import flwr.ee.state.alembic.tables" 2>/dev/null; then
+#   paracelsus inject py/flwr/ee/state/schema/README.md dev.get_schema_base:EEBase \
+#     --import-module "flwr.ee.state.alembic.tables:*" \
+#     --layout elk \
+#     --check
+# fi
 
-echo "- All SQLAlchemy schema checks passed"
+# echo "- All SQLAlchemy schema checks passed"
 
-echo "- Start license checks"
+# echo "- Start license checks"
 
-if $RUN_FULL_TEST; then
-    echo "- copyright: start"
-    python -m devtool.check_copyright py/flwr
-    echo "- copyright: done"
-fi
+# if $RUN_FULL_TEST; then
+#     echo "- copyright: start"
+#     python -m devtool.check_copyright py/flwr
+#     echo "- copyright: done"
+# fi
 
 echo "- licensecheck: start"
 python -m licensecheck --fail-licenses gpl --zero

--- a/framework/dev/test.sh
+++ b/framework/dev/test.sh
@@ -6,121 +6,121 @@ echo "=== test.sh ==="
 
 
 # Default value (true)
-# RUN_FULL_TEST=${1:-true}
-# echo "RUN_FULL_TEST: $RUN_FULL_TEST"
+RUN_FULL_TEST=${1:-true}
+echo "RUN_FULL_TEST: $RUN_FULL_TEST"
 
-# echo "- Start Python checks"
+echo "- Start Python checks"
 
-# echo "- clang-format:  start"
-# clang-format --Werror --dry-run proto/flwr/proto/*
-# echo "- clang-format:  done"
+echo "- clang-format:  start"
+clang-format --Werror --dry-run proto/flwr/proto/*
+echo "- clang-format:  done"
 
-# echo "- isort: start"
-# if $RUN_FULL_TEST; then
-#     python -m isort \
-#         --check-only \
-#         --skip py/flwr/proto \
-#         --skip-glob "**/.venv/**" \
-#         py e2e
-# else
-#     python -m isort --check-only --skip py/flwr/proto py
-# fi
-# echo "- isort: done"
+echo "- isort: start"
+if $RUN_FULL_TEST; then
+    python -m isort \
+        --check-only \
+        --skip py/flwr/proto \
+        --skip-glob "**/.venv/**" \
+        py e2e
+else
+    python -m isort --check-only --skip py/flwr/proto py
+fi
+echo "- isort: done"
 
-# echo "- black: start"
-# if $RUN_FULL_TEST; then
-#     python -m black \
-#         --extend-exclude "py\/flwr\/proto|(^|\/)\.venv\/" \
-#         --check py e2e
-# else
-#     python -m black \
-#         --extend-exclude "py\/flwr\/proto" \
-#         --check py
-# fi
-# echo "- black: done"
+echo "- black: start"
+if $RUN_FULL_TEST; then
+    python -m black \
+        --extend-exclude "py\/flwr\/proto|(^|\/)\.venv\/" \
+        --check py e2e
+else
+    python -m black \
+        --extend-exclude "py\/flwr\/proto" \
+        --check py
+fi
+echo "- black: done"
 
-# echo "- init_py_check: start"
-# python -m devtool.init_py_check py/flwr
-# echo "- init_py_check: done"
+echo "- init_py_check: start"
+python -m devtool.init_py_check py/flwr
+echo "- init_py_check: done"
 
-# echo "- docsig: start"
-# docsig py/flwr
-# echo "- docsig:  done"
+echo "- docsig: start"
+docsig py/flwr
+echo "- docsig:  done"
 
-# echo "- ruff: start"
-# python -m ruff check py/flwr --no-respect-gitignore
-# echo "- ruff: done"
+echo "- ruff: start"
+python -m ruff check py/flwr --no-respect-gitignore
+echo "- ruff: done"
 
-# echo "- mypy: start"
-# python -m mypy py
-# echo "- mypy: done"
+echo "- mypy: start"
+python -m mypy py
+echo "- mypy: done"
 
-# echo "- pylint: start"
-# python -m pylint --ignore=py/flwr/proto py/flwr
-# echo "- pylint: done"
+echo "- pylint: start"
+python -m pylint --ignore=py/flwr/proto py/flwr
+echo "- pylint: done"
 
-# echo "- pytest: start"
-# # Ray's uv runtime-env hook can stall under `uv run` during pytest.
-# RAY_ENABLE_UV_RUN_RUNTIME_ENV=0 python -m pytest --cov=py/flwr
-# echo "- pytest: done"
+echo "- pytest: start"
+# Ray's uv runtime-env hook can stall under `uv run` during pytest.
+RAY_ENABLE_UV_RUN_RUNTIME_ENV=0 python -m pytest --cov=py/flwr
+echo "- pytest: done"
 
-# echo "- All Python checks passed"
+echo "- All Python checks passed"
 
-# echo "- Start Markdown checks"
+echo "- Start Markdown checks"
 
-# if $RUN_FULL_TEST; then
-#     echo "- mdformat: start"
-#     python -m mdformat --check --number docs/source
-#     echo "- mdformat: done"
-# fi
+if $RUN_FULL_TEST; then
+    echo "- mdformat: start"
+    python -m mdformat --check --number docs/source
+    echo "- mdformat: done"
+fi
 
-# echo "- All Markdown checks passed"
+echo "- All Markdown checks passed"
 
-# echo "- Start TOML checks"
+echo "- Start TOML checks"
 
-# echo "- taplo: start"
-# taplo fmt --check
-# echo "- taplo: done"
+echo "- taplo: start"
+taplo fmt --check
+echo "- taplo: done"
 
-# echo "- All TOML checks passed"
+echo "- All TOML checks passed"
 
-# echo "- Start rST checks"
+echo "- Start rST checks"
 
-# if $RUN_FULL_TEST; then
-#     echo "- docstrfmt: start"
-#     docstrfmt --check docs/source
-#     echo "- docstrfmt: done"
-# fi
+if $RUN_FULL_TEST; then
+    echo "- docstrfmt: start"
+    docstrfmt --check docs/source
+    echo "- docstrfmt: done"
+fi
 
-# echo "- All rST checks passed"
+echo "- All rST checks passed"
 
-# echo "- Start SQLAlchemy schema checks"
+echo "- Start SQLAlchemy schema checks"
 
-# # Core schema check
-# paracelsus inject py/flwr/supercore/state/schema/README.md dev.get_schema_base:Base \
-#   --import-module "flwr.supercore.state.schema.linkstate_tables:*" \
-#   --import-module "flwr.supercore.state.schema.corestate_tables:*" \
-#   --import-module "flwr.supercore.state.schema.objectstore_tables:*" \
-#   --layout elk \
-#   --check
+# Core schema check
+paracelsus inject py/flwr/supercore/state/schema/README.md dev.get_schema_base:Base \
+  --import-module "flwr.supercore.state.schema.linkstate_tables:*" \
+  --import-module "flwr.supercore.state.schema.corestate_tables:*" \
+  --import-module "flwr.supercore.state.schema.objectstore_tables:*" \
+  --layout elk \
+  --check
 
-# # EE schema check (if available)
-# if python -c "import flwr.ee.state.alembic.tables" 2>/dev/null; then
-#   paracelsus inject py/flwr/ee/state/schema/README.md dev.get_schema_base:EEBase \
-#     --import-module "flwr.ee.state.alembic.tables:*" \
-#     --layout elk \
-#     --check
-# fi
+# EE schema check (if available)
+if python -c "import flwr.ee.state.alembic.tables" 2>/dev/null; then
+  paracelsus inject py/flwr/ee/state/schema/README.md dev.get_schema_base:EEBase \
+    --import-module "flwr.ee.state.alembic.tables:*" \
+    --layout elk \
+    --check
+fi
 
-# echo "- All SQLAlchemy schema checks passed"
+echo "- All SQLAlchemy schema checks passed"
 
-# echo "- Start license checks"
+echo "- Start license checks"
 
-# if $RUN_FULL_TEST; then
-#     echo "- copyright: start"
-#     python -m devtool.check_copyright py/flwr
-#     echo "- copyright: done"
-# fi
+if $RUN_FULL_TEST; then
+    echo "- copyright: start"
+    python -m devtool.check_copyright py/flwr
+    echo "- copyright: done"
+fi
 
 echo "- licensecheck: start"
 python -m licensecheck --fail-licenses gpl --zero

--- a/framework/uv.lock
+++ b/framework/uv.lock
@@ -3422,7 +3422,7 @@ wheels = [
 
 [[package]]
 name = "requests-cache"
-version = "1.3.1"
+version = "1.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -3432,9 +3432,9 @@ dependencies = [
     { name = "url-normalize" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8c/41/cca56fdb48cbca8feb68770bce70cb315de2a1f7d6bf7ca62c437ac279f0/requests_cache-1.3.1.tar.gz", hash = "sha256:784e9d07f72db4fe234830a065230c59eb446489528f271ba288c640897e47c4", size = 99416, upload-time = "2026-03-04T18:05:50.918Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/ae/90a0f931c7f6b5a674b98c25ecb2593a173bcee14f0d8c148471df3d7b26/requests_cache-1.3.2.tar.gz", hash = "sha256:bdc3680931f98a1dea509d339ea6b45cea526945b47b250ce63ffd2744ee0b14", size = 100167, upload-time = "2026-05-11T04:09:53.233Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5a/08/48fa499c5c4667d5ceda6bd658dabf327b49997a99ac8674c61f4ba557a2/requests_cache-1.3.1-py3-none-any.whl", hash = "sha256:43a67448c3b2964c631ac7027b84607f2f63438e28104b68ad2211f32d9f606c", size = 70211, upload-time = "2026-03-04T18:05:49.628Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/ff/d87d1a7700463afc5440bec80cfbcb56ef929f05fbfdc946ce031b13d040/requests_cache-1.3.2-py3-none-any.whl", hash = "sha256:c52666c76b08daa94d05a99327dd24afc46f405abc044e8c2267b540f90673d0", size = 70633, upload-time = "2026-05-11T04:09:51.554Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

`licensecheck` can fail (e.g. when run locally with `uv run --no-sync --python=3.11.14 ./dev/test.sh`) when fetching PyPI metadata because its cached HTTP client uses `requests-cache==1.3.1`, which is incompatible with `requests==2.34.x` when serializing cached responses.

## Proposal

Update the lockfile to use `requests-cache==1.3.2`, which includes compatibility fixes for `requests 2.34`, allowing `licensecheck` to complete normally.

This allows `licensecheck` to be run locally without the `NameError: name 'RequestsCookieJar' is not defined` error. 