### PR TITLE
fix(framework): Close gRPC channel on exiting `flwr-simulation`

### DIFF
--- a/framework/py/flwr/simulation/app.py
+++ b/framework/py/flwr/simulation/app.py
@@ -207,6 +207,9 @@ def run_simulation_process(  # pylint: disable=R0913, R0914, R0915, R0917, W0212
         if heartbeat_sender and heartbeat_sender.is_running:
             heartbeat_sender.stop()
 
+        # Close the gRPC connection
+        conn._disconnect()
+
         cleanup_app_runtime_environment(runtime_env_dir)
 
     register_signal_handlers(


### PR DESCRIPTION
Full credit to @jafermarq for tracking down the root cause. In all `flwr-*` commands, we close the gRPC channel on exit, but in `flwr-simulation` we somehow missed that.