### PR TITLE
refactor(framework): Move AppIoServicer

### DIFF
--- a/framework/py/flwr/server/superlink/serverappio/serverappio_servicer.py
+++ b/framework/py/flwr/server/superlink/serverappio/serverappio_servicer.py
@@ -64,7 +64,7 @@ from flwr.supercore.inflatable.inflatable_object import (
 )
 from flwr.supercore.interceptors import get_authenticated_task
 from flwr.supercore.object_store import NoObjectInStoreError, ObjectStoreFactory
-from flwr.supercore.servicers import AppIoServicer
+from flwr.supercore.servicer.appio import AppIoServicer
 
 SERVERAPPIO_ENDPOINT_UNAVAILABLE_MESSAGE = (
     "Some ServerAppIo API endpoints are only available for Deployment Runtime runs."

--- a/framework/py/flwr/supercore/servicer/__init__.py
+++ b/framework/py/flwr/supercore/servicer/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2025 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Flower SuperCore servicers."""

--- a/framework/py/flwr/supercore/servicer/appio/__init__.py
+++ b/framework/py/flwr/supercore/servicer/appio/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Shared SuperCore servicers."""
+"""AppIo API Servicer."""
 
 
 from .appio_servicer import AppIoServicer

--- a/framework/py/flwr/supercore/servicer/appio/appio_servicer.py
+++ b/framework/py/flwr/supercore/servicer/appio/appio_servicer.py
@@ -51,9 +51,8 @@ from flwr.supercore.constant import (
     TASK_TYPES_REQUIRING_MODEL_REF,
     TaskType,
 )
+from flwr.supercore.corestate import CoreState
 from flwr.supercore.interceptors import get_authenticated_task
-
-from ...corestate import CoreState
 
 
 # pylint: disable=invalid-name, unused-argument

--- a/framework/py/flwr/supercore/servicer/appio/appio_servicer.py
+++ b/framework/py/flwr/supercore/servicer/appio/appio_servicer.py
@@ -53,7 +53,7 @@ from flwr.supercore.constant import (
 )
 from flwr.supercore.interceptors import get_authenticated_task
 
-from ..corestate import CoreState
+from ...corestate import CoreState
 
 
 # pylint: disable=invalid-name, unused-argument

--- a/framework/py/flwr/supercore/servicer/appio/appio_servicer_test.py
+++ b/framework/py/flwr/supercore/servicer/appio/appio_servicer_test.py
@@ -114,7 +114,7 @@ class TestAppIoServicer(unittest.TestCase):
 
         # Execute
         with patch(
-            "flwr.supercore.servicers.appio_servicer.get_authenticated_task",
+            "flwr.supercore.servicer.appio.appio_servicer.get_authenticated_task",
             return_value=Mock(task_id=123),
         ):
             response = self.servicer.SendTaskHeartbeat(
@@ -136,7 +136,7 @@ class TestAppIoServicer(unittest.TestCase):
 
         # Execute
         with patch(
-            "flwr.supercore.servicers.appio_servicer.get_authenticated_task",
+            "flwr.supercore.servicer.appio.appio_servicer.get_authenticated_task",
             return_value=Mock(task_id=789, run_id=123, type=TaskType.SERVER_APP),
         ):
             response = self.servicer.CreateTask(request, Mock())
@@ -164,7 +164,7 @@ class TestAppIoServicer(unittest.TestCase):
             with self.subTest(requesting_task_type=requesting_task_type):
                 # Execute
                 with patch(
-                    "flwr.supercore.servicers.appio_servicer.get_authenticated_task",
+                    "flwr.supercore.servicer.appio.appio_servicer.get_authenticated_task",
                     return_value=Mock(
                         task_id=789, run_id=123, type=requesting_task_type
                     ),
@@ -192,7 +192,7 @@ class TestAppIoServicer(unittest.TestCase):
         # Execute
         with (
             patch(
-                "flwr.supercore.servicers.appio_servicer.get_authenticated_task",
+                "flwr.supercore.servicer.appio.appio_servicer.get_authenticated_task",
                 return_value=Mock(task_id=789, run_id=123, type=TaskType.SERVER_APP),
             ),
             self.assertRaises(RuntimeError) as err,
@@ -241,7 +241,7 @@ class TestAppIoServicer(unittest.TestCase):
             with self.subTest(task_type=request.type):
                 with (
                     patch(
-                        "flwr.supercore.servicers.appio_servicer.get_authenticated_task",
+                        "flwr.supercore.servicer.appio.appio_servicer.get_authenticated_task",
                         return_value=Mock(
                             task_id=789, run_id=123, type=TaskType.SERVER_APP
                         ),
@@ -270,7 +270,7 @@ class TestAppIoServicer(unittest.TestCase):
         # Execute
         with (
             patch(
-                "flwr.supercore.servicers.appio_servicer.get_authenticated_task",
+                "flwr.supercore.servicer.appio.appio_servicer.get_authenticated_task",
                 return_value=Mock(run_id=123, type=TaskType.SERVER_APP),
             ),
             self.assertRaises(grpc.RpcError),
@@ -296,7 +296,7 @@ class TestAppIoServicer(unittest.TestCase):
 
         # Execute
         with patch(
-            "flwr.supercore.servicers.appio_servicer.get_authenticated_task",
+            "flwr.supercore.servicer.appio.appio_servicer.get_authenticated_task",
             return_value=Task(task_id=123, run_id=789),
         ):
             response = self.servicer.PushTaskMessage(request, Mock())
@@ -323,7 +323,7 @@ class TestAppIoServicer(unittest.TestCase):
         # Execute
         with (
             patch(
-                "flwr.supercore.servicers.appio_servicer.get_authenticated_task",
+                "flwr.supercore.servicer.appio.appio_servicer.get_authenticated_task",
                 return_value=Task(task_id=123, run_id=789),
             ),
             self.assertRaises(grpc.RpcError),
@@ -355,7 +355,7 @@ class TestAppIoServicer(unittest.TestCase):
 
         # Execute
         with patch(
-            "flwr.supercore.servicers.appio_servicer.get_authenticated_task",
+            "flwr.supercore.servicer.appio.appio_servicer.get_authenticated_task",
             return_value=Task(task_id=123, run_id=789),
         ):
             response = self.servicer.PushTaskEvents(request, Mock())
@@ -387,10 +387,10 @@ class TestAppIoServicer(unittest.TestCase):
         # Execute
         with (
             patch(
-                "flwr.supercore.servicers.appio_servicer.get_authenticated_task",
+                "flwr.supercore.servicer.appio.appio_servicer.get_authenticated_task",
                 return_value=Task(task_id=123, run_id=789),
             ),
-            patch("flwr.supercore.servicers.appio_servicer.log") as log_mock,
+            patch("flwr.supercore.servicer.appio.appio_servicer.log") as log_mock,
         ):
             response = self.servicer.PushTaskEvents(request, context)
 
@@ -417,7 +417,7 @@ class TestAppIoServicer(unittest.TestCase):
 
         # Execute
         with patch(
-            "flwr.supercore.servicers.appio_servicer.get_authenticated_task",
+            "flwr.supercore.servicer.appio.appio_servicer.get_authenticated_task",
             return_value=Task(task_id=321, run_id=789),
         ):
             response = self.servicer.PullTaskMessage(
@@ -453,7 +453,7 @@ class TestAppIoServicer(unittest.TestCase):
                 # Execute
                 with (
                     patch(
-                        "flwr.supercore.servicers.appio_servicer.get_authenticated_task",
+                        "flwr.supercore.servicer.appio.appio_servicer.get_authenticated_task",
                         return_value=Mock(run_id=123, type=requesting_task_type),
                     ),
                     self.assertRaises(grpc.RpcError),
@@ -475,7 +475,7 @@ class TestAppIoServicer(unittest.TestCase):
         """PushLogs should concatenate fragments and store them via state."""
         # Execute
         with patch(
-            "flwr.supercore.servicers.appio_servicer.get_authenticated_task",
+            "flwr.supercore.servicer.appio.appio_servicer.get_authenticated_task",
             return_value=Mock(task_id=123),
         ):
             response = self.servicer.PushLogs(

--- a/framework/py/flwr/supernode/servicer/clientappio/clientappio_servicer.py
+++ b/framework/py/flwr/supernode/servicer/clientappio/clientappio_servicer.py
@@ -55,7 +55,7 @@ from flwr.proto.run_pb2 import GetRunRequest, GetRunResponse
 from flwr.supercore.inflatable.inflatable_object import UnexpectedObjectContentError
 from flwr.supercore.interceptors import get_authenticated_task
 from flwr.supercore.object_store import NoObjectInStoreError, ObjectStoreFactory
-from flwr.supercore.servicers import AppIoServicer
+from flwr.supercore.servicer.appio import AppIoServicer
 from flwr.supernode.nodestate import NodeState, NodeStateFactory
 
 

--- a/framework/py/flwr/supernode/servicer/clientappio/clientappio_servicer_test.py
+++ b/framework/py/flwr/supernode/servicer/clientappio/clientappio_servicer_test.py
@@ -337,7 +337,7 @@ class TestClientAppIoServicer(unittest.TestCase):
 
         # Execute
         with patch(
-            "flwr.supercore.servicers.appio_servicer.get_authenticated_task",
+            "flwr.supercore.servicer.appio.appio_servicer.get_authenticated_task",
             return_value=Mock(task_id=task_id),
         ):
             response = self.servicer.SendTaskHeartbeat(request, Mock())


### PR DESCRIPTION
This PR aligns the structure of `flwr.supercore.servicer` with that of `flwr.superlink.servicer` and `flwr.supernode.servicer`:

- Rename `.servicers` to `.servicer`
- Move `AppIoServicer` into a sub-package