### PR TITLE
feat(datasets): Add partition skew distance metrics

### DIFF
--- a/datasets/README.md
+++ b/datasets/README.md
@@ -25,7 +25,8 @@ pip install flwr-datasets[vision]
 Flower Datasets library supports:
 * **downloading datasets** - choose the dataset from Hugging Face's `datasets`,
 * **partitioning datasets** - customize the partitioning scheme,
-* **creating centralized datasets** - leave parts of the dataset unpartitioned (e.g. for centralized evaluation).
+* **creating centralized datasets** - leave parts of the dataset unpartitioned (e.g. for centralized evaluation),
+* **measuring partition skew** - compute label-distribution counts, frequencies, and categorical distance metrics.
 
 Thanks to using Hugging Face's `datasets` used under the hood, Flower Datasets integrates with the following popular formats/frameworks:
 * Hugging Face,
@@ -81,5 +82,13 @@ centralized_data = fds.load_split("test")
 If a local dataset is sorted by label or another target column, use
 `IidPartitioner(num_partitions=100, shuffle=True, seed=42)` to shuffle the dataset
 once before sharding it.
+
+To inspect categorical partition skew, use `flwr_datasets.metrics`:
+
+```
+from flwr_datasets.metrics import compute_hellinger_distances
+
+distances = compute_hellinger_distances(partitioner, column_name="label")
+```
 
 For more details, please refer to the specific how-to guides or tutorials. They showcase customization and more advanced features.

--- a/datasets/docs/source/index.rst
+++ b/datasets/docs/source/index.rst
@@ -82,6 +82,7 @@ Flower Datasets library supports:
 - **Partitioning datasets** - choose one of the implemented partitioning schemes or create your own.
 - **Creating centralized datasets** - leave parts of the dataset unpartitioned (e.g. for centralized evaluation)
 - **Visualization of the partitioned datasets** - visualize the label distribution of the partitioned dataset (and compare the results on different parameters of the same partitioning schemes, different datasets, different partitioning schemes, or any mix of them)
+- **Measuring partition skew** - compute label-distribution counts, frequencies, and categorical distance metrics such as Hellinger and Jensen-Shannon distances.
 
 .. note::
 

--- a/datasets/flwr_datasets/metrics/__init__.py
+++ b/datasets/flwr_datasets/metrics/__init__.py
@@ -15,9 +15,18 @@
 """Metrics package."""
 
 
-from flwr_datasets.metrics.utils import compute_counts, compute_frequencies
+from flwr_datasets.metrics.distances import (
+    compute_hellinger_distances,
+    compute_jensen_shannon_distances,
+)
+from flwr_datasets.metrics.utils import (
+    compute_counts,
+    compute_frequencies,
+)
 
 __all__ = [
     "compute_counts",
     "compute_frequencies",
+    "compute_hellinger_distances",
+    "compute_jensen_shannon_distances",
 ]

--- a/datasets/flwr_datasets/metrics/distances.py
+++ b/datasets/flwr_datasets/metrics/distances.py
@@ -1,0 +1,177 @@
+# Copyright 2024 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Distance metrics for partition distributions."""
+
+
+from collections.abc import Callable
+
+import numpy as np
+import pandas as pd
+
+from flwr_datasets.common.typing import NDArray
+from flwr_datasets.metrics.utils import _compute_counts, compute_counts
+from flwr_datasets.partitioner import Partitioner
+
+
+def compute_hellinger_distances(
+    partitioner: Partitioner,
+    column_name: str,
+    max_num_partitions: int | None = None,
+) -> pd.Series:
+    """Compute Hellinger distances between partitions and the full dataset.
+
+    The distance is computed between each partition's categorical distribution over
+    ``column_name`` and the full dataset distribution over the same column. Values are
+    in the interval ``[0, 1]``. A value of ``0`` means that the partition distribution
+    exactly matches the full dataset distribution.
+
+    Parameters
+    ----------
+    partitioner : Partitioner
+        Partitioner with an assigned dataset.
+    column_name : str
+        Column name identifying the categorical values used to compute the
+        distributions.
+    max_num_partitions : Optional[int]
+        The maximum number of partitions that will be used. If greater than the
+        total number of partitions in a partitioner, it won't have an effect. If left
+        as None, then all partitions will be used.
+
+    Returns
+    -------
+    distances : pd.Series
+        Hellinger distance for each partition id.
+    """
+    return _compute_partition_distances(
+        partitioner=partitioner,
+        column_name=column_name,
+        max_num_partitions=max_num_partitions,
+        distance_fn=_hellinger_distance,
+        name="Hellinger distance",
+    )
+
+
+def compute_jensen_shannon_distances(
+    partitioner: Partitioner,
+    column_name: str,
+    max_num_partitions: int | None = None,
+) -> pd.Series:
+    """Compute Jensen-Shannon distances between partitions and the full dataset.
+
+    The distance is computed between each partition's categorical distribution over
+    ``column_name`` and the full dataset distribution over the same column. Values are
+    in the interval ``[0, 1]``. A value of ``0`` means that the partition distribution
+    exactly matches the full dataset distribution.
+
+    Parameters
+    ----------
+    partitioner : Partitioner
+        Partitioner with an assigned dataset.
+    column_name : str
+        Column name identifying the categorical values used to compute the
+        distributions.
+    max_num_partitions : Optional[int]
+        The maximum number of partitions that will be used. If greater than the
+        total number of partitions in a partitioner, it won't have an effect. If left
+        as None, then all partitions will be used.
+
+    Returns
+    -------
+    distances : pd.Series
+        Jensen-Shannon distance for each partition id.
+    """
+    return _compute_partition_distances(
+        partitioner=partitioner,
+        column_name=column_name,
+        max_num_partitions=max_num_partitions,
+        distance_fn=_jensen_shannon_distance,
+        name="Jensen-Shannon distance",
+    )
+
+
+def _compute_partition_distances(
+    partitioner: Partitioner,
+    column_name: str,
+    max_num_partitions: int | None,
+    distance_fn: Callable[[NDArray, NDArray], float],
+    name: str,
+) -> pd.Series:
+    """Compute distances from partition distributions to the full distribution."""
+    _check_max_num_partitions(max_num_partitions)
+    counts = compute_counts(
+        partitioner=partitioner,
+        column_name=column_name,
+        max_num_partitions=max_num_partitions,
+    )
+    reference_counts = _compute_counts(
+        labels=partitioner.dataset[column_name],
+        unique_labels=list(counts.columns),
+    )
+    frequencies = _normalize_counts(counts)
+    reference_frequency = _normalize_count_series(reference_counts)
+
+    return pd.Series(
+        [
+            distance_fn(
+                partition_frequency.to_numpy(dtype=float),
+                reference_frequency.to_numpy(dtype=float),
+            )
+            for _, partition_frequency in frequencies.iterrows()
+        ],
+        index=frequencies.index,
+        name=name,
+    )
+
+
+def _check_max_num_partitions(max_num_partitions: int | None) -> None:
+    """Check that the optional partition limit is positive."""
+    if max_num_partitions is not None and max_num_partitions <= 0:
+        raise ValueError("max_num_partitions must be greater than zero.")
+
+
+def _normalize_counts(counts: pd.DataFrame) -> pd.DataFrame:
+    """Normalize count rows into frequency rows."""
+    row_totals = counts.sum(axis=1)
+    if (row_totals <= 0).any():
+        raise ValueError("Cannot compute distances for empty partitions.")
+    return counts.astype(float).div(row_totals, axis=0)
+
+
+def _normalize_count_series(counts: pd.Series) -> pd.Series:
+    """Normalize counts into frequencies."""
+    total = counts.sum()
+    if total <= 0:
+        raise ValueError("Cannot compute distances for an empty dataset.")
+    return counts.astype(float).divide(total)
+
+
+def _hellinger_distance(first: NDArray, second: NDArray) -> float:
+    """Compute Hellinger distance between two probability distributions."""
+    return float(np.linalg.norm(np.sqrt(first) - np.sqrt(second)) / np.sqrt(2))
+
+
+def _jensen_shannon_distance(first: NDArray, second: NDArray) -> float:
+    """Compute Jensen-Shannon distance between two probability distributions."""
+    midpoint = (first + second) / 2
+    divergence = (
+        _kl_divergence(first, midpoint) + _kl_divergence(second, midpoint)
+    ) / 2
+    return float(np.sqrt(divergence))
+
+
+def _kl_divergence(first: NDArray, second: NDArray) -> float:
+    """Compute base-2 Kullback-Leibler divergence, ignoring zero-probability terms."""
+    non_zero = first > 0
+    return float(np.sum(first[non_zero] * np.log2(first[non_zero] / second[non_zero])))

--- a/datasets/flwr_datasets/metrics/distances_test.py
+++ b/datasets/flwr_datasets/metrics/distances_test.py
@@ -1,0 +1,131 @@
+# Copyright 2024 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for distribution distance metrics."""
+
+
+import unittest
+from math import log2, sqrt
+
+import pandas as pd
+
+import datasets
+from flwr_datasets.metrics import (
+    compute_hellinger_distances,
+    compute_jensen_shannon_distances,
+)
+from flwr_datasets.partitioner import IidPartitioner
+
+
+class TestDistributionDistanceMetrics(unittest.TestCase):
+    """Test distribution distance metrics."""
+
+    def test_distances_are_zero_for_matching_partition_distributions(self) -> None:
+        """Test distances are zero when partitions match the full distribution."""
+        dataset = datasets.Dataset.from_dict(
+            {"feature": list(range(4)), "label": [0, 1, 0, 1]}
+        )
+        iid_partitioner = IidPartitioner(num_partitions=2)
+        iid_partitioner.dataset = dataset
+        expected_hellinger = pd.Series(
+            [0.0, 0.0],
+            index=pd.Index([0, 1], name="Partition ID"),
+            name="Hellinger distance",
+        )
+        expected_jensen_shannon = pd.Series(
+            [0.0, 0.0],
+            index=pd.Index([0, 1], name="Partition ID"),
+            name="Jensen-Shannon distance",
+        )
+
+        pd.testing.assert_series_equal(
+            compute_hellinger_distances(iid_partitioner, column_name="label"),
+            expected_hellinger,
+        )
+        pd.testing.assert_series_equal(
+            compute_jensen_shannon_distances(iid_partitioner, column_name="label"),
+            expected_jensen_shannon,
+        )
+
+    def test_hellinger_distances_for_label_skew(self) -> None:
+        """Test Hellinger distance for fully skewed label partitions."""
+        dataset = datasets.Dataset.from_dict(
+            {"feature": list(range(20)), "label": [0] * 10 + [1] * 10}
+        )
+        iid_partitioner = IidPartitioner(num_partitions=2)
+        iid_partitioner.dataset = dataset
+        expected_distance = sqrt((1 - sqrt(0.5)) ** 2 + (sqrt(0.5)) ** 2) / sqrt(2)
+        expected = pd.Series(
+            [expected_distance, expected_distance],
+            index=pd.Index([0, 1], name="Partition ID"),
+            name="Hellinger distance",
+        )
+
+        distances = compute_hellinger_distances(iid_partitioner, column_name="label")
+
+        pd.testing.assert_series_equal(distances, expected)
+
+    def test_jensen_shannon_distances_for_label_skew(self) -> None:
+        """Test Jensen-Shannon distance for fully skewed label partitions."""
+        dataset = datasets.Dataset.from_dict(
+            {"feature": list(range(20)), "label": [0] * 10 + [1] * 10}
+        )
+        iid_partitioner = IidPartitioner(num_partitions=2)
+        iid_partitioner.dataset = dataset
+        divergence = 0.5 * (
+            log2(1 / 0.75) + 0.5 * log2(0.5 / 0.75) + 0.5 * log2(0.5 / 0.25)
+        )
+        expected_distance = sqrt(divergence)
+        expected = pd.Series(
+            [expected_distance, expected_distance],
+            index=pd.Index([0, 1], name="Partition ID"),
+            name="Jensen-Shannon distance",
+        )
+
+        distances = compute_jensen_shannon_distances(
+            iid_partitioner, column_name="label"
+        )
+
+        pd.testing.assert_series_equal(distances, expected)
+
+    def test_distances_respect_max_num_partitions(self) -> None:
+        """Test max_num_partitions limits the returned partition distances."""
+        dataset = datasets.Dataset.from_dict(
+            {"feature": list(range(20)), "label": [0] * 10 + [1] * 10}
+        )
+        iid_partitioner = IidPartitioner(num_partitions=2)
+        iid_partitioner.dataset = dataset
+
+        distances = compute_hellinger_distances(
+            iid_partitioner, column_name="label", max_num_partitions=1
+        )
+
+        self.assertEqual(list(distances.index), [0])
+
+    def test_distances_reject_invalid_max_num_partitions(self) -> None:
+        """Test invalid max_num_partitions raises ValueError."""
+        dataset = datasets.Dataset.from_dict(
+            {"feature": list(range(4)), "label": [0, 1, 0, 1]}
+        )
+        iid_partitioner = IidPartitioner(num_partitions=2)
+        iid_partitioner.dataset = dataset
+
+        with self.assertRaises(ValueError):
+            compute_hellinger_distances(
+                iid_partitioner, column_name="label", max_num_partitions=0
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/datasets/flwr_datasets/metrics/utils.py
+++ b/datasets/flwr_datasets/metrics/utils.py
@@ -16,6 +16,7 @@
 
 
 import warnings
+from collections.abc import Hashable, Sequence
 
 import pandas as pd
 
@@ -205,7 +206,7 @@ def compute_frequencies(
 
 
 def _compute_counts(
-    labels: list[int] | list[str], unique_labels: list[int] | list[str]
+    labels: Sequence[Hashable], unique_labels: Sequence[Hashable]
 ) -> pd.Series:
     """Compute the count of labels when taking into account all possible labels.
 
@@ -236,7 +237,7 @@ def _compute_counts(
 
 
 def _compute_frequencies(
-    labels: list[int] | list[str], unique_labels: list[int] | list[str]
+    labels: Sequence[Hashable], unique_labels: Sequence[Hashable]
 ) -> pd.Series:
     """Compute the distribution of labels when taking into account all possible labels.
 

--- a/datasets/flwr_datasets/metrics/utils_test.py
+++ b/datasets/flwr_datasets/metrics/utils_test.py
@@ -22,12 +22,8 @@ from parameterized import parameterized, parameterized_class
 
 import datasets
 from datasets import ClassLabel
-from flwr_datasets.metrics.utils import (
-    _compute_counts,
-    _compute_frequencies,
-    compute_counts,
-    compute_frequencies,
-)
+from flwr_datasets.metrics import compute_counts, compute_frequencies
+from flwr_datasets.metrics.utils import _compute_counts, _compute_frequencies
 from flwr_datasets.partitioner import IidPartitioner
 
 


### PR DESCRIPTION
## What changed

- Add public Hellinger and Jensen-Shannon distance helpers for categorical partition-label distributions
- Keep the distance implementation in a dedicated `flwr_datasets.metrics.distances` module
- Export the helpers from `flwr_datasets.metrics`
- Document a small categorical partition-skew measurement workflow

## Review scope

This is split out from #7385 and should be reviewed after the shuffle-only IID partitioner change. The PR is intentionally stacked on `fix/flwr-datasets-iid-metrics` so this diff contains only the metrics follow-up.

To keep this first metrics PR lightweight, continuous-target binning and additional distance configuration are left for a later follow-up if needed.

## Issue/PR mapping

- Follow-up to #7385
- Revives the focused partition-skew metrics subset of #2971

## Validation

- `pytest`, `ruff`, `mypy`, and `black --check` on the touched metrics files
- `git diff --check`