### PR TITLE
feat(framework): Add k3d harness infra proof

### DIFF
--- a/framework/dev/kubernetes_executor_harness.py
+++ b/framework/dev/kubernetes_executor_harness.py
@@ -1,0 +1,542 @@
+# Copyright 2026 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""F7a evidence contract scaffold for the integrated k3d launch-path harness.
+
+This dev-maintained module defines the portable event, summary, redaction, and
+evidence-bundle shape for a future integrated harness. It does not create a k3d
+cluster, talk to Kubernetes, start SuperLink, start SuperExec, or launch a
+TaskExecutor Pod.
+
+Usage:
+    python dev/kubernetes_executor_harness.py --output-dir ./f7a-evidence
+    python dev/kubernetes_executor_harness.py --output-dir ./f7a-evidence --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from uuid import uuid4
+
+import yaml
+
+SCHEMA_VERSION = "f7a-harness-v1"
+REDACTED = "<redacted>"
+HARNESS_EVENT_CLASSES = (
+    "harness.start",
+    "profile.loaded",
+    "cluster.detected",
+    "namespace.ready",
+    "tls.material.ready",
+    "rbac.applied",
+    "rbac.negative_check",
+    "superlink.pod.ready",
+    "appio.seeded",
+    "superexec.pod.ready",
+    "superexec.claim_observed",
+    "kubernetes_executor.pod_created",
+    "taskexecutor.pod_phase",
+    "taskexecutor.appio_connectivity",
+    "capacity.wait_observed",
+    "cleanup.observed",
+    "policy.not_validated_locally",
+    "harness.result",
+)
+
+_PEM_BLOCK_RE = re.compile(r"-----BEGIN [^-]+-----.*?-----END [^-]+-----", re.DOTALL)
+_CREDENTIAL_ASSIGNMENT_RE = re.compile(
+    r"(?i)\b(token|password|api[-_]?key|authorization)\s*([:=])\s*([^\s,;]+)"
+)
+_SECRET_DATA_KEYS = {"data", "stringData", "binaryData"}
+_SENSITIVE_KEYS = {
+    "api_key",
+    "appio_token",
+    "authorization",
+    "client_secret",
+    "credential",
+    "credentials",
+    "password",
+    "private_key",
+    "root_ca_pem",
+    "secret_data",
+    "task_token",
+    "token",
+}
+_CREDENTIAL_ARG_NAMES = {
+    "--api-key",
+    "--appio-token",
+    "--authorization",
+    "--credential",
+    "--password",
+    "--secret",
+    "--token",
+}
+_ROOT_CERT_ARG_NAMES = {
+    "--appio-root-certificates",
+    "--root-certificates",
+    "--root-certificates-bytes",
+}
+
+
+@dataclass
+class HarnessEvent:
+    """One JSONL event emitted by the future integrated harness."""
+
+    event: str
+    status: str
+    message: str
+    details: dict[str, object] = field(default_factory=dict)
+    timestamp: str = field(default_factory=lambda: _utc_now())
+    schema_version: str = SCHEMA_VERSION
+
+    def to_record(self) -> dict[str, object]:
+        """Return a JSON-ready event record."""
+        if self.event not in HARNESS_EVENT_CLASSES:
+            raise ValueError(f"Unsupported harness event class: {self.event}")
+        return asdict(self)
+
+
+@dataclass
+class HarnessSummary:
+    """Machine-readable summary for one harness evidence bundle."""
+
+    status: str
+    result: str
+    profile_name: str
+    output_dir: str
+    started_at: str
+    namespace: str
+    resource_pool: str
+    event_count: int = 0
+    completed_at: str | None = None
+    failures: list[str] = field(default_factory=list)
+    not_validated: list[str] = field(default_factory=list)
+    details: dict[str, object] = field(default_factory=dict)
+    schema_version: str = SCHEMA_VERSION
+
+    def to_record(self) -> dict[str, object]:
+        """Return a JSON-ready summary record."""
+        return asdict(self)
+
+
+@dataclass
+class HarnessProfile:  # pylint: disable=too-many-instance-attributes
+    """Portable profile sketch for a future integrated k3d harness run."""
+
+    name: str
+    namespace: str
+    resource_pool: str
+    image: str
+    image_pull_policy: str
+    labels: dict[str, str] = field(default_factory=dict)
+    annotations: dict[str, str] = field(default_factory=dict)
+    timeout_seconds: int = 600
+    cleanup_mode: str = "always"
+    appio_tls_mode: str = "test-ca-secret"
+    expected_cni: str = "not-validated-locally"
+    executor_config_path: str | None = None
+
+    def to_mapping(self) -> dict[str, object]:
+        """Return the profile as a JSON/YAML-ready mapping."""
+        executor_config: dict[str, object] = {
+            "namespace": self.namespace,
+            "image": self.image,
+            "image-pull-policy": self.image_pull_policy,
+            "resource-pool": self.resource_pool,
+            "labels": dict(self.labels),
+            "annotations": dict(self.annotations),
+        }
+        if self.executor_config_path is not None:
+            executor_config["path"] = self.executor_config_path
+        return {
+            "schema-version": SCHEMA_VERSION,
+            "name": self.name,
+            "executor-config": executor_config,
+            "harness": {
+                "timeout-seconds": self.timeout_seconds,
+                "cleanup-mode": self.cleanup_mode,
+                "appio-tls-mode": self.appio_tls_mode,
+                "expected-cni": self.expected_cni,
+            },
+        }
+
+
+class EvidenceBundleWriter:
+    """Write a portable harness evidence bundle under a selected directory."""
+
+    def __init__(self, output_dir: str | Path) -> None:
+        self.output_dir = Path(output_dir)
+        self.event_count = 0
+
+    def initialize(self) -> None:
+        """Create the evidence bundle directory layout."""
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        for directory in ("objects", "diagnostics"):
+            (self.output_dir / directory).mkdir(exist_ok=True)
+
+    def write_event(self, event: HarnessEvent) -> None:
+        """Append one redacted JSONL event."""
+        self.initialize()
+        record = redact_sensitive_data(event.to_record())
+        with (self.output_dir / "events.jsonl").open("a", encoding="utf-8") as file:
+            file.write(json.dumps(record, sort_keys=True, separators=(",", ":")))
+            file.write("\n")
+        self.event_count += 1
+
+    def write_summary(self, summary: HarnessSummary) -> None:
+        """Write the redacted ``summary.json`` file."""
+        self.write_json("summary.json", summary.to_record())
+
+    def write_json(self, relative_path: str, value: object) -> None:
+        """Write redacted JSON inside the evidence bundle."""
+        path = self._bundle_path(relative_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(redact_sensitive_data(value), indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+    def write_yaml(self, relative_path: str, value: object) -> None:
+        """Write redacted YAML inside the evidence bundle."""
+        path = self._bundle_path(relative_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            yaml.safe_dump(redact_sensitive_data(value), sort_keys=True),
+            encoding="utf-8",
+        )
+
+    def write_text(self, relative_path: str, content: str) -> None:
+        """Write redacted text inside the evidence bundle."""
+        path = self._bundle_path(relative_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(redact_text(content), encoding="utf-8")
+
+    def _bundle_path(self, relative_path: str) -> Path:
+        path = Path(relative_path)
+        if path.is_absolute() or ".." in path.parts:
+            raise ValueError(f"Evidence path must stay inside bundle: {relative_path}")
+        return self.output_dir / path
+
+
+def generic_k3d_profile() -> HarnessProfile:
+    """Return the default OSS-friendly profile sketch for future k3d runs."""
+    return HarnessProfile(
+        name="generic-k3d",
+        namespace="flower-f7",
+        resource_pool="generic-k3d",
+        image="ghcr.io/flwrlabs/taskexecutor:dev",
+        image_pull_policy="IfNotPresent",
+        labels={
+            "flower.ai/harness": "f7",
+            "flower.ai/profile": "generic-k3d",
+        },
+    )
+
+
+def run_contract_scaffold(
+    output_dir: str | Path, *, profile: HarnessProfile | None = None
+) -> HarnessSummary:
+    """Write a scaffold evidence bundle without running Kubernetes work."""
+    profile = profile or generic_k3d_profile()
+    writer = EvidenceBundleWriter(output_dir)
+    writer.initialize()
+    run_id = f"f7a-{uuid4().hex[:12]}"
+    started_at = _utc_now()
+
+    writer.write_event(
+        HarnessEvent(
+            event="harness.start",
+            status="passed",
+            message="F7a contract scaffold started.",
+            details={
+                "run_id": run_id,
+                "profile": profile.name,
+                "output_dir": str(writer.output_dir),
+            },
+            timestamp=started_at,
+        )
+    )
+    writer.write_event(
+        HarnessEvent(
+            event="profile.loaded",
+            status="passed",
+            message="Generic harness profile loaded.",
+            details=profile.to_mapping(),
+        )
+    )
+    writer.write_event(
+        HarnessEvent(
+            event="policy.not_validated_locally",
+            status="not_validated",
+            message="F7a does not validate CNI, RBAC, or Kubernetes runtime policy.",
+            details={
+                "expected_cni": profile.expected_cni,
+                "reason": "contract scaffold only",
+            },
+        )
+    )
+
+    writer.write_yaml("sanitized-config.yaml", profile.to_mapping())
+    writer.write_json("objects/pods.json", {"items": []})
+    writer.write_json("objects/services.json", {"items": []})
+    writer.write_json("objects/rbac.json", {"items": []})
+    writer.write_text(
+        "harness.log",
+        "F7a scaffold only; no Kubernetes resources were created.\n",
+    )
+    writer.write_text(
+        "diagnostics/commands.txt",
+        "No external commands were executed by the F7a scaffold.\n",
+    )
+    writer.write_text("diagnostics/failures.txt", "")
+
+    writer.write_event(
+        HarnessEvent(
+            event="harness.result",
+            status="passed",
+            message="F7a contract scaffold written.",
+            details={"run_id": run_id, "result": "scaffold-written"},
+        )
+    )
+
+    summary = HarnessSummary(
+        status="passed",
+        result="scaffold-written",
+        profile_name=profile.name,
+        output_dir=str(writer.output_dir),
+        started_at=started_at,
+        completed_at=_utc_now(),
+        namespace=profile.namespace,
+        resource_pool=profile.resource_pool,
+        event_count=writer.event_count,
+        not_validated=[
+            "k3d cluster detection",
+            "Kubernetes namespace setup",
+            "SuperLink AppIo",
+            "SuperExec task claim",
+            "TaskExecutor Pod launch",
+            "RBAC negative checks",
+            "NetworkPolicy/CNI enforcement",
+        ],
+    )
+    writer.write_summary(summary)
+    return summary
+
+
+def redact_sensitive_data(value: object) -> object:
+    """Return ``value`` with credentials, Secret data, and PEM blocks redacted."""
+    if isinstance(value, Mapping):
+        return _redact_mapping(value)
+    if isinstance(value, list):
+        return [redact_sensitive_data(item) for item in value]
+    if isinstance(value, tuple):
+        return [redact_sensitive_data(item) for item in value]
+    if isinstance(value, str):
+        return redact_text(value)
+    return value
+
+
+def redact_command_args(args: Sequence[str]) -> list[str]:
+    """Redact credential-bearing command arguments while preserving structure."""
+    redacted: list[str] = []
+    index = 0
+    while index < len(args):
+        arg = args[index]
+        if arg.startswith("--") and "=" in arg:
+            flag, value = arg.split("=", maxsplit=1)
+            if _is_credential_arg(flag):
+                redacted.append(f"{flag}={REDACTED}")
+            elif _is_root_cert_arg(flag) and _contains_pem(value):
+                redacted.append(f"{flag}={REDACTED}")
+            else:
+                redacted.append(redact_text(arg))
+            index += 1
+            continue
+
+        if _is_credential_arg(arg):
+            redacted.append(arg)
+            if index + 1 < len(args):
+                redacted.append(REDACTED)
+                index += 2
+            else:
+                index += 1
+            continue
+
+        if _is_root_cert_arg(arg) and index + 1 < len(args):
+            redacted.append(arg)
+            next_arg = args[index + 1]
+            redacted.append(REDACTED if _contains_pem(next_arg) else next_arg)
+            index += 2
+            continue
+
+        redacted.append(redact_text(arg))
+        index += 1
+
+    return redacted
+
+
+def redact_text(content: str) -> str:
+    """Redact inline PEM blocks and credential assignments in text."""
+    content = _PEM_BLOCK_RE.sub(REDACTED, content)
+    return _CREDENTIAL_ASSIGNMENT_RE.sub(
+        lambda match: f"{match.group(1)}{match.group(2)}{REDACTED}", content
+    )
+
+
+def _redact_mapping(mapping: Mapping[object, object]) -> dict[str, object]:
+    is_secret = str(mapping.get("kind")) == "Secret"
+    redacted: dict[str, object] = {}
+    for key, value in mapping.items():
+        key_str = str(key)
+        if is_secret and key_str in _SECRET_DATA_KEYS:
+            redacted[key_str] = _redact_secret_payload(value)
+        elif _is_sensitive_key(key_str):
+            redacted[key_str] = REDACTED
+        else:
+            redacted[key_str] = redact_sensitive_data(value)
+    return redacted
+
+
+def _redact_secret_payload(value: object) -> object:
+    if isinstance(value, Mapping):
+        return {str(key): REDACTED for key in value}
+    return REDACTED
+
+
+def _is_sensitive_key(key: str) -> bool:
+    return _normalize_key(key) in _SENSITIVE_KEYS
+
+
+def _is_credential_arg(arg: str) -> bool:
+    return arg in _CREDENTIAL_ARG_NAMES
+
+
+def _is_root_cert_arg(arg: str) -> bool:
+    return arg in _ROOT_CERT_ARG_NAMES
+
+
+def _normalize_key(key: str) -> str:
+    return key.strip().lower().replace("-", "_").replace(".", "_")
+
+
+def _contains_pem(value: str) -> bool:
+    return "-----BEGIN " in value and "-----END " in value
+
+
+def _utc_now() -> str:
+    return datetime.now(tz=UTC).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Write the F7a integrated k3d harness contract scaffold. This does "
+            "not start k3d, Kubernetes, SuperLink, SuperExec, or TaskExecutor."
+        )
+    )
+    default_profile = generic_k3d_profile()
+    parser.add_argument(
+        "--output-dir",
+        required=True,
+        help="Directory where the portable evidence bundle should be written.",
+    )
+    parser.add_argument(
+        "--profile",
+        choices=("generic-k3d",),
+        default=default_profile.name,
+        help="Harness profile sketch to write.",
+    )
+    parser.add_argument(
+        "--namespace",
+        default=default_profile.namespace,
+        help="Namespace planned for future k3d harness objects.",
+    )
+    parser.add_argument(
+        "--resource-pool",
+        default=default_profile.resource_pool,
+        help="Resource-pool label value planned for TaskExecutor Pods.",
+    )
+    parser.add_argument(
+        "--image",
+        default=default_profile.image,
+        help="TaskExecutor image reference planned for the future harness.",
+    )
+    parser.add_argument(
+        "--image-pull-policy",
+        default=default_profile.image_pull_policy,
+        help="TaskExecutor imagePullPolicy planned for the future harness.",
+    )
+    parser.add_argument(
+        "--timeout-seconds",
+        type=int,
+        default=default_profile.timeout_seconds,
+        help="Future harness timeout recorded in the profile sketch.",
+    )
+    parser.add_argument(
+        "--cleanup-mode",
+        default=default_profile.cleanup_mode,
+        help="Future harness cleanup mode recorded in the profile sketch.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit compact JSON summary on stdout.",
+    )
+    return parser.parse_args(argv)
+
+
+def _profile_from_args(args: argparse.Namespace) -> HarnessProfile:
+    return HarnessProfile(
+        name=args.profile,
+        namespace=args.namespace,
+        resource_pool=args.resource_pool,
+        image=args.image,
+        image_pull_policy=args.image_pull_policy,
+        timeout_seconds=args.timeout_seconds,
+        cleanup_mode=args.cleanup_mode,
+        labels={
+            "flower.ai/harness": "f7",
+            "flower.ai/profile": args.profile,
+        },
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Write the F7a contract scaffold evidence bundle."""
+    args = _parse_args(argv)
+    summary = run_contract_scaffold(
+        args.output_dir,
+        profile=_profile_from_args(args),
+    )
+    if args.json:
+        print(
+            json.dumps(
+                redact_sensitive_data(summary.to_record()),
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+        )
+    else:
+        print(f"Wrote F7a harness contract bundle to {summary.output_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/framework/dev/kubernetes_executor_harness.py
+++ b/framework/dev/kubernetes_executor_harness.py
@@ -12,23 +12,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""F7a evidence contract scaffold for the integrated k3d launch-path harness.
+"""Evidence tooling for the integrated k3d launch-path harness.
 
-This dev-maintained module defines the portable event, summary, redaction, and
-evidence-bundle shape for a future integrated harness. It does not create a k3d
-cluster, talk to Kubernetes, start SuperLink, start SuperExec, or launch a
-TaskExecutor Pod.
+This dev-maintained module defines the portable event, summary, redaction,
+evidence-bundle, and infrastructure-proof shape for the future integrated
+harness. The default command only writes the F7a contract scaffold. F7b
+infrastructure checks are explicit and dry-run host commands unless ``--execute``
+is passed.
 
 Usage:
     python dev/kubernetes_executor_harness.py --output-dir ./f7a-evidence
     python dev/kubernetes_executor_harness.py --output-dir ./f7a-evidence --json
+    python dev/kubernetes_executor_harness.py --mode infra-proof \
+        --output-dir ./f7b-evidence
 """
 
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import re
+import shlex
+import subprocess
 from collections.abc import Mapping, Sequence
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
@@ -141,6 +147,7 @@ class HarnessProfile:  # pylint: disable=too-many-instance-attributes
     """Portable profile sketch for a future integrated k3d harness run."""
 
     name: str
+    cluster_name: str
     namespace: str
     resource_pool: str
     image: str
@@ -152,6 +159,11 @@ class HarnessProfile:  # pylint: disable=too-many-instance-attributes
     appio_tls_mode: str = "test-ca-secret"
     expected_cni: str = "not-validated-locally"
     executor_config_path: str | None = None
+    kubectl_context: str | None = None
+    appio_root_certificates_path: str | None = None
+    tls_secret_name: str = "flower-appio-root-certificates"
+    superexec_service_account: str = "flower-superexec"
+    rbac_name: str = "flower-superexec-kubernetes-executor"
 
     def to_mapping(self) -> dict[str, object]:
         """Return the profile as a JSON/YAML-ready mapping."""
@@ -168,6 +180,11 @@ class HarnessProfile:  # pylint: disable=too-many-instance-attributes
         return {
             "schema-version": SCHEMA_VERSION,
             "name": self.name,
+            "cluster": {
+                "type": "k3d",
+                "name": self.cluster_name,
+                "kubectl-context": _kubectl_context(self),
+            },
             "executor-config": executor_config,
             "harness": {
                 "timeout-seconds": self.timeout_seconds,
@@ -175,7 +192,52 @@ class HarnessProfile:  # pylint: disable=too-many-instance-attributes
                 "appio-tls-mode": self.appio_tls_mode,
                 "expected-cni": self.expected_cni,
             },
+            "tls": {
+                "appio-root-certificates-path": self.appio_root_certificates_path,
+                "secret-name": self.tls_secret_name,
+            },
+            "rbac": {
+                "name": self.rbac_name,
+                "superexec-service-account": self.superexec_service_account,
+                "resources": ["pods", "secrets"],
+            },
         }
+
+
+@dataclass
+class CommandResult:
+    """Result of one host command used by the optional F7b proof."""
+
+    args: list[str]
+    returncode: int
+    stdout: str = ""
+    stderr: str = ""
+    dry_run: bool = False
+
+
+class HostCommandRunner:
+    """Run host commands, or report them without execution in dry-run mode."""
+
+    def __init__(self, *, dry_run: bool = True) -> None:
+        self.dry_run = dry_run
+
+    def run(self, args: Sequence[str]) -> CommandResult:
+        """Run one command and return a captured result."""
+        command = [str(arg) for arg in args]
+        if self.dry_run:
+            return CommandResult(args=command, returncode=0, dry_run=True)
+        completed = subprocess.run(
+            command,
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+        return CommandResult(
+            args=command,
+            returncode=completed.returncode,
+            stdout=completed.stdout,
+            stderr=completed.stderr,
+        )
 
 
 class EvidenceBundleWriter:
@@ -239,6 +301,7 @@ def generic_k3d_profile() -> HarnessProfile:
     """Return the default OSS-friendly profile sketch for future k3d runs."""
     return HarnessProfile(
         name="generic-k3d",
+        cluster_name="flower-f7",
         namespace="flower-f7",
         resource_pool="generic-k3d",
         image="ghcr.io/flwrlabs/taskexecutor:dev",
@@ -338,6 +401,332 @@ def run_contract_scaffold(
     )
     writer.write_summary(summary)
     return summary
+
+
+def run_infra_proof(
+    output_dir: str | Path,
+    *,
+    profile: HarnessProfile | None = None,
+    runner: HostCommandRunner | None = None,
+    execute: bool = False,
+    create_cluster: bool = False,
+    apply_manifests: bool = False,
+) -> HarnessSummary:
+    """Write F7b infra/TLS/RBAC evidence with optional host command execution."""
+    profile = profile or generic_k3d_profile()
+    runner = runner or HostCommandRunner(dry_run=not execute)
+    writer = EvidenceBundleWriter(output_dir)
+    writer.initialize()
+    run_id = f"f7b-{uuid4().hex[:12]}"
+    started_at = _utc_now()
+    command_results: list[CommandResult] = []
+    failures: list[str] = []
+
+    namespace_manifest = render_namespace_manifest(profile)
+    rbac_manifests = render_superexec_rbac_manifests(profile)
+    rbac_manifest_list = {
+        "apiVersion": "v1",
+        "kind": "List",
+        "items": rbac_manifests,
+    }
+    tls_contract = build_tls_material_contract(profile)
+    writer.write_yaml("sanitized-config.yaml", profile.to_mapping())
+    writer.write_json("objects/namespace.json", namespace_manifest)
+    writer.write_yaml("objects/namespace.yaml", namespace_manifest)
+    writer.write_json("objects/rbac.json", rbac_manifest_list)
+    writer.write_yaml("objects/rbac.yaml", rbac_manifest_list)
+    writer.write_json("objects/tls.json", tls_contract)
+    writer.write_json("objects/pods.json", {"items": []})
+    writer.write_json("objects/services.json", {"items": []})
+
+    def write_event(event: str, status: str, message: str, details: object) -> None:
+        writer.write_event(
+            HarnessEvent(
+                event=event,
+                status=status,
+                message=message,
+                details={
+                    "run_id": run_id,
+                    "mode": "f7b-infra-proof",
+                    "dry_run": not execute,
+                    "data": details,
+                },
+            )
+        )
+
+    def run_command(
+        args: Sequence[str], failure_context: str, *, record_failure: bool = True
+    ) -> CommandResult:
+        result = runner.run(args)
+        command_results.append(result)
+        if result.returncode != 0 and not result.dry_run and record_failure:
+            failures.append(f"{failure_context}: {_command_error(result)}")
+        return result
+
+    write_event(
+        "harness.start",
+        "passed",
+        "F7b infrastructure proof started.",
+        {
+            "output_dir": str(writer.output_dir),
+            "execute": execute,
+            "create_cluster": create_cluster,
+            "apply_manifests": apply_manifests,
+        },
+    )
+    write_event(
+        "profile.loaded",
+        "passed",
+        "Generic harness profile loaded.",
+        profile.to_mapping(),
+    )
+
+    cluster_result = run_command(
+        ["k3d", "cluster", "list", profile.cluster_name],
+        "k3d cluster detection",
+        record_failure=False,
+    )
+    if cluster_result.returncode != 0 and not cluster_result.dry_run and create_cluster:
+        cluster_result = run_command(
+            ["k3d", "cluster", "create", profile.cluster_name, "--wait"],
+            "k3d cluster creation",
+        )
+    elif cluster_result.dry_run and create_cluster:
+        cluster_result = run_command(
+            ["k3d", "cluster", "create", profile.cluster_name, "--wait"],
+            "k3d cluster creation",
+        )
+    elif cluster_result.returncode != 0 and not cluster_result.dry_run:
+        failures.append(f"k3d cluster detection: {_command_error(cluster_result)}")
+    write_event(
+        "cluster.detected",
+        _status_from_command(cluster_result, planned_status="planned"),
+        "k3d cluster detection command recorded.",
+        {
+            "cluster_name": profile.cluster_name,
+            "kubectl_context": _kubectl_context(profile),
+            "command": _command_record(cluster_result),
+        },
+    )
+
+    namespace_file = writer.output_dir / "objects" / "namespace.yaml"
+    namespace_command = (
+        _kubectl_args(profile, ["apply", "-f", str(namespace_file)])
+        if apply_manifests
+        else _kubectl_args(profile, ["get", "namespace", profile.namespace])
+    )
+    namespace_result = run_command(namespace_command, "namespace readiness")
+    write_event(
+        "namespace.ready",
+        _status_from_command(namespace_result, planned_status="planned"),
+        "Namespace manifest rendered and readiness command recorded.",
+        {
+            "namespace": profile.namespace,
+            "manifest": "objects/namespace.yaml",
+            "command": _command_record(namespace_result),
+        },
+    )
+
+    tls_status = "passed" if tls_contract["ready"] else "not_validated"
+    if profile.appio_root_certificates_path is not None and not tls_contract["ready"]:
+        tls_status = "failed"
+        failures.append(
+            "TLS material path was configured but could not be read: "
+            f"{profile.appio_root_certificates_path}"
+        )
+    write_event(
+        "tls.material.ready",
+        tls_status,
+        "TLS material contract recorded without PEM content.",
+        tls_contract,
+    )
+
+    rbac_file = writer.output_dir / "objects" / "rbac.yaml"
+    rbac_result = CommandResult(args=[], returncode=0, dry_run=not execute)
+    if apply_manifests:
+        rbac_result = run_command(
+            _kubectl_args(profile, ["apply", "-f", str(rbac_file)]),
+            "RBAC manifest apply",
+        )
+    rbac_status = (
+        _status_from_command(rbac_result, planned_status="planned")
+        if apply_manifests
+        else "planned"
+    )
+    write_event(
+        "rbac.applied",
+        rbac_status,
+        "SuperExec RBAC manifests rendered and apply command recorded.",
+        {
+            "manifest": "objects/rbac.yaml",
+            "service_account": profile.superexec_service_account,
+            "command": _command_record(rbac_result) if rbac_result.args else None,
+        },
+    )
+
+    rbac_check = _run_rbac_checks(profile, runner, command_results)
+    if rbac_check["status"] == "failed":
+        failures.extend(str(failure) for failure in rbac_check["failures"])
+    write_event(
+        "rbac.negative_check",
+        str(rbac_check["status"]),
+        "RBAC positive and negative authorization checks recorded.",
+        rbac_check,
+    )
+
+    write_event(
+        "policy.not_validated_locally",
+        "not_validated",
+        "NetworkPolicy/CNI enforcement is not validated by F7b.",
+        {
+            "expected_cni": profile.expected_cni,
+            "reason": "F7b only proves infrastructure/TLS/RBAC readiness",
+        },
+    )
+
+    result = "infra-proof" if execute else "infra-proof-dry-run"
+    status = "failed" if failures else "passed"
+    write_event(
+        "harness.result",
+        status,
+        "F7b infrastructure proof evidence written.",
+        {"result": result, "failures": failures},
+    )
+    _write_command_log(writer, command_results)
+    writer.write_text("diagnostics/failures.txt", "\n".join(failures))
+    writer.write_text(
+        "harness.log",
+        (
+            f"F7b {result} wrote infra/TLS/RBAC evidence for "
+            f"namespace {profile.namespace}.\n"
+        ),
+    )
+
+    not_validated = [
+        "SuperLink AppIo",
+        "SuperExec task claim",
+        "TaskExecutor Pod launch",
+        "TaskExecutor AppIo connectivity",
+        "capacity wait proof",
+        "completed Pod and Secret cleanup proof",
+        "NetworkPolicy/CNI enforcement",
+    ]
+    if not execute:
+        not_validated.append("host command execution")
+    summary = HarnessSummary(
+        status=status,
+        result=result,
+        profile_name=profile.name,
+        output_dir=str(writer.output_dir),
+        started_at=started_at,
+        completed_at=_utc_now(),
+        namespace=profile.namespace,
+        resource_pool=profile.resource_pool,
+        event_count=writer.event_count,
+        failures=failures,
+        not_validated=not_validated,
+        details={
+            "run_id": run_id,
+            "dry_run": not execute,
+            "cluster_name": profile.cluster_name,
+            "kubectl_context": _kubectl_context(profile),
+            "tls": tls_contract,
+            "rbac": rbac_check,
+        },
+    )
+    writer.write_summary(summary)
+    return summary
+
+
+def render_namespace_manifest(profile: HarnessProfile) -> dict[str, object]:
+    """Render the namespace manifest for the optional local k3d proof."""
+    return {
+        "apiVersion": "v1",
+        "kind": "Namespace",
+        "metadata": {
+            "name": profile.namespace,
+            "labels": _harness_object_labels(profile),
+        },
+    }
+
+
+def render_superexec_rbac_manifests(
+    profile: HarnessProfile,
+) -> list[dict[str, object]]:
+    """Render minimal SuperExec ServiceAccount, Role, and RoleBinding objects."""
+    labels = _harness_object_labels(profile)
+    subject = {
+        "kind": "ServiceAccount",
+        "name": profile.superexec_service_account,
+        "namespace": profile.namespace,
+    }
+    return [
+        {
+            "apiVersion": "v1",
+            "kind": "ServiceAccount",
+            "metadata": {
+                "name": profile.superexec_service_account,
+                "namespace": profile.namespace,
+                "labels": labels,
+            },
+            "automountServiceAccountToken": True,
+        },
+        {
+            "apiVersion": "rbac.authorization.k8s.io/v1",
+            "kind": "Role",
+            "metadata": {
+                "name": profile.rbac_name,
+                "namespace": profile.namespace,
+                "labels": labels,
+            },
+            "rules": [
+                {
+                    "apiGroups": [""],
+                    "resources": ["pods", "secrets"],
+                    "verbs": ["get", "list", "watch", "create", "delete"],
+                }
+            ],
+        },
+        {
+            "apiVersion": "rbac.authorization.k8s.io/v1",
+            "kind": "RoleBinding",
+            "metadata": {
+                "name": profile.rbac_name,
+                "namespace": profile.namespace,
+                "labels": labels,
+            },
+            "subjects": [subject],
+            "roleRef": {
+                "apiGroup": "rbac.authorization.k8s.io",
+                "kind": "Role",
+                "name": profile.rbac_name,
+            },
+        },
+    ]
+
+
+def build_tls_material_contract(profile: HarnessProfile) -> dict[str, object]:
+    """Return sanitized TLS material evidence without storing PEM contents."""
+    path = (
+        Path(profile.appio_root_certificates_path).expanduser()
+        if profile.appio_root_certificates_path is not None
+        else None
+    )
+    ready = path is not None and path.is_file()
+    root_certificates: dict[str, object] = {
+        "source": "configured-path" if path is not None else "planned-test-ca",
+        "path": str(path) if path is not None else None,
+        "ready": ready,
+        "sha256": _sha256_file(path) if ready and path is not None else None,
+        "pem_redacted": True,
+    }
+    return {
+        "ready": ready,
+        "appio_tls_mode": profile.appio_tls_mode,
+        "secret_name": profile.tls_secret_name,
+        "root_certificates": root_certificates,
+        "taskexecutor_mount_path": "/run/flwr/appio/ca.crt",
+    }
 
 
 def redact_sensitive_data(value: object) -> object:
@@ -440,6 +829,179 @@ def _contains_pem(value: str) -> bool:
     return "-----BEGIN " in value and "-----END " in value
 
 
+def _kubectl_context(profile: HarnessProfile) -> str:
+    if profile.kubectl_context is not None:
+        return profile.kubectl_context
+    return f"k3d-{profile.cluster_name}"
+
+
+def _kubectl_args(profile: HarnessProfile, args: Sequence[str]) -> list[str]:
+    return ["kubectl", "--context", _kubectl_context(profile), *args]
+
+
+def _harness_object_labels(profile: HarnessProfile) -> dict[str, str]:
+    labels = dict(profile.labels)
+    labels["flower.ai/harness"] = "f7"
+    labels["flower.ai/profile"] = profile.name
+    labels["flower.ai/resource-pool"] = profile.resource_pool
+    return labels
+
+
+def _run_rbac_checks(
+    profile: HarnessProfile,
+    runner: HostCommandRunner,
+    command_results: list[CommandResult],
+) -> dict[str, object]:
+    subject = (
+        f"system:serviceaccount:{profile.namespace}:"
+        f"{profile.superexec_service_account}"
+    )
+    checks: list[dict[str, object]] = []
+    failures: list[str] = []
+    planned = False
+
+    for name, expect_allowed, args in _rbac_check_specs(profile, subject):
+        result = runner.run(args)
+        command_results.append(result)
+        if result.dry_run:
+            planned = True
+            check_status = "planned"
+            allowed: bool | None = None
+        else:
+            allowed = _is_yes_result(result)
+            check_status = "passed" if allowed is expect_allowed else "failed"
+            if check_status == "failed":
+                expectation = "allowed" if expect_allowed else "denied"
+                failures.append(f"{name} expected {expectation}.")
+        checks.append(
+            {
+                "name": name,
+                "expected_allowed": expect_allowed,
+                "allowed": allowed,
+                "status": check_status,
+                "command": _command_record(result),
+            }
+        )
+
+    if failures:
+        status = "failed"
+    elif planned:
+        status = "planned"
+    else:
+        status = "passed"
+    return {
+        "status": status,
+        "subject": subject,
+        "checks": checks,
+        "failures": failures,
+    }
+
+
+def _rbac_check_specs(
+    profile: HarnessProfile, subject: str
+) -> list[tuple[str, bool, list[str]]]:
+    namespace_args = ["--as", subject, "-n", profile.namespace]
+    return [
+        (
+            "can-create-pods",
+            True,
+            _kubectl_args(
+                profile, ["auth", "can-i", "create", "pods", *namespace_args]
+            ),
+        ),
+        (
+            "can-create-secrets",
+            True,
+            _kubectl_args(
+                profile, ["auth", "can-i", "create", "secrets", *namespace_args]
+            ),
+        ),
+        (
+            "can-list-pods",
+            True,
+            _kubectl_args(profile, ["auth", "can-i", "list", "pods", *namespace_args]),
+        ),
+        (
+            "can-delete-secrets",
+            True,
+            _kubectl_args(
+                profile, ["auth", "can-i", "delete", "secrets", *namespace_args]
+            ),
+        ),
+        (
+            "cannot-create-deployments",
+            False,
+            _kubectl_args(
+                profile,
+                ["auth", "can-i", "create", "deployments.apps", *namespace_args],
+            ),
+        ),
+        (
+            "cannot-read-nodes",
+            False,
+            _kubectl_args(profile, ["auth", "can-i", "get", "nodes", "--as", subject]),
+        ),
+    ]
+
+
+def _is_yes_result(result: CommandResult) -> bool:
+    if result.returncode != 0:
+        return False
+    return result.stdout.strip().lower().splitlines()[:1] == ["yes"]
+
+
+def _status_from_command(result: CommandResult, *, planned_status: str) -> str:
+    if result.dry_run:
+        return planned_status
+    if result.returncode == 0:
+        return "passed"
+    return "failed"
+
+
+def _command_record(result: CommandResult) -> dict[str, object]:
+    return {
+        "args": redact_command_args(result.args),
+        "command": _format_command(result.args),
+        "returncode": result.returncode,
+        "dry_run": result.dry_run,
+        "stdout": redact_text(result.stdout.strip()),
+        "stderr": redact_text(result.stderr.strip()),
+    }
+
+
+def _command_error(result: CommandResult) -> str:
+    stderr = redact_text(result.stderr.strip())
+    stdout = redact_text(result.stdout.strip())
+    detail = stderr or stdout or "no output"
+    return f"{_format_command(result.args)} exited {result.returncode}: {detail}"
+
+
+def _write_command_log(
+    writer: EvidenceBundleWriter, command_results: Sequence[CommandResult]
+) -> None:
+    lines: list[str] = []
+    if not command_results:
+        lines.append("No external commands were executed or planned.")
+    for result in command_results:
+        prefix = "DRY-RUN " if result.dry_run else ""
+        lines.append(f"{prefix}$ {_format_command(result.args)}")
+        if not result.dry_run:
+            lines.append(f"returncode: {result.returncode}")
+            if result.stdout.strip():
+                lines.append(f"stdout: {redact_text(result.stdout.strip())}")
+            if result.stderr.strip():
+                lines.append(f"stderr: {redact_text(result.stderr.strip())}")
+    writer.write_text("diagnostics/commands.txt", "\n".join(lines) + "\n")
+
+
+def _format_command(args: Sequence[str]) -> str:
+    return " ".join(shlex.quote(arg) for arg in redact_command_args(args))
+
+
+def _sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
 def _utc_now() -> str:
     return datetime.now(tz=UTC).isoformat(timespec="seconds").replace("+00:00", "Z")
 
@@ -447,11 +1009,21 @@ def _utc_now() -> str:
 def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=(
-            "Write the F7a integrated k3d harness contract scaffold. This does "
-            "not start k3d, Kubernetes, SuperLink, SuperExec, or TaskExecutor."
+            "Write F7 integrated k3d harness evidence. The default mode writes "
+            "the F7a contract scaffold; infra-proof mode writes F7b "
+            "infra/TLS/RBAC evidence and only runs host commands with "
+            "--execute."
         )
     )
     default_profile = generic_k3d_profile()
+    parser.add_argument(
+        "--mode",
+        choices=("contract-scaffold", "infra-proof"),
+        default="contract-scaffold",
+        help=(
+            "Write the F7a contract scaffold or the F7b infra/TLS/RBAC proof bundle."
+        ),
+    )
     parser.add_argument(
         "--output-dir",
         required=True,
@@ -462,6 +1034,16 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         choices=("generic-k3d",),
         default=default_profile.name,
         help="Harness profile sketch to write.",
+    )
+    parser.add_argument(
+        "--cluster-name",
+        default=default_profile.cluster_name,
+        help="k3d cluster name planned or used by infra-proof mode.",
+    )
+    parser.add_argument(
+        "--kubectl-context",
+        default=None,
+        help="kubectl context for infra-proof mode; defaults to k3d-<cluster>.",
     )
     parser.add_argument(
         "--namespace",
@@ -495,6 +1077,47 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         help="Future harness cleanup mode recorded in the profile sketch.",
     )
     parser.add_argument(
+        "--appio-root-certificates-path",
+        default=None,
+        help=(
+            "Optional local AppIo root certificate PEM path. The evidence "
+            "records only path and SHA-256, never PEM content."
+        ),
+    )
+    parser.add_argument(
+        "--tls-secret-name",
+        default=default_profile.tls_secret_name,
+        help="Planned local Kubernetes Secret name for AppIo root certificates.",
+    )
+    parser.add_argument(
+        "--superexec-service-account",
+        default=default_profile.superexec_service_account,
+        help="ServiceAccount name rendered for the SuperExec infra proof.",
+    )
+    parser.add_argument(
+        "--rbac-name",
+        default=default_profile.rbac_name,
+        help="Role and RoleBinding name rendered for the SuperExec infra proof.",
+    )
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help=(
+            "Run host k3d/kubectl commands in infra-proof mode. Without this, "
+            "commands are only recorded as dry-run evidence."
+        ),
+    )
+    parser.add_argument(
+        "--create-cluster",
+        action="store_true",
+        help="Create the k3d cluster if detection fails in infra-proof mode.",
+    )
+    parser.add_argument(
+        "--apply-manifests",
+        action="store_true",
+        help="Apply namespace and RBAC manifests in infra-proof mode.",
+    )
+    parser.add_argument(
         "--json",
         action="store_true",
         help="Emit compact JSON summary on stdout.",
@@ -505,12 +1128,18 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
 def _profile_from_args(args: argparse.Namespace) -> HarnessProfile:
     return HarnessProfile(
         name=args.profile,
+        cluster_name=args.cluster_name,
         namespace=args.namespace,
         resource_pool=args.resource_pool,
         image=args.image,
         image_pull_policy=args.image_pull_policy,
         timeout_seconds=args.timeout_seconds,
         cleanup_mode=args.cleanup_mode,
+        kubectl_context=args.kubectl_context,
+        appio_root_certificates_path=args.appio_root_certificates_path,
+        tls_secret_name=args.tls_secret_name,
+        superexec_service_account=args.superexec_service_account,
+        rbac_name=args.rbac_name,
         labels={
             "flower.ai/harness": "f7",
             "flower.ai/profile": args.profile,
@@ -519,12 +1148,21 @@ def _profile_from_args(args: argparse.Namespace) -> HarnessProfile:
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    """Write the F7a contract scaffold evidence bundle."""
+    """Write the requested F7 evidence bundle."""
     args = _parse_args(argv)
-    summary = run_contract_scaffold(
-        args.output_dir,
-        profile=_profile_from_args(args),
-    )
+    if args.mode == "infra-proof":
+        summary = run_infra_proof(
+            args.output_dir,
+            profile=_profile_from_args(args),
+            execute=args.execute,
+            create_cluster=args.create_cluster,
+            apply_manifests=args.apply_manifests,
+        )
+    else:
+        summary = run_contract_scaffold(
+            args.output_dir,
+            profile=_profile_from_args(args),
+        )
     if args.json:
         print(
             json.dumps(
@@ -534,8 +1172,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
         )
     else:
-        print(f"Wrote F7a harness contract bundle to {summary.output_dir}")
-    return 0
+        print(f"Wrote {summary.result} harness bundle to {summary.output_dir}")
+    return 0 if summary.status == "passed" else 1
 
 
 if __name__ == "__main__":

--- a/framework/dev/kubernetes_executor_smoke.py
+++ b/framework/dev/kubernetes_executor_smoke.py
@@ -1,0 +1,369 @@
+# Copyright 2026 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Dev-maintained in-cluster smoke script for the Kubernetes executor.
+
+This is not a stable ``flwr-*`` command. It uses the production in-cluster
+Kubernetes auth path, so run it inside a Kubernetes Pod with the optional
+``kubernetes`` Python package installed. The runner ServiceAccount needs scoped
+``pods`` and ``secrets`` list/create/delete permissions in the configured
+namespace.
+
+The smoke only proves config loading, client construction, RBAC/admission, and
+create/list/delete for executor-rendered Kubernetes objects. It does not require
+TaskExecutor completion or AppIo connectivity.
+
+Usage:
+    python dev/kubernetes_executor_smoke.py --executor-config executor.yaml
+    python dev/kubernetes_executor_smoke.py --executor-config executor.yaml --json
+"""
+
+# pylint: disable=protected-access
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import asdict, dataclass, field
+from textwrap import dedent
+from typing import Any
+from uuid import uuid4
+
+from flwr.supercore.constant import ExecutorType, TaskType
+from flwr.supercore.superexec.executor.config import load_executor_config
+from flwr.supercore.superexec.executor.factory import get_executor
+from flwr.supercore.superexec.executor.kubernetes_executor import (
+    KubernetesExecutor,
+    KubernetesExecutorConfig,
+    _build_appio_credentials_secret,
+    _build_taskexecutor_pod,
+    _label_selector,
+    _object_name,
+    _pod_items,
+    _raise_unless_not_found,
+    _secret_items,
+    _taskexecutor_pool_label_selector,
+)
+from flwr.supercore.superexec.executor.types import ExecutionSpec
+
+_SMOKE_LABEL = "flower.ai/smoke-run"
+_SMOKE_TOKEN = "flower-kubernetes-executor-smoke-token"
+
+
+@dataclass
+class SmokeSummary:
+    """Machine-readable summary for one smoke run."""
+
+    status: str
+    config_path: str
+    smoke_run: str
+    namespace: str | None = None
+    resource_pool: str | None = None
+    pool_selector: str | None = None
+    smoke_selector: str | None = None
+    secret_name: str | None = None
+    pod_name: str | None = None
+    secret_created: bool = False
+    pod_created: bool = False
+    secret_visible: bool = False
+    pod_visible: bool = False
+    secret_deleted: bool = False
+    pod_deleted: bool = False
+    cleanup_errors: list[str] = field(default_factory=list)
+    error: str | None = None
+
+
+def run_smoke(
+    executor_config_path: str,
+    *,
+    smoke_run: str | None = None,
+    log: Callable[[str], None] = print,
+) -> SmokeSummary:
+    """Run a bounded Kubernetes executor smoke check."""
+    smoke_run = smoke_run or f"smoke-{uuid4().hex[:12]}"
+    summary = SmokeSummary(
+        status="failed",
+        config_path=executor_config_path,
+        smoke_run=smoke_run,
+    )
+    client: Any | None = None
+    config: KubernetesExecutorConfig | None = None
+
+    try:
+        log(f"Loading executor config: {executor_config_path}")
+        executor_config = load_executor_config(
+            executor_config_path, ExecutorType.KUBERNETES
+        )
+        executor_config = _executor_config_with_smoke_label(executor_config, smoke_run)
+
+        log("Constructing Kubernetes executor with in-cluster client")
+        executor = get_executor(
+            ExecutorType.KUBERNETES, executor_config=executor_config
+        )
+        if not isinstance(executor, KubernetesExecutor):
+            raise RuntimeError("Factory did not return a KubernetesExecutor.")
+
+        client = executor._client
+        config = executor._config
+        summary.namespace = config.namespace
+        summary.resource_pool = config.resource_pool
+        summary.pool_selector = _taskexecutor_pool_label_selector(config)
+        summary.smoke_selector = _label_selector({_SMOKE_LABEL: smoke_run})
+
+        log(f"Namespace: {config.namespace}")
+        log(f"Resource pool: {config.resource_pool or '<none>'}")
+        log(f"Pool selector: {summary.pool_selector}")
+        log(f"Smoke selector: {summary.smoke_selector}")
+
+        _check_scoped_list_access(client, config, summary, log)
+        _create_smoke_objects(client, config, smoke_run, summary, log)
+        _check_created_objects_visible(client, config, summary, log)
+        summary.status = "passed"
+        log("Kubernetes executor smoke passed")
+    except Exception as err:  # pylint: disable=broad-exception-caught
+        summary.status = "failed"
+        summary.error = _safe_error_message(err)
+        log(f"Kubernetes executor smoke failed: {summary.error}")
+    finally:
+        if client is not None and config is not None:
+            _cleanup_created_objects(client, config, summary, log)
+
+    if summary.cleanup_errors and summary.status == "passed":
+        summary.status = "failed"
+        summary.error = "Cleanup failed for one or more smoke objects."
+    return summary
+
+
+def _executor_config_with_smoke_label(
+    executor_config: dict[object, object], smoke_run: str
+) -> dict[object, object]:
+    """Return executor config with a unique per-run smoke label."""
+    updated_config = dict(executor_config)
+    labels = updated_config.get("labels")
+    if labels is None:
+        updated_labels: dict[object, object] = {}
+    elif isinstance(labels, Mapping):
+        updated_labels = dict(labels)
+    else:
+        raise ValueError("Kubernetes executor config field 'labels' must be a mapping.")
+    updated_labels[_SMOKE_LABEL] = smoke_run
+    updated_config["labels"] = updated_labels
+    return updated_config
+
+
+def _check_scoped_list_access(
+    client: Any,
+    config: KubernetesExecutorConfig,
+    summary: SmokeSummary,
+    log: Callable[[str], None],
+) -> None:
+    """Check scoped Pod and Secret list access before creating objects."""
+    if summary.smoke_selector is None:
+        raise RuntimeError("Smoke selector was not initialized.")
+    log("Checking scoped Pod and Secret list access")
+    client.list_namespaced_pod(
+        config.namespace,
+        label_selector=summary.smoke_selector,
+    )
+    client.list_namespaced_secret(
+        config.namespace,
+        label_selector=summary.smoke_selector,
+    )
+
+
+def _create_smoke_objects(
+    client: Any,
+    config: KubernetesExecutorConfig,
+    smoke_run: str,
+    summary: SmokeSummary,
+    log: Callable[[str], None],
+) -> None:
+    """Create one smoke Secret and Pod using executor object rendering."""
+    spec = ExecutionSpec(
+        task_type=TaskType.SERVER_APP,
+        appio_api_address="127.0.0.1:9091",
+        token=_SMOKE_TOKEN,
+        insecure=True,
+        root_certificates_path=None,
+        runtime_dependency_install=False,
+        parent_pid=None,
+        suppress_output=True,
+        task_id=1,
+    )
+    secret = _build_appio_credentials_secret(
+        spec=spec,
+        config=config,
+        appio_root_certificates=None,
+        launch_attempt_id=smoke_run,
+    )
+    pod = _build_taskexecutor_pod(
+        spec=spec,
+        config=config,
+        appio_root_certificates=None,
+        launch_attempt_id=smoke_run,
+    )
+    secret_name = _metadata_name(secret)
+    pod_name = _metadata_name(pod)
+    summary.secret_name = secret_name
+    summary.pod_name = pod_name
+
+    log(f"Creating smoke Secret: {secret_name}")
+    client.create_namespaced_secret(config.namespace, secret)
+    summary.secret_created = True
+
+    log(f"Creating smoke Pod: {pod_name}")
+    client.create_namespaced_pod(config.namespace, pod)
+    summary.pod_created = True
+
+
+def _check_created_objects_visible(
+    client: Any,
+    config: KubernetesExecutorConfig,
+    summary: SmokeSummary,
+    log: Callable[[str], None],
+) -> None:
+    """Check that created smoke objects are visible through the scoped selector."""
+    if summary.smoke_selector is None:
+        raise RuntimeError("Smoke selector was not initialized.")
+    log("Checking created objects through scoped selectors")
+    pods = _pod_items(
+        client.list_namespaced_pod(
+            config.namespace,
+            label_selector=summary.smoke_selector,
+        )
+    )
+    secrets = _secret_items(
+        client.list_namespaced_secret(
+            config.namespace,
+            label_selector=summary.smoke_selector,
+        )
+    )
+    summary.pod_visible = summary.pod_name in {_object_name(pod) for pod in pods}
+    summary.secret_visible = summary.secret_name in {
+        _object_name(secret) for secret in secrets
+    }
+    if not summary.pod_visible or not summary.secret_visible:
+        raise RuntimeError("Created smoke objects were not visible through selector.")
+
+
+def _cleanup_created_objects(
+    client: Any,
+    config: KubernetesExecutorConfig,
+    summary: SmokeSummary,
+    log: Callable[[str], None],
+) -> None:
+    """Delete smoke objects created by this run."""
+    if summary.pod_created and summary.pod_name is not None:
+        log(f"Deleting smoke Pod: {summary.pod_name}")
+        try:
+            client.delete_namespaced_pod(
+                name=summary.pod_name,
+                namespace=config.namespace,
+                grace_period_seconds=0,
+            )
+            summary.pod_deleted = True
+        except Exception as err:  # pylint: disable=broad-exception-caught
+            try:
+                _raise_unless_not_found(err)
+            except Exception as cleanup_err:  # pylint: disable=broad-exception-caught
+                message = _safe_error_message(cleanup_err)
+                summary.cleanup_errors.append(f"Pod {summary.pod_name}: {message}")
+                log(f"Failed to delete smoke Pod {summary.pod_name}: {message}")
+            else:
+                summary.pod_deleted = True
+
+    if summary.secret_created and summary.secret_name is not None:
+        log(f"Deleting smoke Secret: {summary.secret_name}")
+        try:
+            client.delete_namespaced_secret(
+                name=summary.secret_name,
+                namespace=config.namespace,
+            )
+            summary.secret_deleted = True
+        except Exception as err:  # pylint: disable=broad-exception-caught
+            try:
+                _raise_unless_not_found(err)
+            except Exception as cleanup_err:  # pylint: disable=broad-exception-caught
+                message = _safe_error_message(cleanup_err)
+                summary.cleanup_errors.append(
+                    f"Secret {summary.secret_name}: {message}"
+                )
+                log(f"Failed to delete smoke Secret {summary.secret_name}: {message}")
+            else:
+                summary.secret_deleted = True
+
+
+def _metadata_name(value: object) -> str:
+    """Return a Kubernetes object metadata name or fail clearly."""
+    name = _object_name(value)
+    if name is None:
+        raise RuntimeError("Rendered Kubernetes object is missing metadata.name.")
+    return name
+
+
+def _safe_error_message(err: Exception) -> str:
+    """Return a redacted error message safe for smoke output."""
+    return f"{type(err).__name__}: {str(err).replace(_SMOKE_TOKEN, '<redacted>')}"
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Smoke-test Kubernetes executor config and scoped API access from "
+            "inside a Kubernetes Pod."
+        ),
+        epilog=dedent(
+            """
+            This dev-maintained script is not a stable flwr-* command. It uses
+            production in-cluster auth, requires the optional kubernetes Python
+            package, and needs runner ServiceAccount permissions to list,
+            create, and delete Pods and Secrets in the configured namespace.
+            It proves executor config/client/RBAC/admission/create/list/delete
+            only; TaskExecutor completion and AppIo connectivity are out of
+            scope.
+            """
+        ).strip(),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--executor-config",
+        required=True,
+        help="Path to the trusted Kubernetes executor YAML config.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit compact JSON summary on stdout; human logs go to stderr.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the Kubernetes executor smoke script."""
+    args = _parse_args(argv)
+    log_stream = sys.stderr if args.json else sys.stdout
+    summary = run_smoke(
+        args.executor_config,
+        log=lambda message: print(message, file=log_stream),
+    )
+    if args.json:
+        print(json.dumps(asdict(summary), sort_keys=True, separators=(",", ":")))
+    return 0 if summary.status == "passed" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/framework/docs/source/ref-exit-codes/402.rst
+++ b/framework/docs/source/ref-exit-codes/402.rst
@@ -6,14 +6,15 @@
  Description
 *************
 
-The SuperExec executor configuration could not be loaded, parsed, or applied for the
-selected executor.
+The SuperExec executor could not be selected, or its configuration could not be loaded,
+parsed, or applied.
 
 ****************
  How to Resolve
 ****************
 
-1. Confirm that the ``--executor-config`` path exists and is readable.
-2. Ensure the file is valid YAML.
-3. Ensure the YAML document is a mapping.
-4. Review the accompanying error message for the exact load or parse failure.
+1. Confirm that the selected ``--executor`` is supported by the running Flower version.
+2. Confirm that the ``--executor-config`` path exists and is readable.
+3. Ensure the file is valid YAML.
+4. Ensure the YAML document is a mapping.
+5. Review the accompanying error message for the exact failure.

--- a/framework/docs/source/ref-exit-codes/402.rst
+++ b/framework/docs/source/ref-exit-codes/402.rst
@@ -1,0 +1,19 @@
+#########################################
+ [402] SUPEREXEC_INVALID_EXECUTOR_CONFIG
+#########################################
+
+*************
+ Description
+*************
+
+The SuperExec executor configuration could not be loaded, parsed, or applied for the
+selected executor.
+
+****************
+ How to Resolve
+****************
+
+1. Confirm that the ``--executor-config`` path exists and is readable.
+2. Ensure the file is valid YAML.
+3. Ensure the YAML document is a mapping.
+4. Review the accompanying error message for the exact load or parse failure.

--- a/framework/py/flwr/common/exit/exit_code.py
+++ b/framework/py/flwr/common/exit/exit_code.py
@@ -161,7 +161,7 @@ EXIT_CODE_HELP = {
         "Failed to load the SuperExec authentication secret."
     ),
     ExitCode.SUPEREXEC_INVALID_EXECUTOR_CONFIG: (
-        "Failed to load or apply the SuperExec executor configuration."
+        "Failed to select, load, or apply the SuperExec executor configuration."
     ),
     # FlowerCLI-specific exit codes (500-599)
     ExitCode.FLWRCLI_NODE_AUTH_PUBLIC_KEY_INVALID: (

--- a/framework/py/flwr/common/exit/exit_code.py
+++ b/framework/py/flwr/common/exit/exit_code.py
@@ -54,6 +54,7 @@ class ExitCode:
     # SuperExec-specific exit codes (400-499)
     SUPEREXEC_INVALID_PLUGIN_CONFIG = 400
     SUPEREXEC_AUTH_SECRET_LOAD_FAILED = 401
+    SUPEREXEC_INVALID_EXECUTOR_CONFIG = 402
 
     # FlowerCLI-specific exit codes (500-599)
     FLWRCLI_NODE_AUTH_PUBLIC_KEY_INVALID = 500
@@ -158,6 +159,9 @@ EXIT_CODE_HELP = {
     ),
     ExitCode.SUPEREXEC_AUTH_SECRET_LOAD_FAILED: (
         "Failed to load the SuperExec authentication secret."
+    ),
+    ExitCode.SUPEREXEC_INVALID_EXECUTOR_CONFIG: (
+        "Failed to load or apply the SuperExec executor configuration."
     ),
     # FlowerCLI-specific exit codes (500-599)
     ExitCode.FLWRCLI_NODE_AUTH_PUBLIC_KEY_INVALID: (

--- a/framework/py/flwr/supercore/cli/flower_superexec.py
+++ b/framework/py/flwr/supercore/cli/flower_superexec.py
@@ -35,6 +35,11 @@ from flwr.supercore.auth import (
 )
 from flwr.supercore.constant import EXEC_PLUGIN_SECTION, ExecutorType
 from flwr.supercore.grpc_health import add_args_health
+from flwr.supercore.superexec.executor.config import (
+    ExecutorConfig,
+    ExecutorConfigError,
+    load_executor_config,
+)
 from flwr.supercore.superexec.plugin import (
     ClientAppExecPlugin,
     ExecPlugin,
@@ -72,6 +77,10 @@ def flower_superexec() -> None:
                 ExitCode.SUPEREXEC_INVALID_PLUGIN_CONFIG,
                 f"Failed to load plugin config from '{plugin_config_path}': {e!r}",
             )
+
+    executor_config = _load_executor_config(
+        getattr(args, "executor_config", None), args.executor
+    )
 
     # Get the plugin class and stub class based on the plugin type
     if args.plugin_type == ExecPluginType.SIMULATION:
@@ -128,6 +137,7 @@ def flower_superexec() -> None:
         health_server_address=args.health_server_address,
         runtime_dependency_install=args.runtime_dependency_install,
         executor_type=args.executor,
+        executor_config=executor_config,
     )
 
 
@@ -181,10 +191,29 @@ def _parse_args() -> argparse.ArgumentParser:
         help="The executor used to run task processes, for example as local "
         "subprocesses.",
     )
+    parser.add_argument(
+        "--executor-config",
+        metavar="PATH",
+        type=str,
+        help="Path to a YAML config file for the selected executor.",
+    )
     add_superexec_auth_secret_args(parser)
     add_args_health(parser)
     add_args_runtime_dependency_install(parser)
     return parser
+
+
+def _load_executor_config(
+    executor_config_path: str | None, executor_type: ExecutorType
+) -> ExecutorConfig | None:
+    """Load executor config from a YAML file if needed."""
+    if executor_config_path is None:
+        return None
+
+    try:
+        return load_executor_config(executor_config_path, executor_type)
+    except ExecutorConfigError as err:
+        flwr_exit(ExitCode.SUPEREXEC_INVALID_EXECUTOR_CONFIG, str(err))
 
 
 def _get_plugin_and_stub_class(

--- a/framework/py/flwr/supercore/cli/flower_superexec_test.py
+++ b/framework/py/flwr/supercore/cli/flower_superexec_test.py
@@ -45,6 +45,25 @@ def test_parse_superexec_version_flag(
     assert captured.out == f"Flower version: {package_version}\n"
 
 
+def test_parse_superexec_accepts_kubernetes_executor_config() -> None:
+    """SuperExec should accept Kubernetes executor selection and config path."""
+    args = _parse_args().parse_args(
+        [
+            "--appio-api-address",
+            "127.0.0.1:9091",
+            "--plugin-type",
+            ExecPluginType.CLIENT_APP,
+            "--executor",
+            "kubernetes",
+            "--executor-config",
+            "executor.yaml",
+        ]
+    )
+
+    assert args.executor == ExecutorType.KUBERNETES
+    assert args.executor_config == "executor.yaml"
+
+
 def test_flower_superexec_checks_for_update(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -214,3 +233,4 @@ def test_flower_superexec_passes_executor_to_run_superexec(
     assert (
         run_superexec_mock.call_args.kwargs["executor_type"] == ExecutorType.SUBPROCESS
     )
+    assert run_superexec_mock.call_args.kwargs["executor_config"] is None

--- a/framework/py/flwr/supercore/constant.py
+++ b/framework/py/flwr/supercore/constant.py
@@ -198,6 +198,7 @@ class ExecutorType(StrEnum):
     """Supported SuperExec executor types."""
 
     SUBPROCESS = "subprocess"
+    KUBERNETES = "kubernetes"
 
 
 class TaskType(StrEnum):

--- a/framework/py/flwr/supercore/superexec/executor/__init__.py
+++ b/framework/py/flwr/supercore/superexec/executor/__init__.py
@@ -15,7 +15,11 @@
 """Executor abstractions and implementations for SuperExec."""
 
 from .factory import get_executor
-from .kubernetes_executor import KubernetesExecutor, KubernetesExecutorConfig
+from .kubernetes_executor import (
+    KubernetesExecutor,
+    KubernetesExecutorConfig,
+    create_incluster_kubernetes_client,
+)
 from .subprocess_executor import SubprocessExecutor
 from .types import ExecutionSpec, Executor, LaunchResult, LaunchResultStatus
 
@@ -27,5 +31,6 @@ __all__ = [
     "LaunchResult",
     "LaunchResultStatus",
     "SubprocessExecutor",
+    "create_incluster_kubernetes_client",
     "get_executor",
 ]

--- a/framework/py/flwr/supercore/superexec/executor/config.py
+++ b/framework/py/flwr/supercore/superexec/executor/config.py
@@ -23,7 +23,7 @@ import yaml
 
 from flwr.supercore.constant import ExecutorType
 
-ExecutorConfig = dict[str, object]
+ExecutorConfig = dict[object, object]
 
 
 class ExecutorConfigError(ValueError):

--- a/framework/py/flwr/supercore/superexec/executor/config.py
+++ b/framework/py/flwr/supercore/superexec/executor/config.py
@@ -1,0 +1,79 @@
+# Copyright 2026 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Executor config loading for SuperExec."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+
+import yaml
+
+from flwr.supercore.constant import ExecutorType
+
+ExecutorConfig = dict[str, object]
+
+
+class ExecutorConfigError(ValueError):
+    """Raised when executor config loading fails."""
+
+    def __init__(self, path: str | None, errors: Sequence[str]) -> None:
+        message = "Failed to load executor config"
+        if path is not None:
+            message += f" from '{path}'"
+        bullets = "\n".join(f"- {error}" for error in errors)
+        super().__init__(f"{message}:\n{bullets}")
+
+
+def load_executor_config(path: str, executor_type: ExecutorType) -> ExecutorConfig:
+    """Load executor config for the selected executor."""
+    if executor_type == ExecutorType.SUBPROCESS:
+        raise ExecutorConfigError(
+            path,
+            ["subprocess executor does not support --executor-config."],
+        )
+    raw_config = _load_yaml(path)
+    if raw_config is None:
+        raise ExecutorConfigError(path, ["file must not be empty."])
+    if not isinstance(raw_config, Mapping):
+        raise ExecutorConfigError(path, ["root must be a mapping."])
+
+    return dict(raw_config)
+
+
+def _load_yaml(path: str) -> object:
+    try:
+        with open(Path(path).expanduser(), encoding="utf-8") as file:
+            return yaml.safe_load(file)
+    except FileNotFoundError as exc:
+        raise ExecutorConfigError(path, ["file does not exist."]) from exc
+    except OSError as exc:
+        message = exc.strerror or str(exc)
+        raise ExecutorConfigError(
+            path, [f"file could not be read: {message}."]
+        ) from exc
+    except yaml.YAMLError as exc:
+        raise ExecutorConfigError(path, [_yaml_error_message(exc)]) from exc
+
+
+def _yaml_error_message(exc: yaml.YAMLError) -> str:
+    problem = getattr(exc, "problem", None)
+    mark = getattr(exc, "problem_mark", None)
+    if problem is not None and mark is not None:
+        return (
+            "file must contain valid YAML near "
+            f"line {mark.line + 1}, column {mark.column + 1}: {problem}."
+        )
+    return "file must contain valid YAML."

--- a/framework/py/flwr/supercore/superexec/executor/config_test.py
+++ b/framework/py/flwr/supercore/superexec/executor/config_test.py
@@ -1,0 +1,50 @@
+# Copyright 2026 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for SuperExec executor config parsing."""
+
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from flwr.supercore.constant import ExecutorType
+
+from .config import ExecutorConfigError, load_executor_config
+
+
+def _write_yaml(path: Path, content: str) -> None:
+    path.write_text(dedent(content).strip() + "\n", encoding="utf-8")
+
+
+def test_load_executor_config_rejects_subprocess_config(tmp_path: Path) -> None:
+    """Test subprocess executor config is rejected rather than ignored."""
+    config_path = tmp_path / "executor.yaml"
+    _write_yaml(config_path, "kubernetes: {}")
+
+    with pytest.raises(ExecutorConfigError) as exc_info:
+        load_executor_config(str(config_path), ExecutorType.SUBPROCESS)
+
+    assert "subprocess executor does not support --executor-config" in str(
+        exc_info.value
+    )
+
+
+def test_load_executor_config_rejects_empty_yaml(tmp_path: Path) -> None:
+    """Test empty YAML files are invalid."""
+    config_path = tmp_path / "executor.yaml"
+    config_path.write_text("", encoding="utf-8")
+
+    with pytest.raises(ExecutorConfigError, match="file must not be empty"):
+        load_executor_config(str(config_path), ExecutorType.KUBERNETES)

--- a/framework/py/flwr/supercore/superexec/executor/factory.py
+++ b/framework/py/flwr/supercore/superexec/executor/factory.py
@@ -14,15 +14,108 @@
 # ==============================================================================
 """Executor factory for SuperExec TaskExecutor processes."""
 
+from pathlib import Path
+from typing import Any
+
 from flwr.supercore.constant import ExecutorType
 
+from .config import ExecutorConfig
+from .kubernetes_executor import (
+    KubernetesExecutor,
+    KubernetesExecutorConfig,
+    create_incluster_kubernetes_client,
+)
 from .subprocess_executor import SubprocessExecutor
 from .types import Executor
 
 
-def get_executor(executor_type: ExecutorType) -> Executor:
+_KUBERNETES_CONFIG_FIELD_MAP = {
+    "image-pull-policy": "image_pull_policy",
+    "resource-pool": "resource_pool",
+    "active-pod-budget": "active_pod_budget",
+    "capacity-poll-interval": "capacity_poll_interval",
+    "capacity-log-interval": "capacity_log_interval",
+    "labels": "labels",
+    "annotations": "annotations",
+    "resources": "resources",
+    "node-selector": "node_selector",
+    "tolerations": "tolerations",
+    "affinity": "affinity",
+    "priority-class-name": "priority_class_name",
+    "pod-security-context": "pod_security_context",
+    "container-security-context": "container_security_context",
+    "service-account-name": "service_account_name",
+}
+
+
+def get_executor(
+    executor_type: ExecutorType, executor_config: ExecutorConfig | None = None
+) -> Executor:
     """Return the executor for the configured executor type."""
     if executor_type == ExecutorType.SUBPROCESS:
         return SubprocessExecutor()
 
+    if executor_type == ExecutorType.KUBERNETES:
+        if executor_config is None:
+            raise ValueError("Kubernetes executor requires --executor-config.")
+        config = _kubernetes_executor_config_from_mapping(executor_config)
+        try:
+            client = create_incluster_kubernetes_client()
+        except RuntimeError as err:
+            raise ValueError(str(err)) from err
+        return KubernetesExecutor(
+            client=client,
+            config=config,
+        )
+
     raise ValueError(f"Unsupported executor selection: {executor_type.value}")
+
+
+def _kubernetes_executor_config_from_mapping(
+    config: ExecutorConfig,
+) -> KubernetesExecutorConfig:
+    """Build Kubernetes executor config from the trusted root mapping."""
+    namespace = _required_nonempty_string(config, "namespace")
+    image = _required_nonempty_string(config, "image")
+    kwargs: dict[str, Any] = {
+        "namespace": namespace,
+        "image": image,
+    }
+
+    for config_key, field_name in _KUBERNETES_CONFIG_FIELD_MAP.items():
+        if config_key in config:
+            kwargs[field_name] = config[config_key]
+
+    if "appio-root-certificates-path" in config:
+        kwargs["appio_root_certificates"] = _read_appio_root_certificates(
+            config["appio-root-certificates-path"]
+        )
+
+    return KubernetesExecutorConfig(**kwargs)
+
+
+def _required_nonempty_string(config: ExecutorConfig, field_name: str) -> str:
+    """Return a required string field or raise a clear construction error."""
+    value = config.get(field_name)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(
+            f"Kubernetes executor config requires non-empty '{field_name}'."
+        )
+    return value
+
+
+def _read_appio_root_certificates(path_value: object) -> str:
+    """Read AppIo root certificate PEM data from the configured path."""
+    if not isinstance(path_value, str) or not path_value.strip():
+        raise ValueError(
+            "Kubernetes executor config field 'appio-root-certificates-path' "
+            "must be a non-empty path."
+        )
+    try:
+        return Path(path_value).expanduser().read_text(encoding="utf-8")
+    except OSError as err:
+        message = err.strerror or str(err)
+        raise ValueError(
+            "Failed to read Kubernetes executor config field "
+            f"'appio-root-certificates-path' from '{path_value}': {message}."
+        ) from err

--- a/framework/py/flwr/supercore/superexec/executor/factory.py
+++ b/framework/py/flwr/supercore/superexec/executor/factory.py
@@ -25,4 +25,4 @@ def get_executor(executor_type: ExecutorType) -> Executor:
     if executor_type == ExecutorType.SUBPROCESS:
         return SubprocessExecutor()
 
-    raise ValueError(f"Unsupported executor: {executor_type}")
+    raise ValueError(f"Unsupported executor selection: {executor_type.value}")

--- a/framework/py/flwr/supercore/superexec/executor/factory.py
+++ b/framework/py/flwr/supercore/superexec/executor/factory.py
@@ -28,7 +28,6 @@ from .kubernetes_executor import (
 from .subprocess_executor import SubprocessExecutor
 from .types import Executor
 
-
 _KUBERNETES_CONFIG_FIELD_MAP = {
     "image-pull-policy": "image_pull_policy",
     "resource-pool": "resource_pool",

--- a/framework/py/flwr/supercore/superexec/executor/factory_test.py
+++ b/framework/py/flwr/supercore/superexec/executor/factory_test.py
@@ -1,0 +1,163 @@
+# Copyright 2026 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for SuperExec executor factory."""
+
+# pylint: disable=protected-access
+
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from flwr.supercore.constant import ExecutorType
+
+from . import factory as factory_module
+from .factory import get_executor
+from .kubernetes_executor import KubernetesExecutor
+from .subprocess_executor import SubprocessExecutor
+
+
+def test_get_executor_returns_subprocess_executor_by_default() -> None:
+    """Test subprocess selection preserves the default executor."""
+    executor = get_executor(ExecutorType.SUBPROCESS)
+
+    assert isinstance(executor, SubprocessExecutor)
+
+
+def test_get_executor_requires_kubernetes_config() -> None:
+    """Test Kubernetes selection requires executor config."""
+    with pytest.raises(ValueError, match="requires --executor-config"):
+        get_executor(ExecutorType.KUBERNETES)
+
+
+def test_get_executor_builds_kubernetes_executor_from_config(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Test Kubernetes config fields are mapped into executor construction."""
+    root_certificates_path = tmp_path / "ca.pem"
+    root_certificates_path.write_text("root-ca", encoding="utf-8")
+    client = Mock()
+    create_client = Mock(return_value=client)
+    monkeypatch.setattr(
+        factory_module, "create_incluster_kubernetes_client", create_client
+    )
+
+    executor = get_executor(
+        ExecutorType.KUBERNETES,
+        executor_config={
+            "namespace": "flower-system",
+            "image": "ghcr.io/flwrlabs/taskexecutor:dev",
+            "image-pull-policy": "IfNotPresent",
+            "resource-pool": "gpu-pool",
+            "active-pod-budget": 5,
+            "capacity-poll-interval": 0.25,
+            "capacity-log-interval": 30.0,
+            "appio-root-certificates-path": str(root_certificates_path),
+            "labels": {"flower.ai/deployment": "dev"},
+            "annotations": {"flower.ai/owner": "superexec"},
+            "resources": {"requests": {"cpu": "1"}},
+            "node-selector": {"kubernetes.io/os": "linux"},
+            "tolerations": [{"key": "dedicated", "operator": "Exists"}],
+            "affinity": {"podAntiAffinity": {}},
+            "priority-class-name": "high-priority",
+            "pod-security-context": {"runAsNonRoot": True},
+            "container-security-context": {"allowPrivilegeEscalation": False},
+            "service-account-name": "taskexecutor",
+            "unknown-field": "ignored",
+        },
+    )
+
+    assert isinstance(executor, KubernetesExecutor)
+    assert executor._client is client
+    config = executor._config
+    assert config.namespace == "flower-system"
+    assert config.image == "ghcr.io/flwrlabs/taskexecutor:dev"
+    assert config.image_pull_policy == "IfNotPresent"
+    assert config.resource_pool == "gpu-pool"
+    assert config.active_pod_budget == 5
+    assert config.capacity_poll_interval == 0.25
+    assert config.capacity_log_interval == 30.0
+    assert config.appio_root_certificates == "root-ca"
+    assert config.labels == {"flower.ai/deployment": "dev"}
+    assert config.annotations == {"flower.ai/owner": "superexec"}
+    assert config.resources == {"requests": {"cpu": "1"}}
+    assert config.node_selector == {"kubernetes.io/os": "linux"}
+    assert config.tolerations == [{"key": "dedicated", "operator": "Exists"}]
+    assert config.affinity == {"podAntiAffinity": {}}
+    assert config.priority_class_name == "high-priority"
+    assert config.pod_security_context == {"runAsNonRoot": True}
+    assert config.container_security_context == {"allowPrivilegeEscalation": False}
+    assert config.service_account_name == "taskexecutor"
+    assert not hasattr(config, "unknown_field")
+    create_client.assert_called_once_with()
+
+
+@pytest.mark.parametrize("field_name", ["namespace", "image"])
+def test_get_executor_rejects_missing_required_kubernetes_field(
+    field_name: str,
+) -> None:
+    """Test required Kubernetes construction fields fail clearly."""
+    executor_config: dict[object, object] = {
+        "namespace": "flower-system",
+        "image": "ghcr.io/flwrlabs/taskexecutor:dev",
+    }
+    del executor_config[field_name]
+
+    with pytest.raises(ValueError, match=f"'{field_name}'"):
+        get_executor(ExecutorType.KUBERNETES, executor_config=executor_config)
+
+
+def test_get_executor_rejects_unreadable_appio_root_certificates_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Test AppIo root certificate load failures do not reach client
+    creation."""
+    create_client = Mock()
+    monkeypatch.setattr(
+        factory_module, "create_incluster_kubernetes_client", create_client
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        get_executor(
+            ExecutorType.KUBERNETES,
+            executor_config={
+                "namespace": "flower-system",
+                "image": "ghcr.io/flwrlabs/taskexecutor:dev",
+                "appio-root-certificates-path": str(tmp_path / "missing-ca.pem"),
+            },
+        )
+
+    assert "appio-root-certificates-path" in str(exc_info.value)
+    create_client.assert_not_called()
+
+
+def test_get_executor_wraps_kubernetes_client_construction_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test Kubernetes dependency/auth failures surface as config failures."""
+    monkeypatch.setattr(
+        factory_module,
+        "create_incluster_kubernetes_client",
+        Mock(side_effect=RuntimeError("in-cluster auth unavailable")),
+    )
+
+    with pytest.raises(ValueError, match="in-cluster auth unavailable"):
+        get_executor(
+            ExecutorType.KUBERNETES,
+            executor_config={
+                "namespace": "flower-system",
+                "image": "ghcr.io/flwrlabs/taskexecutor:dev",
+            },
+        )

--- a/framework/py/flwr/supercore/superexec/executor/kubernetes_executor.py
+++ b/framework/py/flwr/supercore/superexec/executor/kubernetes_executor.py
@@ -14,12 +14,13 @@
 # ==============================================================================
 """Kubernetes executor for SuperExec TaskExecutor processes."""
 
+import importlib
 import time
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from logging import INFO, WARNING
 from pathlib import Path
-from typing import Protocol, cast
+from typing import Any, Protocol, cast
 from uuid import uuid4
 
 from flwr.common.logger import log
@@ -72,6 +73,34 @@ class KubernetesClient(Protocol):
         self, namespace: str, label_selector: str
     ) -> KubernetesList:
         """List Kubernetes Pods in the selected namespace."""
+
+
+def create_incluster_kubernetes_client() -> KubernetesClient:
+    """Create a KubernetesClient backed by in-cluster ServiceAccount auth."""
+    try:
+        kubernetes_client = importlib.import_module("kubernetes.client")
+        kubernetes_config = importlib.import_module("kubernetes.config")
+    except ModuleNotFoundError as exc:
+        if exc.name == "kubernetes" or (
+            exc.name is not None and exc.name.startswith("kubernetes.")
+        ):
+            raise RuntimeError(
+                "Kubernetes Python client package is required for the Kubernetes "
+                "executor. Install the official 'kubernetes' package in the "
+                "SuperExec environment."
+            ) from exc
+        raise
+
+    try:
+        cast(Any, kubernetes_config).load_incluster_config()
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        raise RuntimeError(
+            "Failed to load in-cluster Kubernetes configuration for the Kubernetes "
+            "executor. Run SuperExec in a Kubernetes Pod with ServiceAccount "
+            "credentials."
+        ) from exc
+
+    return cast(KubernetesClient, cast(Any, kubernetes_client).CoreV1Api())
 
 
 @dataclass

--- a/framework/py/flwr/supercore/superexec/executor/kubernetes_executor.py
+++ b/framework/py/flwr/supercore/superexec/executor/kubernetes_executor.py
@@ -73,7 +73,7 @@ class KubernetesClient(Protocol):
         """List Kubernetes Pods in the selected namespace."""
 
 
-@dataclass(frozen=True)
+@dataclass
 class KubernetesExecutorConfig:  # pylint: disable=too-many-instance-attributes
     """Configuration needed to build one TaskExecutor Pod and Secret.
 
@@ -89,8 +89,7 @@ class KubernetesExecutorConfig:  # pylint: disable=too-many-instance-attributes
     image_pull_policy : str | None
         Optional Kubernetes imagePullPolicy for the TaskExecutor container.
     labels : dict[str, str] | None
-        Extra labels added to generated Pods and Secrets. Executor-owned labels
-        cannot be overridden.
+        Extra labels added to generated Pods and Secrets.
     annotations : dict[str, str] | None
         Extra annotations added to generated Pods and Secrets.
     resource_pool : str | None
@@ -135,31 +134,6 @@ class KubernetesExecutorConfig:  # pylint: disable=too-many-instance-attributes
     capacity_log_interval: float | None = None
     sleep: Callable[[float], None] = time.sleep
     monotonic: Callable[[], float] = time.monotonic
-
-    def __post_init__(self) -> None:
-        """Validate required object-building inputs."""
-        _validate_required_string("Kubernetes namespace", self.namespace)
-        _validate_required_string("TaskExecutor image", self.image)
-        _validate_optional_string(
-            "AppIo root certificates", self.appio_root_certificates
-        )
-        _validate_optional_string("Image pull policy", self.image_pull_policy)
-        _validate_optional_string("Service account name", self.service_account_name)
-        _validate_optional_string("Resource pool", self.resource_pool)
-        _validate_optional_string("Priority class name", self.priority_class_name)
-        if self.labels is not None:
-            _validate_labels(self.labels)
-        if self.active_pod_budget is not None:
-            if self.active_pod_budget <= 0:
-                raise ValueError("Active Pod budget must be positive.")
-            if self.resource_pool is None:
-                raise ValueError(
-                    "Resource pool must be configured when active Pod budget is set."
-                )
-        if self.capacity_poll_interval <= 0:
-            raise ValueError("Capacity poll interval must be positive.")
-        if self.capacity_log_interval is not None and self.capacity_log_interval <= 0:
-            raise ValueError("Capacity log interval must be positive.")
 
 
 class KubernetesExecutor:
@@ -386,11 +360,9 @@ def _build_taskexecutor_pod(
     if config.image_pull_policy is not None:
         container["imagePullPolicy"] = config.image_pull_policy
     if config.resources is not None:
-        container["resources"] = _copy_json_object(config.resources)
+        container["resources"] = config.resources
     if config.container_security_context is not None:
-        container["securityContext"] = _copy_json_object(
-            config.container_security_context
-        )
+        container["securityContext"] = config.container_security_context
 
     pod_spec: JSONObject = {
         "automountServiceAccountToken": False,
@@ -409,17 +381,15 @@ def _build_taskexecutor_pod(
     if config.service_account_name is not None:
         pod_spec["serviceAccountName"] = config.service_account_name
     if config.node_selector is not None:
-        pod_spec["nodeSelector"] = cast(JSONObject, dict(config.node_selector))
+        pod_spec["nodeSelector"] = cast(JSONObject, config.node_selector)
     if config.tolerations is not None:
-        pod_spec["tolerations"] = [
-            _copy_json_object(toleration) for toleration in config.tolerations
-        ]
+        pod_spec["tolerations"] = config.tolerations
     if config.affinity is not None:
-        pod_spec["affinity"] = _copy_json_object(config.affinity)
+        pod_spec["affinity"] = config.affinity
     if config.priority_class_name is not None:
         pod_spec["priorityClassName"] = config.priority_class_name
     if config.pod_security_context is not None:
-        pod_spec["securityContext"] = _copy_json_object(config.pod_security_context)
+        pod_spec["securityContext"] = config.pod_security_context
 
     return {
         "apiVersion": "v1",
@@ -509,7 +479,7 @@ def _metadata(
         "labels": _labels(spec, config, launch_attempt_id),
     }
     if config.annotations is not None:
-        metadata["annotations"] = cast(JSONObject, dict(config.annotations))
+        metadata["annotations"] = cast(JSONObject, config.annotations)
     return metadata
 
 
@@ -517,17 +487,20 @@ def _labels(
     spec: ExecutionSpec, config: KubernetesExecutorConfig, launch_attempt_id: str
 ) -> JSONObject:
     """Return stable labels for Kubernetes objects."""
-    labels: JSONObject = {
-        "app.kubernetes.io/name": "flower",
-        "app.kubernetes.io/component": "taskexecutor",
-        "flower.ai/superexec-task-id": str(spec.task_id),
-        "flower.ai/task-type": spec.task_type.value,
-        LAUNCH_ATTEMPT_LABEL: launch_attempt_id,
-    }
-    if config.resource_pool is not None:
-        labels["flower.ai/resource-pool"] = config.resource_pool
+    labels: JSONObject = {}
     if config.labels is not None:
         labels.update(config.labels)
+    labels.update(
+        {
+            "app.kubernetes.io/name": "flower",
+            "app.kubernetes.io/component": "taskexecutor",
+            "flower.ai/superexec-task-id": str(spec.task_id),
+            "flower.ai/task-type": spec.task_type.value,
+            LAUNCH_ATTEMPT_LABEL: launch_attempt_id,
+        }
+    )
+    if config.resource_pool is not None:
+        labels["flower.ai/resource-pool"] = config.resource_pool
     return labels
 
 
@@ -543,14 +516,15 @@ def _taskexecutor_pool_label_selector(config: KubernetesExecutorConfig) -> str:
 
 def _taskexecutor_pool_labels(config: KubernetesExecutorConfig) -> dict[str, str]:
     """Return labels identifying a scoped TaskExecutor pool."""
-    labels = {
-        "app.kubernetes.io/name": "flower",
-        "app.kubernetes.io/component": "taskexecutor",
-    }
+    labels = dict(config.labels or {})
+    labels.update(
+        {
+            "app.kubernetes.io/name": "flower",
+            "app.kubernetes.io/component": "taskexecutor",
+        }
+    )
     if config.resource_pool is not None:
         labels["flower.ai/resource-pool"] = config.resource_pool
-    if config.labels is not None:
-        labels.update(config.labels)
     return labels
 
 
@@ -608,54 +582,6 @@ def _object_field(value: object, field_name: str) -> object | None:
     if isinstance(value, dict):
         return value.get(field_name)
     return getattr(value, field_name, None)
-
-
-def _validate_labels(labels: dict[str, str]) -> None:
-    """Validate that caller-provided labels do not replace stable labels."""
-    stable_label_names = {
-        "app.kubernetes.io/name",
-        "app.kubernetes.io/component",
-        "flower.ai/superexec-task-id",
-        "flower.ai/task-type",
-        LAUNCH_ATTEMPT_LABEL,
-        "flower.ai/resource-pool",
-    }
-    conflicts = sorted(stable_label_names.intersection(labels))
-    if conflicts:
-        raise ValueError(
-            f"Kubernetes labels must not override stable labels: {conflicts}"
-        )
-
-
-def _validate_required_string(name: str, value: str) -> None:
-    """Validate that a required string field is not empty."""
-    if not value.strip():
-        raise ValueError(f"{name} must not be empty.")
-
-
-def _validate_optional_string(name: str, value: str | None) -> None:
-    """Validate that an optional string field is not empty when provided."""
-    if value is None:
-        return
-    _validate_required_string(name, value)
-
-
-def _copy_json_object(value: object) -> JSONObject:
-    """Return a plain dict/list copy of a JSON object."""
-    # Keep config objects normal and copy only when rendering Kubernetes payloads.
-    # This avoids recursive freeze/thaw while preventing rendered bodies from sharing
-    # mutable nested structures with caller-owned config.
-    return cast(JSONObject, _copy_json_value(value))
-
-
-def _copy_json_value(value: object) -> object:
-    """Return a mutable copy of a JSON-compatible value."""
-    if isinstance(value, Mapping):
-        return {key: _copy_json_value(nested) for key, nested in value.items()}
-    if isinstance(value, Sequence) and not isinstance(value, str):
-        # Normalize tuples and other sequences to JSON lists at the API boundary.
-        return [_copy_json_value(nested) for nested in value]
-    return value
 
 
 def _launch_result_from_exception(exc: Exception) -> LaunchResult:

--- a/framework/py/flwr/supercore/superexec/executor/kubernetes_executor.py
+++ b/framework/py/flwr/supercore/superexec/executor/kubernetes_executor.py
@@ -17,7 +17,6 @@
 import time
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
-from datetime import UTC, datetime
 from logging import INFO, WARNING
 from pathlib import Path
 from typing import Protocol, cast
@@ -36,11 +35,8 @@ APPIO_CREDENTIALS_MOUNT_PATH = "/run/flwr/appio"
 APPIO_TOKEN_FILE_PATH = f"{APPIO_CREDENTIALS_MOUNT_PATH}/token"
 APPIO_ROOT_CERTIFICATES_FILE_PATH = f"{APPIO_CREDENTIALS_MOUNT_PATH}/ca.crt"
 LAUNCH_ATTEMPT_LABEL = "flower.ai/launch-attempt"
-
-
-def _utcnow() -> datetime:
-    """Return the current UTC time."""
-    return datetime.now(UTC)
+_APPIO_CREDENTIAL_SECRET_SUFFIX = "-appio"
+_COMPLETED_POD_SWEEP_INTERVAL_SECONDS = 60.0
 
 
 class KubernetesList(Protocol):
@@ -135,12 +131,10 @@ class KubernetesExecutorConfig:  # pylint: disable=too-many-instance-attributes
     # Optional Pod field only; service account policy/RBAC is decided elsewhere.
     service_account_name: str | None = None
     active_pod_budget: int | None = None
-    completed_pod_retention_seconds: float = 0.0
     capacity_poll_interval: float = 1.0
     capacity_log_interval: float | None = None
     sleep: Callable[[float], None] = time.sleep
     monotonic: Callable[[], float] = time.monotonic
-    now: Callable[[], datetime] = _utcnow
 
     def __post_init__(self) -> None:
         """Validate required object-building inputs."""
@@ -166,8 +160,6 @@ class KubernetesExecutorConfig:  # pylint: disable=too-many-instance-attributes
             raise ValueError("Capacity poll interval must be positive.")
         if self.capacity_log_interval is not None and self.capacity_log_interval <= 0:
             raise ValueError("Capacity log interval must be positive.")
-        if self.completed_pod_retention_seconds < 0:
-            raise ValueError("Completed Pod retention must not be negative.")
 
 
 class KubernetesExecutor:
@@ -181,9 +173,12 @@ class KubernetesExecutor:
     ) -> None:
         self._client = client
         self._config = config
+        self._completed_pod_sweeper = CompletedPodSweeper(client=client, config=config)
+        self._last_completed_pod_sweep_at: float | None = None
 
     def wait_for_capacity(self) -> None:
         """Wait until the configured resource pool is below its active Pod budget."""
+        self._sweep_completed_pods_if_due()
         if self._config.active_pod_budget is None:
             return
 
@@ -220,6 +215,27 @@ class KubernetesExecutor:
                     last_log_at = now
 
             self._config.sleep(self._config.capacity_poll_interval)
+
+    def _sweep_completed_pods_if_due(self) -> None:
+        """Run best-effort completed Pod cleanup if the internal throttle allows it."""
+        now = self._config.monotonic()
+        if (
+            self._last_completed_pod_sweep_at is not None
+            and now - self._last_completed_pod_sweep_at
+            < _COMPLETED_POD_SWEEP_INTERVAL_SECONDS
+        ):
+            return
+
+        self._last_completed_pod_sweep_at = now
+        try:
+            self._completed_pod_sweeper.sweep()
+        except Exception:  # pylint: disable=broad-exception-caught
+            log(
+                WARNING,
+                "Kubernetes completed Pod sweep failed; proceeding. selector=%s",
+                _taskexecutor_pool_label_selector(self._config),
+                exc_info=True,
+            )
 
     def launch(self, spec: ExecutionSpec) -> LaunchResult:
         """Submit the TaskExecutor Pod and credential Secret."""
@@ -271,7 +287,7 @@ class CompletedPodSweeper:
         self._config = config
 
     def sweep(self) -> None:
-        """Delete eligible terminal Pods and orphaned per-task Secrets."""
+        """Delete terminal Pods and orphaned credential Secrets."""
         selector = _taskexecutor_pool_label_selector(self._config)
         pods = _pod_items(
             self._client.list_namespaced_pod(
@@ -283,31 +299,26 @@ class CompletedPodSweeper:
                 self._config.namespace, label_selector=selector
             )
         )
-        remaining_pod_task_ids: set[str] = set()
-        swept_pod_task_ids: set[str] = set()
+        pod_names = {name for pod in pods if (name := _object_name(pod)) is not None}
 
         for pod in pods:
-            task_id = _object_task_id(pod)
-            if task_id is None:
+            pod_name = _object_name(pod)
+            if pod_name is None or not _is_terminal_pod(pod):
                 continue
-            if _is_eligible_terminal_pod(pod, self._config):
-                self._delete_pod(pod)
-                swept_pod_task_ids.add(task_id)
-            else:
-                remaining_pod_task_ids.add(task_id)
+            self._delete_pod(pod_name)
+            self._delete_secret(_credential_secret_name_from_pod_name(pod_name))
 
         for secret in secrets:
-            task_id = _object_task_id(secret)
-            if task_id is None:
+            secret_name = _object_name(secret)
+            if secret_name is None:
                 continue
-            if task_id in swept_pod_task_ids or task_id not in remaining_pod_task_ids:
-                self._delete_secret(secret)
+            pod_name = _pod_name_from_credential_secret_name(secret_name)
+            if pod_name is None or pod_name in pod_names:
+                continue
+            self._delete_secret(secret_name)
 
-    def _delete_pod(self, pod: object) -> None:
+    def _delete_pod(self, name: str) -> None:
         """Delete a Pod, tolerating already-deleted objects."""
-        name = _object_name(pod)
-        if name is None:
-            return
         try:
             self._client.delete_namespaced_pod(
                 name=name,
@@ -317,11 +328,8 @@ class CompletedPodSweeper:
         except Exception as exc:  # pylint: disable=broad-exception-caught
             _raise_unless_not_found(exc)
 
-    def _delete_secret(self, secret: object) -> None:
+    def _delete_secret(self, name: str) -> None:
         """Delete a Secret, tolerating already-deleted objects."""
-        name = _object_name(secret)
-        if name is None:
-            return
         try:
             self._client.delete_namespaced_secret(
                 name=name, namespace=self._config.namespace
@@ -470,7 +478,22 @@ def _pod_name(spec: ExecutionSpec, launch_attempt_id: str) -> str:
 
 def _credential_secret_name(spec: ExecutionSpec, launch_attempt_id: str) -> str:
     """Return the AppIo credential Secret name."""
-    return f"{_pod_name(spec, launch_attempt_id)}-appio"
+    return _credential_secret_name_from_pod_name(_pod_name(spec, launch_attempt_id))
+
+
+def _credential_secret_name_from_pod_name(pod_name: str) -> str:
+    """Return the AppIo credential Secret name for a TaskExecutor Pod name."""
+    return f"{pod_name}{_APPIO_CREDENTIAL_SECRET_SUFFIX}"
+
+
+def _pod_name_from_credential_secret_name(secret_name: str) -> str | None:
+    """Return the owner Pod name encoded in a credential Secret name."""
+    if not secret_name.endswith(_APPIO_CREDENTIAL_SECRET_SUFFIX):
+        return None
+    pod_name = secret_name[: -len(_APPIO_CREDENTIAL_SECRET_SUFFIX)]
+    if not pod_name:
+        return None
+    return pod_name
 
 
 def _metadata(
@@ -565,75 +588,10 @@ def _is_active_pod(pod: object) -> bool:
     return _object_field(status, "phase") not in {"Succeeded", "Failed"}
 
 
-def _is_eligible_terminal_pod(pod: object, config: KubernetesExecutorConfig) -> bool:
-    """Return true if a terminal Pod is old enough for cleanup."""
+def _is_terminal_pod(pod: object) -> bool:
+    """Return true if a Pod reached a terminal phase."""
     status = _object_field(pod, "status")
-    if _object_field(status, "phase") not in {"Succeeded", "Failed"}:
-        return False
-
-    if config.completed_pod_retention_seconds == 0:
-        return True
-
-    terminal_time = _terminal_time(pod)
-    if terminal_time is None:
-        # Without a termination timestamp, a configured retention window cannot
-        # be evaluated safely, so keep the Pod for a later sweep.
-        return False
-
-    elapsed = _as_utc(config.now()) - terminal_time
-    return elapsed.total_seconds() >= config.completed_pod_retention_seconds
-
-
-def _terminal_time(pod: object) -> datetime | None:
-    """Return the latest container termination time for a Pod."""
-    status = _object_field(pod, "status")
-    container_statuses = _object_field(status, "container_statuses")
-    if container_statuses is None:
-        container_statuses = _object_field(status, "containerStatuses")
-    if not isinstance(container_statuses, Sequence) or isinstance(
-        container_statuses, str
-    ):
-        return None
-
-    terminal_times = []
-    for container_status in container_statuses:
-        state = _object_field(container_status, "state")
-        terminated = _object_field(state, "terminated")
-        if terminated is None:
-            continue
-        finished_at = _object_field(terminated, "finished_at")
-        if finished_at is None:
-            finished_at = _object_field(terminated, "finishedAt")
-        terminal_time = _parse_datetime(finished_at)
-        if terminal_time is not None:
-            terminal_times.append(terminal_time)
-    if not terminal_times:
-        return None
-    return max(terminal_times)
-
-
-def _parse_datetime(value: object) -> datetime | None:
-    """Parse Kubernetes timestamp values."""
-    if isinstance(value, datetime):
-        return _as_utc(value)
-    if not isinstance(value, str):
-        return None
-    timestamp = value.strip()
-    if not timestamp:
-        return None
-    if timestamp.endswith("Z"):
-        timestamp = f"{timestamp[:-1]}+00:00"
-    try:
-        return _as_utc(datetime.fromisoformat(timestamp))
-    except ValueError:
-        return None
-
-
-def _as_utc(value: datetime) -> datetime:
-    """Return a timezone-aware UTC datetime."""
-    if value.tzinfo is None:
-        return value.replace(tzinfo=UTC)
-    return value.astimezone(UTC)
+    return _object_field(status, "phase") in {"Succeeded", "Failed"}
 
 
 def _object_name(value: object) -> str | None:
@@ -642,18 +600,6 @@ def _object_name(value: object) -> str | None:
     name = _object_field(metadata, "name")
     if isinstance(name, str) and name.strip():
         return name
-    return None
-
-
-def _object_task_id(value: object) -> str | None:
-    """Return an object's stable TaskExecutor task-id label."""
-    metadata = _object_field(value, "metadata")
-    labels = _object_field(metadata, "labels")
-    if not isinstance(labels, dict):
-        return None
-    task_id = labels.get("flower.ai/superexec-task-id")
-    if isinstance(task_id, str) and task_id.strip():
-        return task_id
     return None
 
 

--- a/framework/py/flwr/supercore/superexec/executor/kubernetes_executor.py
+++ b/framework/py/flwr/supercore/superexec/executor/kubernetes_executor.py
@@ -35,6 +35,7 @@ APPIO_CREDENTIALS_MOUNT_PATH = "/run/flwr/appio"
 APPIO_TOKEN_FILE_PATH = f"{APPIO_CREDENTIALS_MOUNT_PATH}/token"
 APPIO_ROOT_CERTIFICATES_FILE_PATH = f"{APPIO_CREDENTIALS_MOUNT_PATH}/ca.crt"
 LAUNCH_ATTEMPT_LABEL = "flower.ai/launch-attempt"
+_TASK_ID_LABEL = "flower.ai/superexec-task-id"
 _APPIO_CREDENTIAL_SECRET_SUFFIX = "-appio"
 _COMPLETED_POD_SWEEP_INTERVAL_SECONDS = 60.0
 
@@ -274,17 +275,28 @@ class CompletedPodSweeper:
             )
         )
         pod_names = {name for pod in pods if (name := _object_name(pod)) is not None}
+        task_secret_names = {
+            name
+            for secret in secrets
+            if (name := _object_name(secret)) is not None and _has_task_id_label(secret)
+        }
 
         for pod in pods:
             pod_name = _object_name(pod)
-            if pod_name is None or not _is_terminal_pod(pod):
+            if (
+                pod_name is None
+                or not _has_task_id_label(pod)
+                or not _is_terminal_pod(pod)
+            ):
                 continue
             self._delete_pod(pod_name)
-            self._delete_secret(_credential_secret_name_from_pod_name(pod_name))
+            credential_secret_name = _credential_secret_name_from_pod_name(pod_name)
+            if credential_secret_name in task_secret_names:
+                self._delete_secret(credential_secret_name)
 
         for secret in secrets:
             secret_name = _object_name(secret)
-            if secret_name is None:
+            if secret_name is None or not _has_task_id_label(secret):
                 continue
             pod_name = _pod_name_from_credential_secret_name(secret_name)
             if pod_name is None or pod_name in pod_names:
@@ -494,7 +506,7 @@ def _labels(
         {
             "app.kubernetes.io/name": "flower",
             "app.kubernetes.io/component": "taskexecutor",
-            "flower.ai/superexec-task-id": str(spec.task_id),
+            _TASK_ID_LABEL: str(spec.task_id),
             "flower.ai/task-type": spec.task_type.value,
             LAUNCH_ATTEMPT_LABEL: launch_attempt_id,
         }
@@ -575,6 +587,14 @@ def _object_name(value: object) -> str | None:
     if isinstance(name, str) and name.strip():
         return name
     return None
+
+
+def _has_task_id_label(value: object) -> bool:
+    """Return true if an object carries a TaskExecutor task-id label."""
+    metadata = _object_field(value, "metadata")
+    labels = _object_field(metadata, "labels")
+    task_id = _object_field(labels, _TASK_ID_LABEL)
+    return isinstance(task_id, str) and bool(task_id.strip())
 
 
 def _object_field(value: object, field_name: str) -> object | None:

--- a/framework/py/flwr/supercore/superexec/executor/kubernetes_executor.py
+++ b/framework/py/flwr/supercore/superexec/executor/kubernetes_executor.py
@@ -17,6 +17,7 @@
 import time
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from logging import INFO, WARNING
 from pathlib import Path
 from typing import Protocol, cast
@@ -37,10 +38,9 @@ APPIO_ROOT_CERTIFICATES_FILE_PATH = f"{APPIO_CREDENTIALS_MOUNT_PATH}/ca.crt"
 LAUNCH_ATTEMPT_LABEL = "flower.ai/launch-attempt"
 
 
-class KubernetesPodList(Protocol):
-    """Subset of Kubernetes PodList used by capacity checks."""
-
-    items: Sequence[object]
+def _utcnow() -> datetime:
+    """Return the current UTC time."""
+    return datetime.now(UTC)
 
 
 class KubernetesClient(Protocol):
@@ -55,9 +55,15 @@ class KubernetesClient(Protocol):
     def delete_namespaced_secret(self, name: str, namespace: str) -> object:
         """Delete a Kubernetes Secret from the selected namespace."""
 
-    def list_namespaced_pod(
-        self, namespace: str, label_selector: str
-    ) -> KubernetesPodList:
+    def list_namespaced_secret(self, namespace: str, label_selector: str) -> object:
+        """List Kubernetes Secrets in the selected namespace."""
+
+    def delete_namespaced_pod(
+        self, name: str, namespace: str, grace_period_seconds: int = 0
+    ) -> object:
+        """Delete a Kubernetes Pod in the selected namespace."""
+
+    def list_namespaced_pod(self, namespace: str, label_selector: str) -> object:
         """List Kubernetes Pods in the selected namespace."""
 
 
@@ -119,10 +125,12 @@ class KubernetesExecutorConfig:  # pylint: disable=too-many-instance-attributes
     # Optional Pod field only; service account policy/RBAC is decided elsewhere.
     service_account_name: str | None = None
     active_pod_budget: int | None = None
+    completed_pod_retention_seconds: float = 0.0
     capacity_poll_interval: float = 1.0
     capacity_log_interval: float | None = None
     sleep: Callable[[float], None] = time.sleep
     monotonic: Callable[[], float] = time.monotonic
+    now: Callable[[], datetime] = _utcnow
 
     def __post_init__(self) -> None:
         """Validate required object-building inputs."""
@@ -148,6 +156,8 @@ class KubernetesExecutorConfig:  # pylint: disable=too-many-instance-attributes
             raise ValueError("Capacity poll interval must be positive.")
         if self.capacity_log_interval is not None and self.capacity_log_interval <= 0:
             raise ValueError("Capacity log interval must be positive.")
+        if self.completed_pod_retention_seconds < 0:
+            raise ValueError("Completed Pod retention must not be negative.")
 
 
 class KubernetesExecutor:
@@ -236,6 +246,78 @@ class KubernetesExecutor:
             label_selector=_capacity_label_selector(self._config),
         )
         return sum(1 for pod in _pod_items(pod_list) if _is_active_pod(pod))
+
+
+class CompletedPodSweeper:
+    """Delete terminal TaskExecutor Pods and orphaned credential Secrets."""
+
+    def __init__(
+        self,
+        *,
+        client: KubernetesClient,
+        config: KubernetesExecutorConfig,
+    ) -> None:
+        self._client = client
+        self._config = config
+
+    def sweep(self) -> None:
+        """Delete eligible terminal Pods and orphaned per-task Secrets."""
+        selector = _taskexecutor_pool_label_selector(self._config)
+        pods = _pod_items(
+            self._client.list_namespaced_pod(
+                self._config.namespace, label_selector=selector
+            )
+        )
+        secrets = _secret_items(
+            self._client.list_namespaced_secret(
+                self._config.namespace, label_selector=selector
+            )
+        )
+        remaining_pod_task_ids: set[str] = set()
+        swept_pod_task_ids: set[str] = set()
+
+        for pod in pods:
+            task_id = _object_task_id(pod)
+            if task_id is None:
+                continue
+            if _is_eligible_terminal_pod(pod, self._config):
+                self._delete_pod(pod)
+                swept_pod_task_ids.add(task_id)
+            else:
+                remaining_pod_task_ids.add(task_id)
+
+        for secret in secrets:
+            task_id = _object_task_id(secret)
+            if task_id is None:
+                continue
+            if task_id in swept_pod_task_ids or task_id not in remaining_pod_task_ids:
+                self._delete_secret(secret)
+
+    def _delete_pod(self, pod: object) -> None:
+        """Delete a Pod, tolerating already-deleted objects."""
+        name = _object_name(pod)
+        if name is None:
+            return
+        try:
+            self._client.delete_namespaced_pod(
+                name=name,
+                namespace=self._config.namespace,
+                grace_period_seconds=0,
+            )
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            _raise_unless_not_found(exc)
+
+    def _delete_secret(self, secret: object) -> None:
+        """Delete a Secret, tolerating already-deleted objects."""
+        name = _object_name(secret)
+        if name is None:
+            return
+        try:
+            self._client.delete_namespaced_secret(
+                name=name, namespace=self._config.namespace
+            )
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            _raise_unless_not_found(exc)
 
 
 def _build_appio_credentials_secret(
@@ -418,11 +500,16 @@ def _labels(
 
 def _capacity_label_selector(config: KubernetesExecutorConfig) -> str:
     """Return the label selector used for resource-pool capacity checks."""
-    return _label_selector(_capacity_labels(config))
+    return _taskexecutor_pool_label_selector(config)
 
 
-def _capacity_labels(config: KubernetesExecutorConfig) -> dict[str, str]:
-    """Return labels identifying the constrained TaskExecutor pool."""
+def _taskexecutor_pool_label_selector(config: KubernetesExecutorConfig) -> str:
+    """Return the label selector for TaskExecutor pool-scoped operations."""
+    return _label_selector(_taskexecutor_pool_labels(config))
+
+
+def _taskexecutor_pool_labels(config: KubernetesExecutorConfig) -> dict[str, str]:
+    """Return labels identifying a scoped TaskExecutor pool."""
     labels = {
         "app.kubernetes.io/name": "flower",
         "app.kubernetes.io/component": "taskexecutor",
@@ -439,9 +526,17 @@ def _label_selector(labels: dict[str, str]) -> str:
     return ",".join(f"{key}={value}" for key, value in sorted(labels.items()))
 
 
-def _pod_items(pod_list: KubernetesPodList | Mapping[str, object]) -> list[object]:
+def _pod_items(pod_list: object) -> list[object]:
     """Return Pod items from a Kubernetes list response."""
     items = _object_field(pod_list, "items")
+    if isinstance(items, Sequence) and not isinstance(items, str):
+        return list(items)
+    return []
+
+
+def _secret_items(secret_list: object) -> list[object]:
+    """Return Secret items from a Kubernetes list response."""
+    items = _object_field(secret_list, "items")
     if isinstance(items, Sequence) and not isinstance(items, str):
         return list(items)
     return []
@@ -458,6 +553,98 @@ def _is_active_pod(pod: object) -> bool:
 
     status = _object_field(pod, "status")
     return _object_field(status, "phase") not in {"Succeeded", "Failed"}
+
+
+def _is_eligible_terminal_pod(pod: object, config: KubernetesExecutorConfig) -> bool:
+    """Return true if a terminal Pod is old enough for cleanup."""
+    status = _object_field(pod, "status")
+    if _object_field(status, "phase") not in {"Succeeded", "Failed"}:
+        return False
+
+    if config.completed_pod_retention_seconds == 0:
+        return True
+
+    terminal_time = _terminal_time(pod)
+    if terminal_time is None:
+        # Without a termination timestamp, a configured retention window cannot
+        # be evaluated safely, so keep the Pod for a later sweep.
+        return False
+
+    elapsed = _as_utc(config.now()) - terminal_time
+    return elapsed.total_seconds() >= config.completed_pod_retention_seconds
+
+
+def _terminal_time(pod: object) -> datetime | None:
+    """Return the latest container termination time for a Pod."""
+    status = _object_field(pod, "status")
+    container_statuses = _object_field(status, "container_statuses")
+    if container_statuses is None:
+        container_statuses = _object_field(status, "containerStatuses")
+    if not isinstance(container_statuses, Sequence) or isinstance(
+        container_statuses, str
+    ):
+        return None
+
+    terminal_times = []
+    for container_status in container_statuses:
+        state = _object_field(container_status, "state")
+        terminated = _object_field(state, "terminated")
+        if terminated is None:
+            continue
+        finished_at = _object_field(terminated, "finished_at")
+        if finished_at is None:
+            finished_at = _object_field(terminated, "finishedAt")
+        terminal_time = _parse_datetime(finished_at)
+        if terminal_time is not None:
+            terminal_times.append(terminal_time)
+    if not terminal_times:
+        return None
+    return max(terminal_times)
+
+
+def _parse_datetime(value: object) -> datetime | None:
+    """Parse Kubernetes timestamp values."""
+    if isinstance(value, datetime):
+        return _as_utc(value)
+    if not isinstance(value, str):
+        return None
+    timestamp = value.strip()
+    if not timestamp:
+        return None
+    if timestamp.endswith("Z"):
+        timestamp = f"{timestamp[:-1]}+00:00"
+    try:
+        return _as_utc(datetime.fromisoformat(timestamp))
+    except ValueError:
+        return None
+
+
+def _as_utc(value: datetime) -> datetime:
+    """Return a timezone-aware UTC datetime."""
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+def _object_name(value: object) -> str | None:
+    """Return an object's metadata name."""
+    metadata = _object_field(value, "metadata")
+    name = _object_field(metadata, "name")
+    if isinstance(name, str) and name.strip():
+        return name
+    return None
+
+
+def _object_task_id(value: object) -> str | None:
+    """Return an object's stable TaskExecutor task-id label."""
+    metadata = _object_field(value, "metadata")
+    labels = _object_field(metadata, "labels")
+    if not isinstance(labels, dict):
+        return None
+    task_id = labels.get("flower.ai/superexec-task-id")
+    if isinstance(task_id, str) and task_id.strip():
+        return task_id
+    return None
 
 
 def _object_field(value: object, field_name: str) -> object | None:
@@ -569,6 +756,13 @@ def _exception_status(exc: Exception) -> int | None:
     if isinstance(status, str) and status.isdigit():
         return int(status)
     return None
+
+
+def _raise_unless_not_found(exc: Exception) -> None:
+    """Raise Kubernetes client exceptions except already-deleted objects."""
+    if _exception_status(exc) == 404:
+        return
+    raise exc
 
 
 def _is_capacity_message(message: str) -> bool:

--- a/framework/py/flwr/supercore/superexec/executor/kubernetes_executor.py
+++ b/framework/py/flwr/supercore/superexec/executor/kubernetes_executor.py
@@ -43,6 +43,12 @@ def _utcnow() -> datetime:
     return datetime.now(UTC)
 
 
+class KubernetesList(Protocol):
+    """Subset of Kubernetes list responses used by executor list helpers."""
+
+    items: Sequence[object]
+
+
 class KubernetesClient(Protocol):
     """Subset of Kubernetes CoreV1Api used by the executor."""
 
@@ -55,7 +61,9 @@ class KubernetesClient(Protocol):
     def delete_namespaced_secret(self, name: str, namespace: str) -> object:
         """Delete a Kubernetes Secret from the selected namespace."""
 
-    def list_namespaced_secret(self, namespace: str, label_selector: str) -> object:
+    def list_namespaced_secret(
+        self, namespace: str, label_selector: str
+    ) -> KubernetesList:
         """List Kubernetes Secrets in the selected namespace."""
 
     def delete_namespaced_pod(
@@ -63,7 +71,9 @@ class KubernetesClient(Protocol):
     ) -> object:
         """Delete a Kubernetes Pod in the selected namespace."""
 
-    def list_namespaced_pod(self, namespace: str, label_selector: str) -> object:
+    def list_namespaced_pod(
+        self, namespace: str, label_selector: str
+    ) -> KubernetesList:
         """List Kubernetes Pods in the selected namespace."""
 
 
@@ -526,7 +536,7 @@ def _label_selector(labels: dict[str, str]) -> str:
     return ",".join(f"{key}={value}" for key, value in sorted(labels.items()))
 
 
-def _pod_items(pod_list: object) -> list[object]:
+def _pod_items(pod_list: KubernetesList | Mapping[str, object]) -> list[object]:
     """Return Pod items from a Kubernetes list response."""
     items = _object_field(pod_list, "items")
     if isinstance(items, Sequence) and not isinstance(items, str):
@@ -534,7 +544,7 @@ def _pod_items(pod_list: object) -> list[object]:
     return []
 
 
-def _secret_items(secret_list: object) -> list[object]:
+def _secret_items(secret_list: KubernetesList | Mapping[str, object]) -> list[object]:
     """Return Secret items from a Kubernetes list response."""
     items = _object_field(secret_list, "items")
     if isinstance(items, Sequence) and not isinstance(items, str):

--- a/framework/py/flwr/supercore/superexec/executor/kubernetes_executor.py
+++ b/framework/py/flwr/supercore/superexec/executor/kubernetes_executor.py
@@ -294,6 +294,7 @@ class CompletedPodSweeper:
             if credential_secret_name in task_secret_names:
                 self._delete_secret(credential_secret_name)
 
+        # Delete credential Secrets whose owner Pod is no longer listed.
         for secret in secrets:
             secret_name = _object_name(secret)
             if secret_name is None or not _has_task_id_label(secret):
@@ -502,6 +503,7 @@ def _labels(
     labels: JSONObject = {}
     if config.labels is not None:
         labels.update(config.labels)
+    # Apply executor-owned labels last; selectors and cleanup rely on them.
     labels.update(
         {
             "app.kubernetes.io/name": "flower",

--- a/framework/py/flwr/supercore/superexec/executor/kubernetes_executor_harness_test.py
+++ b/framework/py/flwr/supercore/superexec/executor/kubernetes_executor_harness_test.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import importlib.util
+import hashlib
 import json
 import sys
 from pathlib import Path
@@ -215,6 +216,176 @@ def test_main_writes_json_summary(
     assert summary["namespace"] == "flower-dev"
     assert summary["resource_pool"] == "pool-a"
     assert (output_dir / "summary.json").is_file()
+
+
+def test_render_superexec_rbac_manifests_scope_pods_and_secrets() -> None:
+    """Test F7b RBAC manifests grant only Pod and Secret access."""
+    profile = harness_module.generic_k3d_profile()
+
+    manifests = harness_module.render_superexec_rbac_manifests(profile)
+
+    assert [manifest["kind"] for manifest in manifests] == [
+        "ServiceAccount",
+        "Role",
+        "RoleBinding",
+    ]
+    service_account, role, role_binding = manifests
+    assert service_account["metadata"]["name"] == "flower-superexec"
+    assert service_account["automountServiceAccountToken"] is True
+
+    rules = role["rules"]
+    assert rules == [
+        {
+            "apiGroups": [""],
+            "resources": ["pods", "secrets"],
+            "verbs": ["get", "list", "watch", "create", "delete"],
+        }
+    ]
+    assert "*" not in rules[0]["resources"]
+    assert "deployments" not in rules[0]["resources"]
+    assert role_binding["subjects"] == [
+        {
+            "kind": "ServiceAccount",
+            "name": "flower-superexec",
+            "namespace": "flower-f7",
+        }
+    ]
+
+
+def test_tls_material_contract_records_fingerprint_without_pem(tmp_path: Path) -> None:
+    """Test TLS evidence records fingerprint and never writes PEM content."""
+    pem = "-----BEGIN CERTIFICATE-----\nroot-ca\n-----END CERTIFICATE-----\n"
+    ca_path = tmp_path / "appio-ca.pem"
+    ca_path.write_text(pem, encoding="utf-8")
+    profile = harness_module.generic_k3d_profile()
+    profile.appio_root_certificates_path = str(ca_path)
+
+    summary = harness_module.run_infra_proof(tmp_path / "evidence", profile=profile)
+
+    expected_sha256 = hashlib.sha256(pem.encode()).hexdigest()
+    tls_text = (tmp_path / "evidence" / "objects" / "tls.json").read_text()
+    tls = json.loads(tls_text)
+    assert summary.status == "passed"
+    assert tls["ready"] is True
+    assert tls["root_certificates"]["sha256"] == expected_sha256
+    assert "BEGIN CERTIFICATE" not in tls_text
+    assert "root-ca" not in tls_text
+
+
+def test_run_infra_proof_dry_run_writes_f7b_evidence(tmp_path: Path) -> None:
+    """Test F7b dry-run writes infra, TLS, RBAC, and command evidence."""
+    output_dir = tmp_path / "f7b"
+
+    summary = harness_module.run_infra_proof(
+        output_dir,
+        create_cluster=True,
+        apply_manifests=True,
+    )
+
+    assert summary.status == "passed"
+    assert summary.result == "infra-proof-dry-run"
+    assert summary.event_count == 9
+    assert (output_dir / "objects" / "namespace.yaml").is_file()
+    assert (output_dir / "objects" / "rbac.yaml").is_file()
+    assert (output_dir / "objects" / "tls.json").is_file()
+    rbac_apply_document = yaml.safe_load(
+        (output_dir / "objects" / "rbac.yaml").read_text()
+    )
+    assert rbac_apply_document["kind"] == "List"
+    assert [item["kind"] for item in rbac_apply_document["items"]] == [
+        "ServiceAccount",
+        "Role",
+        "RoleBinding",
+    ]
+
+    events = _read_jsonl(output_dir / "events.jsonl")
+    assert [event["event"] for event in events] == [
+        "harness.start",
+        "profile.loaded",
+        "cluster.detected",
+        "namespace.ready",
+        "tls.material.ready",
+        "rbac.applied",
+        "rbac.negative_check",
+        "policy.not_validated_locally",
+        "harness.result",
+    ]
+    assert events[2]["status"] == "planned"
+    assert events[5]["status"] == "planned"
+    assert events[6]["status"] == "planned"
+
+    summary_record = json.loads((output_dir / "summary.json").read_text())
+    assert "host command execution" in summary_record["not_validated"]
+
+    commands_text = (output_dir / "diagnostics" / "commands.txt").read_text()
+    assert "DRY-RUN $ k3d cluster list flower-f7" in commands_text
+    assert "DRY-RUN $ k3d cluster create flower-f7 --wait" in commands_text
+    assert "kubectl --context k3d-flower-f7 apply -f" in commands_text
+    assert "auth can-i create pods" in commands_text
+
+
+def test_run_infra_proof_fails_when_negative_rbac_check_allows_too_much(
+    tmp_path: Path,
+) -> None:
+    """Test F7b records a failure when broader RBAC access is allowed."""
+    runner = _AllowEverythingRunner()
+
+    summary = harness_module.run_infra_proof(
+        tmp_path / "f7b",
+        runner=runner,
+        execute=True,
+        apply_manifests=True,
+    )
+
+    assert summary.status == "failed"
+    assert any("cannot-create-deployments" in item for item in summary.failures)
+    events = _read_jsonl(tmp_path / "f7b" / "events.jsonl")
+    assert events[6]["event"] == "rbac.negative_check"
+    assert events[6]["status"] == "failed"
+
+
+def test_main_writes_infra_proof_json_summary(
+    capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    """Test the CLI can write F7b dry-run evidence explicitly."""
+    output_dir = tmp_path / "from-main"
+
+    exit_code = harness_module.main(
+        [
+            "--mode",
+            "infra-proof",
+            "--output-dir",
+            str(output_dir),
+            "--namespace",
+            "flower-dev",
+            "--json",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    summary = json.loads(captured.out)
+    assert exit_code == 0
+    assert summary["status"] == "passed"
+    assert summary["result"] == "infra-proof-dry-run"
+    assert summary["namespace"] == "flower-dev"
+    assert (output_dir / "objects" / "rbac.yaml").is_file()
+
+
+class _AllowEverythingRunner:
+    """Fake command runner that reports yes for every RBAC can-i check."""
+
+    def __init__(self) -> None:
+        self.commands: list[list[str]] = []
+
+    def run(self, args: list[str]) -> Any:
+        """Return success for all commands and broad allow for RBAC checks."""
+        self.commands.append(list(args))
+        stdout = "yes\n" if "can-i" in args else ""
+        return harness_module.CommandResult(
+            args=list(args),
+            returncode=0,
+            stdout=stdout,
+        )
 
 
 def _read_jsonl(path: Path) -> list[dict[str, Any]]:

--- a/framework/py/flwr/supercore/superexec/executor/kubernetes_executor_harness_test.py
+++ b/framework/py/flwr/supercore/superexec/executor/kubernetes_executor_harness_test.py
@@ -16,8 +16,8 @@
 
 from __future__ import annotations
 
-import importlib.util
 import hashlib
+import importlib.util
 import json
 import sys
 from pathlib import Path

--- a/framework/py/flwr/supercore/superexec/executor/kubernetes_executor_harness_test.py
+++ b/framework/py/flwr/supercore/superexec/executor/kubernetes_executor_harness_test.py
@@ -1,0 +1,222 @@
+# Copyright 2026 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for the F7a Kubernetes executor harness contract scaffold."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+import yaml
+
+
+def _load_harness_module() -> ModuleType:
+    """Load the dev harness scaffold from its file path."""
+    harness_path = (
+        Path(__file__).resolve().parents[5] / "dev" / ("kubernetes_executor_harness.py")
+    )
+    spec = importlib.util.spec_from_file_location(
+        "kubernetes_executor_harness", harness_path
+    )
+    if spec is None or spec.loader is None:
+        raise AssertionError("Could not load Kubernetes executor harness module")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+harness_module = _load_harness_module()
+
+
+def test_run_contract_scaffold_writes_bundle_to_selected_output_dir(
+    tmp_path: Path,
+) -> None:
+    """Test the scaffold writes the portable evidence bundle layout."""
+    output_dir = tmp_path / "evidence"
+
+    summary = harness_module.run_contract_scaffold(output_dir)
+
+    assert summary.status == "passed"
+    assert summary.result == "scaffold-written"
+    assert summary.output_dir == str(output_dir)
+    assert summary.event_count == 4
+    assert (output_dir / "summary.json").is_file()
+    assert (output_dir / "events.jsonl").is_file()
+    assert (output_dir / "harness.log").is_file()
+    assert (output_dir / "sanitized-config.yaml").is_file()
+    assert (output_dir / "objects" / "pods.json").is_file()
+    assert (output_dir / "objects" / "services.json").is_file()
+    assert (output_dir / "objects" / "rbac.json").is_file()
+    assert (output_dir / "diagnostics" / "commands.txt").is_file()
+    assert (output_dir / "diagnostics" / "failures.txt").is_file()
+
+    events = _read_jsonl(output_dir / "events.jsonl")
+    assert [event["event"] for event in events] == [
+        "harness.start",
+        "profile.loaded",
+        "policy.not_validated_locally",
+        "harness.result",
+    ]
+    assert events[2]["status"] == "not_validated"
+
+    summary_record = json.loads((output_dir / "summary.json").read_text())
+    assert summary_record["event_count"] == 4
+    assert "TaskExecutor Pod launch" in summary_record["not_validated"]
+
+    config = yaml.safe_load((output_dir / "sanitized-config.yaml").read_text())
+    assert config["name"] == "generic-k3d"
+    assert config["executor-config"]["namespace"] == "flower-f7"
+    assert config["executor-config"]["image"] == "ghcr.io/flwrlabs/taskexecutor:dev"
+
+
+def test_writer_redacts_events_summary_yaml_and_text(tmp_path: Path) -> None:
+    """Test the writer redacts sensitive fields in each output format."""
+    writer = harness_module.EvidenceBundleWriter(tmp_path)
+    secret = {
+        "kind": "Secret",
+        "metadata": {"name": "task-1-appio"},
+        "stringData": {
+            "token": "task-token",
+            "ca.crt": "-----BEGIN CERTIFICATE-----\nroot-ca\n-----END CERTIFICATE-----",
+        },
+    }
+
+    writer.write_event(
+        harness_module.HarnessEvent(
+            event="harness.start",
+            status="passed",
+            message="token=task-token",
+            details={"secret_name": "task-1-appio", "secret": secret},
+        )
+    )
+    writer.write_summary(
+        harness_module.HarnessSummary(
+            status="failed",
+            result="failed",
+            profile_name="generic-k3d",
+            output_dir=str(tmp_path),
+            started_at="2026-06-15T00:00:00Z",
+            namespace="flower-f7",
+            resource_pool="generic-k3d",
+            details={"task_token": "task-token"},
+        )
+    )
+    writer.write_yaml("sanitized-config.yaml", secret)
+    writer.write_text(
+        "harness.log",
+        "authorization: bearer-token\n"
+        "-----BEGIN CERTIFICATE-----\nroot-ca\n-----END CERTIFICATE-----\n",
+    )
+
+    event = _read_jsonl(tmp_path / "events.jsonl")[0]
+    assert event["message"] == f"token={harness_module.REDACTED}"
+    assert event["details"]["secret_name"] == "task-1-appio"
+    assert event["details"]["secret"]["metadata"]["name"] == "task-1-appio"
+    assert event["details"]["secret"]["stringData"] == {
+        "ca.crt": harness_module.REDACTED,
+        "token": harness_module.REDACTED,
+    }
+
+    summary = json.loads((tmp_path / "summary.json").read_text())
+    assert summary["details"]["task_token"] == harness_module.REDACTED
+
+    config = yaml.safe_load((tmp_path / "sanitized-config.yaml").read_text())
+    assert config["metadata"]["name"] == "task-1-appio"
+    assert config["stringData"]["token"] == harness_module.REDACTED
+
+    log_text = (tmp_path / "harness.log").read_text()
+    assert "bearer-token" not in log_text
+    assert "BEGIN CERTIFICATE" not in log_text
+    assert harness_module.REDACTED in log_text
+
+
+def test_redact_command_args_removes_credentials_but_preserves_safe_paths() -> None:
+    """Test command redaction keeps argument shape and safe file paths."""
+    pem = "-----BEGIN CERTIFICATE-----\nroot-ca\n-----END CERTIFICATE-----"
+
+    redacted = harness_module.redact_command_args(
+        [
+            "flwr-serverapp",
+            "--token",
+            "task-token",
+            "--token-file",
+            "/run/flwr/appio/token",
+            "--root-certificates",
+            pem,
+            "--executor-config=config.yaml",
+        ]
+    )
+
+    assert redacted == [
+        "flwr-serverapp",
+        "--token",
+        harness_module.REDACTED,
+        "--token-file",
+        "/run/flwr/appio/token",
+        "--root-certificates",
+        harness_module.REDACTED,
+        "--executor-config=config.yaml",
+    ]
+
+
+def test_writer_rejects_paths_outside_bundle(tmp_path: Path) -> None:
+    """Test evidence writes cannot escape the selected output directory."""
+    writer = harness_module.EvidenceBundleWriter(tmp_path)
+
+    with pytest.raises(ValueError, match="inside bundle"):
+        writer.write_text("../outside.txt", "content")
+
+    with pytest.raises(ValueError, match="inside bundle"):
+        writer.write_json(str(tmp_path / "outside.json"), {})
+
+
+def test_main_writes_json_summary(
+    capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    """Test the minimal command surface writes the scaffold and prints JSON."""
+    output_dir = tmp_path / "from-main"
+
+    exit_code = harness_module.main(
+        [
+            "--output-dir",
+            str(output_dir),
+            "--namespace",
+            "flower-dev",
+            "--resource-pool",
+            "pool-a",
+            "--image",
+            "example/taskexecutor:test",
+            "--json",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    summary = json.loads(captured.out)
+    assert exit_code == 0
+    assert summary["status"] == "passed"
+    assert summary["namespace"] == "flower-dev"
+    assert summary["resource_pool"] == "pool-a"
+    assert (output_dir / "summary.json").is_file()
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    """Read a JSONL file into records."""
+    return [json.loads(line) for line in path.read_text().splitlines()]

--- a/framework/py/flwr/supercore/superexec/executor/kubernetes_executor_smoke_test.py
+++ b/framework/py/flwr/supercore/superexec/executor/kubernetes_executor_smoke_test.py
@@ -1,0 +1,246 @@
+# Copyright 2026 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for the Kubernetes executor dev smoke script."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from textwrap import dedent
+from types import ModuleType
+from unittest.mock import Mock
+
+import pytest
+
+from . import factory as factory_module
+
+
+def _load_smoke_module() -> ModuleType:
+    """Load the dev smoke script from its file path."""
+    smoke_path = (
+        Path(__file__).resolve().parents[5] / "dev" / ("kubernetes_executor_smoke.py")
+    )
+    spec = importlib.util.spec_from_file_location(
+        "kubernetes_executor_smoke", smoke_path
+    )
+    if spec is None or spec.loader is None:
+        raise AssertionError("Could not load Kubernetes executor smoke module")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+smoke_module = _load_smoke_module()
+
+
+class _KubernetesList:
+    """Small Kubernetes list response stand-in."""
+
+    def __init__(self, items: list[object]) -> None:
+        self.items = items
+
+
+class _FakeKubernetesClient:
+    """Fake CoreV1Api for the smoke script."""
+
+    def __init__(self, *, pod_create_error: Exception | None = None) -> None:
+        self.pod_create_error = pod_create_error
+        self.pods: dict[str, object] = {}
+        self.secrets: dict[str, object] = {}
+        self.created_pods: list[object] = []
+        self.created_secrets: list[object] = []
+        self.deleted_pods: list[str] = []
+        self.deleted_secrets: list[str] = []
+
+    def create_namespaced_secret(self, namespace: str, body: object) -> object:
+        """Create a fake Secret."""
+        del namespace
+        name = _metadata_name(body)
+        self.created_secrets.append(body)
+        self.secrets[name] = body
+        return body
+
+    def create_namespaced_pod(self, namespace: str, body: object) -> object:
+        """Create a fake Pod."""
+        del namespace
+        if self.pod_create_error is not None:
+            raise self.pod_create_error
+        name = _metadata_name(body)
+        self.created_pods.append(body)
+        self.pods[name] = body
+        return body
+
+    def list_namespaced_pod(
+        self, namespace: str, label_selector: str
+    ) -> _KubernetesList:
+        """List fake Pods."""
+        del namespace
+        return _KubernetesList(
+            [
+                pod
+                for pod in self.pods.values()
+                if _matches_selector(pod, label_selector)
+            ]
+        )
+
+    def list_namespaced_secret(
+        self, namespace: str, label_selector: str
+    ) -> _KubernetesList:
+        """List fake Secrets."""
+        del namespace
+        return _KubernetesList(
+            [
+                secret
+                for secret in self.secrets.values()
+                if _matches_selector(secret, label_selector)
+            ]
+        )
+
+    def delete_namespaced_pod(
+        self, name: str, namespace: str, grace_period_seconds: int = 0
+    ) -> object:
+        """Delete a fake Pod."""
+        del namespace, grace_period_seconds
+        self.deleted_pods.append(name)
+        return self.pods.pop(name)
+
+    def delete_namespaced_secret(self, name: str, namespace: str) -> object:
+        """Delete a fake Secret."""
+        del namespace
+        self.deleted_secrets.append(name)
+        return self.secrets.pop(name)
+
+
+def test_run_smoke_creates_visible_objects_and_cleans_them_up(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Test the smoke path creates, lists, and deletes scoped objects."""
+    client = _FakeKubernetesClient()
+    monkeypatch.setattr(
+        factory_module, "create_incluster_kubernetes_client", Mock(return_value=client)
+    )
+    config_path = _write_executor_config(tmp_path)
+    logs: list[str] = []
+
+    summary = smoke_module.run_smoke(
+        str(config_path), smoke_run="smoke-test", log=logs.append
+    )
+
+    assert summary.status == "passed"
+    assert summary.namespace == "flower-system"
+    assert summary.resource_pool == "gpu-pool"
+    assert summary.smoke_selector == "flower.ai/smoke-run=smoke-test"
+    assert summary.secret_created
+    assert summary.pod_created
+    assert summary.secret_visible
+    assert summary.pod_visible
+    assert summary.secret_deleted
+    assert summary.pod_deleted
+    assert client.pods == {}
+    assert client.secrets == {}
+    assert "flower-kubernetes-executor-smoke-token" not in "\n".join(logs)
+
+    pod = client.created_pods[0]
+    labels = _metadata_labels(pod)
+    assert labels["flower.ai/smoke-run"] == "smoke-test"
+    assert labels["flower.ai/resource-pool"] == "gpu-pool"
+    assert _pod_spec(pod)["automountServiceAccountToken"] is False
+
+
+def test_run_smoke_cleans_up_secret_if_pod_creation_fails(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Test a rejected Pod still cleans up the created credential Secret."""
+    client = _FakeKubernetesClient(
+        pod_create_error=RuntimeError(
+            "Pod rejected for token flower-kubernetes-executor-smoke-token"
+        )
+    )
+    monkeypatch.setattr(
+        factory_module, "create_incluster_kubernetes_client", Mock(return_value=client)
+    )
+    config_path = _write_executor_config(tmp_path)
+
+    summary = smoke_module.run_smoke(
+        str(config_path), smoke_run="smoke-test", log=lambda _: None
+    )
+
+    assert summary.status == "failed"
+    assert summary.secret_created
+    assert not summary.pod_created
+    assert summary.secret_deleted
+    assert client.secrets == {}
+    assert summary.error is not None
+    assert "flower-kubernetes-executor-smoke-token" not in summary.error
+    assert "<redacted>" in summary.error
+
+
+def _write_executor_config(tmp_path: Path) -> Path:
+    """Write a minimal Kubernetes executor config."""
+    config_path = tmp_path / "executor.yaml"
+    config_path.write_text(
+        dedent(
+            """
+            namespace: flower-system
+            image: ghcr.io/flwrlabs/taskexecutor:dev
+            resource-pool: gpu-pool
+            labels:
+              flower.ai/deployment: dev
+            """
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    return config_path
+
+
+def _metadata_name(value: object) -> str:
+    metadata = _field(value, "metadata")
+    name = _field(metadata, "name")
+    if not isinstance(name, str):
+        raise AssertionError("Object does not have metadata.name")
+    return name
+
+
+def _metadata_labels(value: object) -> dict[str, str]:
+    metadata = _field(value, "metadata")
+    labels = _field(metadata, "labels")
+    if not isinstance(labels, dict):
+        raise AssertionError("Object does not have metadata.labels")
+    return labels
+
+
+def _pod_spec(value: object) -> dict[str, object]:
+    spec = _field(value, "spec")
+    if not isinstance(spec, dict):
+        raise AssertionError("Object does not have spec")
+    return spec
+
+
+def _matches_selector(value: object, selector: str) -> bool:
+    labels = _metadata_labels(value)
+    for requirement in selector.split(","):
+        key, expected = requirement.split("=", maxsplit=1)
+        if labels.get(key) != expected:
+            return False
+    return True
+
+
+def _field(value: object, field_name: str) -> object | None:
+    if isinstance(value, dict):
+        return value.get(field_name)
+    return getattr(value, field_name, None)

--- a/framework/py/flwr/supercore/superexec/executor/kubernetes_executor_test.py
+++ b/framework/py/flwr/supercore/superexec/executor/kubernetes_executor_test.py
@@ -36,6 +36,7 @@ from .kubernetes_executor import (
     _build_appio_credentials_secret,
     _build_taskexecutor_pod,
     _get_appio_root_certificates,
+    create_incluster_kubernetes_client,
 )
 from .types import ExecutionSpec, LaunchResultStatus
 
@@ -54,6 +55,75 @@ _POD_NAME = f"flwr-taskexecutor-123-{_LAUNCH_ATTEMPT_ID}"
 _NEXT_POD_NAME = f"flwr-taskexecutor-123-{_NEXT_LAUNCH_ATTEMPT_ID}"
 _SECRET_NAME = f"{_POD_NAME}-appio"
 _NEXT_SECRET_NAME = f"{_NEXT_POD_NAME}-appio"
+
+
+def test_create_incluster_kubernetes_client_loads_config_before_api(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test in-cluster auth loads before CoreV1Api construction."""
+    core_v1_api = Mock()
+    calls: list[str] = []
+    client_module = Mock()
+    config_module = Mock()
+
+    def core_v1_api_factory() -> object:
+        calls.append("CoreV1Api")
+        return core_v1_api
+
+    def load_incluster_config() -> None:
+        calls.append("load_incluster_config")
+
+    client_module.CoreV1Api.side_effect = core_v1_api_factory
+    config_module.load_incluster_config.side_effect = load_incluster_config
+    modules = {
+        "kubernetes.client": client_module,
+        "kubernetes.config": config_module,
+    }
+    monkeypatch.setattr(kube.importlib, "import_module", modules.__getitem__)
+
+    client = create_incluster_kubernetes_client()
+
+    assert client is core_v1_api
+    assert calls == ["load_incluster_config", "CoreV1Api"]
+
+
+def test_create_incluster_kubernetes_client_fails_if_package_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test missing Kubernetes package raises clear construction error."""
+
+    def import_module(_name: str) -> object:
+        raise ModuleNotFoundError("No module named 'kubernetes'", name="kubernetes")
+
+    monkeypatch.setattr(kube.importlib, "import_module", import_module)
+
+    with pytest.raises(
+        RuntimeError,
+        match="Kubernetes Python client package is required",
+    ):
+        create_incluster_kubernetes_client()
+
+
+def test_create_incluster_kubernetes_client_fails_if_auth_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test unavailable in-cluster auth raises a clear construction error."""
+    client_module = Mock()
+    config_module = Mock()
+    config_module.load_incluster_config.side_effect = RuntimeError("missing host")
+    modules = {
+        "kubernetes.client": client_module,
+        "kubernetes.config": config_module,
+    }
+    monkeypatch.setattr(kube.importlib, "import_module", modules.__getitem__)
+
+    with pytest.raises(
+        RuntimeError,
+        match="Failed to load in-cluster Kubernetes configuration",
+    ):
+        create_incluster_kubernetes_client()
+
+    client_module.CoreV1Api.assert_not_called()
 
 
 def _execution_spec(**overrides: Any) -> ExecutionSpec:

--- a/framework/py/flwr/supercore/superexec/executor/kubernetes_executor_test.py
+++ b/framework/py/flwr/supercore/superexec/executor/kubernetes_executor_test.py
@@ -447,62 +447,6 @@ def test_build_taskexecutor_pod_supports_labels_annotations_and_security() -> No
     assert pod["spec"]["containers"][0]["securityContext"] == container_security_context
 
 
-def test_config_rejects_extra_labels_that_override_stable_labels() -> None:
-    """Test extra labels cannot replace executor-owned stable labels."""
-    with pytest.raises(ValueError, match="must not override stable labels"):
-        _executor_config(labels={"flower.ai/superexec-task-id": "999"})
-
-
-def test_build_taskexecutor_pod_copies_nested_json_config() -> None:
-    """Test rendered Pod JSON does not share nested config objects."""
-    resources = {"requests": {"cpu": "500m", "memory": "1Gi"}}
-    tolerations = [{"key": "flower.ai/taskexecutor", "value": "true"}]
-    config = _executor_config(resources=resources, tolerations=tolerations)
-
-    pod = _as_dict(
-        _build_taskexecutor_pod(
-            _execution_spec(), config, "root-ca", _LAUNCH_ATTEMPT_ID
-        )
-    )
-    pod_resources = _as_dict(pod["spec"]["containers"][0]["resources"])
-    pod_requests = _as_dict(pod_resources["requests"])
-    pod_toleration = _as_dict(pod["spec"]["tolerations"][0])
-
-    pod_requests["cpu"] = "2"
-    pod_toleration["value"] = "pod-only"
-    resources["requests"]["memory"] = "4Gi"
-    tolerations[0]["key"] = "changed"
-
-    assert resources["requests"]["cpu"] == "500m"
-    assert tolerations[0]["value"] == "true"
-    assert pod_resources["requests"]["memory"] == "1Gi"
-    assert pod_toleration["key"] == "flower.ai/taskexecutor"
-
-
-def test_config_rejects_capacity_budget_without_resource_pool() -> None:
-    """Test capacity gating requires an explicit resource pool."""
-    with pytest.raises(ValueError, match="Resource pool must be configured"):
-        _executor_config(active_pod_budget=10)
-
-
-def test_config_rejects_non_positive_active_pod_budget() -> None:
-    """Test active Pod budget must be positive when configured."""
-    with pytest.raises(ValueError, match="Active Pod budget must be positive"):
-        _executor_config(active_pod_budget=0)
-
-
-def test_config_rejects_invalid_capacity_poll_interval() -> None:
-    """Test capacity poll interval must be positive."""
-    with pytest.raises(ValueError, match="Capacity poll interval must be positive"):
-        _executor_config(capacity_poll_interval=0)
-
-
-def test_config_rejects_invalid_capacity_log_interval() -> None:
-    """Test capacity log interval must be positive when provided."""
-    with pytest.raises(ValueError, match="Capacity log interval must be positive"):
-        _executor_config(capacity_log_interval=0)
-
-
 def test_wait_for_capacity_returns_below_budget_without_sleeping() -> None:
     """Test capacity wait returns immediately when the active Pod count fits."""
     client = Mock()

--- a/framework/py/flwr/supercore/superexec/executor/kubernetes_executor_test.py
+++ b/framework/py/flwr/supercore/superexec/executor/kubernetes_executor_test.py
@@ -731,10 +731,7 @@ def test_sweeper_keeps_secret_without_credential_secret_name() -> None:
         "items": [
             _secret(
                 "manual-secret",
-                {
-                    "app.kubernetes.io/name": "flower",
-                    "app.kubernetes.io/component": "taskexecutor",
-                },
+                _task_labels(123),
             )
         ]
     }

--- a/framework/py/flwr/supercore/superexec/executor/kubernetes_executor_test.py
+++ b/framework/py/flwr/supercore/superexec/executor/kubernetes_executor_test.py
@@ -94,10 +94,15 @@ def _appio_root_certificates(
 
 
 def _task_labels(task_id: int) -> dict[str, str]:
+    labels = _taskexecutor_labels()
+    labels["flower.ai/superexec-task-id"] = str(task_id)
+    return labels
+
+
+def _taskexecutor_labels() -> dict[str, str]:
     return {
         "app.kubernetes.io/name": "flower",
         "app.kubernetes.io/component": "taskexecutor",
-        "flower.ai/superexec-task-id": str(task_id),
         "flower.ai/task-type": "flwr-serverapp",
     }
 
@@ -624,6 +629,39 @@ def test_sweeper_deletes_terminal_pod_and_matching_secret(phase: str) -> None:
     )
 
 
+def test_sweeper_keeps_terminal_pod_without_task_id_label() -> None:
+    """Test cleanup ignores selector-matching Pods without a task-id label."""
+    client = Mock()
+    labels = _taskexecutor_labels()
+    client.list_namespaced_pod.return_value = {
+        "items": [_pod("Succeeded", labels=labels)]
+    }
+    client.list_namespaced_secret.return_value = {
+        "items": [_secret(_SECRET_NAME, labels)]
+    }
+
+    CompletedPodSweeper(client=client, config=_executor_config()).sweep()
+
+    client.delete_namespaced_pod.assert_not_called()
+    client.delete_namespaced_secret.assert_not_called()
+
+
+def test_sweeper_keeps_matching_secret_without_task_id_label() -> None:
+    """Test cleanup ignores derived Secrets without a task-id label."""
+    client = Mock()
+    client.list_namespaced_pod.return_value = {
+        "items": [_pod("Succeeded", labels=_task_labels(123))]
+    }
+    client.list_namespaced_secret.return_value = {
+        "items": [_secret(_SECRET_NAME, _taskexecutor_labels())]
+    }
+
+    CompletedPodSweeper(client=client, config=_executor_config()).sweep()
+
+    client.delete_namespaced_pod.assert_called_once()
+    client.delete_namespaced_secret.assert_not_called()
+
+
 def test_sweeper_keeps_pending_and_running_pods_and_secrets() -> None:
     """Test cleanup ignores non-terminal Pods and their credential Secrets."""
     client = Mock()
@@ -699,6 +737,19 @@ def test_sweeper_keeps_secret_without_credential_secret_name() -> None:
                 },
             )
         ]
+    }
+
+    CompletedPodSweeper(client=client, config=_executor_config()).sweep()
+
+    client.delete_namespaced_secret.assert_not_called()
+
+
+def test_sweeper_keeps_orphaned_credential_secret_without_task_id_label() -> None:
+    """Test cleanup ignores orphaned credential Secrets without a task-id label."""
+    client = Mock()
+    client.list_namespaced_pod.return_value = {"items": []}
+    client.list_namespaced_secret.return_value = {
+        "items": [_secret("flwr-taskexecutor-999-appio", _taskexecutor_labels())]
     }
 
     CompletedPodSweeper(client=client, config=_executor_config()).sweep()

--- a/framework/py/flwr/supercore/superexec/executor/kubernetes_executor_test.py
+++ b/framework/py/flwr/supercore/superexec/executor/kubernetes_executor_test.py
@@ -14,7 +14,6 @@
 # ==============================================================================
 """Tests for SuperExec Kubernetes executor."""
 
-from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, cast
 from unittest.mock import Mock, call
@@ -32,6 +31,7 @@ from .kubernetes_executor import (
     CompletedPodSweeper,
     KubernetesExecutor,
     KubernetesExecutorConfig,
+    _COMPLETED_POD_SWEEP_INTERVAL_SECONDS,
     _build_appio_credentials_secret,
     _build_taskexecutor_pod,
     _get_appio_root_certificates,
@@ -108,7 +108,6 @@ def _pod(
     *,
     name: str = _POD_NAME,
     labels: dict[str, str] | None = None,
-    finished_at: str | None = None,
 ) -> dict[str, Any]:
     metadata: dict[str, Any] = {"name": name}
     if deletion_timestamp is not None:
@@ -117,10 +116,6 @@ def _pod(
         metadata["labels"] = labels
 
     status: dict[str, Any] = {"phase": phase}
-    if finished_at is not None:
-        status["containerStatuses"] = [
-            {"state": {"terminated": {"finishedAt": finished_at}}}
-        ]
     return {"metadata": metadata, "status": status}
 
 
@@ -508,16 +503,14 @@ def test_config_rejects_invalid_capacity_log_interval() -> None:
         _executor_config(capacity_log_interval=0)
 
 
-def test_config_rejects_negative_completed_pod_retention() -> None:
-    """Test completed Pod retention must not be negative."""
-    with pytest.raises(ValueError, match="Completed Pod retention"):
-        _executor_config(completed_pod_retention_seconds=-1)
-
-
 def test_wait_for_capacity_returns_below_budget_without_sleeping() -> None:
     """Test capacity wait returns immediately when the active Pod count fits."""
     client = Mock()
-    client.list_namespaced_pod.return_value = {"items": [_pod("Running")]}
+    client.list_namespaced_pod.side_effect = [
+        {"items": []},
+        {"items": [_pod("Running")]},
+    ]
+    client.list_namespaced_secret.return_value = {"items": []}
     sleep = Mock()
     config = _executor_config(
         labels={"flower.ai/team": "platform"},
@@ -529,15 +522,8 @@ def test_wait_for_capacity_returns_below_budget_without_sleeping() -> None:
 
     KubernetesExecutor(client=client, config=config).wait_for_capacity()
 
-    client.list_namespaced_pod.assert_called_once_with(
-        "flower-system",
-        label_selector=(
-            "app.kubernetes.io/component=taskexecutor,"
-            "app.kubernetes.io/name=flower,"
-            "flower.ai/resource-pool=gpu-pool,"
-            "flower.ai/team=platform"
-        ),
-    )
+    assert client.list_namespaced_pod.call_count == 2
+    client.list_namespaced_secret.assert_called_once()
     sleep.assert_not_called()
 
 
@@ -545,9 +531,11 @@ def test_wait_for_capacity_sleeps_and_polls_again_at_budget() -> None:
     """Test capacity wait sleeps when the active Pod count reaches the budget."""
     client = Mock()
     client.list_namespaced_pod.side_effect = [
+        {"items": []},
         {"items": [_pod("Pending")]},
         {"items": []},
     ]
+    client.list_namespaced_secret.return_value = {"items": []}
     sleep = Mock()
     config = _executor_config(
         resource_pool="gpu-pool",
@@ -558,7 +546,7 @@ def test_wait_for_capacity_sleeps_and_polls_again_at_budget() -> None:
 
     KubernetesExecutor(client=client, config=config).wait_for_capacity()
 
-    assert client.list_namespaced_pod.call_count == 2
+    assert client.list_namespaced_pod.call_count == 3
     sleep.assert_called_once_with(3.0)
 
 
@@ -566,6 +554,7 @@ def test_wait_for_capacity_counts_pending_running_and_terminating_pods() -> None
     """Test active Pod counting includes phase-active and terminating Pods."""
     client = Mock()
     client.list_namespaced_pod.side_effect = [
+        {"items": []},
         {
             "items": [
                 _pod("Pending"),
@@ -576,6 +565,7 @@ def test_wait_for_capacity_counts_pending_running_and_terminating_pods() -> None
         },
         {"items": []},
     ]
+    client.list_namespaced_secret.return_value = {"items": []}
     sleep = Mock()
     config = _executor_config(
         resource_pool="gpu-pool",
@@ -591,9 +581,11 @@ def test_wait_for_capacity_counts_pending_running_and_terminating_pods() -> None
 def test_wait_for_capacity_ignores_terminal_pods_not_terminating() -> None:
     """Test Succeeded and Failed Pods do not count when they are not terminating."""
     client = Mock()
-    client.list_namespaced_pod.return_value = {
-        "items": [_pod("Succeeded"), _pod("Failed")]
-    }
+    client.list_namespaced_pod.side_effect = [
+        {"items": []},
+        {"items": [_pod("Succeeded"), _pod("Failed")]},
+    ]
+    client.list_namespaced_secret.return_value = {"items": []}
     sleep = Mock()
     config = _executor_config(
         resource_pool="gpu-pool",
@@ -604,6 +596,50 @@ def test_wait_for_capacity_ignores_terminal_pods_not_terminating() -> None:
     KubernetesExecutor(client=client, config=config).wait_for_capacity()
 
     sleep.assert_not_called()
+
+
+def test_wait_for_capacity_sweeps_terminal_pods_before_capacity_check() -> None:
+    """Test capacity wait runs completed Pod cleanup opportunistically."""
+    client = Mock()
+    labels = _task_labels(123)
+    client.list_namespaced_pod.side_effect = [
+        {"items": [_pod("Succeeded", labels=labels)]},
+        {"items": []},
+    ]
+    client.list_namespaced_secret.return_value = {
+        "items": [_secret(_SECRET_NAME, labels)]
+    }
+    config = _executor_config(resource_pool="gpu-pool", active_pod_budget=1)
+
+    KubernetesExecutor(client=client, config=config).wait_for_capacity()
+
+    client.delete_namespaced_pod.assert_called_once_with(
+        name=_POD_NAME,
+        namespace="flower-system",
+        grace_period_seconds=0,
+    )
+    client.delete_namespaced_secret.assert_called_once_with(
+        name=_SECRET_NAME, namespace="flower-system"
+    )
+
+
+def test_wait_for_capacity_throttles_completed_pod_sweeps() -> None:
+    """Test capacity wait does not sweep more often than the internal interval."""
+    client = Mock()
+    client.list_namespaced_pod.return_value = {"items": []}
+    client.list_namespaced_secret.return_value = {"items": []}
+    config = _executor_config(
+        resource_pool="gpu-pool",
+        active_pod_budget=1,
+        monotonic=Mock(side_effect=[0.0, _COMPLETED_POD_SWEEP_INTERVAL_SECONDS - 1.0]),
+    )
+    executor = KubernetesExecutor(client=client, config=config)
+
+    executor.wait_for_capacity()
+    executor.wait_for_capacity()
+
+    assert client.list_namespaced_pod.call_count == 3
+    client.list_namespaced_secret.assert_called_once()
 
 
 @pytest.mark.parametrize("phase", ["Succeeded", "Failed"])
@@ -666,47 +702,8 @@ def test_sweeper_keeps_pending_and_running_pods_and_secrets() -> None:
     client.delete_namespaced_secret.assert_not_called()
 
 
-@pytest.mark.parametrize(
-    ("finished_at", "expect_deleted"),
-    [
-        ("2026-05-27T18:59:30Z", False),
-        ("2026-05-27T18:58:00Z", True),
-    ],
-)
-def test_sweeper_respects_completed_pod_retention_window(
-    finished_at: str, expect_deleted: bool
-) -> None:
-    """Test cleanup honors the configured completed Pod retention window."""
-    client = Mock()
-    client.list_namespaced_pod.return_value = {
-        "items": [
-            _pod(
-                "Succeeded",
-                labels=_task_labels(123),
-                finished_at=finished_at,
-            )
-        ]
-    }
-    client.list_namespaced_secret.return_value = {
-        "items": [_secret(_SECRET_NAME, _task_labels(123))]
-    }
-    config = _executor_config(
-        completed_pod_retention_seconds=60.0,
-        now=lambda: datetime(2026, 5, 27, 19, 0, 0, tzinfo=UTC),
-    )
-
-    CompletedPodSweeper(client=client, config=config).sweep()
-
-    if expect_deleted:
-        client.delete_namespaced_pod.assert_called_once()
-        client.delete_namespaced_secret.assert_called_once()
-    else:
-        client.delete_namespaced_pod.assert_not_called()
-        client.delete_namespaced_secret.assert_not_called()
-
-
-def test_sweeper_deletes_orphaned_per_task_secret() -> None:
-    """Test cleanup deletes a labeled per-task Secret when its Pod is gone."""
+def test_sweeper_deletes_orphaned_credential_secret() -> None:
+    """Test cleanup deletes a credential Secret when its Pod is gone."""
     client = Mock()
     client.list_namespaced_pod.return_value = {"items": []}
     client.list_namespaced_secret.return_value = {
@@ -721,11 +718,14 @@ def test_sweeper_deletes_orphaned_per_task_secret() -> None:
     )
 
 
-def test_sweeper_deletes_all_matching_secrets_for_terminal_pod() -> None:
-    """Test cleanup deletes all labeled Secrets for a swept terminal Pod."""
+def test_sweeper_keeps_active_retry_secret_for_same_task() -> None:
+    """Test cleanup keeps the Secret for a newer active retry of the same task."""
     client = Mock()
     client.list_namespaced_pod.return_value = {
-        "items": [_pod("Succeeded", labels=_task_labels(123))]
+        "items": [
+            _pod("Succeeded", name=_POD_NAME, labels=_task_labels(123)),
+            _pod("Running", name=_NEXT_POD_NAME, labels=_task_labels(123)),
+        ]
     }
     client.list_namespaced_secret.return_value = {
         "items": [
@@ -738,12 +738,11 @@ def test_sweeper_deletes_all_matching_secrets_for_terminal_pod() -> None:
 
     assert client.delete_namespaced_secret.mock_calls == [
         call(name=_SECRET_NAME, namespace="flower-system"),
-        call(name=_NEXT_SECRET_NAME, namespace="flower-system"),
     ]
 
 
-def test_sweeper_keeps_secret_without_taskexecutor_task_label() -> None:
-    """Test cleanup does not delete Secrets missing the task ownership label."""
+def test_sweeper_keeps_secret_without_credential_secret_name() -> None:
+    """Test cleanup does not delete Secrets without the credential name suffix."""
     client = Mock()
     client.list_namespaced_pod.return_value = {"items": []}
     client.list_namespaced_secret.return_value = {

--- a/framework/py/flwr/supercore/superexec/executor/kubernetes_executor_test.py
+++ b/framework/py/flwr/supercore/superexec/executor/kubernetes_executor_test.py
@@ -14,6 +14,7 @@
 # ==============================================================================
 """Tests for SuperExec Kubernetes executor."""
 
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, cast
 from unittest.mock import Mock, call
@@ -28,6 +29,7 @@ from .kubernetes_executor import (
     APPIO_ROOT_CERTIFICATES_FILE_PATH,
     APPIO_TOKEN_FILE_PATH,
     LAUNCH_ATTEMPT_LABEL,
+    CompletedPodSweeper,
     KubernetesExecutor,
     KubernetesExecutorConfig,
     _build_appio_credentials_secret,
@@ -91,11 +93,42 @@ def _appio_root_certificates(
     return _get_appio_root_certificates(spec, config)
 
 
-def _pod(phase: str, deletion_timestamp: str | None = None) -> dict[str, Any]:
-    metadata = {}
+def _task_labels(task_id: int) -> dict[str, str]:
+    return {
+        "app.kubernetes.io/name": "flower",
+        "app.kubernetes.io/component": "taskexecutor",
+        "flower.ai/superexec-task-id": str(task_id),
+        "flower.ai/task-type": "flwr-serverapp",
+    }
+
+
+def _pod(
+    phase: str,
+    deletion_timestamp: str | None = None,
+    *,
+    name: str = _POD_NAME,
+    labels: dict[str, str] | None = None,
+    finished_at: str | None = None,
+) -> dict[str, Any]:
+    metadata: dict[str, Any] = {"name": name}
     if deletion_timestamp is not None:
         metadata["deletionTimestamp"] = deletion_timestamp
-    return {"metadata": metadata, "status": {"phase": phase}}
+    if labels is not None:
+        metadata["labels"] = labels
+
+    status: dict[str, Any] = {"phase": phase}
+    if finished_at is not None:
+        status["containerStatuses"] = [
+            {"state": {"terminated": {"finishedAt": finished_at}}}
+        ]
+    return {"metadata": metadata, "status": status}
+
+
+def _secret(name: str, labels: dict[str, str] | None = None) -> dict[str, Any]:
+    metadata: dict[str, Any] = {"name": name}
+    if labels is not None:
+        metadata["labels"] = labels
+    return {"metadata": metadata}
 
 
 def test_build_appio_credentials_secret_contains_token_and_ca() -> None:
@@ -475,6 +508,12 @@ def test_config_rejects_invalid_capacity_log_interval() -> None:
         _executor_config(capacity_log_interval=0)
 
 
+def test_config_rejects_negative_completed_pod_retention() -> None:
+    """Test completed Pod retention must not be negative."""
+    with pytest.raises(ValueError, match="Completed Pod retention"):
+        _executor_config(completed_pod_retention_seconds=-1)
+
+
 def test_wait_for_capacity_returns_below_budget_without_sleeping() -> None:
     """Test capacity wait returns immediately when the active Pod count fits."""
     client = Mock()
@@ -565,6 +604,181 @@ def test_wait_for_capacity_ignores_terminal_pods_not_terminating() -> None:
     KubernetesExecutor(client=client, config=config).wait_for_capacity()
 
     sleep.assert_not_called()
+
+
+@pytest.mark.parametrize("phase", ["Succeeded", "Failed"])
+def test_sweeper_deletes_terminal_pod_and_matching_secret(phase: str) -> None:
+    """Test cleanup deletes terminal Pods and their credential Secrets."""
+    client = Mock()
+    labels = _task_labels(123)
+    client.list_namespaced_pod.return_value = {"items": [_pod(phase, labels=labels)]}
+    client.list_namespaced_secret.return_value = {
+        "items": [_secret(_SECRET_NAME, labels)]
+    }
+    config = _executor_config(
+        labels={"flower.ai/team": "platform"},
+        resource_pool="gpu-pool",
+    )
+
+    CompletedPodSweeper(client=client, config=config).sweep()
+
+    selector = (
+        "app.kubernetes.io/component=taskexecutor,"
+        "app.kubernetes.io/name=flower,"
+        "flower.ai/resource-pool=gpu-pool,"
+        "flower.ai/team=platform"
+    )
+    client.list_namespaced_pod.assert_called_once_with(
+        "flower-system", label_selector=selector
+    )
+    client.list_namespaced_secret.assert_called_once_with(
+        "flower-system", label_selector=selector
+    )
+    client.delete_namespaced_pod.assert_called_once_with(
+        name=_POD_NAME,
+        namespace="flower-system",
+        grace_period_seconds=0,
+    )
+    client.delete_namespaced_secret.assert_called_once_with(
+        name=_SECRET_NAME, namespace="flower-system"
+    )
+
+
+def test_sweeper_keeps_pending_and_running_pods_and_secrets() -> None:
+    """Test cleanup ignores non-terminal Pods and their credential Secrets."""
+    client = Mock()
+    client.list_namespaced_pod.return_value = {
+        "items": [
+            _pod("Pending", name=_POD_NAME, labels=_task_labels(123)),
+            _pod("Running", name=_NEXT_POD_NAME, labels=_task_labels(124)),
+        ]
+    }
+    client.list_namespaced_secret.return_value = {
+        "items": [
+            _secret(_SECRET_NAME, _task_labels(123)),
+            _secret(_NEXT_SECRET_NAME, _task_labels(124)),
+        ]
+    }
+
+    CompletedPodSweeper(client=client, config=_executor_config()).sweep()
+
+    client.delete_namespaced_pod.assert_not_called()
+    client.delete_namespaced_secret.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("finished_at", "expect_deleted"),
+    [
+        ("2026-05-27T18:59:30Z", False),
+        ("2026-05-27T18:58:00Z", True),
+    ],
+)
+def test_sweeper_respects_completed_pod_retention_window(
+    finished_at: str, expect_deleted: bool
+) -> None:
+    """Test cleanup honors the configured completed Pod retention window."""
+    client = Mock()
+    client.list_namespaced_pod.return_value = {
+        "items": [
+            _pod(
+                "Succeeded",
+                labels=_task_labels(123),
+                finished_at=finished_at,
+            )
+        ]
+    }
+    client.list_namespaced_secret.return_value = {
+        "items": [_secret(_SECRET_NAME, _task_labels(123))]
+    }
+    config = _executor_config(
+        completed_pod_retention_seconds=60.0,
+        now=lambda: datetime(2026, 5, 27, 19, 0, 0, tzinfo=UTC),
+    )
+
+    CompletedPodSweeper(client=client, config=config).sweep()
+
+    if expect_deleted:
+        client.delete_namespaced_pod.assert_called_once()
+        client.delete_namespaced_secret.assert_called_once()
+    else:
+        client.delete_namespaced_pod.assert_not_called()
+        client.delete_namespaced_secret.assert_not_called()
+
+
+def test_sweeper_deletes_orphaned_per_task_secret() -> None:
+    """Test cleanup deletes a labeled per-task Secret when its Pod is gone."""
+    client = Mock()
+    client.list_namespaced_pod.return_value = {"items": []}
+    client.list_namespaced_secret.return_value = {
+        "items": [_secret("flwr-taskexecutor-999-appio", _task_labels(999))]
+    }
+
+    CompletedPodSweeper(client=client, config=_executor_config()).sweep()
+
+    client.delete_namespaced_pod.assert_not_called()
+    client.delete_namespaced_secret.assert_called_once_with(
+        name="flwr-taskexecutor-999-appio", namespace="flower-system"
+    )
+
+
+def test_sweeper_deletes_all_matching_secrets_for_terminal_pod() -> None:
+    """Test cleanup deletes all labeled Secrets for a swept terminal Pod."""
+    client = Mock()
+    client.list_namespaced_pod.return_value = {
+        "items": [_pod("Succeeded", labels=_task_labels(123))]
+    }
+    client.list_namespaced_secret.return_value = {
+        "items": [
+            _secret(_SECRET_NAME, _task_labels(123)),
+            _secret(_NEXT_SECRET_NAME, _task_labels(123)),
+        ]
+    }
+
+    CompletedPodSweeper(client=client, config=_executor_config()).sweep()
+
+    assert client.delete_namespaced_secret.mock_calls == [
+        call(name=_SECRET_NAME, namespace="flower-system"),
+        call(name=_NEXT_SECRET_NAME, namespace="flower-system"),
+    ]
+
+
+def test_sweeper_keeps_secret_without_taskexecutor_task_label() -> None:
+    """Test cleanup does not delete Secrets missing the task ownership label."""
+    client = Mock()
+    client.list_namespaced_pod.return_value = {"items": []}
+    client.list_namespaced_secret.return_value = {
+        "items": [
+            _secret(
+                "manual-secret",
+                {
+                    "app.kubernetes.io/name": "flower",
+                    "app.kubernetes.io/component": "taskexecutor",
+                },
+            )
+        ]
+    }
+
+    CompletedPodSweeper(client=client, config=_executor_config()).sweep()
+
+    client.delete_namespaced_secret.assert_not_called()
+
+
+def test_sweeper_tolerates_already_deleted_pod_and_secret() -> None:
+    """Test cleanup treats 404 delete responses as idempotent success."""
+    client = Mock()
+    client.list_namespaced_pod.return_value = {
+        "items": [_pod("Failed", labels=_task_labels(123))]
+    }
+    client.list_namespaced_secret.return_value = {
+        "items": [_secret(_SECRET_NAME, _task_labels(123))]
+    }
+    client.delete_namespaced_pod.side_effect = _KubernetesApiError(404, "Not Found")
+    client.delete_namespaced_secret.side_effect = _KubernetesApiError(404, "Not Found")
+
+    CompletedPodSweeper(client=client, config=_executor_config()).sweep()
+
+    client.delete_namespaced_pod.assert_called_once()
+    client.delete_namespaced_secret.assert_called_once()
 
 
 def test_launch_submits_secret_before_pod_and_returns_accepted(

--- a/framework/py/flwr/supercore/superexec/executor/kubernetes_executor_test.py
+++ b/framework/py/flwr/supercore/superexec/executor/kubernetes_executor_test.py
@@ -24,6 +24,7 @@ from flwr.supercore.constant import TaskType
 
 from . import kubernetes_executor as kube
 from .kubernetes_executor import (
+    _COMPLETED_POD_SWEEP_INTERVAL_SECONDS,
     APPIO_CREDENTIALS_MOUNT_PATH,
     APPIO_ROOT_CERTIFICATES_FILE_PATH,
     APPIO_TOKEN_FILE_PATH,
@@ -31,7 +32,6 @@ from .kubernetes_executor import (
     CompletedPodSweeper,
     KubernetesExecutor,
     KubernetesExecutorConfig,
-    _COMPLETED_POD_SWEEP_INTERVAL_SECONDS,
     _build_appio_credentials_secret,
     _build_taskexecutor_pod,
     _get_appio_root_certificates,

--- a/framework/py/flwr/supercore/superexec/executor/kubernetes_executor_test.py
+++ b/framework/py/flwr/supercore/superexec/executor/kubernetes_executor_test.py
@@ -25,6 +25,7 @@ from flwr.supercore.constant import TaskType
 from . import kubernetes_executor as kube
 from .kubernetes_executor import (
     _COMPLETED_POD_SWEEP_INTERVAL_SECONDS,
+    _TASK_ID_LABEL,
     APPIO_CREDENTIALS_MOUNT_PATH,
     APPIO_ROOT_CERTIFICATES_FILE_PATH,
     APPIO_TOKEN_FILE_PATH,
@@ -95,7 +96,7 @@ def _appio_root_certificates(
 
 def _task_labels(task_id: int) -> dict[str, str]:
     labels = _taskexecutor_labels()
-    labels["flower.ai/superexec-task-id"] = str(task_id)
+    labels[_TASK_ID_LABEL] = str(task_id)
     return labels
 
 

--- a/framework/py/flwr/supercore/superexec/run_superexec.py
+++ b/framework/py/flwr/supercore/superexec/run_superexec.py
@@ -150,9 +150,8 @@ def run_superexec(  # pylint: disable=R0912,R0913,R0914,R0915,R0917
     executor_config : Optional[ExecutorConfig] (default: None)
         Parsed executor configuration.
     """
-    _ = executor_config
     try:
-        executor = get_executor(executor_type)
+        executor = get_executor(executor_type, executor_config=executor_config)
     except ValueError as err:
         flwr_exit(ExitCode.SUPEREXEC_INVALID_EXECUTOR_CONFIG, str(err))
 

--- a/framework/py/flwr/supercore/superexec/run_superexec.py
+++ b/framework/py/flwr/supercore/superexec/run_superexec.py
@@ -51,6 +51,7 @@ from flwr.supercore.run import Run
 from flwr.supercore.tls import validate_and_resolve_root_certificates
 
 from .executor import LaunchResult, LaunchResultStatus, get_executor
+from .executor.config import ExecutorConfig
 from .plugin import ExecPlugin
 from .plugin.base_ephemeral_exec_plugin import BaseEphemeralExecPlugin
 
@@ -114,6 +115,7 @@ def run_superexec(  # pylint: disable=R0912,R0913,R0914,R0915,R0917
     health_server_address: str | None = None,
     runtime_dependency_install: bool = RUNTIME_DEPENDENCY_INSTALL,
     executor_type: ExecutorType = ExecutorType.SUBPROCESS,
+    executor_config: ExecutorConfig | None = None,
 ) -> None:
     """Run Flower SuperExec.
 
@@ -145,8 +147,14 @@ def run_superexec(  # pylint: disable=R0912,R0913,R0914,R0915,R0917
         Whether runtime dependency installation is allowed.
     executor_type : ExecutorType (default: ExecutorType.SUBPROCESS)
         The executor to use for non-ephemeral app processes.
+    executor_config : Optional[ExecutorConfig] (default: None)
+        Parsed executor configuration.
     """
-    executor = get_executor(executor_type)
+    _ = executor_config
+    try:
+        executor = get_executor(executor_type)
+    except ValueError as err:
+        flwr_exit(ExitCode.SUPEREXEC_INVALID_EXECUTOR_CONFIG, str(err))
 
     interceptors: list[grpc.UnaryUnaryClientInterceptor] = [
         RuntimeVersionClientInterceptor(component_name="SuperExec")

--- a/framework/py/flwr/supercore/superexec/run_superexec_test.py
+++ b/framework/py/flwr/supercore/superexec/run_superexec_test.py
@@ -21,6 +21,8 @@ from unittest.mock import Mock
 
 import pytest
 
+from flwr.common.exit import ExitCode
+from flwr.supercore.constant import ExecutorType
 from flwr.supercore.interceptors import (
     RuntimeVersionClientInterceptor,
     SuperExecAuthClientInterceptor,
@@ -108,6 +110,61 @@ def test_run_superexec_adds_runtime_version_interceptor(
 
     assert tuple(type(interceptor) for interceptor in captured["interceptors"]) == (
         expected_interceptor_types
+    )
+
+
+def test_run_superexec_passes_executor_config_to_factory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SuperExec should pass selected executor config to the factory."""
+    channel = Mock()
+    stub = Mock()
+    stub.PullPendingTasks.side_effect = KeyboardInterrupt()
+    executor_config = {"namespace": "flower-system", "image": "taskexecutor:dev"}
+    get_executor = Mock(return_value=Mock())
+
+    monkeypatch.setattr(
+        run_superexec_module, "create_channel", Mock(return_value=channel)
+    )
+    monkeypatch.setattr(run_superexec_module, "register_signal_handlers", Mock())
+    monkeypatch.setattr(run_superexec_module, "wrap_stub", Mock())
+    monkeypatch.setattr(run_superexec_module, "get_executor", get_executor)
+
+    with pytest.raises(KeyboardInterrupt):
+        run_superexec_module.run_superexec(
+            plugin_class=Mock(),
+            stub_class=Mock(return_value=stub),
+            appio_api_address="127.0.0.1:9091",
+            insecure=True,
+            executor_type=ExecutorType.KUBERNETES,
+            executor_config=executor_config,
+        )
+
+    get_executor.assert_called_once_with(
+        ExecutorType.KUBERNETES, executor_config=executor_config
+    )
+
+
+def test_run_superexec_exits_for_invalid_executor_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SuperExec should exit with executor-config failure before task
+    polling."""
+    flwr_exit = Mock(side_effect=SystemExit())
+    monkeypatch.setattr(run_superexec_module, "flwr_exit", flwr_exit)
+
+    with pytest.raises(SystemExit):
+        run_superexec_module.run_superexec(
+            plugin_class=Mock(),
+            stub_class=Mock(),
+            appio_api_address="127.0.0.1:9091",
+            insecure=True,
+            executor_type=ExecutorType.KUBERNETES,
+        )
+
+    flwr_exit.assert_called_once_with(
+        ExitCode.SUPEREXEC_INVALID_EXECUTOR_CONFIG,
+        "Kubernetes executor requires --executor-config.",
     )
 
 


### PR DESCRIPTION
## Issue

### Description

This PR is F7b in the Kubernetes executor rollout stack. F7a introduced the portable evidence bundle/schema scaffold for a future integrated k3d launch-path harness. The next slice needs a local, optional way to prove the Kubernetes infrastructure assumptions for that future harness without yet running the full SuperLink AppIo, SuperExec, and TaskExecutor path.

### Related issues/PRs

Stacked on #7383.

## Proposal

### Explanation

This PR extends the dev-maintained Kubernetes executor harness with an explicit `infra-proof` mode. The mode records k3d infrastructure, namespace, TLS material contract, and RBAC proof evidence through the F7a evidence bundle format.

Host commands are dry-run by default. Real k3d/kubectl execution requires `--execute`, and local cluster creation is additionally gated behind `--create-cluster`. The harness can render/apply namespace and SuperExec ServiceAccount/Role/RoleBinding manifests, run positive and negative `kubectl auth can-i` checks, and record sanitized command evidence. TLS certificate generation is intentionally deferred; this slice records a supplied AppIo root certificate path/fingerprint or marks TLS material as planned.

This does not implement the full integrated launch path. SuperLink AppIo, SuperExec task claiming, TaskExecutor Pod launch, capacity wait proof, cleanup proof, and CNI/NetworkPolicy validation remain future F7 work.

### Checklist

- [x] Implement proposed change
- [x] Write tests
- [ ] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [ ] Address LLM-reviewer comments, if applicable (e.g., GitHub Copilot)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

Validation run locally:

- `python -m py_compile framework/dev/kubernetes_executor_harness.py framework/py/flwr/supercore/superexec/executor/kubernetes_executor_harness_test.py`
- `python -m pytest framework/py/flwr/supercore/superexec/executor/kubernetes_executor_harness_test.py`
- `git diff --check`
- `python -m black --check framework/dev/kubernetes_executor_harness.py framework/py/flwr/supercore/superexec/executor/kubernetes_executor_harness_test.py`
- `python -m ruff check --no-cache framework/py/flwr/supercore/superexec/executor/kubernetes_executor_harness_test.py`

Optional real proof was run by the implementation thread:

`python framework/dev/kubernetes_executor_harness.py --mode infra-proof --output-dir /private/tmp/f7b-harness-real-2 --execute --create-cluster --apply-manifests --json`

Result: passed. The local k3d cluster `flower-f7` was left in place for inspection.
