### PR TITLE
refactor(framework): Move cleanup logic of `flwr-*` processes to exit handler

### DIFF
--- a/framework/py/flwr/server/serverapp/app.py
+++ b/framework/py/flwr/server/serverapp/app.py
@@ -135,10 +135,46 @@ def run_serverapp(  # pylint: disable=R0912, R0913, R0914, R0915, R0917, W0212
     runtime_env_dir: Path | None = None
     exit_code = ExitCode.SUCCESS
 
+    def on_exit() -> None:
+        log(DEBUG, "[flwr-serverapp] Will push ServerApp task output")
+
+        # Set Grpc max retries to 1 to avoid blocking on exit
+        grid._retry_invoker.max_tries = 1
+
+        # Upload any remaining logs before pushing final output
+        if log_uploader:
+            flush_logs(log_queue)
+
+        # Push final status and context (if available)
+        pushoutput_req = PushTaskOutputRequest(
+            context=context_to_proto(context) if context else None,
+            sub_status=sub_status,
+            details=details,
+        )
+        try:
+            grid._stub.PushTaskOutput(pushoutput_req)
+        except grpc.RpcError as err:
+            log(ERROR, "Failed to push task output: %s", str(err))
+
+        # Stop log uploader for this run and upload final logs
+        if log_uploader:
+            stop_log_uploader(log_queue, log_uploader)
+
+        # Stop heartbeat sender
+        if heartbeat_sender and heartbeat_sender.is_running:
+            heartbeat_sender.stop()
+
+        # Close the Grpc connection
+        grid.close()
+
+        # Clean up run-scoped runtime environment, if any.
+        cleanup_app_runtime_environment(runtime_env_dir)
+
     # Register signal handlers for graceful shutdown
     register_signal_handlers(
         event_type=EventType.FLWR_SERVERAPP_RUN_LEAVE,
         exit_message="Task stopped by user.",
+        exit_handlers=[on_exit],
     )
 
     try:
@@ -247,41 +283,6 @@ def run_serverapp(  # pylint: disable=R0912, R0913, R0914, R0915, R0917, W0212
         exit_code = ExitCode.SERVERAPP_EXCEPTION  # General exit code
         if isinstance(ex, AppExitException):
             exit_code = ex.exit_code
-
-    finally:
-        log(DEBUG, "[flwr-serverapp] Will push ServerApp task output")
-
-        # Set Grpc max retries to 1 to avoid blocking on exit
-        grid._retry_invoker.max_tries = 1
-
-        # Upload any remaining logs before pushing final output
-        if log_uploader:
-            flush_logs(log_queue)
-
-        # Push final status and context (if available)
-        pushoutput_req = PushTaskOutputRequest(
-            context=context_to_proto(context) if context else None,
-            sub_status=sub_status,
-            details=details,
-        )
-        try:
-            grid._stub.PushTaskOutput(pushoutput_req)
-        except grpc.RpcError as err:
-            log(ERROR, "Failed to push task output: %s", str(err))
-
-        # Stop log uploader for this run and upload final logs
-        if log_uploader:
-            stop_log_uploader(log_queue, log_uploader)
-
-        # Stop heartbeat sender
-        if heartbeat_sender and heartbeat_sender.is_running:
-            heartbeat_sender.stop()
-
-        # Close the Grpc connection
-        grid.close()
-
-        # Clean up run-scoped runtime environment, if any.
-        cleanup_app_runtime_environment(runtime_env_dir)
 
     flwr_exit(
         code=exit_code,

--- a/framework/py/flwr/simulation/app.py
+++ b/framework/py/flwr/simulation/app.py
@@ -160,7 +160,7 @@ def run_simulation_process(  # pylint: disable=R0913, R0914, R0915, R0917, W0212
         token=token,
     )
 
-    # Initialize variables for finally block
+    # Initialize variables for exit handler
     log_uploader = None
     run_id_hash = None
     heartbeat_sender = None
@@ -171,9 +171,42 @@ def run_simulation_process(  # pylint: disable=R0913, R0914, R0915, R0917, W0212
     runtime_env_dir = None
     exit_code = ExitCode.SUCCESS
 
+    def on_exit() -> None:
+        log(DEBUG, "[flwr-simulation] Will push Simulation task output")
+
+        # Set Grpc max retries to 1 to avoid blocking on exit
+        conn._retry_invoker.max_tries = 1
+
+        # Upload any remaining logs before pushing final output
+        if log_uploader:
+            flush_logs(log_queue)
+
+        # Push final status and context (if available)
+        out_req = PushTaskOutputRequest(
+            context=context_to_proto(context) if context else None,
+            sub_status=sub_status,
+            details=details,
+            clientapp_runtime=metrics.clientapp_runtime,
+        )
+        try:
+            conn._stub.PushTaskOutput(out_req)
+        except grpc.RpcError as err:
+            log(ERROR, "Failed to push task output: %s", str(err))
+
+        # Stop log uploader for this run and upload final logs
+        if log_uploader:
+            stop_log_uploader(log_queue, log_uploader)
+
+        # Stop heartbeat sender
+        if heartbeat_sender and heartbeat_sender.is_running:
+            heartbeat_sender.stop()
+
+        cleanup_app_runtime_environment(runtime_env_dir)
+
     register_signal_handlers(
         event_type=EventType.FLWR_SIMULATION_RUN_LEAVE,
         exit_message="Task stopped by user.",
+        exit_handlers=[on_exit],
     )
 
     try:
@@ -296,37 +329,6 @@ def run_simulation_process(  # pylint: disable=R0913, R0914, R0915, R0917, W0212
 
         # General exit code
         exit_code = ExitCode.SIMULATION_EXCEPTION
-    finally:
-        log(DEBUG, "[flwr-simulation] Will push Simulation task output")
-
-        # Set Grpc max retries to 1 to avoid blocking on exit
-        conn._retry_invoker.max_tries = 1
-
-        # Upload any remaining logs before pushing final output
-        if log_uploader:
-            flush_logs(log_queue)
-
-        # Push final status and context (if available)
-        out_req = PushTaskOutputRequest(
-            context=context_to_proto(context) if context else None,
-            sub_status=sub_status,
-            details=details,
-            clientapp_runtime=metrics.clientapp_runtime,
-        )
-        try:
-            conn._stub.PushTaskOutput(out_req)
-        except grpc.RpcError as err:
-            log(ERROR, "Failed to push task output: %s", str(err))
-
-        # Stop log uploader for this run and upload final logs
-        if log_uploader:
-            stop_log_uploader(log_queue, log_uploader)
-
-        # Stop heartbeat sender
-        if heartbeat_sender and heartbeat_sender.is_running:
-            heartbeat_sender.stop()
-
-        cleanup_app_runtime_environment(runtime_env_dir)
 
     flwr_exit(
         code=exit_code,

--- a/framework/py/flwr/supercore/task_process/agent/run_agentapp.py
+++ b/framework/py/flwr/supercore/task_process/agent/run_agentapp.py
@@ -94,9 +94,38 @@ def run_agentapp(  # pylint: disable=R0912, R0913, R0914, R0915, R0917, W0212
     runtime_env_dir: Path | None = None
     exit_code = ExitCode.SUCCESS
 
+    def on_exit() -> None:
+        log(DEBUG, "[flwr-agentapp] Will push AgentApp task output")
+
+        grid._retry_invoker.max_tries = 1
+
+        if log_uploader:
+            flush_logs(log_queue)
+
+        pushoutput_req = PushTaskOutputRequest(
+            context=context_to_proto(context) if context else None,
+            sub_status=sub_status,
+            details=details,
+        )
+        try:
+            grid._stub.PushTaskOutput(pushoutput_req)
+        except grpc.RpcError as err:
+            log(ERROR, "Failed to push task output: %s", str(err))
+
+        if log_uploader:
+            stop_log_uploader(log_queue, log_uploader)
+
+        if heartbeat_sender and heartbeat_sender.is_running:
+            heartbeat_sender.stop()
+
+        grid.close()
+
+        cleanup_app_runtime_environment(runtime_env_dir)
+
     register_signal_handlers(
         event_type=EventType.FLWR_AGENTAPP_RUN_LEAVE,
         exit_message="Task stopped by user.",
+        exit_handlers=[on_exit],
     )
 
     try:
@@ -211,34 +240,6 @@ def run_agentapp(  # pylint: disable=R0912, R0913, R0914, R0915, R0917, W0212
         exit_code = ExitCode.TASK_PROC_EXCEPTION
         if isinstance(ex, AppExitException):
             exit_code = ex.exit_code
-
-    finally:
-        log(DEBUG, "[flwr-agentapp] Will push AgentApp task output")
-
-        grid._retry_invoker.max_tries = 1
-
-        if log_uploader:
-            flush_logs(log_queue)
-
-        pushoutput_req = PushTaskOutputRequest(
-            context=context_to_proto(context) if context else None,
-            sub_status=sub_status,
-            details=details,
-        )
-        try:
-            grid._stub.PushTaskOutput(pushoutput_req)
-        except grpc.RpcError as err:
-            log(ERROR, "Failed to push task output: %s", str(err))
-
-        if log_uploader:
-            stop_log_uploader(log_queue, log_uploader)
-
-        if heartbeat_sender and heartbeat_sender.is_running:
-            heartbeat_sender.stop()
-
-        grid.close()
-
-        cleanup_app_runtime_environment(runtime_env_dir)
 
     flwr_exit(
         code=exit_code,

--- a/framework/py/flwr/supercore/task_process/connector/run_connector.py
+++ b/framework/py/flwr/supercore/task_process/connector/run_connector.py
@@ -70,9 +70,29 @@ def run_connector(  # pylint: disable=too-many-locals
     details = "Connector task failed with unknown error."
     exit_code = ExitCode.SUCCESS
 
+    def on_exit() -> None:
+        log(DEBUG, "[flwr-connector] Will push Connector task output")
+
+        retry_invoker.max_tries = 1
+
+        pushoutput_req = PushTaskOutputRequest(
+            sub_status=sub_status,
+            details=details,
+        )
+        try:
+            stub.PushTaskOutput(pushoutput_req)
+        except grpc.RpcError as err:
+            log(ERROR, "Failed to push task output: %s", str(err))
+
+        if heartbeat_sender and heartbeat_sender.is_running:
+            heartbeat_sender.stop()
+
+        channel.close()
+
     register_signal_handlers(
         event_type=EventType.FLWR_CONNECTOR_RUN_LEAVE,
         exit_message="Task stopped by user.",
+        exit_handlers=[on_exit],
     )
 
     try:
@@ -100,25 +120,6 @@ def run_connector(  # pylint: disable=too-many-locals
         details = f"Connector task failed with exception: {str(ex)}"
 
         exit_code = ExitCode.TASK_PROC_EXCEPTION
-
-    finally:
-        log(DEBUG, "[flwr-connector] Will push Connector task output")
-
-        retry_invoker.max_tries = 1
-
-        pushoutput_req = PushTaskOutputRequest(
-            sub_status=sub_status,
-            details=details,
-        )
-        try:
-            stub.PushTaskOutput(pushoutput_req)
-        except grpc.RpcError as err:
-            log(ERROR, "Failed to push task output: %s", str(err))
-
-        if heartbeat_sender and heartbeat_sender.is_running:
-            heartbeat_sender.stop()
-
-        channel.close()
 
     flwr_exit(exit_code, event_type=EventType.FLWR_CONNECTOR_RUN_LEAVE)
 

--- a/framework/py/flwr/supercore/task_process/model/run_model.py
+++ b/framework/py/flwr/supercore/task_process/model/run_model.py
@@ -72,9 +72,33 @@ def run_model(  # pylint: disable=too-many-locals
     details = "Model task failed with unknown error."
     exit_code = ExitCode.SUCCESS
 
+    def on_exit() -> None:
+        log(DEBUG, "[flwr-model] Will push Model task output")
+
+        # Set Grpc max retries to 1 to avoid blocking on exit
+        retry_invoker.max_tries = 1
+
+        # Push final status
+        pushoutput_req = PushTaskOutputRequest(
+            sub_status=sub_status,
+            details=details,
+        )
+        try:
+            stub.PushTaskOutput(pushoutput_req)
+        except grpc.RpcError as err:
+            log(ERROR, "Failed to push task output: %s", str(err))
+
+        # Stop heartbeat sender
+        if heartbeat_sender and heartbeat_sender.is_running:
+            heartbeat_sender.stop()
+
+        # Close the Grpc connection
+        channel.close()
+
     register_signal_handlers(
         event_type=EventType.FLWR_MODEL_RUN_LEAVE,
         exit_message="Run stopped by user.",
+        exit_handlers=[on_exit],
     )
 
     try:
@@ -107,29 +131,6 @@ def run_model(  # pylint: disable=too-many-locals
 
         # Set exit code
         exit_code = ExitCode.TASK_PROC_EXCEPTION
-
-    finally:
-        log(DEBUG, "[flwr-model] Will push Model task output")
-
-        # Set Grpc max retries to 1 to avoid blocking on exit
-        retry_invoker.max_tries = 1
-
-        # Push final status
-        pushoutput_req = PushTaskOutputRequest(
-            sub_status=sub_status,
-            details=details,
-        )
-        try:
-            stub.PushTaskOutput(pushoutput_req)
-        except grpc.RpcError as err:
-            log(ERROR, "Failed to push task output: %s", str(err))
-
-        # Stop heartbeat sender
-        if heartbeat_sender and heartbeat_sender.is_running:
-            heartbeat_sender.stop()
-
-        # Close the Grpc connection
-        channel.close()
 
     flwr_exit(exit_code, event_type=EventType.FLWR_MODEL_RUN_LEAVE)
 

--- a/framework/py/flwr/supernode/runtime/run_clientapp.py
+++ b/framework/py/flwr/supernode/runtime/run_clientapp.py
@@ -149,78 +149,78 @@ def run_clientapp(  # pylint: disable=R0913, R0914, R0915, R0917
         # Pull Message, Context, Run and FAB from SuperNode
         message, context, run, fab = pull_task_input(stub)
 
-        try:
+        # Install FAB
+        log(DEBUG, "[flwr-clientapp] Start FAB installation.")
+        install_from_fab(fab.content, skip_prompt=True)
 
-            # Install FAB
-            log(DEBUG, "[flwr-clientapp] Start FAB installation.")
-            install_from_fab(fab.content, skip_prompt=True)
-
-            app_path = get_project_dir(run.fab_id, run.fab_version, fab.hash_str)
-            if runtime_dependency_install:
-                log(DEBUG, "[flwr-clientapp] Installing app dependencies.")
-                runtime_env_dir = install_app_dependencies(
-                    app_path,
-                    launch_id=token,
-                    run_id=run.run_id,
-                    index_context={
-                        "component": "clientapp",
-                        "project_dir": str(app_path),
-                        "run_id": run.run_id,
-                        "launch_id": token,
-                        "fab_id": run.fab_id,
-                        "fab_version": run.fab_version,
-                        "fab_hash": fab.hash_str,
-                    },
-                )
-            else:
-                log(
-                    DEBUG,
-                    "[flwr-clientapp] Runtime dependency installation is disabled.",
-                )
-
-            load_client_app_fn = get_load_client_app_fn(
-                default_app_ref="",
-                app_path=None,
-                multi_app=True,
+        app_path = get_project_dir(run.fab_id, run.fab_version, fab.hash_str)
+        if runtime_dependency_install:
+            log(DEBUG, "[flwr-clientapp] Installing app dependencies.")
+            runtime_env_dir = install_app_dependencies(
+                app_path,
+                launch_id=token,
+                run_id=run.run_id,
+                index_context={
+                    "component": "clientapp",
+                    "project_dir": str(app_path),
+                    "run_id": run.run_id,
+                    "launch_id": token,
+                    "fab_id": run.fab_id,
+                    "fab_version": run.fab_version,
+                    "fab_hash": fab.hash_str,
+                },
+            )
+        else:
+            log(
+                DEBUG,
+                "[flwr-clientapp] Runtime dependency installation is disabled.",
             )
 
-            # Load ClientApp
-            log(DEBUG, "[flwr-clientapp] Start `ClientApp` Loading.")
-            client_app: ClientApp = load_client_app_fn(
-                run.fab_id, run.fab_version, fab.hash_str
-            )
+        load_client_app_fn = get_load_client_app_fn(
+            default_app_ref="",
+            app_path=None,
+            multi_app=True,
+        )
 
-            # Execute ClientApp
-            reply_message = client_app(message=message, context=context)
-            sub_status = SubStatus.COMPLETED
-            details = ""
+        # Load ClientApp
+        log(DEBUG, "[flwr-clientapp] Start `ClientApp` Loading.")
+        client_app: ClientApp = load_client_app_fn(
+            run.fab_id, run.fab_version, fab.hash_str
+        )
 
-        except Exception as ex:  # pylint: disable=broad-exception-caught
-            # Don't update/change NodeState
+        # Execute ClientApp
+        reply_message = client_app(message=message, context=context)
+        sub_status = SubStatus.COMPLETED
+        details = ""
 
-            e_code = ErrorCode.CLIENT_APP_RAISED_EXCEPTION
-            # Ex fmt: "<class 'ZeroDivisionError'>:<'division by zero'>"
-            reason = str(type(ex)) + ":<'" + str(ex) + "'>"
-            exc_entity = "ClientApp"
-            if isinstance(ex, LoadClientAppError):
-                reason = "An exception was raised when attempting to load `ClientApp`"
-                e_code = ErrorCode.LOAD_CLIENT_APP_EXCEPTION
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        # Don't update/change NodeState
+        e_code = ErrorCode.CLIENT_APP_RAISED_EXCEPTION
+        # Ex fmt: "<class 'ZeroDivisionError'>:<'division by zero'>"
+        reason = str(type(ex)) + ":<'" + str(ex) + "'>"
+        exc_entity = "ClientApp"
+        if isinstance(ex, LoadClientAppError):
+            reason = "An exception was raised when attempting to load `ClientApp`"
+            e_code = ErrorCode.LOAD_CLIENT_APP_EXCEPTION
 
-            log(ERROR, "%s raised an exception", exc_entity, exc_info=ex)
+        log(ERROR, "%s raised an exception", exc_entity, exc_info=ex)
 
-            # Create error message
+        # Create error message
+        if message:
             reply_message = Message(Error(code=e_code, reason=reason), reply_to=message)
             sub_status = SubStatus.FAILED
             details = reason
 
-        finally:
-            # Push reply message to SuperNode
-            if reply_message:
+        # Set exit code
+        exit_code = ExitCode.TASK_PROC_EXCEPTION
+    finally:
+        # Push reply message to SuperNode
+        if reply_message and context:
+            try:
                 push_message(stub, reply_message, context)
-
-    except grpc.RpcError as e:
-        log(ERROR, "gRPC error occurred: %s", str(e))
-        exit_code = ExitCode.CLIENTAPP_COMMUNICATION_ERROR
+            except Exception as ex:  # pylint: disable=broad-exception-caught
+                log(ERROR, "Failed to push reply message", exc_info=ex)
+                exit_code = ExitCode.CLIENTAPP_COMMUNICATION_ERROR
 
     flwr_exit(
         code=exit_code,
@@ -230,36 +230,30 @@ def run_clientapp(  # pylint: disable=R0913, R0914, R0915, R0917
 
 def pull_task_input(stub: ClientAppIoStub) -> tuple[Message, Context, Run, Fab]:
     """Pull TaskInput from SuperNode."""
-    try:
-        # Pull Context, Run and FAB
-        res: PullTaskInputResponse = stub.PullTaskInput(PullTaskInputRequest())
-        context = context_from_proto(res.context)
-        run = run_from_proto(res.run)
-        fab = fab_from_proto(res.fab)
+    # Pull Context, Run and FAB
+    res: PullTaskInputResponse = stub.PullTaskInput(PullTaskInputRequest())
+    context = context_from_proto(res.context)
+    run = run_from_proto(res.run)
+    fab = fab_from_proto(res.fab)
 
-        # Pull and inflate the message
-        pull_msg_res: PullAppMessagesResponse = stub.PullMessage(
-            PullAppMessagesRequest()
-        )
-        run_id = context.run_id
-        node = Node(node_id=context.node_id)
-        object_tree = pull_msg_res.message_object_trees[0]
-        message = pull_and_inflate_object_from_tree(
-            object_tree,
-            make_pull_object_fn_protobuf(stub.PullObject, node, run_id),
-            make_confirm_message_received_fn_protobuf(
-                stub.ConfirmMessageReceived, node, run_id
-            ),
-            return_type=Message,
-        )
+    # Pull and inflate the message
+    pull_msg_res: PullAppMessagesResponse = stub.PullMessage(PullAppMessagesRequest())
+    run_id = context.run_id
+    node = Node(node_id=context.node_id)
+    object_tree = pull_msg_res.message_object_trees[0]
+    message = pull_and_inflate_object_from_tree(
+        object_tree,
+        make_pull_object_fn_protobuf(stub.PullObject, node, run_id),
+        make_confirm_message_received_fn_protobuf(
+            stub.ConfirmMessageReceived, node, run_id
+        ),
+        return_type=Message,
+    )
 
-        # Set the message ID
-        # The deflated message doesn't contain the message_id (its own object_id)
-        message.metadata.__dict__["_message_id"] = object_tree.object_id
-        return message, context, run, fab
-    except grpc.RpcError as e:
-        log(ERROR, "[PullTaskInput] gRPC error occurred: %s", str(e))
-        raise e
+    # Set the message ID
+    # The deflated message doesn't contain the message_id (its own object_id)
+    message.metadata.__dict__["_message_id"] = object_tree.object_id
+    return message, context, run, fab
 
 
 def push_message(stub: ClientAppIoStub, message: Message, context: Context) -> None:

--- a/framework/py/flwr/supernode/runtime/run_clientapp.py
+++ b/framework/py/flwr/supernode/runtime/run_clientapp.py
@@ -116,9 +116,29 @@ def run_clientapp(  # pylint: disable=R0913, R0914, R0915, R0917
     runtime_env_dir = None
     exit_code = ExitCode.SUCCESS
 
+    def on_exit() -> None:
+        # Set Grpc max retries to 1 to avoid blocking on exit
+        retry_invoker.max_tries = 1
+
+        # Push final status and context (if available)
+        push_task_output(
+            stub=stub,
+            context=context,
+            sub_status=sub_status,
+            details=details,
+        )
+
+        # Stop heartbeat sender
+        if heartbeat_sender is not None and heartbeat_sender.is_running:
+            heartbeat_sender.stop()
+        channel.close()
+
+        cleanup_app_runtime_environment(runtime_env_dir)
+
     register_signal_handlers(
         event_type=EventType.FLWR_CLIENTAPP_RUN_LEAVE,
         exit_message="Task stopped by user.",
+        exit_handlers=[on_exit],
     )
 
     try:
@@ -201,24 +221,6 @@ def run_clientapp(  # pylint: disable=R0913, R0914, R0915, R0917
     except grpc.RpcError as e:
         log(ERROR, "gRPC error occurred: %s", str(e))
         exit_code = ExitCode.CLIENTAPP_COMMUNICATION_ERROR
-    finally:
-        # Set Grpc max retries to 1 to avoid blocking on exit
-        retry_invoker.max_tries = 1
-
-        # Push final status and context (if available)
-        push_task_output(
-            stub=stub,
-            context=context,
-            sub_status=sub_status,
-            details=details,
-        )
-
-        # Stop heartbeat sender
-        if heartbeat_sender is not None and heartbeat_sender.is_running:
-            heartbeat_sender.stop()
-        channel.close()
-
-        cleanup_app_runtime_environment(runtime_env_dir)
 
     flwr_exit(
         code=exit_code,

--- a/framework/py/flwr/supernode/runtime/run_clientapp_test.py
+++ b/framework/py/flwr/supernode/runtime/run_clientapp_test.py
@@ -69,6 +69,5 @@ class TestRunClientApp(unittest.TestCase):
         channel.return_value.subscribe.assert_called_once()
         flwr_exit.assert_called_once()
         self.assertEqual(
-            flwr_exit.call_args.kwargs["code"],
-            ExitCode.CLIENTAPP_COMMUNICATION_ERROR,
+            flwr_exit.call_args.kwargs["code"], ExitCode.TASK_PROC_EXCEPTION
         )


### PR DESCRIPTION
This PR is to ensure that the exit message printed by `flwr_exit` can be included in the task logs.