### PR TITLE
fix(framework): Run local SuperLink process as a new process group on Windows

### DIFF
--- a/framework/py/flwr/cli/local_superlink.py
+++ b/framework/py/flwr/cli/local_superlink.py
@@ -21,6 +21,7 @@ import os
 import subprocess
 import time
 from pathlib import Path
+from typing import Any
 
 import click
 import grpc
@@ -100,6 +101,17 @@ def _is_local_superlink_started() -> bool:
         channel.close()
 
 
+def _get_process_detach_kwargs() -> dict[str, Any]:
+    """Return platform-specific Popen kwargs to detach the local SuperLink."""
+    if os.name == "nt":
+        return {
+            # The Windows-only constant is absent from non-Windows type stubs.
+            "creationflags": subprocess.CREATE_NEW_PROCESS_GROUP,  # type: ignore[attr-defined]
+        }
+
+    return {"start_new_session": True}
+
+
 def _start_local_superlink(in_memory: bool = False) -> None:
     """Start a managed local SuperLink in simulation mode and wait for readiness."""
     database_path, log_file_path = _get_local_superlink_paths()
@@ -140,7 +152,7 @@ def _start_local_superlink(in_memory: bool = False) -> None:
             env=env,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
-            start_new_session=True,
+            **_get_process_detach_kwargs(),
         )
     except OSError as exc:
         raise click.ClickException(


### PR DESCRIPTION
This avoids killing local SuperLink in the background accidentally by a Ctrl + C.