### PR TITLE
test(framework): Harden local k8s harness evidence

### DIFF
--- a/framework/dev/k8s/README.md
+++ b/framework/dev/k8s/README.md
@@ -54,13 +54,95 @@ Evidence is written under the selected output directory:
 | Path | Purpose |
 | --- | --- |
 | `summary.json` | Machine-readable result and details. |
+| `invocation.json` | Redacted invocation, cwd/repo context, selected profile, and run settings. |
 | `events.jsonl` | Ordered harness events. |
+| `task-lineage.json` | Seeded run to TaskExecutor Pod and credential Secret mapping. |
+| `taskexecutor-pods.json` | Full redacted TaskExecutor Pod object snapshot. |
+| `taskexecutor-secrets.redacted.json` | Redacted per-task Secret evidence with key names and byte lengths. |
+| `final-state.json` | Pre-cleanup resource counts and object summaries for the run selectors. |
+| `proof-checklist.json` | Reviewer-facing map from claims to artifact fields, with out-of-scope claims. |
 | `objects/real-launch.yaml` | Rendered SuperLink, executor config, and SuperExec objects. |
 | `objects/seed-job.yaml` | Rendered seed ConfigMap and Job. |
 | `objects/pods.json` | Observed TaskExecutor Pod list and phases. |
 | `diagnostics/commands.txt` | Planned or executed host commands. |
 | `diagnostics/taskexecutor-logs.txt` | Captured TaskExecutor logs. |
 | `diagnostics/cleanup.txt` | Cleanup defaults and the namespace delete command. |
+
+## How The Evidence Proves Correctness
+
+Use this section when reviewing an evidence directory without rerunning the
+harness. The generated `proof-checklist.json` contains the same claim-to-file
+map in machine-readable form.
+
+1. Confirm the run was real and from the expected source tree.
+
+   Open `invocation.json` and check:
+
+   - `mode` is `local-k8s-launch-path`;
+   - `dry_run` is `false`;
+   - `repo.branch` and `repo.sha` match the checkout under review;
+   - `equivalent_argv` shows the harness mode, output directory, namespace,
+     images, `--execute`, `--apply-manifests`, and `--import-images`.
+
+2. Confirm SuperExec was actually configured to use the Kubernetes executor.
+
+   Open `objects/real-launch.yaml` and inspect the SuperExec Pod. Its container
+   args must include `--executor kubernetes` and `--executor-config
+   /etc/flower/executor-config.yaml`. The ConfigMap in the same file should
+   contain the executor config used to render TaskExecutor Pods, including the
+   namespace, image, resource pool, and harness-run label.
+
+3. Confirm one deterministic ServerApp task was seeded through AppIo.
+
+   Open `objects/seed-job.yaml` and check that the Job runs
+   `/opt/flower-local-k8s/seed_run.py` against the SuperLink Control API.
+   Then check `summary.json` and `task-lineage.json`: `seed_run_id` and
+   `seeded_run_id` should be present and should match.
+
+4. Confirm the Kubernetes executor created the TaskExecutor Pod.
+
+   Open `task-lineage.json`. Each task record should have a `pod_name`,
+   `pod_uid`, `task_id`, `launch_attempt`, `resource_pool`, and
+   `credential_secret_name`. Then open `taskexecutor-pods.json` and find the
+   same Pod. Its labels should include:
+
+   - `app.kubernetes.io/component: taskexecutor`;
+   - `flower.ai/harness-run`;
+   - `flower.ai/superexec-task-id`;
+   - `flower.ai/launch-attempt`;
+   - `flower.ai/resource-pool`.
+
+   The Pod spec should show the TaskExecutor command, `--token-file
+   /run/flwr/appio/token`, and a Secret volume mounted at `/run/flwr/appio`.
+
+5. Confirm the credential Secret existed without exposing the token.
+
+   Open `taskexecutor-secrets.redacted.json`. The matching Secret should have
+   the same task labels as the Pod, a `token` entry in `data_keys`, useful byte
+   length evidence in `data_byte_lengths`, and `redacted: true`. The file must
+   not contain the token value.
+
+6. Confirm the TaskExecutor actually ran the probe ServerApp.
+
+   Open `diagnostics/taskexecutor-logs.txt` and look for
+   `K8s launch probe ServerApp ran`. The verifier requires this marker. Also
+   check `taskexecutor-pods.json` or `summary.json` for Pod phase `Succeeded`.
+
+7. Confirm the final state was captured before broad namespace cleanup.
+
+   Open `final-state.json`. It records the Pod, Secret, Job, Service, and
+   Namespace observation commands plus resource counts before namespace
+   deletion. This proves what remained at the end of the proof stage. It does
+   not claim executor-owned completed Pod or Secret cleanup; that is deliberately
+   out of scope for this slice.
+
+8. Confirm the verifier accepted the bundle.
+
+   The wrapper runs `framework/dev/k8s/verify_evidence.py` after the harness.
+   A passing report should show `Verification: PASSED`, one TaskExecutor Pod,
+   one lineage record, one credential Secret record, final state Pod/Secret
+   counts, a `Succeeded` phase, and a successful cleanup command when cleanup
+   was required.
 
 ## What Is Tested
 

--- a/framework/dev/k8s/real_launch.py
+++ b/framework/dev/k8s/real_launch.py
@@ -16,10 +16,13 @@
 
 from __future__ import annotations
 
+import base64
+import json
+import subprocess
 import time
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from pathlib import Path
-from typing import cast
+from typing import Protocol, cast
 from uuid import uuid4
 
 from common import (
@@ -29,6 +32,8 @@ from common import (
     HarnessProfile,
     HarnessSummary,
     HostCommandRunner,
+    REDACTED,
+    SCHEMA_VERSION,
     _command_error,
     _command_record,
     _combined_status,
@@ -46,6 +51,7 @@ from common import (
     build_image_preflight,
     build_tls_material_contract,
     generic_k3d_profile,
+    redact_command_args,
 )
 from manifests import (
     render_appio_seed_manifests,
@@ -69,6 +75,8 @@ from observations import (
 )
 
 _TASKEXECUTOR_POD_POLL_INTERVAL_SECONDS = 1.0
+_TASK_ID_LABEL = "flower.ai/superexec-task-id"
+_LAUNCH_ATTEMPT_LABEL = "flower.ai/launch-attempt"
 
 
 def run_local_k8s_launch_path(
@@ -105,6 +113,19 @@ def run_local_k8s_launch_path(
     image_preflight = build_image_preflight(profile)
     cleanup_plan = build_cleanup_plan(profile)
 
+    writer.write_json(
+        "invocation.json",
+        _invocation_record(
+            profile=profile,
+            writer=writer,
+            run_id=run_id,
+            execute=execute,
+            create_cluster=create_cluster,
+            apply_manifests=apply_manifests,
+            import_images=import_images,
+            cleanup=cleanup,
+        ),
+    )
     writer.write_yaml("sanitized-config.yaml", profile.to_mapping())
     writer.write_json("diagnostics/image-preflight.json", image_preflight)
     writer.write_text(
@@ -234,7 +255,10 @@ def run_local_k8s_launch_path(
     write_event(
         "tls.material.ready",
         tls_status,
-        "TLS material contract recorded; local k8s launch-path uses insecure AppIo unless supplied.",
+        (
+            "TLS material contract recorded; local k8s launch-path uses insecure "
+            "AppIo unless supplied."
+        ),
         tls_contract,
     )
 
@@ -422,7 +446,9 @@ def run_local_k8s_launch_path(
             "delete_previous": (
                 _command_record(seed_prune_result) if seed_prune_result.args else None
             ),
-            "apply": _command_record(seed_apply_result) if seed_apply_result.args else None,
+            "apply": (
+                _command_record(seed_apply_result) if seed_apply_result.args else None
+            ),
             "wait": _command_record(seed_wait_result),
             "logs": _command_record(seed_logs_result),
         },
@@ -540,7 +566,9 @@ def run_local_k8s_launch_path(
         )
         for pod_name in taskexecutor_pod_names
     ]
+    taskexecutor_pod_snapshot = _json_list_snapshot(taskexecutor_pods_result)
     writer.write_json("objects/pods.json", taskexecutor_observation)
+    writer.write_json("taskexecutor-pods.json", taskexecutor_pod_snapshot)
     writer.write_text(
         "diagnostics/taskexecutor-logs.txt",
         _format_taskexecutor_logs(taskexecutor_log_results),
@@ -581,6 +609,65 @@ def run_local_k8s_launch_path(
         },
     )
 
+    taskexecutor_secrets_result = run_command(
+        _kubectl_args(
+            profile,
+            [
+                "get",
+                "secrets",
+                "-n",
+                profile.namespace,
+                "-l",
+                taskexecutor_selector,
+                "-o",
+                "json",
+            ],
+        ),
+        "TaskExecutor credential Secret observation",
+    )
+    taskexecutor_secret_snapshot = _json_list_snapshot(taskexecutor_secrets_result)
+    _redact_secret_observation_stdout(taskexecutor_secrets_result)
+    taskexecutor_secret_evidence = _taskexecutor_secret_evidence(
+        taskexecutor_secret_snapshot,
+        selector=taskexecutor_selector,
+        command=_command_record(taskexecutor_secrets_result),
+    )
+    writer.write_json(
+        "taskexecutor-secrets.redacted.json", taskexecutor_secret_evidence
+    )
+    if (
+        execute
+        and taskexecutor_observation["items"]
+        and not taskexecutor_secret_evidence["items"]
+    ):
+        failures.append(
+            "No TaskExecutor credential Secret was observed through the local k8s "
+            "selector before namespace cleanup."
+        )
+
+    task_lineage = _task_lineage(
+        profile=profile,
+        run_id=run_id,
+        seed_run_id=seed_observation["run_id"],
+        selector=taskexecutor_selector,
+        pod_snapshot=taskexecutor_pod_snapshot,
+        secret_evidence=taskexecutor_secret_evidence,
+    )
+    writer.write_json("task-lineage.json", task_lineage)
+
+    final_state = _final_state_record(
+        profile=profile,
+        run_id=run_id,
+        cleanup_requested=cleanup,
+        taskexecutor_selector=taskexecutor_selector,
+        pod_snapshot=taskexecutor_pod_snapshot,
+        pod_result=taskexecutor_pods_result,
+        secret_evidence=taskexecutor_secret_evidence,
+        secret_result=taskexecutor_secrets_result,
+        run_command=run_command,
+    )
+    writer.write_json("final-state.json", final_state)
+
     cleanup_result = CommandResult(args=[], returncode=0, dry_run=not execute)
     if cleanup:
         cleanup_result = run_command(
@@ -590,6 +677,15 @@ def run_local_k8s_launch_path(
 
     result = "local-k8s-launch-path" if execute else "local-k8s-launch-path-dry-run"
     status = "failed" if failures else "passed"
+    writer.write_json(
+        "proof-checklist.json",
+        _proof_checklist(
+            status=status,
+            dry_run=not execute,
+            run_id=run_id,
+            cleanup_requested=cleanup,
+        ),
+    )
     write_event(
         "harness.result",
         status,
@@ -643,6 +739,16 @@ def run_local_k8s_launch_path(
             "selector": taskexecutor_selector,
             "seed_run_id": seed_observation["run_id"],
             "pods": taskexecutor_observation["items"],
+            "credential_secrets": taskexecutor_secret_evidence["items"],
+            "final_state_counts": final_state["counts"],
+            "artifacts": {
+                "invocation": "invocation.json",
+                "task_lineage": "task-lineage.json",
+                "taskexecutor_pods": "taskexecutor-pods.json",
+                "taskexecutor_secrets": "taskexecutor-secrets.redacted.json",
+                "final_state": "final-state.json",
+                "proof_checklist": "proof-checklist.json",
+            },
             "rbac": rbac_check,
             "image_preflight": {
                 "required_images": image_preflight["required_images"],
@@ -668,3 +774,518 @@ def run_local_k8s_launch_path(
     )
     writer.write_summary(summary)
     return summary
+
+
+def _invocation_record(
+    *,
+    profile: HarnessProfile,
+    writer: EvidenceBundleWriter,
+    run_id: str,
+    execute: bool,
+    create_cluster: bool,
+    apply_manifests: bool,
+    import_images: bool,
+    cleanup: bool,
+) -> dict[str, object]:
+    """Return reviewer-facing inputs for one local k8s launch-path run."""
+    cwd = Path.cwd()
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "mode": "local-k8s-launch-path",
+        "run_id": run_id,
+        "dry_run": not execute,
+        "cwd": str(cwd),
+        "repo": _git_context(cwd),
+        "output_dir": str(writer.output_dir),
+        "profile_name": profile.name,
+        "profile": profile.to_mapping(),
+        "settings": {
+            "execute": execute,
+            "create_cluster": create_cluster,
+            "apply_manifests": apply_manifests,
+            "import_images": import_images,
+            "cleanup_requested": cleanup,
+        },
+        "equivalent_argv": _equivalent_argv(
+            profile=profile,
+            output_dir=writer.output_dir,
+            execute=execute,
+            create_cluster=create_cluster,
+            apply_manifests=apply_manifests,
+            import_images=import_images,
+            cleanup=cleanup,
+        ),
+    }
+
+
+def _equivalent_argv(
+    *,
+    profile: HarnessProfile,
+    output_dir: Path,
+    execute: bool,
+    create_cluster: bool,
+    apply_manifests: bool,
+    import_images: bool,
+    cleanup: bool,
+) -> list[str]:
+    args = [
+        "python",
+        "framework/dev/k8s/harness.py",
+        "--mode",
+        "local-k8s-launch-path",
+        "--output-dir",
+        str(output_dir),
+        "--cluster-name",
+        profile.cluster_name,
+        "--namespace",
+        profile.namespace,
+        "--resource-pool",
+        profile.resource_pool,
+        "--image",
+        profile.image,
+        "--superlink-image",
+        profile.superlink_image,
+        "--superexec-image",
+        profile.superexec_image,
+        "--timeout-seconds",
+        str(profile.timeout_seconds),
+    ]
+    if execute:
+        args.append("--execute")
+    if create_cluster:
+        args.append("--create-cluster")
+    if apply_manifests:
+        args.append("--apply-manifests")
+    if import_images:
+        args.append("--import-images")
+    if cleanup:
+        args.append("--cleanup")
+    return redact_command_args(args)
+
+
+def _git_context(cwd: Path) -> dict[str, object]:
+    return {
+        "root": _git_output(cwd, "rev-parse", "--show-toplevel"),
+        "branch": _git_output(cwd, "rev-parse", "--abbrev-ref", "HEAD"),
+        "sha": _git_output(cwd, "rev-parse", "HEAD"),
+    }
+
+
+def _git_output(cwd: Path, *args: str) -> str | None:
+    try:
+        completed = subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+    except OSError:
+        return None
+    if completed.returncode != 0:
+        return None
+    value = completed.stdout.strip()
+    return value or None
+
+
+def _json_list_snapshot(result: CommandResult) -> dict[str, object]:
+    snapshot = _json_snapshot(result)
+    items = snapshot.get("items")
+    if not isinstance(items, list):
+        snapshot["items"] = []
+    return snapshot
+
+
+def _json_snapshot(result: CommandResult) -> dict[str, object]:
+    if result.dry_run or not result.stdout.strip():
+        return {"items": []}
+    try:
+        parsed = json.loads(result.stdout)
+    except json.JSONDecodeError as err:
+        return {"items": [], "parse_error": f"invalid JSON: {err}"}
+    if isinstance(parsed, Mapping):
+        return dict(parsed)
+    return {"items": [], "parse_error": "JSON output was not an object"}
+
+
+def _taskexecutor_secret_evidence(
+    secret_snapshot: Mapping[str, object],
+    *,
+    selector: str,
+    command: Mapping[str, object],
+) -> dict[str, object]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "redacted": True,
+        "selector": selector,
+        "command": dict(command),
+        "items": [_secret_summary(secret) for secret in _object_items(secret_snapshot)],
+    }
+
+
+def _redact_secret_observation_stdout(result: CommandResult) -> None:
+    if result.stdout.strip():
+        result.stdout = f"{REDACTED} Secret list JSON; see summarized items"
+
+
+def _secret_summary(secret: Mapping[str, object]) -> dict[str, object]:
+    metadata = _mapping(secret.get("metadata"))
+    data = _mapping(secret.get("data"))
+    string_data = _mapping(secret.get("stringData"))
+    binary_data = _mapping(secret.get("binaryData"))
+    return {
+        "name": _string_or_none(metadata.get("name")),
+        "namespace": _string_or_none(metadata.get("namespace")),
+        "uid": _string_or_none(metadata.get("uid")),
+        "labels": _string_mapping(metadata.get("labels")),
+        "annotations": _string_mapping(metadata.get("annotations")),
+        "type": _string_or_none(secret.get("type")),
+        "data_keys": sorted(str(key) for key in data),
+        "data_byte_lengths": _base64_byte_lengths(data),
+        "stringData_keys": sorted(str(key) for key in string_data),
+        "binaryData_keys": sorted(str(key) for key in binary_data),
+        "redacted": True,
+    }
+
+
+def _task_lineage(
+    *,
+    profile: HarnessProfile,
+    run_id: str,
+    seed_run_id: object,
+    selector: str,
+    pod_snapshot: Mapping[str, object],
+    secret_evidence: Mapping[str, object],
+) -> dict[str, object]:
+    secrets_by_name = {
+        str(secret["name"]): secret
+        for secret in _object_items(secret_evidence)
+        if isinstance(secret.get("name"), str)
+    }
+    tasks: list[dict[str, object]] = []
+    for pod in _object_items(pod_snapshot):
+        metadata = _mapping(pod.get("metadata"))
+        labels = _string_mapping(metadata.get("labels"))
+        status = _mapping(pod.get("status"))
+        pod_name = _string_or_none(metadata.get("name"))
+        secret_name = _pod_secret_name(pod)
+        secret = secrets_by_name.get(secret_name or "")
+        if secret is None:
+            secret = _secret_matching_task(
+                secret_evidence,
+                task_id=labels.get(_TASK_ID_LABEL),
+                launch_attempt=labels.get(_LAUNCH_ATTEMPT_LABEL),
+            )
+            if isinstance(secret.get("name"), str):
+                secret_name = str(secret["name"])
+        tasks.append(
+            {
+                "seeded_run_id": seed_run_id,
+                "task_id": labels.get(_TASK_ID_LABEL),
+                "task_type": labels.get("flower.ai/task-type"),
+                "pod_name": pod_name,
+                "pod_uid": _string_or_none(metadata.get("uid")),
+                "pod_phase": _string_or_none(status.get("phase")),
+                "terminal_phase": _string_or_none(status.get("phase")),
+                "launch_attempt": labels.get(_LAUNCH_ATTEMPT_LABEL),
+                "resource_pool": labels.get("flower.ai/resource-pool"),
+                "credential_secret_name": secret_name,
+                "credential_secret_uid": _string_or_none(secret.get("uid")),
+            }
+        )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "mode": "local-k8s-launch-path",
+        "run_id": run_id,
+        "seeded_run_id": seed_run_id,
+        "resource_pool": profile.resource_pool,
+        "selector": selector,
+        "tasks": tasks,
+    }
+
+
+def _final_state_record(
+    *,
+    profile: HarnessProfile,
+    run_id: str,
+    cleanup_requested: bool,
+    taskexecutor_selector: str,
+    pod_snapshot: Mapping[str, object],
+    pod_result: CommandResult,
+    secret_evidence: Mapping[str, object],
+    secret_result: CommandResult,
+    run_command: object,
+) -> dict[str, object]:
+    command_runner = cast(
+        CallableCommand,
+        run_command,
+    )
+    run_selector = f"flower.ai/harness-run={run_id}"
+    jobs_result = command_runner(
+        _kubectl_args(
+            profile,
+            ["get", "jobs", "-n", profile.namespace, "-l", run_selector, "-o", "json"],
+        ),
+        "final-state Job observation",
+    )
+    services_result = command_runner(
+        _kubectl_args(
+            profile,
+            [
+                "get",
+                "services",
+                "-n",
+                profile.namespace,
+                "-l",
+                run_selector,
+                "-o",
+                "json",
+            ],
+        ),
+        "final-state Service observation",
+    )
+    namespace_result = command_runner(
+        _kubectl_args(profile, ["get", "namespace", profile.namespace, "-o", "json"]),
+        "final-state namespace observation",
+    )
+
+    jobs_snapshot = _json_list_snapshot(jobs_result)
+    services_snapshot = _json_list_snapshot(services_result)
+    namespace_snapshot = _json_snapshot(namespace_result)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "mode": "local-k8s-launch-path",
+        "run_id": run_id,
+        "captured_before_namespace_cleanup": True,
+        "cleanup_requested": cleanup_requested,
+        "selectors": {
+            "taskexecutor": taskexecutor_selector,
+            "run": run_selector,
+        },
+        "commands": {
+            "taskexecutor_pods": _command_record(pod_result),
+            "taskexecutor_secrets": _command_record(secret_result),
+            "jobs": _command_record(jobs_result),
+            "services": _command_record(services_result),
+            "namespace": _command_record(namespace_result),
+        },
+        "counts": {
+            "taskexecutor_pods": len(_object_items(pod_snapshot)),
+            "taskexecutor_secrets": len(_object_items(secret_evidence)),
+            "jobs": len(_object_items(jobs_snapshot)),
+            "services": len(_object_items(services_snapshot)),
+            "namespace": 1 if namespace_snapshot.get("metadata") else 0,
+        },
+        "resources": {
+            "pods": _pod_summaries(pod_snapshot),
+            "secrets": list(_object_items(secret_evidence)),
+            "jobs": _object_summaries(jobs_snapshot),
+            "services": _object_summaries(services_snapshot),
+            "namespace": _namespace_summary(namespace_snapshot),
+        },
+    }
+
+
+def _proof_checklist(
+    *,
+    status: str,
+    dry_run: bool,
+    run_id: str,
+    cleanup_requested: bool,
+) -> dict[str, object]:
+    proof_status = "planned" if dry_run else status
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "mode": "local-k8s-launch-path",
+        "run_id": run_id,
+        "claims": [
+            {
+                "claim": "Harness invocation and selected inputs are inspectable.",
+                "status": "proved",
+                "artifact": "invocation.json",
+                "fields": ["equivalent_argv", "repo", "profile", "settings"],
+            },
+            {
+                "claim": "SuperExec is configured to use the Kubernetes executor.",
+                "status": proof_status,
+                "artifact": "objects/real-launch.yaml",
+                "fields": [
+                    "SuperExec container args include --executor kubernetes",
+                    "executor config is mounted at /etc/flower/executor-config.yaml",
+                ],
+            },
+            {
+                "claim": (
+                    "One seeded ServerApp run maps to observed TaskExecutor objects."
+                ),
+                "status": proof_status,
+                "artifact": "task-lineage.json",
+                "fields": [
+                    "seeded_run_id",
+                    "tasks[].pod_name",
+                    "tasks[].credential_secret_name",
+                ],
+            },
+            {
+                "claim": (
+                    "The executor-created TaskExecutor Pod is captured as a full "
+                    "redacted object snapshot."
+                ),
+                "status": proof_status,
+                "artifact": "taskexecutor-pods.json",
+                "fields": ["items[].metadata", "items[].spec", "items[].status"],
+            },
+            {
+                "claim": (
+                    "The per-task credential Secret existed without exposing "
+                    "credential values."
+                ),
+                "status": proof_status,
+                "artifact": "taskexecutor-secrets.redacted.json",
+                "fields": [
+                    "items[].name",
+                    "items[].data_keys",
+                    "items[].data_byte_lengths",
+                    "items[].redacted",
+                ],
+            },
+            {
+                "claim": (
+                    "Pre-cleanup resource state is captured before namespace deletion."
+                ),
+                "status": proof_status,
+                "artifact": "final-state.json",
+                "fields": ["counts", "resources", "captured_before_namespace_cleanup"],
+            },
+        ],
+        "out_of_scope": [
+            "active Pod budget behavior",
+            "two-task capacity waiting",
+            "executor-owned completed Pod cleanup proof",
+            "executor-owned per-task Secret cleanup proof",
+            "F7e cardinality behavior",
+            "AppIo TLS proof",
+            "production deployment readiness",
+        ],
+        "cleanup_requested": cleanup_requested,
+    }
+
+
+class CallableCommand(Protocol):
+    """Callable shape for the local run_command closure."""
+
+    def __call__(
+        self, args: Sequence[str], failure_context: str, *, record_failure: bool = True
+    ) -> CommandResult:
+        """Run a command and return its result."""
+
+
+def _pod_summaries(snapshot: Mapping[str, object]) -> list[dict[str, object]]:
+    summaries: list[dict[str, object]] = []
+    for pod in _object_items(snapshot):
+        metadata = _mapping(pod.get("metadata"))
+        status = _mapping(pod.get("status"))
+        summaries.append(
+            {
+                "name": _string_or_none(metadata.get("name")),
+                "namespace": _string_or_none(metadata.get("namespace")),
+                "uid": _string_or_none(metadata.get("uid")),
+                "labels": _string_mapping(metadata.get("labels")),
+                "phase": _string_or_none(status.get("phase")),
+                "deletionTimestamp": _string_or_none(metadata.get("deletionTimestamp")),
+            }
+        )
+    return summaries
+
+
+def _object_summaries(snapshot: Mapping[str, object]) -> list[dict[str, object]]:
+    summaries: list[dict[str, object]] = []
+    for item in _object_items(snapshot):
+        metadata = _mapping(item.get("metadata"))
+        status = _mapping(item.get("status"))
+        summaries.append(
+            {
+                "kind": _string_or_none(item.get("kind")),
+                "name": _string_or_none(metadata.get("name")),
+                "namespace": _string_or_none(metadata.get("namespace")),
+                "uid": _string_or_none(metadata.get("uid")),
+                "labels": _string_mapping(metadata.get("labels")),
+                "phase": _string_or_none(status.get("phase")),
+            }
+        )
+    return summaries
+
+
+def _namespace_summary(snapshot: Mapping[str, object]) -> dict[str, object]:
+    metadata = _mapping(snapshot.get("metadata"))
+    status = _mapping(snapshot.get("status"))
+    return {
+        "name": _string_or_none(metadata.get("name")),
+        "uid": _string_or_none(metadata.get("uid")),
+        "phase": _string_or_none(status.get("phase")),
+    }
+
+
+def _secret_matching_task(
+    secret_evidence: Mapping[str, object],
+    *,
+    task_id: str | None,
+    launch_attempt: str | None,
+) -> Mapping[str, object]:
+    for secret in _object_items(secret_evidence):
+        labels = _string_mapping(secret.get("labels"))
+        if labels.get(_TASK_ID_LABEL) != task_id:
+            continue
+        if labels.get(_LAUNCH_ATTEMPT_LABEL) == launch_attempt:
+            return secret
+    return {}
+
+
+def _pod_secret_name(pod: Mapping[str, object]) -> str | None:
+    spec = _mapping(pod.get("spec"))
+    volumes = spec.get("volumes", [])
+    if not isinstance(volumes, Sequence) or isinstance(volumes, str):
+        return None
+    for volume in volumes:
+        if not isinstance(volume, Mapping):
+            continue
+        secret = _mapping(volume.get("secret"))
+        secret_name = _string_or_none(secret.get("secretName"))
+        if secret_name is not None:
+            return secret_name
+    return None
+
+
+def _object_items(snapshot: Mapping[str, object]) -> list[Mapping[str, object]]:
+    items = snapshot.get("items", [])
+    if not isinstance(items, Sequence) or isinstance(items, str):
+        return []
+    return [item for item in items if isinstance(item, Mapping)]
+
+
+def _mapping(value: object) -> Mapping[str, object]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _string_mapping(value: object) -> dict[str, str]:
+    if not isinstance(value, Mapping):
+        return {}
+    return {str(key): str(item) for key, item in value.items() if isinstance(item, str)}
+
+
+def _base64_byte_lengths(data: Mapping[str, object]) -> list[dict[str, object]]:
+    lengths: list[dict[str, object]] = []
+    for key, value in data.items():
+        if not isinstance(value, str):
+            lengths.append({"key": str(key), "bytes": None})
+            continue
+        try:
+            byte_length = len(base64.b64decode(value, validate=True))
+        except ValueError:
+            byte_length = len(value.encode("utf-8"))
+        lengths.append({"key": str(key), "bytes": byte_length})
+    return lengths
+
+
+def _string_or_none(value: object) -> str | None:
+    return value if isinstance(value, str) else None

--- a/framework/dev/k8s/verify_evidence.py
+++ b/framework/dev/k8s/verify_evidence.py
@@ -42,6 +42,18 @@ def verify_evidence(
 
     summary = _read_json(summary_path, failures)
     details = _mapping(summary.get("details"))
+    invocation = _read_required_json(evidence_path, "invocation.json", failures)
+    task_lineage = _read_required_json(evidence_path, "task-lineage.json", failures)
+    taskexecutor_pods = _read_required_json(
+        evidence_path, "taskexecutor-pods.json", failures
+    )
+    taskexecutor_secrets = _read_required_json(
+        evidence_path, "taskexecutor-secrets.redacted.json", failures
+    )
+    final_state = _read_required_json(evidence_path, "final-state.json", failures)
+    proof_checklist = _read_required_json(
+        evidence_path, "proof-checklist.json", failures
+    )
 
     _expect(summary.get("status") == "passed", "summary status is not passed", failures)
     _expect(
@@ -50,7 +62,21 @@ def verify_evidence(
         failures,
     )
     _expect(not summary.get("failures"), "summary contains failures", failures)
-    _expect(details.get("dry_run") is False, "harness did not execute host commands", failures)
+    _expect(
+        details.get("dry_run") is False,
+        "harness did not execute host commands",
+        failures,
+    )
+    _expect(
+        invocation.get("mode") == "local-k8s-launch-path",
+        "invocation.json mode is not local-k8s-launch-path",
+        failures,
+    )
+    _expect(
+        invocation.get("dry_run") is False,
+        "invocation.json does not record a real execution",
+        failures,
+    )
 
     image_preflight = _mapping(details.get("image_preflight"))
     docker_inspect = _mapping(image_preflight.get("docker_inspect"))
@@ -60,7 +86,9 @@ def verify_evidence(
         "Docker image inspection did not pass",
         failures,
     )
-    _expect(k3d_import.get("returncode") == 0, "k3d image import did not pass", failures)
+    _expect(
+        k3d_import.get("returncode") == 0, "k3d image import did not pass", failures
+    )
 
     rbac = _mapping(details.get("rbac"))
     _expect(rbac.get("status") == "passed", "RBAC verification did not pass", failures)
@@ -76,6 +104,71 @@ def verify_evidence(
     _expect(
         all(phase == "Succeeded" for phase in pod_phases),
         f"TaskExecutor Pod phases were not all Succeeded: {', '.join(pod_phases)}",
+        failures,
+    )
+    task_lineage_tasks = _sequence(task_lineage.get("tasks"))
+    _expect(bool(task_lineage_tasks), "task-lineage.json contains no tasks", failures)
+    _expect(
+        task_lineage.get("seeded_run_id") == details.get("seed_run_id"),
+        "task-lineage.json seeded_run_id does not match summary",
+        failures,
+    )
+    _expect(
+        bool(_sequence(taskexecutor_pods.get("items"))),
+        "taskexecutor-pods.json contains no Pod items",
+        failures,
+    )
+
+    secret_items = _sequence(taskexecutor_secrets.get("items"))
+    _expect(
+        taskexecutor_secrets.get("redacted") is True,
+        "taskexecutor-secrets.redacted.json does not declare redaction",
+        failures,
+    )
+    _expect(
+        bool(secret_items),
+        "taskexecutor-secrets.redacted.json contains no Secret items",
+        failures,
+    )
+    _expect(
+        all(_mapping(secret).get("redacted") is True for secret in secret_items),
+        "one or more Secret evidence records are not marked redacted",
+        failures,
+    )
+    _expect(
+        all(
+            "token" in _sequence(_mapping(secret).get("data_keys"))
+            for secret in secret_items
+        ),
+        "Secret evidence does not include the token key name",
+        failures,
+    )
+
+    final_counts = _mapping(final_state.get("counts"))
+    _expect(
+        final_state.get("captured_before_namespace_cleanup") is True,
+        "final-state.json was not marked as pre-cleanup state",
+        failures,
+    )
+    _expect(
+        _int_value(final_counts.get("taskexecutor_pods")) >= 1,
+        "final-state.json does not count TaskExecutor Pods",
+        failures,
+    )
+    _expect(
+        _int_value(final_counts.get("taskexecutor_secrets")) >= 1,
+        "final-state.json does not count TaskExecutor Secrets",
+        failures,
+    )
+
+    checklist_claims = _sequence(proof_checklist.get("claims"))
+    out_of_scope = [
+        str(item) for item in _sequence(proof_checklist.get("out_of_scope"))
+    ]
+    _expect(bool(checklist_claims), "proof-checklist.json contains no claims", failures)
+    _expect(
+        any("capacity" in item for item in out_of_scope),
+        "proof-checklist.json does not keep capacity claims out of scope",
         failures,
     )
 
@@ -116,6 +209,9 @@ def verify_evidence(
         evidence_path=evidence_path,
         summary=summary,
         details=details,
+        task_lineage_tasks=task_lineage_tasks,
+        secret_items=secret_items,
+        final_counts=final_counts,
         pod_phases=pod_phases,
         cleanup_result=cleanup_result,
         require_cleanup=require_cleanup,
@@ -135,11 +231,24 @@ def _read_json(path: Path, failures: list[str]) -> dict[str, object]:
     return value
 
 
+def _read_required_json(
+    evidence_path: Path, relative_path: str, failures: list[str]
+) -> dict[str, object]:
+    path = evidence_path / relative_path
+    if not path.is_file():
+        failures.append(f"{relative_path} not found under {evidence_path}")
+        return {}
+    return _read_json(path, failures)
+
+
 def _format_report(
     *,
     evidence_path: Path,
     summary: Mapping[str, object],
     details: Mapping[str, object],
+    task_lineage_tasks: Sequence[object],
+    secret_items: Sequence[object],
+    final_counts: Mapping[str, object],
     pod_phases: Sequence[str],
     cleanup_result: Mapping[str, object],
     require_cleanup: bool,
@@ -165,6 +274,13 @@ def _format_report(
         lines.append(f"  - {pod.get('name')} phase={pod.get('phase')}")
     lines.extend(
         [
+            f"Task lineage records: {len(task_lineage_tasks)}",
+            f"Credential Secret records: {len(secret_items)}",
+            (
+                "Final state counts: "
+                f"pods={final_counts.get('taskexecutor_pods')} "
+                f"secrets={final_counts.get('taskexecutor_secrets')}"
+            ),
             f"TaskExecutor log captures: {len(taskexecutor_logs)}",
             f"TaskExecutor phases: {', '.join(pod_phases) or '<none>'}",
             f"Cleanup required: {str(require_cleanup).lower()}",
@@ -190,6 +306,10 @@ def _mapping(value: object) -> Mapping[str, object]:
 
 def _sequence(value: object) -> Sequence[object]:
     return value if isinstance(value, list) else []
+
+
+def _int_value(value: object) -> int:
+    return value if isinstance(value, int) else 0
 
 
 def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:

--- a/framework/py/flwr/supercore/superexec/executor/factory.py
+++ b/framework/py/flwr/supercore/superexec/executor/factory.py
@@ -28,7 +28,6 @@ from .kubernetes_executor import (
 from .subprocess_executor import SubprocessExecutor
 from .types import Executor
 
-
 _KUBERNETES_CONFIG_FIELD_MAP = {
     "image-pull-policy": "image_pull_policy",
     "resource-pool": "resource_pool",

--- a/framework/py/flwr/supercore/superexec/executor/kubernetes_executor_harness_test.py
+++ b/framework/py/flwr/supercore/superexec/executor/kubernetes_executor_harness_test.py
@@ -30,9 +30,7 @@ import yaml
 
 def _load_harness_module() -> ModuleType:
     """Load the dev harness scaffold from its file path."""
-    harness_path = (
-        Path(__file__).resolve().parents[5] / "dev" / "k8s" / "harness.py"
-    )
+    harness_path = Path(__file__).resolve().parents[5] / "dev" / "k8s" / "harness.py"
     spec = importlib.util.spec_from_file_location(
         "kubernetes_executor_harness", harness_path
     )
@@ -348,7 +346,7 @@ def test_run_infra_proof_dry_run_writes_local_k8s_infra_evidence(
 def test_run_infra_proof_fails_when_negative_rbac_check_allows_too_much(
     tmp_path: Path,
 ) -> None:
-    """Test local k8s infra proof records a failure when broader RBAC access is allowed."""
+    """Test local k8s infra proof rejects broader RBAC access."""
     runner = _AllowEverythingRunner()
 
     summary = harness_module.run_infra_proof(
@@ -538,6 +536,12 @@ def test_run_local_k8s_launch_path_dry_run_writes_evidence(tmp_path: Path) -> No
     assert (output_dir / "objects" / "real-launch.yaml").is_file()
     assert (output_dir / "objects" / "seed-job.yaml").is_file()
     assert (output_dir / "objects" / "executor-config.yaml").is_file()
+    assert (output_dir / "invocation.json").is_file()
+    assert (output_dir / "task-lineage.json").is_file()
+    assert (output_dir / "taskexecutor-pods.json").is_file()
+    assert (output_dir / "taskexecutor-secrets.redacted.json").is_file()
+    assert (output_dir / "final-state.json").is_file()
+    assert (output_dir / "proof-checklist.json").is_file()
 
     events = _read_jsonl(output_dir / "events.jsonl")
     assert [event["event"] for event in events] == [
@@ -569,7 +573,9 @@ def test_run_local_k8s_launch_path_dry_run_writes_evidence(tmp_path: Path) -> No
     assert "wait --for=condition=Ready pod/flower-superlink" in commands_text
     assert "wait --for=condition=Ready pod/flower-superexec" in commands_text
     assert "delete job flower-local-k8s-seed-run" in commands_text
-    assert "wait --for=condition=Complete job/flower-local-k8s-seed-run" in commands_text
+    assert (
+        "wait --for=condition=Complete job/flower-local-k8s-seed-run" in commands_text
+    )
     assert "app.kubernetes.io/component=taskexecutor" in commands_text
     assert (output_dir / "diagnostics" / "image-preflight.txt").is_file()
     assert (output_dir / "diagnostics" / "cleanup.txt").is_file()
@@ -599,6 +605,11 @@ def test_run_local_k8s_launch_path_records_terminal_pod_logs_and_cleanup(
     assert summary.result == "local-k8s-launch-path"
     assert summary.details["seed_run_id"] == 123
     assert summary.details["pods"][0]["phase"] == "Succeeded"
+    assert summary.details["credential_secrets"][0]["name"] == (
+        "flwr-taskexecutor-123-abc-appio"
+    )
+    assert summary.details["final_state_counts"]["taskexecutor_pods"] == 1
+    assert summary.details["final_state_counts"]["taskexecutor_secrets"] == 1
     assert summary.details["cleanup"]["requested"] is True
     assert summary.details["cleanup"]["result"]["returncode"] == 0
     cleanup_text = (output_dir / "diagnostics" / "cleanup.txt").read_text()
@@ -606,11 +617,70 @@ def test_run_local_k8s_launch_path_records_terminal_pod_logs_and_cleanup(
 
     pods = json.loads((output_dir / "objects" / "pods.json").read_text())
     assert pods["phases"] == ["Succeeded"]
+    taskexecutor_pods = json.loads((output_dir / "taskexecutor-pods.json").read_text())
+    assert taskexecutor_pods["items"][0]["metadata"]["uid"] == "pod-uid-123"
+
+    secret_text = (output_dir / "taskexecutor-secrets.redacted.json").read_text()
+    assert "task-token" not in secret_text
+    assert "dGFzay10b2tlbg==" not in secret_text
+    taskexecutor_secrets = json.loads(secret_text)
+    assert taskexecutor_secrets["redacted"] is True
+    assert taskexecutor_secrets["command"]["stdout"] == (
+        f"{harness_module.REDACTED} Secret list JSON; see summarized items"
+    )
+    assert taskexecutor_secrets["items"][0]["data_keys"] == ["token"]
+    assert taskexecutor_secrets["items"][0]["data_byte_lengths"] == [
+        {"bytes": 10, "key": "token"}
+    ]
+
+    lineage = json.loads((output_dir / "task-lineage.json").read_text())
+    assert lineage["seeded_run_id"] == 123
+    assert lineage["tasks"] == [
+        {
+            "credential_secret_name": "flwr-taskexecutor-123-abc-appio",
+            "credential_secret_uid": "secret-uid-123",
+            "launch_attempt": "abc",
+            "pod_name": "flwr-taskexecutor-123-abc",
+            "pod_phase": "Succeeded",
+            "pod_uid": "pod-uid-123",
+            "resource_pool": "generic-k3d",
+            "seeded_run_id": 123,
+            "task_id": "123",
+            "task_type": "flwr-serverapp",
+            "terminal_phase": "Succeeded",
+        }
+    ]
+
+    final_state_text = (output_dir / "final-state.json").read_text()
+    assert "task-token" not in final_state_text
+    assert "dGFzay10b2tlbg==" not in final_state_text
+    final_state = json.loads((output_dir / "final-state.json").read_text())
+    assert final_state["captured_before_namespace_cleanup"] is True
+    assert final_state["cleanup_requested"] is True
+    assert final_state["commands"]["taskexecutor_secrets"]["stdout"] == (
+        f"{harness_module.REDACTED} Secret list JSON; see summarized items"
+    )
+    assert final_state["counts"] == {
+        "jobs": 1,
+        "namespace": 1,
+        "services": 1,
+        "taskexecutor_pods": 1,
+        "taskexecutor_secrets": 1,
+    }
+
+    checklist = json.loads((output_dir / "proof-checklist.json").read_text())
+    assert any("capacity" in item for item in checklist["out_of_scope"])
+    assert checklist["claims"][4]["artifact"] == "taskexecutor-secrets.redacted.json"
 
     taskexecutor_logs = (
         output_dir / "diagnostics" / "taskexecutor-logs.txt"
     ).read_text()
     assert "K8s launch probe ServerApp ran" in taskexecutor_logs
+
+    command_text = (output_dir / "diagnostics" / "commands.txt").read_text()
+    assert "task-token" not in command_text
+    assert "dGFzay10b2tlbg==" not in command_text
+    assert f"stdout: {harness_module.REDACTED} Secret list JSON" in command_text
 
     commands = [" ".join(command) for command in runner.commands]
     assert any(command.startswith("docker image inspect ") for command in commands)
@@ -624,7 +694,9 @@ def test_run_local_k8s_launch_path_records_terminal_pod_logs_and_cleanup(
         in command
         for command in commands
     )
-    assert any("delete job flower-local-k8s-seed-run" in command for command in commands)
+    assert any(
+        "delete job flower-local-k8s-seed-run" in command for command in commands
+    )
     assert any("logs pod/flwr-taskexecutor-123-abc" in command for command in commands)
     assert any("delete namespace flower-local-k8s" in command for command in commands)
 
@@ -806,6 +878,14 @@ class _RealLaunchRunner:
                 else self.terminal_phase
             )
             return self._result(args, stdout=json.dumps(_pod_list(phase)))
+        if "get" in args and "secrets" in args and "-o" in args and "json" in args:
+            return self._result(args, stdout=json.dumps(_secret_list()))
+        if "get" in args and "jobs" in args and "-o" in args and "json" in args:
+            return self._result(args, stdout=json.dumps(_object_list("Job")))
+        if "get" in args and "services" in args and "-o" in args and "json" in args:
+            return self._result(args, stdout=json.dumps(_object_list("Service")))
+        if "get" in args and "namespace" in args and "-o" in args and "json" in args:
+            return self._result(args, stdout=json.dumps(_namespace()))
         if "logs" in args and "job/flower-local-k8s-seed-run" in args:
             return self._result(args, stdout="K8s launch seed created run_id=123\n")
         if "logs" in args and "pod/flower-superexec" in args:
@@ -854,14 +934,92 @@ def _pod_list(phase: str) -> dict[str, Any]:
                 "metadata": {
                     "name": "flwr-taskexecutor-123-abc",
                     "namespace": "flower-local-k8s",
+                    "uid": "pod-uid-123",
                     "labels": {
                         "app.kubernetes.io/name": "flower",
                         "app.kubernetes.io/component": "taskexecutor",
+                        "flower.ai/harness-run": "k8s-launch-test",
+                        "flower.ai/launch-attempt": "abc",
+                        "flower.ai/resource-pool": "generic-k3d",
+                        "flower.ai/superexec-task-id": "123",
+                        "flower.ai/task-type": "flwr-serverapp",
                     },
+                },
+                "spec": {
+                    "containers": [
+                        {
+                            "name": "taskexecutor",
+                            "image": "flwr/superexec:dev",
+                            "args": [
+                                "--serverappio-api-address",
+                                "flower-superlink:9091",
+                                "--token-file",
+                                "/run/flwr/appio/token",
+                                "--insecure",
+                            ],
+                        }
+                    ],
+                    "volumes": [
+                        {
+                            "name": "appio-credentials",
+                            "secret": {"secretName": "flwr-taskexecutor-123-abc-appio"},
+                        }
+                    ],
                 },
                 "status": {"phase": phase},
             }
         ]
+    }
+
+
+def _secret_list() -> dict[str, Any]:
+    return {
+        "items": [
+            {
+                "kind": "Secret",
+                "metadata": {
+                    "name": "flwr-taskexecutor-123-abc-appio",
+                    "namespace": "flower-local-k8s",
+                    "uid": "secret-uid-123",
+                    "labels": {
+                        "app.kubernetes.io/name": "flower",
+                        "app.kubernetes.io/component": "taskexecutor",
+                        "flower.ai/harness-run": "k8s-launch-test",
+                        "flower.ai/launch-attempt": "abc",
+                        "flower.ai/resource-pool": "generic-k3d",
+                        "flower.ai/superexec-task-id": "123",
+                        "flower.ai/task-type": "flwr-serverapp",
+                    },
+                },
+                "type": "Opaque",
+                "data": {"token": "dGFzay10b2tlbg=="},
+            }
+        ]
+    }
+
+
+def _object_list(kind: str) -> dict[str, Any]:
+    return {
+        "items": [
+            {
+                "kind": kind,
+                "metadata": {
+                    "name": f"flower-local-k8s-{kind.lower()}",
+                    "namespace": "flower-local-k8s",
+                    "uid": f"{kind.lower()}-uid",
+                    "labels": {"flower.ai/harness-run": "k8s-launch-test"},
+                },
+                "status": {},
+            }
+        ]
+    }
+
+
+def _namespace() -> dict[str, Any]:
+    return {
+        "kind": "Namespace",
+        "metadata": {"name": "flower-local-k8s", "uid": "namespace-uid"},
+        "status": {"phase": "Active"},
     }
 
 
@@ -888,6 +1046,61 @@ def _write_verifier_evidence(
         },
     }
     (output_dir / "summary.json").write_text(json.dumps(summary), encoding="utf-8")
+    (output_dir / "invocation.json").write_text(
+        json.dumps({"mode": "local-k8s-launch-path", "dry_run": False}),
+        encoding="utf-8",
+    )
+    (output_dir / "task-lineage.json").write_text(
+        json.dumps(
+            {
+                "seeded_run_id": 123,
+                "tasks": [
+                    {
+                        "pod_name": "flwr-taskexecutor-test",
+                        "credential_secret_name": "flwr-taskexecutor-test-appio",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (output_dir / "taskexecutor-pods.json").write_text(
+        json.dumps({"items": [{"metadata": {"name": "flwr-taskexecutor-test"}}]}),
+        encoding="utf-8",
+    )
+    (output_dir / "taskexecutor-secrets.redacted.json").write_text(
+        json.dumps(
+            {
+                "redacted": True,
+                "items": [
+                    {
+                        "name": "flwr-taskexecutor-test-appio",
+                        "data_keys": ["token"],
+                        "redacted": True,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (output_dir / "final-state.json").write_text(
+        json.dumps(
+            {
+                "captured_before_namespace_cleanup": True,
+                "counts": {"taskexecutor_pods": 1, "taskexecutor_secrets": 1},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (output_dir / "proof-checklist.json").write_text(
+        json.dumps(
+            {
+                "claims": [{"claim": "TaskExecutor Pod observed"}],
+                "out_of_scope": ["capacity wait proof"],
+            }
+        ),
+        encoding="utf-8",
+    )
     (output_dir / "diagnostics" / "taskexecutor-logs.txt").write_text(
         taskexecutor_log_text,
         encoding="utf-8",

--- a/framework/py/flwr/supercore/superexec/executor/kubernetes_executor_harness_test.py
+++ b/framework/py/flwr/supercore/superexec/executor/kubernetes_executor_harness_test.py
@@ -16,8 +16,8 @@
 
 from __future__ import annotations
 
-import importlib.util
 import hashlib
+import importlib.util
 import json
 import sys
 from pathlib import Path


### PR DESCRIPTION
## Summary

- add reviewer-facing local k8s evidence artifacts for the F7 harness
- map seeded run, TaskExecutor Pod, and per-task Secret evidence without leaking Secret payloads
- require the new artifacts in the verifier and document how reviewers should inspect them

## Stack

- Stacked on #7401
- Base branch: `codex/f7-integrated-k3d-real-launch-path`

## Validation

- `python -m py_compile framework/dev/k8s/common.py framework/dev/k8s/harness.py framework/dev/k8s/real_launch.py framework/dev/k8s/observations.py framework/dev/k8s/verify_evidence.py framework/py/flwr/supercore/superexec/executor/kubernetes_executor_harness_test.py`
- `python -m pytest framework/py/flwr/supercore/superexec/executor/kubernetes_executor_harness_test.py`
- `python -m ruff check framework/dev/k8s/real_launch.py framework/dev/k8s/verify_evidence.py framework/py/flwr/supercore/superexec/executor/kubernetes_executor_harness_test.py`
- `git diff --check`
- `framework/dev/k8s/test-real-launch-path.sh --skip-build --output-dir /private/tmp/f7d0-secret-redaction-real-smoke`
- `rg -n "task-token|dGFzay10b2tlbg==" /private/tmp/f7d0-secret-redaction-real-smoke` returned no matches
