### PR TITLE
fix(framework): Disable early `ray` import that conflicts with runtime environment switch if app dependencies are installed

### DIFF
--- a/framework/py/flwr/simulation/__init__.py
+++ b/framework/py/flwr/simulation/__init__.py
@@ -16,26 +16,28 @@
 
 
 import importlib
+from typing import Any
 
 from flwr.simulation.app import run_simulation_process
 from flwr.simulation.run_simulation import run_simulation
 from flwr.simulation.simulationio_connection import SimulationIoConnection
 
-is_ray_installed = importlib.util.find_spec("ray") is not None
-
-if is_ray_installed:
-    from flwr.simulation.legacy_app import start_simulation
-else:
-    RAY_IMPORT_ERROR: str = """Unable to import module `ray`.
+RAY_IMPORT_ERROR: str = """Unable to import module `ray`.
 
 To install the necessary dependencies, install `flwr` with the `simulation` extra:
 
     pip install -U "flwr[simulation]"
 """
 
-    def start_simulation(*args, **kwargs):  # type: ignore
-        """Log error stating that module `ray` could not be imported."""
+
+def start_simulation(*args: Any, **kwargs: Any) -> Any:
+    """Start a Ray-based Flower simulation server."""
+    if importlib.util.find_spec("ray") is None:
         raise ImportError(RAY_IMPORT_ERROR)
+
+    from flwr.simulation.legacy_app import start_simulation as start_simulation_legacy
+
+    return start_simulation_legacy(*args, **kwargs)
 
 
 __all__ = [

--- a/framework/py/flwr/simulation/__init__.py
+++ b/framework/py/flwr/simulation/__init__.py
@@ -35,6 +35,7 @@ def start_simulation(*args: Any, **kwargs: Any) -> Any:
     if importlib.util.find_spec("ray") is None:
         raise ImportError(RAY_IMPORT_ERROR)
 
+    # pylint: disable-next=import-outside-toplevel
     from flwr.simulation.legacy_app import start_simulation as start_simulation_legacy
 
     return start_simulation_legacy(*args, **kwargs)


### PR DESCRIPTION
Without this change, if the base environment has `ray` intalled, even though the installation of app dependencies at runtime will install `ray` in the runtime environment, the switch to use that `ray` binary won't be actioned. This is because `ray` is already loaded. 