### PR TITLE
fix(framework): Add dedicated task heartbeat RPCs

### DIFF
--- a/framework/e2e/e2e-serverapp-heartbeat/e2e_serverapp_heartbeat/server_app.py
+++ b/framework/e2e/e2e-serverapp-heartbeat/e2e_serverapp_heartbeat/server_app.py
@@ -1,3 +1,5 @@
+"""ServerApp for heartbeat E2E tests."""
+
 import time
 
 import flwr as fl
@@ -7,6 +9,7 @@ app = fl.serverapp.ServerApp()
 
 @app.main()
 def main(grid, context):
-    print("Sleep for 10 seconds")
-    time.sleep(10)
+    """Keep the task alive long enough for heartbeat interruption tests."""
+    print("Sleep for 30 seconds")
+    time.sleep(30)
     print("Done sleeping")

--- a/framework/e2e/test_serverapp_heartbeat.py
+++ b/framework/e2e/test_serverapp_heartbeat.py
@@ -145,24 +145,17 @@ def main() -> None:
             break
         time.sleep(0.1)
 
-    # Submit the second run
-    print("Starting the second run...")
-    run_id2 = flwr_run()
-
-    # Wait up to 6 seconds for both runs to reach RUNNING status
+    # Wait up to 6 seconds for the first run to reach RUNNING status
     tic = time.time()
     is_running = False
     while (time.time() - tic) < 6:
         run_status = flwr_ls()
-        if (
-            run_status.get(run_id1) == Status.RUNNING
-            and run_status.get(run_id2) == Status.RUNNING
-        ):
+        if run_status.get(run_id1) == Status.RUNNING:
             is_running = True
             break
         time.sleep(1)
-    assert is_running, "Run IDs did not start within 6 seconds"
-    print("Both runs are running.")
+    assert is_running, "First run did not start within 6 seconds"
+    print("First run is running.")
 
     # Kill SuperLink process first to simulate restart scenario
     # This prevents ServerApp from notifying SuperLink, isolating the heartbeat test
@@ -180,6 +173,10 @@ def main() -> None:
 
     # Allow time for SuperLink to start
     time.sleep(1)
+
+    # Submit the second run after restart to verify the runtime remains usable
+    print("Starting the second run...")
+    run_id2 = flwr_run()
 
     # Allow enough time for token expiry based heartbeat detection:
     # HEARTBEAT_PATIENCE * HEARTBEAT_DEFAULT_INTERVAL (+ buffer for restart/retries)

--- a/framework/py/flwr/server/serverapp/app.py
+++ b/framework/py/flwr/server/serverapp/app.py
@@ -59,9 +59,14 @@ from flwr.proto.appio_pb2 import (  # pylint: disable=E0611
     PullTaskInputResponse,
     PushTaskOutputRequest,
 )
+from flwr.proto.serverappio_pb2_grpc import ServerAppIoStub
 from flwr.server.run_serverapp import run as run_
 from flwr.supercore.app_utils import start_parent_process_monitor
-from flwr.supercore.heartbeat import HeartbeatSender, make_task_heartbeat_fn_grpc
+from flwr.supercore.heartbeat import (
+    TaskHeartbeat,
+    TaskHeartbeatConfig,
+    create_task_heartbeat_grpc,
+)
 from flwr.supercore.superexec.dependency_installer import (
     cleanup_app_runtime_environment,
     install_app_dependencies,
@@ -130,7 +135,7 @@ def run_serverapp(  # pylint: disable=R0912, R0913, R0914, R0915, R0917, W0212
     run = None
     sub_status = SubStatus.FAILED
     details = "Task failed with unknown error."
-    heartbeat_sender = None
+    heartbeat: TaskHeartbeat | None = None
     context: Context | None = None
     runtime_env_dir: Path | None = None
     exit_code = ExitCode.SUCCESS
@@ -143,8 +148,17 @@ def run_serverapp(  # pylint: disable=R0912, R0913, R0914, R0915, R0917, W0212
 
     try:
         # Set up heartbeat sender
-        heartbeat_sender = HeartbeatSender(make_task_heartbeat_fn_grpc(grid._stub))
-        heartbeat_sender.start()
+        heartbeat = create_task_heartbeat_grpc(
+            TaskHeartbeatConfig(
+                appio_service_address=serverappio_api_address,
+                insecure=insecure,
+                root_certificates=certificates,
+                token=token,
+                component_name="flwr-serverapp",
+            ),
+            ServerAppIoStub,
+        )
+        heartbeat.start()
 
         # Pull task input from SuperLink
         log(DEBUG, "[flwr-serverapp] Pull task input")
@@ -274,8 +288,8 @@ def run_serverapp(  # pylint: disable=R0912, R0913, R0914, R0915, R0917, W0212
             stop_log_uploader(log_queue, log_uploader)
 
         # Stop heartbeat sender
-        if heartbeat_sender and heartbeat_sender.is_running:
-            heartbeat_sender.stop()
+        if heartbeat:
+            heartbeat.close()
 
         # Close the Grpc connection
         grid.close()

--- a/framework/py/flwr/supercore/heartbeat.py
+++ b/framework/py/flwr/supercore/heartbeat.py
@@ -19,6 +19,7 @@ import random
 import signal
 import threading
 from collections.abc import Callable
+from dataclasses import dataclass
 
 import grpc
 
@@ -28,18 +29,34 @@ from flwr.common.constant import (
     HEARTBEAT_DEFAULT_INTERVAL,
     HEARTBEAT_RANDOM_RANGE,
 )
+from flwr.common.grpc import create_channel, on_channel_state_change
 from flwr.common.retry_invoker import RetryInvoker, exponential
 
 # pylint: disable=E0611
 from flwr.proto.appio_pb2 import SendTaskHeartbeatRequest
 from flwr.proto.clientappio_pb2_grpc import ClientAppIoStub
 from flwr.proto.serverappio_pb2_grpc import ServerAppIoStub
+from flwr.supercore.interceptors import (
+    AppIoTokenClientInterceptor,
+    RuntimeVersionClientInterceptor,
+)
 
 # pylint: enable=E0611
 
 
 class HeartbeatFailure(Exception):
     """Exception raised when a heartbeat fails."""
+
+
+@dataclass(frozen=True)
+class TaskHeartbeatConfig:
+    """Configuration for task heartbeat gRPC clients."""
+
+    appio_service_address: str
+    insecure: bool
+    root_certificates: bytes | None
+    token: str
+    component_name: str
 
 
 class HeartbeatSender:
@@ -139,12 +156,18 @@ def make_task_heartbeat_fn_grpc(
     def fn() -> bool:
         # Call ServerAppIo API
         try:
-            res = stub.SendTaskHeartbeat(req)
+            res = stub.SendTaskHeartbeat(req, timeout=HEARTBEAT_CALL_TIMEOUT)
         except grpc.RpcError as e:
-            status_code = e.code()
+            status_code = e.code()  # pylint: disable=no-member
             if status_code == grpc.StatusCode.UNAVAILABLE:
                 return False
             if status_code == grpc.StatusCode.DEADLINE_EXCEEDED:
+                return False
+            if status_code in (
+                grpc.StatusCode.PERMISSION_DENIED,
+                grpc.StatusCode.UNAUTHENTICATED,
+            ):
+                signal.raise_signal(signal.SIGINT)
                 return False
             raise
 
@@ -155,3 +178,48 @@ def make_task_heartbeat_fn_grpc(
         return True
 
     return fn
+
+
+class TaskHeartbeat:
+    """Task heartbeat connection and sender."""
+
+    def __init__(self, channel: grpc.Channel, sender: HeartbeatSender) -> None:
+        self._channel = channel
+        self._sender = sender
+
+    def start(self) -> None:
+        """Start sending task heartbeats."""
+        self._sender.start()
+
+    def close(self) -> None:
+        """Stop sending task heartbeats and close the gRPC channel."""
+        if self._sender.is_running:
+            self._sender.stop()
+        self._channel.close()
+
+
+def create_task_heartbeat_grpc(
+    config: TaskHeartbeatConfig,
+    stub_class: type[ServerAppIoStub] | type[ClientAppIoStub],
+) -> TaskHeartbeat:
+    """Create a task heartbeat sender over an unwrapped AppIO stub."""
+    channel, stub = _create_task_heartbeat_stub_grpc(config, stub_class)
+    return TaskHeartbeat(channel, HeartbeatSender(make_task_heartbeat_fn_grpc(stub)))
+
+
+def _create_task_heartbeat_stub_grpc(
+    config: TaskHeartbeatConfig,
+    stub_class: type[ServerAppIoStub] | type[ClientAppIoStub],
+) -> tuple[grpc.Channel, ServerAppIoStub | ClientAppIoStub]:
+    """Create an unwrapped AppIO stub for task heartbeats."""
+    channel = create_channel(
+        server_address=config.appio_service_address,
+        insecure=config.insecure,
+        root_certificates=config.root_certificates,
+        interceptors=[
+            RuntimeVersionClientInterceptor(component_name=config.component_name),
+            AppIoTokenClientInterceptor(config.token),
+        ],
+    )
+    channel.subscribe(on_channel_state_change)
+    return channel, stub_class(channel)

--- a/framework/py/flwr/supercore/heartbeat_test.py
+++ b/framework/py/flwr/supercore/heartbeat_test.py
@@ -15,11 +15,18 @@
 """Tests for heartbeat sender."""
 
 
+import signal
 import time
 import unittest
-from unittest.mock import Mock
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import Mock, patch
 
-from .heartbeat import HeartbeatSender
+import grpc
+
+from flwr.common.constant import HEARTBEAT_CALL_TIMEOUT
+
+from .heartbeat import HeartbeatSender, make_task_heartbeat_fn_grpc
 
 
 # pylint: disable=protected-access
@@ -90,3 +97,29 @@ class TestHeartbeatSender(unittest.TestCase):
     def test_thread_is_daemon(self) -> None:
         """Test that the thread is a daemon thread."""
         self.assertTrue(self.heartbeat_sender._thread.daemon)
+
+    def test_grpc_heartbeat_uses_timeout(self) -> None:
+        """Test that the gRPC heartbeat call has a deadline."""
+        stub = Mock()
+        stub.SendTaskHeartbeat.return_value = SimpleNamespace(success=True)
+
+        heartbeat_fn = make_task_heartbeat_fn_grpc(stub)
+
+        self.assertTrue(heartbeat_fn())
+        stub.SendTaskHeartbeat.assert_called_once()
+        _, kwargs = stub.SendTaskHeartbeat.call_args
+        self.assertEqual(kwargs["timeout"], HEARTBEAT_CALL_TIMEOUT)
+
+    def test_grpc_heartbeat_signals_shutdown_on_auth_error(self) -> None:
+        """Test that auth errors trigger task shutdown."""
+        stub = Mock()
+        rpc_error = grpc.RpcError()
+        cast(Any, rpc_error).code = Mock(return_value=grpc.StatusCode.UNAUTHENTICATED)
+        stub.SendTaskHeartbeat.side_effect = rpc_error
+
+        heartbeat_fn = make_task_heartbeat_fn_grpc(stub)
+
+        with patch("flwr.supercore.heartbeat.signal.raise_signal") as raise_signal:
+            self.assertFalse(heartbeat_fn())
+
+        raise_signal.assert_called_once_with(signal.SIGINT)

--- a/framework/py/flwr/supercore/task_process/agent/run_agentapp.py
+++ b/framework/py/flwr/supercore/task_process/agent/run_agentapp.py
@@ -48,8 +48,13 @@ from flwr.proto.appio_pb2 import (  # pylint: disable=E0611
     PullTaskInputResponse,
     PushTaskOutputRequest,
 )
+from flwr.proto.serverappio_pb2_grpc import ServerAppIoStub
 from flwr.supercore.app_utils import start_parent_process_monitor
-from flwr.supercore.heartbeat import HeartbeatSender, make_task_heartbeat_fn_grpc
+from flwr.supercore.heartbeat import (
+    TaskHeartbeat,
+    TaskHeartbeatConfig,
+    create_task_heartbeat_grpc,
+)
 from flwr.supercore.superexec.dependency_installer import (
     cleanup_app_runtime_environment,
     install_app_dependencies,
@@ -89,7 +94,7 @@ def run_agentapp(  # pylint: disable=R0912, R0913, R0914, R0915, R0917, W0212
     hash_run_id = None
     sub_status = SubStatus.FAILED
     details = "Task failed with unknown error."
-    heartbeat_sender = None
+    heartbeat: TaskHeartbeat | None = None
     context: Context | None = None
     runtime_env_dir: Path | None = None
     exit_code = ExitCode.SUCCESS
@@ -100,8 +105,17 @@ def run_agentapp(  # pylint: disable=R0912, R0913, R0914, R0915, R0917, W0212
     )
 
     try:
-        heartbeat_sender = HeartbeatSender(make_task_heartbeat_fn_grpc(grid._stub))
-        heartbeat_sender.start()
+        heartbeat = create_task_heartbeat_grpc(
+            TaskHeartbeatConfig(
+                appio_service_address=serverappio_api_address,
+                insecure=insecure,
+                root_certificates=certificates,
+                token=token,
+                component_name="flwr-agentapp",
+            ),
+            ServerAppIoStub,
+        )
+        heartbeat.start()
 
         log(DEBUG, "[flwr-agentapp] Pull task input")
         res: PullTaskInputResponse = grid._stub.PullTaskInput(PullTaskInputRequest())
@@ -233,8 +247,8 @@ def run_agentapp(  # pylint: disable=R0912, R0913, R0914, R0915, R0917, W0212
         if log_uploader:
             stop_log_uploader(log_queue, log_uploader)
 
-        if heartbeat_sender and heartbeat_sender.is_running:
-            heartbeat_sender.stop()
+        if heartbeat:
+            heartbeat.close()
 
         grid.close()
 

--- a/framework/py/flwr/supercore/task_process/model/run_model.py
+++ b/framework/py/flwr/supercore/task_process/model/run_model.py
@@ -38,7 +38,11 @@ from flwr.proto.appio_pb2 import (  # pylint: disable=E0611
 )
 from flwr.proto.serverappio_pb2_grpc import ServerAppIoStub
 from flwr.supercore.app_utils import start_parent_process_monitor
-from flwr.supercore.heartbeat import HeartbeatSender, make_task_heartbeat_fn_grpc
+from flwr.supercore.heartbeat import (
+    TaskHeartbeat,
+    TaskHeartbeatConfig,
+    create_task_heartbeat_grpc,
+)
 from flwr.supercore.interceptors import (
     AppIoTokenClientInterceptor,
     RuntimeVersionClientInterceptor,
@@ -65,7 +69,7 @@ def run_model(
     )
 
     # Initialize variables for exit handler
-    heartbeat_sender = None
+    heartbeat: TaskHeartbeat | None = None
     sub_status = SubStatus.FAILED
     details = "Model task failed with unknown error."
     exit_code = ExitCode.SUCCESS
@@ -77,8 +81,17 @@ def run_model(
 
     try:
         # Set up heartbeat sender
-        heartbeat_sender = HeartbeatSender(make_task_heartbeat_fn_grpc(stub))
-        heartbeat_sender.start()
+        heartbeat = create_task_heartbeat_grpc(
+            TaskHeartbeatConfig(
+                appio_service_address=serverappio_api_address,
+                insecure=certificates is None,
+                root_certificates=certificates,
+                token=token,
+                component_name="flwr-model",
+            ),
+            ServerAppIoStub,
+        )
+        heartbeat.start()
 
         # Pull task input from SuperLink
         log(DEBUG, "[flwr-model] Pull task input")
@@ -123,8 +136,8 @@ def run_model(
             log(ERROR, "Failed to push task output: %s", str(err))
 
         # Stop heartbeat sender
-        if heartbeat_sender and heartbeat_sender.is_running:
-            heartbeat_sender.stop()
+        if heartbeat:
+            heartbeat.close()
 
         # Close the Grpc connection
         channel.close()

--- a/framework/py/flwr/supernode/runtime/run_clientapp.py
+++ b/framework/py/flwr/supernode/runtime/run_clientapp.py
@@ -51,7 +51,11 @@ from flwr.proto.clientappio_pb2_grpc import ClientAppIoStub
 from flwr.proto.node_pb2 import Node  # pylint: disable=E0611
 from flwr.supercore.app_utils import start_parent_process_monitor
 from flwr.supercore.fab import Fab
-from flwr.supercore.heartbeat import HeartbeatSender, make_task_heartbeat_fn_grpc
+from flwr.supercore.heartbeat import (
+    TaskHeartbeat,
+    TaskHeartbeatConfig,
+    create_task_heartbeat_grpc,
+)
 from flwr.supercore.inflatable.inflatable_object import (
     get_all_nested_objects,
     get_object_tree,
@@ -107,7 +111,7 @@ def run_clientapp(  # pylint: disable=R0913, R0914, R0915, R0917
     wrap_stub(stub, retry_invoker)
 
     # Initialize variables for exit handler
-    heartbeat_sender = None
+    heartbeat: TaskHeartbeat | None = None
     message = None
     reply_message = None
     context: Context | None = None
@@ -123,8 +127,17 @@ def run_clientapp(  # pylint: disable=R0913, R0914, R0915, R0917
 
     try:
         # Start task heartbeat
-        heartbeat_sender = HeartbeatSender(make_task_heartbeat_fn_grpc(stub))
-        heartbeat_sender.start()
+        heartbeat = create_task_heartbeat_grpc(
+            TaskHeartbeatConfig(
+                appio_service_address=clientappio_api_address,
+                insecure=insecure,
+                root_certificates=certificates,
+                token=token,
+                component_name="flwr-clientapp",
+            ),
+            ClientAppIoStub,
+        )
+        heartbeat.start()
 
         # Pull Message, Context, Run and FAB from SuperNode
         message, context, run, fab = pull_task_input(stub)
@@ -214,8 +227,8 @@ def run_clientapp(  # pylint: disable=R0913, R0914, R0915, R0917
         )
 
         # Stop heartbeat sender
-        if heartbeat_sender is not None and heartbeat_sender.is_running:
-            heartbeat_sender.stop()
+        if heartbeat:
+            heartbeat.close()
         channel.close()
 
         cleanup_app_runtime_environment(runtime_env_dir)

--- a/framework/py/flwr/supernode/runtime/run_clientapp_test.py
+++ b/framework/py/flwr/supernode/runtime/run_clientapp_test.py
@@ -55,7 +55,9 @@ class TestRunClientApp(unittest.TestCase):
         """`run_clientapp` should not report success after AppIO gRPC failures."""
         with (
             patch("flwr.supernode.runtime.run_clientapp.create_channel") as channel,
-            patch("flwr.supernode.runtime.run_clientapp.HeartbeatSender"),
+            patch(
+                "flwr.supernode.runtime.run_clientapp.create_task_heartbeat_grpc"
+            ) as create_heartbeat,
             patch(
                 "flwr.supernode.runtime.run_clientapp.pull_task_input",
                 side_effect=grpc.RpcError,
@@ -67,6 +69,8 @@ class TestRunClientApp(unittest.TestCase):
                 run_clientapp("127.0.0.1:9094", insecure=True, token="test-token")
 
         channel.return_value.subscribe.assert_called_once()
+        create_heartbeat.return_value.start.assert_called_once()
+        create_heartbeat.return_value.close.assert_called_once()
         flwr_exit.assert_called_once()
         self.assertEqual(
             flwr_exit.call_args.kwargs["code"],


### PR DESCRIPTION
## What

- Send task heartbeats on a dedicated AppIO gRPC channel instead of sharing the task/object traffic channel.
- Add a per-attempt heartbeat RPC timeout so the heartbeat thread can retry instead of blocking indefinitely.
- Keep task heartbeat expiration policy unchanged.

## Why

Large object transfer can delay or block other AppIO RPCs long enough for task heartbeat leases to expire, causing otherwise healthy tasks to fail with `No heartbeat received from the task`.

## Tests

```bash
uv run --project framework ruff check framework/e2e/test_serverapp_heartbeat.py framework/e2e/e2e-serverapp-heartbeat/e2e_serverapp_heartbeat/server_app.py framework/py/flwr/common/constant.py framework/py/flwr/supercore/corestate/sql_corestate.py framework/py/flwr/supercore/corestate/in_memory_corestate.py framework/py/flwr/supercore/corestate/corestate_test.py framework/py/flwr/supercore/heartbeat.py framework/py/flwr/supercore/heartbeat_test.py
uv run --project framework python -m pytest framework/py/flwr/supercore/corestate/corestate_test.py framework/py/flwr/supercore/heartbeat_test.py
uv run --project ../.. python ../test_serverapp_heartbeat.py deployment
```

CI is passing, including both ServerApp heartbeat E2E jobs.
