### PR TITLE
feat(examples:skip) Add custom aggregation strategy example

### DIFF
--- a/examples/custom-aggregation-strategy/LICENSE
+++ b/examples/custom-aggregation-strategy/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/examples/custom-aggregation-strategy/README.md
+++ b/examples/custom-aggregation-strategy/README.md
@@ -1,0 +1,116 @@
+---
+tags: [strategy, custom aggregation, robustness, model poisoning]
+dataset: [CIFAR-10]
+framework: [torch, torchvision]
+---
+
+# Custom Aggregation: Trust-Weighted FedAvg (Flower / PyTorch)
+
+This example shows **how to implement a custom aggregation strategy** on Flower's
+message-based API by subclassing `FedAvg` and overriding a single method,
+`aggregate_train`. It is meant as a minimal, readable template for anyone who wants
+to change *how client updates are combined* (rather than just adding logging or
+checkpointing on top of FedAvg).
+
+As a concrete, testable motivation, the custom strategy implements a simple
+**norm-based robustness filter**: client updates whose L2 norm is far above the
+median are treated as outliers (e.g. poisoned models) and down-weighted before
+averaging. The example ships with an optional attack so you can see the difference
+between vanilla FedAvg and the trust-aware variant under model poisoning.
+
+> This is a *pedagogical* example of writing custom aggregation. Flower already
+> ships production robust strategies (`Krum`, `MultiKrum`, `Bulyan`, `FedMedian`,
+> `FedTrimmedAvg`) in `flwr.serverapp.strategy` — reach for those for real use.
+
+## The idea in one method
+
+`TrustAwareFedAvg` (see [`customagg/strategy.py`](customagg/strategy.py)) overrides
+only `aggregate_train`:
+
+1. Compute each client's update norm `‖client_arrays − global_arrays‖₂`.
+2. Score how much of an outlier it is using robust statistics — a `median + MAD`
+   z-score. Updates within a `trust-z` dead zone of the median are fully trusted
+   (`1.0`); only updates beyond it are down-weighted, decaying as `exp(-beta · excess)`.
+   Using the MAD (median absolute deviation) keeps honest clients near the median
+   from being penalized just for being slightly above it.
+3. Multiply that trust score into the existing `num-examples` weighting key, then
+   reuse `FedAvg`'s weighted aggregation unchanged.
+
+> Assumes an honest majority (the median/MAD must reflect benign clients). This is
+> the standard assumption behind robust-aggregation defenses.
+
+**Design note.** `aggregate_train` only receives the client replies, *not* the
+current global model — so the strategy stashes the global `ArrayRecord` in
+`configure_train` (`self._global = arrays`) to compute the true *update* norm. This
+is the one non-obvious part of writing norm/distance-based aggregation on this API.
+
+## Install
+
+```bash
+pip install -e .
+```
+
+## Run
+
+By default this runs `TrustAwareFedAvg` with 3 (of 10) clients poisoning their
+updates:
+
+```bash
+flwr run . --stream
+```
+
+Reproduce the three-way comparison below by overriding the config:
+
+```bash
+# (1) Vanilla FedAvg, no attackers — clean baseline
+flwr run . --run-config "strategy='fedavg' num-malicious=0" --stream
+
+# (2) Vanilla FedAvg, 3 attackers — training collapses
+flwr run . --run-config "strategy='fedavg' num-malicious=3" --stream
+
+# (3) Trust-aware FedAvg, 3 attackers — recovers
+flwr run . --run-config "strategy='trust' num-malicious=3" --stream
+```
+
+## Results
+
+CIFAR-10, 10 clients, 5 rounds, 1 local epoch (final global accuracy on the
+server-side test set):
+
+| Setting                         | Attackers | Final accuracy |
+| ------------------------------- | :-------: | :------------: |
+| FedAvg                          |     0     |     20.2 %     |
+| FedAvg                          |     3     |  10.1 % 💀     |
+| **TrustAwareFedAvg**            |     3     |  **20.8 %** ✅ |
+
+With 3 poisoning clients, vanilla FedAvg collapses to random-guess accuracy, while
+the trust-aware variant recovers to the clean baseline. The strategy logs which
+clients it down-weighted each round, e.g.:
+
+```
+TrustAware: median_norm=8.054 | down-weighted 3/10 clients
+            #2(norm=250.1,trust=0.00) #6(norm=249.6,trust=0.00) #8(norm=248.7,trust=0.00)
+```
+
+(Honest update norms ≈ 8, poisoned ≈ 250 — cleanly separable.)
+
+## Configuration
+
+| Key               | Default | Meaning                                              |
+| ----------------- | :-----: | ---------------------------------------------------- |
+| `strategy`        | `trust` | `trust` (TrustAwareFedAvg) or `fedavg` (vanilla)     |
+| `num-malicious`   | `3`     | Number of clients that poison their update (0 = off) |
+| `attack-scale`    | `1.0`   | Std of Gaussian noise added by malicious clients     |
+| `trust-z`         | `3.5`   | Dead-zone width (robust-std/MAD units); inside it, trust = 1.0 |
+| `trust-beta`      | `5.0`   | Decay rate of trust past the dead zone               |
+| `num-server-rounds` | `5`   | Federated rounds                                     |
+
+## Running on GPU
+
+The dependencies install the CPU build of PyTorch by default. To use a GPU,
+install a CUDA build of `torch`/`torchvision`, then run with the `gpu-simulation`
+federation defined in `pyproject.toml` (which allocates 0.1 GPU per client):
+
+```bash
+flwr run . gpu-simulation --stream
+```

--- a/examples/custom-aggregation-strategy/customagg/__init__.py
+++ b/examples/custom-aggregation-strategy/customagg/__init__.py
@@ -1,0 +1,1 @@
+"""customagg: Custom aggregation (trust-weighted FedAvg) demo (Flower / PyTorch)."""

--- a/examples/custom-aggregation-strategy/customagg/client_app.py
+++ b/examples/custom-aggregation-strategy/customagg/client_app.py
@@ -1,0 +1,81 @@
+"""customagg: ClientApp. Honest clients train normally; malicious clients poison
+their update with large Gaussian noise to create an outlier (large-norm) update."""
+
+import torch
+from flwr.app import ArrayRecord, Context, Message, MetricRecord, RecordDict
+from flwr.clientapp import ClientApp
+
+from customagg.task import Net, load_data
+from customagg.task import test as test_fn
+from customagg.task import train as train_fn
+
+app = ClientApp()
+
+
+@app.train()
+def train(msg: Message, context: Context):
+    """Train the model on local data (poison the update if this client is malicious)."""
+
+    model = Net()
+    model.load_state_dict(msg.content["arrays"].to_torch_state_dict())
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    model.to(device)
+
+    partition_id = context.node_config["partition-id"]
+    num_partitions = context.node_config["num-partitions"]
+    batch_size = context.run_config["batch-size"]
+    trainloader, _ = load_data(partition_id, num_partitions, batch_size)
+
+    train_loss = train_fn(
+        model,
+        trainloader,
+        context.run_config["local-epochs"],
+        msg.content["config"]["lr"],
+        device,
+    )
+
+    # --- Attack: first `num-malicious` partitions poison their update ---
+    num_malicious = context.run_config["num-malicious"]
+    attack_scale = context.run_config["attack-scale"]
+    is_malicious = partition_id < num_malicious
+    if is_malicious:
+        sd = model.state_dict()
+        for k in sd:
+            if sd[k].dtype.is_floating_point:
+                sd[k] = sd[k] + torch.randn_like(sd[k]) * attack_scale
+        model.load_state_dict(sd)
+
+    model_record = ArrayRecord(model.state_dict())
+    metrics = {
+        "train_loss": train_loss,
+        "num-examples": len(trainloader.dataset),
+    }
+    metric_record = MetricRecord(metrics)
+    content = RecordDict({"arrays": model_record, "metrics": metric_record})
+    return Message(content=content, reply_to=msg)
+
+
+@app.evaluate()
+def evaluate(msg: Message, context: Context):
+    """Evaluate the model on local data."""
+
+    model = Net()
+    model.load_state_dict(msg.content["arrays"].to_torch_state_dict())
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    model.to(device)
+
+    partition_id = context.node_config["partition-id"]
+    num_partitions = context.node_config["num-partitions"]
+    batch_size = context.run_config["batch-size"]
+    _, valloader = load_data(partition_id, num_partitions, batch_size)
+
+    eval_loss, eval_acc = test_fn(model, valloader, device)
+
+    metrics = {
+        "eval_loss": eval_loss,
+        "eval_acc": eval_acc,
+        "num-examples": len(valloader.dataset),
+    }
+    metric_record = MetricRecord(metrics)
+    content = RecordDict({"metrics": metric_record})
+    return Message(content=content, reply_to=msg)

--- a/examples/custom-aggregation-strategy/customagg/server_app.py
+++ b/examples/custom-aggregation-strategy/customagg/server_app.py
@@ -1,0 +1,51 @@
+"""customagg: ServerApp. Selects FedAvg or TrustAwareFedAvg via run-config."""
+
+import torch
+from flwr.app import ArrayRecord, ConfigRecord, Context, MetricRecord
+from flwr.serverapp import Grid, ServerApp
+from flwr.serverapp.strategy import FedAvg
+
+from customagg.strategy import TrustAwareFedAvg
+from customagg.task import Net, load_centralized_dataset, test
+
+app = ServerApp()
+
+
+@app.main()
+def main(grid: Grid, context: Context) -> None:
+    fraction_evaluate: float = context.run_config["fraction-evaluate"]
+    num_rounds: int = context.run_config["num-server-rounds"]
+    lr: float = context.run_config["learning-rate"]
+    strategy_name: str = context.run_config["strategy"]
+
+    global_model = Net()
+    arrays = ArrayRecord(global_model.state_dict())
+
+    if strategy_name == "trust":
+        strategy = TrustAwareFedAvg(
+            fraction_evaluate=fraction_evaluate,
+            trust_beta=context.run_config["trust-beta"],
+            trust_z=context.run_config["trust-z"],
+        )
+    else:
+        strategy = FedAvg(fraction_evaluate=fraction_evaluate)
+
+    result = strategy.start(
+        grid=grid,
+        initial_arrays=arrays,
+        train_config=ConfigRecord({"lr": lr}),
+        num_rounds=num_rounds,
+        evaluate_fn=global_evaluate,
+    )
+
+    _ = result
+
+
+def global_evaluate(server_round: int, arrays: ArrayRecord) -> MetricRecord:
+    model = Net()
+    model.load_state_dict(arrays.to_torch_state_dict())
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    model.to(device)
+    test_dataloader = load_centralized_dataset()
+    test_loss, test_acc = test(model, test_dataloader, device)
+    return MetricRecord({"accuracy": test_acc, "loss": test_loss})

--- a/examples/custom-aggregation-strategy/customagg/strategy.py
+++ b/examples/custom-aggregation-strategy/customagg/strategy.py
@@ -1,0 +1,101 @@
+"""customagg: A minimal custom-aggregation Strategy for the Flower Message API.
+
+TrustAwareFedAvg subclasses FedAvg and overrides ONLY `aggregate_train`. It computes
+each client's update norm ||client_arrays - global_arrays||_2, then down-weights
+clients whose update norm is far above the median (likely outliers / poisoned). The
+trust score is folded into FedAvg's existing weighting key so the parent's weighted
+aggregation is reused unchanged.
+"""
+
+from collections.abc import Iterable
+from logging import INFO
+
+import numpy as np
+from flwr.app import ArrayRecord, ConfigRecord, Message, MetricRecord
+from flwr.common import log
+from flwr.serverapp import Grid
+from flwr.serverapp.strategy import FedAvg
+from flwr.serverapp.strategy.strategy_utils import (
+    aggregate_arrayrecords,
+)
+
+
+class TrustAwareFedAvg(FedAvg):
+    """FedAvg with norm-based trust weighting of client updates."""
+
+    def __init__(
+        self, *args, trust_beta: float = 5.0, trust_z: float = 3.5, **kwargs
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        # trust_beta: decay rate applied past the dead zone.
+        # trust_z: width of the "normal" dead zone, in robust std units (MAD).
+        #   Default 3.5 follows the Iglewicz-Hoaglin modified z-score outlier rule.
+        self.trust_beta = trust_beta
+        self.trust_z = trust_z
+        self._global: ArrayRecord | None = None
+
+    def configure_train(
+        self, server_round: int, arrays: ArrayRecord, config: ConfigRecord, grid: Grid
+    ) -> Iterable[Message]:
+        # Stash current global model so aggregate_train can compute the *update* norm
+        # (the base API only passes replies, not the global model, to aggregate_train).
+        self._global = arrays
+        return super().configure_train(server_round, arrays, config, grid)
+
+    def _update_norm(self, content) -> float:
+        """L2 norm of (client_arrays - global_arrays)."""
+        client_ar = next(iter(content.array_records.values()))
+        sq = 0.0
+        for key, val in client_ar.items():
+            diff = val.numpy() - self._global[key].numpy()
+            sq += float(np.square(diff).sum())
+        return float(np.sqrt(sq))
+
+    def aggregate_train(
+        self, server_round: int, replies: Iterable[Message]
+    ) -> tuple[ArrayRecord | None, MetricRecord | None]:
+        valid_replies, _ = self._check_and_log_replies(replies, is_train=True)
+        if not valid_replies:
+            return None, None
+        contents = [m.content for m in valid_replies]
+
+        # 1) per-client update norm
+        norms = np.array([self._update_norm(c) for c in contents])
+
+        # 2) robust outlier score via median + MAD (assumes an honest majority).
+        #    A "dead zone" of `trust_z` robust-std keeps normal clients at trust=1.0;
+        #    only updates beyond it are down-weighted, decaying with `trust_beta`.
+        median = float(np.median(norms))
+        scaled_mad = 1.4826 * float(np.median(np.abs(norms - median)))
+        if scaled_mad < 1e-9:
+            # Degenerate spread (norms nearly identical): trust everyone equally.
+            trust = np.ones_like(norms)
+        else:
+            z = (norms - median) / scaled_mad
+            excess = np.maximum(0.0, z - self.trust_z)
+            trust = np.exp(-self.trust_beta * excess)
+
+        # 3) fold trust into the weighting key, then reuse FedAvg's weighted aggregation
+        for c, t in zip(contents, trust):
+            mr = next(iter(c.metric_records.values()))
+            mr[self.weighted_by_key] = float(mr[self.weighted_by_key]) * float(t)
+
+        # Transparency: show what got down-weighted
+        flagged = [
+            (i, float(n), float(tr))
+            for i, (n, tr) in enumerate(zip(norms, trust))
+            if tr < 0.5
+        ]
+        log(
+            INFO,
+            "\t└──> TrustAware: median_norm=%.3f mad=%.3f | down-weighted %d/%d clients %s",
+            median,
+            scaled_mad,
+            len(flagged),
+            len(contents),
+            [f"#{i}(norm={n:.1f},trust={tr:.2f})" for i, n, tr in flagged],
+        )
+
+        arrays = aggregate_arrayrecords(contents, self.weighted_by_key)
+        metrics = self.train_metrics_aggr_fn(contents, self.weighted_by_key)
+        return arrays, metrics

--- a/examples/custom-aggregation-strategy/customagg/strategy.py
+++ b/examples/custom-aggregation-strategy/customagg/strategy.py
@@ -33,6 +33,9 @@ class TrustAwareFedAvg(FedAvg):
         self.trust_beta = trust_beta
         self.trust_z = trust_z
         self._global: ArrayRecord | None = None
+        # Aggregation weight derived from trust; kept separate so the client-reported
+        # `num-examples` metric is never overwritten.
+        self._effective_weight_key = "trust-weighted-num-examples"
 
     def configure_train(
         self, server_round: int, arrays: ArrayRecord, config: ConfigRecord, grid: Grid
@@ -75,10 +78,13 @@ class TrustAwareFedAvg(FedAvg):
             excess = np.maximum(0.0, z - self.trust_z)
             trust = np.exp(-self.trust_beta * excess)
 
-        # 3) fold trust into the weighting key, then reuse FedAvg's weighted aggregation
+        # 3) Aggregate metrics first using the original (data-size) weights, then store a
+        #    SEPARATE effective weight for model aggregation. This never overwrites the
+        #    client-reported `num-examples`, which stays intact for downstream use.
+        metrics = self.train_metrics_aggr_fn(contents, self.weighted_by_key)
         for c, t in zip(contents, trust):
             mr = next(iter(c.metric_records.values()))
-            mr[self.weighted_by_key] = float(mr[self.weighted_by_key]) * float(t)
+            mr[self._effective_weight_key] = float(mr[self.weighted_by_key]) * float(t)
 
         # Transparency: show what got down-weighted
         flagged = [
@@ -96,6 +102,5 @@ class TrustAwareFedAvg(FedAvg):
             [f"#{i}(norm={n:.1f},trust={tr:.2f})" for i, n, tr in flagged],
         )
 
-        arrays = aggregate_arrayrecords(contents, self.weighted_by_key)
-        metrics = self.train_metrics_aggr_fn(contents, self.weighted_by_key)
+        arrays = aggregate_arrayrecords(contents, self._effective_weight_key)
         return arrays, metrics

--- a/examples/custom-aggregation-strategy/customagg/task.py
+++ b/examples/custom-aggregation-strategy/customagg/task.py
@@ -1,0 +1,105 @@
+"""customagg: A Flower / PyTorch app. (model + data, unchanged from quickstart)"""
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from datasets import load_dataset
+from flwr_datasets import FederatedDataset
+from flwr_datasets.partitioner import IidPartitioner
+from torch.utils.data import DataLoader
+from torchvision.transforms import Compose, Normalize, ToTensor
+
+
+class Net(nn.Module):
+    """Model (simple CNN adapted from 'PyTorch: A 60 Minute Blitz')"""
+
+    def __init__(self):
+        super(Net, self).__init__()
+        self.conv1 = nn.Conv2d(3, 6, 5)
+        self.pool = nn.MaxPool2d(2, 2)
+        self.conv2 = nn.Conv2d(6, 16, 5)
+        self.fc1 = nn.Linear(16 * 5 * 5, 120)
+        self.fc2 = nn.Linear(120, 84)
+        self.fc3 = nn.Linear(84, 10)
+
+    def forward(self, x):
+        x = self.pool(F.relu(self.conv1(x)))
+        x = self.pool(F.relu(self.conv2(x)))
+        x = x.view(-1, 16 * 5 * 5)
+        x = F.relu(self.fc1(x))
+        x = F.relu(self.fc2(x))
+        return self.fc3(x)
+
+
+fds = None  # Cache FederatedDataset
+
+pytorch_transforms = Compose([ToTensor(), Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))])
+
+
+def apply_transforms(batch):
+    """Apply transforms to the partition from FederatedDataset."""
+    batch["img"] = [pytorch_transforms(img) for img in batch["img"]]
+    return batch
+
+
+def load_data(partition_id: int, num_partitions: int, batch_size: int):
+    """Load partition CIFAR10 data."""
+    global fds
+    if fds is None:
+        partitioner = IidPartitioner(num_partitions=num_partitions)
+        fds = FederatedDataset(
+            dataset="uoft-cs/cifar10",
+            partitioners={"train": partitioner},
+        )
+    partition = fds.load_partition(partition_id)
+    partition_train_test = partition.train_test_split(test_size=0.2, seed=42)
+    partition_train_test = partition_train_test.with_transform(apply_transforms)
+    trainloader = DataLoader(
+        partition_train_test["train"], batch_size=batch_size, shuffle=True
+    )
+    testloader = DataLoader(partition_train_test["test"], batch_size=batch_size)
+    return trainloader, testloader
+
+
+def load_centralized_dataset():
+    """Load test set and return dataloader."""
+    test_dataset = load_dataset("uoft-cs/cifar10", split="test")
+    dataset = test_dataset.with_format("torch").with_transform(apply_transforms)
+    return DataLoader(dataset, batch_size=128)
+
+
+def train(net, trainloader, epochs, lr, device):
+    """Train the model on the training set."""
+    net.to(device)
+    criterion = torch.nn.CrossEntropyLoss().to(device)
+    optimizer = torch.optim.SGD(net.parameters(), lr=lr, momentum=0.9)
+    net.train()
+    running_loss = 0.0
+    for _ in range(epochs):
+        for batch in trainloader:
+            images = batch["img"].to(device)
+            labels = batch["label"].to(device)
+            optimizer.zero_grad()
+            loss = criterion(net(images), labels)
+            loss.backward()
+            optimizer.step()
+            running_loss += loss.item()
+    avg_trainloss = running_loss / (epochs * len(trainloader))
+    return avg_trainloss
+
+
+def test(net, testloader, device):
+    """Validate the model on the test set."""
+    net.to(device)
+    criterion = torch.nn.CrossEntropyLoss()
+    correct, loss = 0, 0.0
+    with torch.no_grad():
+        for batch in testloader:
+            images = batch["img"].to(device)
+            labels = batch["label"].to(device)
+            outputs = net(images)
+            loss += criterion(outputs, labels).item()
+            correct += (torch.max(outputs.data, 1)[1] == labels).sum().item()
+    accuracy = correct / len(testloader.dataset)
+    loss = loss / len(testloader)
+    return loss, accuracy

--- a/examples/custom-aggregation-strategy/pyproject.toml
+++ b/examples/custom-aggregation-strategy/pyproject.toml
@@ -1,0 +1,55 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "custom-aggregation-strategy"
+version = "0.1.0"
+description = "Custom aggregation on the Flower Message API: norm-based trust-weighted FedAvg"
+license = "Apache-2.0"
+dependencies = [
+    "flwr[simulation]>=1.28.0",
+    "flwr-datasets[vision]>=0.6.0",
+    "torch==2.8.0",
+    "torchvision==0.23.0",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.flwr.app]
+publisher = "sunjun"
+
+[tool.flwr.app.components]
+serverapp = "customagg.server_app:app"
+clientapp = "customagg.client_app:app"
+
+[tool.flwr.app.config]
+num-server-rounds = 5
+fraction-evaluate = 0.5
+local-epochs = 1
+learning-rate = 0.1
+batch-size = 32
+# Aggregation strategy: "trust" (TrustAwareFedAvg) or "fedavg" (vanilla baseline)
+strategy = "trust"
+# Number of clients (lowest partition ids) that poison their update, and the
+# std of the Gaussian noise they add. Set num-malicious=0 for a clean run.
+num-malicious = 3
+attack-scale = 1.0
+# trust-z: width of the "normal" dead zone in robust-std (MAD) units; only
+# updates beyond it are down-weighted. trust-beta: decay rate past the dead zone.
+trust-z = 3.5
+trust-beta = 5.0
+
+[tool.flwr.federations]
+default = "local-simulation"
+
+[tool.flwr.federations.local-simulation]
+options.num-supernodes = 10
+
+# Pack 10 clients onto a single GPU (0.1 GPU each). Requires a CUDA build of
+# torch. Run with:  flwr run . gpu-simulation
+[tool.flwr.federations.gpu-simulation]
+options.num-supernodes = 10
+options.backend.client-resources.num-cpus = 2
+options.backend.client-resources.num-gpus = 0.1


### PR DESCRIPTION
## Issue

### Description

The existing `CustomFedAvg` examples (e.g. `advanced-pytorch`, the step-by-step
tutorial) subclass `FedAvg` to add logging, checkpointing or LR scheduling — but
none demonstrate how to customise the *aggregation* itself on the Message API
(overriding `aggregate_train`). There's no small, focused example to copy from
when implementing a new aggregation rule.

### Related issues/PRs

N/A (happy to open a tracking issue if preferred).

## Proposal

### Explanation

This PR adds a minimal `examples/custom-aggregation-strategy` showing how to
implement custom aggregation by subclassing `FedAvg` and overriding only
`aggregate_train`.

As a concrete, testable motivation it implements `TrustAwareFedAvg`: it computes
each client's update norm ‖client − global‖₂, scores outliers with a median+MAD
robust z-score (Iglewicz–Hoaglin), and folds a trust weight into the existing
`num-examples` key so the parent's weighted aggregation is reused. The example
ships with an optional poisoning toggle so the effect is visible — under 3/10
Gaussian-poisoning clients, vanilla FedAvg collapses to ~random accuracy while
the trust-weighted variant recovers to the clean baseline. Runs with `flwr run .`.

This is intended as a *pedagogical* example, not a new algorithm — Flower already
ships production robust strategies (Krum, MultiKrum, Bulyan, FedMedian,
FedTrimmedAvg). Opening as a **draft** to get your guidance on:
1. whether a "custom aggregation" reference is welcome, and
2. whether it fits better as an `examples/` example or as a how-to in the docs.

### Checklist

- [x] Implement proposed change
- [x] Write tests
- [ ] Update documentation
- [ ] Make CI checks pass
- [ ] Ping maintainers on Slack (channel `#contributions`)

### Any other comments?

Built and tested locally on CIFAR-10 (CPU). Results vary slightly by seed since
the example doesn't fix one. Happy to adjust scope, naming, or move it to docs.
