### PR TITLE
ci(framework:skip): Add Kubernetes executor dev smoke script

### DIFF
--- a/framework/dev/kubernetes_executor_smoke.py
+++ b/framework/dev/kubernetes_executor_smoke.py
@@ -1,0 +1,369 @@
+# Copyright 2026 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Dev-maintained in-cluster smoke script for the Kubernetes executor.
+
+This is not a stable ``flwr-*`` command. It uses the production in-cluster
+Kubernetes auth path, so run it inside a Kubernetes Pod with the optional
+``kubernetes`` Python package installed. The runner ServiceAccount needs scoped
+``pods`` and ``secrets`` list/create/delete permissions in the configured
+namespace.
+
+The smoke only proves config loading, client construction, RBAC/admission, and
+create/list/delete for executor-rendered Kubernetes objects. It does not require
+TaskExecutor completion or AppIo connectivity.
+
+Usage:
+    python dev/kubernetes_executor_smoke.py --executor-config executor.yaml
+    python dev/kubernetes_executor_smoke.py --executor-config executor.yaml --json
+"""
+
+# pylint: disable=protected-access
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import asdict, dataclass, field
+from textwrap import dedent
+from typing import Any
+from uuid import uuid4
+
+from flwr.supercore.constant import ExecutorType, TaskType
+from flwr.supercore.superexec.executor.config import load_executor_config
+from flwr.supercore.superexec.executor.factory import get_executor
+from flwr.supercore.superexec.executor.kubernetes_executor import (
+    KubernetesExecutor,
+    KubernetesExecutorConfig,
+    _build_appio_credentials_secret,
+    _build_taskexecutor_pod,
+    _label_selector,
+    _object_name,
+    _pod_items,
+    _raise_unless_not_found,
+    _secret_items,
+    _taskexecutor_pool_label_selector,
+)
+from flwr.supercore.superexec.executor.types import ExecutionSpec
+
+_SMOKE_LABEL = "flower.ai/smoke-run"
+_SMOKE_TOKEN = "flower-kubernetes-executor-smoke-token"
+
+
+@dataclass
+class SmokeSummary:
+    """Machine-readable summary for one smoke run."""
+
+    status: str
+    config_path: str
+    smoke_run: str
+    namespace: str | None = None
+    resource_pool: str | None = None
+    pool_selector: str | None = None
+    smoke_selector: str | None = None
+    secret_name: str | None = None
+    pod_name: str | None = None
+    secret_created: bool = False
+    pod_created: bool = False
+    secret_visible: bool = False
+    pod_visible: bool = False
+    secret_deleted: bool = False
+    pod_deleted: bool = False
+    cleanup_errors: list[str] = field(default_factory=list)
+    error: str | None = None
+
+
+def run_smoke(
+    executor_config_path: str,
+    *,
+    smoke_run: str | None = None,
+    log: Callable[[str], None] = print,
+) -> SmokeSummary:
+    """Run a bounded Kubernetes executor smoke check."""
+    smoke_run = smoke_run or f"smoke-{uuid4().hex[:12]}"
+    summary = SmokeSummary(
+        status="failed",
+        config_path=executor_config_path,
+        smoke_run=smoke_run,
+    )
+    client: Any | None = None
+    config: KubernetesExecutorConfig | None = None
+
+    try:
+        log(f"Loading executor config: {executor_config_path}")
+        executor_config = load_executor_config(
+            executor_config_path, ExecutorType.KUBERNETES
+        )
+        executor_config = _executor_config_with_smoke_label(executor_config, smoke_run)
+
+        log("Constructing Kubernetes executor with in-cluster client")
+        executor = get_executor(
+            ExecutorType.KUBERNETES, executor_config=executor_config
+        )
+        if not isinstance(executor, KubernetesExecutor):
+            raise RuntimeError("Factory did not return a KubernetesExecutor.")
+
+        client = executor._client
+        config = executor._config
+        summary.namespace = config.namespace
+        summary.resource_pool = config.resource_pool
+        summary.pool_selector = _taskexecutor_pool_label_selector(config)
+        summary.smoke_selector = _label_selector({_SMOKE_LABEL: smoke_run})
+
+        log(f"Namespace: {config.namespace}")
+        log(f"Resource pool: {config.resource_pool or '<none>'}")
+        log(f"Pool selector: {summary.pool_selector}")
+        log(f"Smoke selector: {summary.smoke_selector}")
+
+        _check_scoped_list_access(client, config, summary, log)
+        _create_smoke_objects(client, config, smoke_run, summary, log)
+        _check_created_objects_visible(client, config, summary, log)
+        summary.status = "passed"
+        log("Kubernetes executor smoke passed")
+    except Exception as err:  # pylint: disable=broad-exception-caught
+        summary.status = "failed"
+        summary.error = _safe_error_message(err)
+        log(f"Kubernetes executor smoke failed: {summary.error}")
+    finally:
+        if client is not None and config is not None:
+            _cleanup_created_objects(client, config, summary, log)
+
+    if summary.cleanup_errors and summary.status == "passed":
+        summary.status = "failed"
+        summary.error = "Cleanup failed for one or more smoke objects."
+    return summary
+
+
+def _executor_config_with_smoke_label(
+    executor_config: dict[object, object], smoke_run: str
+) -> dict[object, object]:
+    """Return executor config with a unique per-run smoke label."""
+    updated_config = dict(executor_config)
+    labels = updated_config.get("labels")
+    if labels is None:
+        updated_labels: dict[object, object] = {}
+    elif isinstance(labels, Mapping):
+        updated_labels = dict(labels)
+    else:
+        raise ValueError("Kubernetes executor config field 'labels' must be a mapping.")
+    updated_labels[_SMOKE_LABEL] = smoke_run
+    updated_config["labels"] = updated_labels
+    return updated_config
+
+
+def _check_scoped_list_access(
+    client: Any,
+    config: KubernetesExecutorConfig,
+    summary: SmokeSummary,
+    log: Callable[[str], None],
+) -> None:
+    """Check scoped Pod and Secret list access before creating objects."""
+    if summary.smoke_selector is None:
+        raise RuntimeError("Smoke selector was not initialized.")
+    log("Checking scoped Pod and Secret list access")
+    client.list_namespaced_pod(
+        config.namespace,
+        label_selector=summary.smoke_selector,
+    )
+    client.list_namespaced_secret(
+        config.namespace,
+        label_selector=summary.smoke_selector,
+    )
+
+
+def _create_smoke_objects(
+    client: Any,
+    config: KubernetesExecutorConfig,
+    smoke_run: str,
+    summary: SmokeSummary,
+    log: Callable[[str], None],
+) -> None:
+    """Create one smoke Secret and Pod using executor object rendering."""
+    spec = ExecutionSpec(
+        task_type=TaskType.SERVER_APP,
+        appio_api_address="127.0.0.1:9091",
+        token=_SMOKE_TOKEN,
+        insecure=True,
+        root_certificates_path=None,
+        runtime_dependency_install=False,
+        parent_pid=None,
+        suppress_output=True,
+        task_id=1,
+    )
+    secret = _build_appio_credentials_secret(
+        spec=spec,
+        config=config,
+        appio_root_certificates=None,
+        launch_attempt_id=smoke_run,
+    )
+    pod = _build_taskexecutor_pod(
+        spec=spec,
+        config=config,
+        appio_root_certificates=None,
+        launch_attempt_id=smoke_run,
+    )
+    secret_name = _metadata_name(secret)
+    pod_name = _metadata_name(pod)
+    summary.secret_name = secret_name
+    summary.pod_name = pod_name
+
+    log(f"Creating smoke Secret: {secret_name}")
+    client.create_namespaced_secret(config.namespace, secret)
+    summary.secret_created = True
+
+    log(f"Creating smoke Pod: {pod_name}")
+    client.create_namespaced_pod(config.namespace, pod)
+    summary.pod_created = True
+
+
+def _check_created_objects_visible(
+    client: Any,
+    config: KubernetesExecutorConfig,
+    summary: SmokeSummary,
+    log: Callable[[str], None],
+) -> None:
+    """Check that created smoke objects are visible through the scoped selector."""
+    if summary.smoke_selector is None:
+        raise RuntimeError("Smoke selector was not initialized.")
+    log("Checking created objects through scoped selectors")
+    pods = _pod_items(
+        client.list_namespaced_pod(
+            config.namespace,
+            label_selector=summary.smoke_selector,
+        )
+    )
+    secrets = _secret_items(
+        client.list_namespaced_secret(
+            config.namespace,
+            label_selector=summary.smoke_selector,
+        )
+    )
+    summary.pod_visible = summary.pod_name in {_object_name(pod) for pod in pods}
+    summary.secret_visible = summary.secret_name in {
+        _object_name(secret) for secret in secrets
+    }
+    if not summary.pod_visible or not summary.secret_visible:
+        raise RuntimeError("Created smoke objects were not visible through selector.")
+
+
+def _cleanup_created_objects(
+    client: Any,
+    config: KubernetesExecutorConfig,
+    summary: SmokeSummary,
+    log: Callable[[str], None],
+) -> None:
+    """Delete smoke objects created by this run."""
+    if summary.pod_created and summary.pod_name is not None:
+        log(f"Deleting smoke Pod: {summary.pod_name}")
+        try:
+            client.delete_namespaced_pod(
+                name=summary.pod_name,
+                namespace=config.namespace,
+                grace_period_seconds=0,
+            )
+            summary.pod_deleted = True
+        except Exception as err:  # pylint: disable=broad-exception-caught
+            try:
+                _raise_unless_not_found(err)
+            except Exception as cleanup_err:  # pylint: disable=broad-exception-caught
+                message = _safe_error_message(cleanup_err)
+                summary.cleanup_errors.append(f"Pod {summary.pod_name}: {message}")
+                log(f"Failed to delete smoke Pod {summary.pod_name}: {message}")
+            else:
+                summary.pod_deleted = True
+
+    if summary.secret_created and summary.secret_name is not None:
+        log(f"Deleting smoke Secret: {summary.secret_name}")
+        try:
+            client.delete_namespaced_secret(
+                name=summary.secret_name,
+                namespace=config.namespace,
+            )
+            summary.secret_deleted = True
+        except Exception as err:  # pylint: disable=broad-exception-caught
+            try:
+                _raise_unless_not_found(err)
+            except Exception as cleanup_err:  # pylint: disable=broad-exception-caught
+                message = _safe_error_message(cleanup_err)
+                summary.cleanup_errors.append(
+                    f"Secret {summary.secret_name}: {message}"
+                )
+                log(f"Failed to delete smoke Secret {summary.secret_name}: {message}")
+            else:
+                summary.secret_deleted = True
+
+
+def _metadata_name(value: object) -> str:
+    """Return a Kubernetes object metadata name or fail clearly."""
+    name = _object_name(value)
+    if name is None:
+        raise RuntimeError("Rendered Kubernetes object is missing metadata.name.")
+    return name
+
+
+def _safe_error_message(err: Exception) -> str:
+    """Return a redacted error message safe for smoke output."""
+    return f"{type(err).__name__}: {str(err).replace(_SMOKE_TOKEN, '<redacted>')}"
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Smoke-test Kubernetes executor config and scoped API access from "
+            "inside a Kubernetes Pod."
+        ),
+        epilog=dedent(
+            """
+            This dev-maintained script is not a stable flwr-* command. It uses
+            production in-cluster auth, requires the optional kubernetes Python
+            package, and needs runner ServiceAccount permissions to list,
+            create, and delete Pods and Secrets in the configured namespace.
+            It proves executor config/client/RBAC/admission/create/list/delete
+            only; TaskExecutor completion and AppIo connectivity are out of
+            scope.
+            """
+        ).strip(),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--executor-config",
+        required=True,
+        help="Path to the trusted Kubernetes executor YAML config.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit compact JSON summary on stdout; human logs go to stderr.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the Kubernetes executor smoke script."""
+    args = _parse_args(argv)
+    log_stream = sys.stderr if args.json else sys.stdout
+    summary = run_smoke(
+        args.executor_config,
+        log=lambda message: print(message, file=log_stream),
+    )
+    if args.json:
+        print(json.dumps(asdict(summary), sort_keys=True, separators=(",", ":")))
+    return 0 if summary.status == "passed" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/framework/dev/kubernetes_executor_smoke.py
+++ b/framework/dev/kubernetes_executor_smoke.py
@@ -22,7 +22,8 @@ namespace.
 
 The smoke only proves config loading, client construction, RBAC/admission, and
 create/list/delete for executor-rendered Kubernetes objects. It does not require
-TaskExecutor completion or AppIo connectivity.
+TaskExecutor completion or AppIo connectivity. Real in-cluster runs are optional
+deployment evidence, not a Flower PR merge requirement.
 
 Usage:
     python dev/kubernetes_executor_smoke.py --executor-config executor.yaml
@@ -334,7 +335,8 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
             create, and delete Pods and Secrets in the configured namespace.
             It proves executor config/client/RBAC/admission/create/list/delete
             only; TaskExecutor completion and AppIo connectivity are out of
-            scope.
+            scope. Real in-cluster runs are optional deployment evidence, not
+            a Flower PR merge requirement.
             """
         ).strip(),
         formatter_class=argparse.RawDescriptionHelpFormatter,

--- a/framework/py/flwr/supercore/superexec/executor/kubernetes_executor_smoke_test.py
+++ b/framework/py/flwr/supercore/superexec/executor/kubernetes_executor_smoke_test.py
@@ -63,8 +63,6 @@ class _FakeKubernetesClient:
         self.secrets: dict[str, object] = {}
         self.created_pods: list[object] = []
         self.created_secrets: list[object] = []
-        self.deleted_pods: list[str] = []
-        self.deleted_secrets: list[str] = []
 
     def create_namespaced_secret(self, namespace: str, body: object) -> object:
         """Create a fake Secret."""
@@ -115,13 +113,11 @@ class _FakeKubernetesClient:
     ) -> object:
         """Delete a fake Pod."""
         del namespace, grace_period_seconds
-        self.deleted_pods.append(name)
         return self.pods.pop(name)
 
     def delete_namespaced_secret(self, name: str, namespace: str) -> object:
         """Delete a fake Secret."""
         del namespace
-        self.deleted_secrets.append(name)
         return self.secrets.pop(name)
 
 
@@ -141,15 +137,8 @@ def test_run_smoke_creates_visible_objects_and_cleans_them_up(
     )
 
     assert summary.status == "passed"
-    assert summary.namespace == "flower-system"
-    assert summary.resource_pool == "gpu-pool"
-    assert summary.smoke_selector == "flower.ai/smoke-run=smoke-test"
-    assert summary.secret_created
-    assert summary.pod_created
-    assert summary.secret_visible
-    assert summary.pod_visible
-    assert summary.secret_deleted
-    assert summary.pod_deleted
+    assert len(client.created_secrets) == 1
+    assert len(client.created_pods) == 1
     assert client.pods == {}
     assert client.secrets == {}
     assert "flower-kubernetes-executor-smoke-token" not in "\n".join(logs)
@@ -180,9 +169,8 @@ def test_run_smoke_cleans_up_secret_if_pod_creation_fails(
     )
 
     assert summary.status == "failed"
-    assert summary.secret_created
-    assert not summary.pod_created
-    assert summary.secret_deleted
+    assert len(client.created_secrets) == 1
+    assert client.created_pods == []
     assert client.secrets == {}
     assert summary.error is not None
     assert "flower-kubernetes-executor-smoke-token" not in summary.error

--- a/framework/py/flwr/supercore/superexec/executor/kubernetes_executor_smoke_test.py
+++ b/framework/py/flwr/supercore/superexec/executor/kubernetes_executor_smoke_test.py
@@ -17,7 +17,9 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import sys
+from collections.abc import Callable
 from pathlib import Path
 from textwrap import dedent
 from types import ModuleType
@@ -175,6 +177,78 @@ def test_run_smoke_cleans_up_secret_if_pod_creation_fails(
     assert summary.error is not None
     assert "flower-kubernetes-executor-smoke-token" not in summary.error
     assert "<redacted>" in summary.error
+
+
+@pytest.mark.parametrize(
+    ("status", "expected_exit_code"), [("passed", 0), ("failed", 1)]
+)
+def test_main_emits_json_summary_and_uses_status_exit_code(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    status: str,
+    expected_exit_code: int,
+) -> None:
+    """Test command output shape and exit status without Kubernetes access."""
+    config_path = _write_executor_config(tmp_path)
+
+    def _run_smoke(
+        executor_config_path: str,
+        *,
+        smoke_run: str | None = None,
+        log: Callable[[str], None] = print,
+    ) -> object:
+        del smoke_run
+        assert executor_config_path == str(config_path)
+        log("human-readable smoke log")
+        return smoke_module.SmokeSummary(
+            status=status,
+            config_path=executor_config_path,
+            smoke_run="smoke-test",
+            namespace="flower-system",
+        )
+
+    monkeypatch.setattr(smoke_module, "run_smoke", _run_smoke)
+
+    exit_code = smoke_module.main(["--executor-config", str(config_path), "--json"])
+
+    captured = capsys.readouterr()
+    assert exit_code == expected_exit_code
+    assert captured.err == "human-readable smoke log\n"
+    assert json.loads(captured.out) == {
+        "cleanup_errors": [],
+        "config_path": str(config_path),
+        "error": None,
+        "namespace": "flower-system",
+        "pod_created": False,
+        "pod_deleted": False,
+        "pod_name": None,
+        "pod_visible": False,
+        "pool_selector": None,
+        "resource_pool": None,
+        "secret_created": False,
+        "secret_deleted": False,
+        "secret_name": None,
+        "secret_visible": False,
+        "smoke_run": "smoke-test",
+        "smoke_selector": None,
+        "status": status,
+    }
+
+
+def test_help_documents_incluster_scope_without_running_smoke(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Test help text makes the non-gate in-cluster scope discoverable."""
+    with pytest.raises(SystemExit) as exc_info:
+        smoke_module.main(["--help"])
+
+    assert exc_info.value.code == 0
+    captured = capsys.readouterr()
+    assert "not a stable flwr-* command" in captured.out
+    assert "production in-cluster auth" in captured.out
+    assert "runner ServiceAccount permissions" in captured.out
+    assert "Flower PR merge requirement" in captured.out
 
 
 def _write_executor_config(tmp_path: Path) -> Path:

--- a/framework/py/flwr/supercore/superexec/executor/kubernetes_executor_smoke_test.py
+++ b/framework/py/flwr/supercore/superexec/executor/kubernetes_executor_smoke_test.py
@@ -1,0 +1,246 @@
+# Copyright 2026 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for the Kubernetes executor dev smoke script."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from textwrap import dedent
+from types import ModuleType
+from unittest.mock import Mock
+
+import pytest
+
+from . import factory as factory_module
+
+
+def _load_smoke_module() -> ModuleType:
+    """Load the dev smoke script from its file path."""
+    smoke_path = (
+        Path(__file__).resolve().parents[5] / "dev" / ("kubernetes_executor_smoke.py")
+    )
+    spec = importlib.util.spec_from_file_location(
+        "kubernetes_executor_smoke", smoke_path
+    )
+    if spec is None or spec.loader is None:
+        raise AssertionError("Could not load Kubernetes executor smoke module")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+smoke_module = _load_smoke_module()
+
+
+class _KubernetesList:
+    """Small Kubernetes list response stand-in."""
+
+    def __init__(self, items: list[object]) -> None:
+        self.items = items
+
+
+class _FakeKubernetesClient:
+    """Fake CoreV1Api for the smoke script."""
+
+    def __init__(self, *, pod_create_error: Exception | None = None) -> None:
+        self.pod_create_error = pod_create_error
+        self.pods: dict[str, object] = {}
+        self.secrets: dict[str, object] = {}
+        self.created_pods: list[object] = []
+        self.created_secrets: list[object] = []
+        self.deleted_pods: list[str] = []
+        self.deleted_secrets: list[str] = []
+
+    def create_namespaced_secret(self, namespace: str, body: object) -> object:
+        """Create a fake Secret."""
+        del namespace
+        name = _metadata_name(body)
+        self.created_secrets.append(body)
+        self.secrets[name] = body
+        return body
+
+    def create_namespaced_pod(self, namespace: str, body: object) -> object:
+        """Create a fake Pod."""
+        del namespace
+        if self.pod_create_error is not None:
+            raise self.pod_create_error
+        name = _metadata_name(body)
+        self.created_pods.append(body)
+        self.pods[name] = body
+        return body
+
+    def list_namespaced_pod(
+        self, namespace: str, label_selector: str
+    ) -> _KubernetesList:
+        """List fake Pods."""
+        del namespace
+        return _KubernetesList(
+            [
+                pod
+                for pod in self.pods.values()
+                if _matches_selector(pod, label_selector)
+            ]
+        )
+
+    def list_namespaced_secret(
+        self, namespace: str, label_selector: str
+    ) -> _KubernetesList:
+        """List fake Secrets."""
+        del namespace
+        return _KubernetesList(
+            [
+                secret
+                for secret in self.secrets.values()
+                if _matches_selector(secret, label_selector)
+            ]
+        )
+
+    def delete_namespaced_pod(
+        self, name: str, namespace: str, grace_period_seconds: int = 0
+    ) -> object:
+        """Delete a fake Pod."""
+        del namespace, grace_period_seconds
+        self.deleted_pods.append(name)
+        return self.pods.pop(name)
+
+    def delete_namespaced_secret(self, name: str, namespace: str) -> object:
+        """Delete a fake Secret."""
+        del namespace
+        self.deleted_secrets.append(name)
+        return self.secrets.pop(name)
+
+
+def test_run_smoke_creates_visible_objects_and_cleans_them_up(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Test the smoke path creates, lists, and deletes scoped objects."""
+    client = _FakeKubernetesClient()
+    monkeypatch.setattr(
+        factory_module, "create_incluster_kubernetes_client", Mock(return_value=client)
+    )
+    config_path = _write_executor_config(tmp_path)
+    logs: list[str] = []
+
+    summary = smoke_module.run_smoke(
+        str(config_path), smoke_run="smoke-test", log=logs.append
+    )
+
+    assert summary.status == "passed"
+    assert summary.namespace == "flower-system"
+    assert summary.resource_pool == "gpu-pool"
+    assert summary.smoke_selector == "flower.ai/smoke-run=smoke-test"
+    assert summary.secret_created
+    assert summary.pod_created
+    assert summary.secret_visible
+    assert summary.pod_visible
+    assert summary.secret_deleted
+    assert summary.pod_deleted
+    assert client.pods == {}
+    assert client.secrets == {}
+    assert "flower-kubernetes-executor-smoke-token" not in "\n".join(logs)
+
+    pod = client.created_pods[0]
+    labels = _metadata_labels(pod)
+    assert labels["flower.ai/smoke-run"] == "smoke-test"
+    assert labels["flower.ai/resource-pool"] == "gpu-pool"
+    assert _pod_spec(pod)["automountServiceAccountToken"] is False
+
+
+def test_run_smoke_cleans_up_secret_if_pod_creation_fails(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Test a rejected Pod still cleans up the created credential Secret."""
+    client = _FakeKubernetesClient(
+        pod_create_error=RuntimeError(
+            "Pod rejected for token flower-kubernetes-executor-smoke-token"
+        )
+    )
+    monkeypatch.setattr(
+        factory_module, "create_incluster_kubernetes_client", Mock(return_value=client)
+    )
+    config_path = _write_executor_config(tmp_path)
+
+    summary = smoke_module.run_smoke(
+        str(config_path), smoke_run="smoke-test", log=lambda _: None
+    )
+
+    assert summary.status == "failed"
+    assert summary.secret_created
+    assert not summary.pod_created
+    assert summary.secret_deleted
+    assert client.secrets == {}
+    assert summary.error is not None
+    assert "flower-kubernetes-executor-smoke-token" not in summary.error
+    assert "<redacted>" in summary.error
+
+
+def _write_executor_config(tmp_path: Path) -> Path:
+    """Write a minimal Kubernetes executor config."""
+    config_path = tmp_path / "executor.yaml"
+    config_path.write_text(
+        dedent(
+            """
+            namespace: flower-system
+            image: ghcr.io/flwrlabs/taskexecutor:dev
+            resource-pool: gpu-pool
+            labels:
+              flower.ai/deployment: dev
+            """
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    return config_path
+
+
+def _metadata_name(value: object) -> str:
+    metadata = _field(value, "metadata")
+    name = _field(metadata, "name")
+    if not isinstance(name, str):
+        raise AssertionError("Object does not have metadata.name")
+    return name
+
+
+def _metadata_labels(value: object) -> dict[str, str]:
+    metadata = _field(value, "metadata")
+    labels = _field(metadata, "labels")
+    if not isinstance(labels, dict):
+        raise AssertionError("Object does not have metadata.labels")
+    return labels
+
+
+def _pod_spec(value: object) -> dict[str, object]:
+    spec = _field(value, "spec")
+    if not isinstance(spec, dict):
+        raise AssertionError("Object does not have spec")
+    return spec
+
+
+def _matches_selector(value: object, selector: str) -> bool:
+    labels = _metadata_labels(value)
+    for requirement in selector.split(","):
+        key, expected = requirement.split("=", maxsplit=1)
+        if labels.get(key) != expected:
+            return False
+    return True
+
+
+def _field(value: object, field_name: str) -> object | None:
+    if isinstance(value, dict):
+        return value.get(field_name)
+    return getattr(value, field_name, None)


### PR DESCRIPTION
## Stack / Base

F6 is now based on `main`.

The former stack prerequisites have merged:

- F3 / PR #7377 merged into `main` at `59c88450d640b8565c2f82b735ecb8b17114f113`.
- F4 / PR #7378 merged into `main` at `d4e0e6dd0b96a0bbaa159b246b19dd30b0a57eea`.

F7 owns the richer local k3d integrated launch-path proof, including real SuperLink/SuperExec/TaskExecutor interactions and capacity/cleanup/demo evidence.

## Summary

- Add `framework/dev/kubernetes_executor_smoke.py`, a dev-maintained in-cluster smoke script for the Kubernetes executor.
- The script loads the same trusted executor config root mapping used by `flower-superexec --executor kubernetes --executor-config PATH`.
- It constructs the Kubernetes executor through the production factory path, adds a unique smoke-run label, checks scoped Pod/Secret list access, creates one executor-rendered Secret and Pod, verifies selector visibility, and deletes only objects created by the smoke run.
- It emits human-readable logs by default and supports compact JSON output with `--json`.
- It documents that the script uses production in-cluster auth, requires the optional `kubernetes` Python package, and needs runner ServiceAccount `pods`/`secrets` list/create/delete permissions in the configured namespace.

## CI-Runnable Coverage

The Flower PR does not require a real Kubernetes cluster or the optional `kubernetes` package to review/merge. CI-runnable tests cover:

- trusted executor config loading from a temporary YAML file;
- fake-client Secret/Pod create/list/delete behavior;
- cleanup after Pod creation fails;
- redaction of task-token-like values in failure output;
- JSON output shape and exit status;
- `--help`/argument documentation for the in-cluster-only, non-gate scope.

## Optional Real Smoke

The real in-cluster smoke run is optional deployment evidence, not a required Flower PR merge gate.

To run it, use an environment with:

- the Flower framework code available;
- the optional official `kubernetes` Python package installed;
- a mounted in-cluster ServiceAccount token;
- runner ServiceAccount RBAC for `pods` and `secrets` `list`, `create`, and `delete` in the configured namespace;
- an executor config containing at least `namespace` and `image`.

Command:

```bash
cd framework
python dev/kubernetes_executor_smoke.py --executor-config /path/to/executor.yaml --json
```

The smoke proves config/client/RBAC/admission/create/list/delete for executor-rendered objects. It does not require TaskExecutor completion or AppIo connectivity.


