### PR TITLE
fix(framework): Scrub provider keys from FAB task envs

### DIFF
--- a/framework/py/flwr/supercore/superexec/environment.py
+++ b/framework/py/flwr/supercore/superexec/environment.py
@@ -1,0 +1,48 @@
+# Copyright 2026 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Environment helpers for SuperExec-launched task processes."""
+
+
+import os
+
+from flwr.supercore.constant import TaskType
+
+FAB_BACKED_TASK_TYPES = frozenset(
+    {
+        TaskType.AGENT_APP,
+        TaskType.CLIENT_APP,
+        TaskType.SERVER_APP,
+        TaskType.SIMULATION,
+    }
+)
+SENSITIVE_PROVIDER_ENV_VARS = frozenset(
+    {
+        "BRAVE_API_KEY",
+        "EXA_API_KEY",
+        "FLWR_MODEL_API_KEY",
+        "TAVILY_API_KEY",
+    }
+)
+
+
+def task_process_env(task_type: TaskType) -> dict[str, str]:
+    """Return the environment for a task process of the given type."""
+    env = os.environ.copy()
+
+    if task_type in FAB_BACKED_TASK_TYPES:
+        for env_var in SENSITIVE_PROVIDER_ENV_VARS:
+            env.pop(env_var, None)
+
+    return env

--- a/framework/py/flwr/supercore/superexec/executor/subprocess_executor.py
+++ b/framework/py/flwr/supercore/superexec/executor/subprocess_executor.py
@@ -21,6 +21,7 @@ from flwr.supercore.constant import (
     TASK_TYPE_TO_APPIO_API_ADDRESS_ARG,
     TASK_TYPE_TO_COMMAND,
 )
+from flwr.supercore.superexec.environment import task_process_env
 
 from .types import ExecutionSpec, LaunchResult
 
@@ -52,14 +53,17 @@ class SubprocessExecutor:
         if spec.runtime_dependency_install:
             args.append("--allow-runtime-dependency-installation")
 
+        env = task_process_env(spec.task_type)
+
         if spec.suppress_output:
             subprocess.Popen(  # pylint: disable=consider-using-with
                 args,
+                env=env,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
             )
             return LaunchResult.accepted()
 
-        subprocess.Popen(args)  # pylint: disable=consider-using-with
+        subprocess.Popen(args, env=env)  # pylint: disable=consider-using-with
 
         return LaunchResult.accepted()

--- a/framework/py/flwr/supercore/superexec/executor/subprocess_executor_test.py
+++ b/framework/py/flwr/supercore/superexec/executor/subprocess_executor_test.py
@@ -15,9 +15,10 @@
 """Tests for SuperExec subprocess executor."""
 
 
+import os
 import subprocess
 from typing import Any
-from unittest.mock import Mock, patch
+from unittest.mock import ANY, Mock, patch
 
 import pytest
 
@@ -25,6 +26,13 @@ from flwr.supercore.constant import TaskType
 
 from .subprocess_executor import SubprocessExecutor
 from .types import ExecutionSpec, LaunchResultStatus
+
+_PROVIDER_ENV = {
+    "BRAVE_API_KEY": "brave-key",
+    "EXA_API_KEY": "exa-key",
+    "FLWR_MODEL_API_KEY": "model-key",
+    "TAVILY_API_KEY": "tavily-key",
+}
 
 
 def _execution_spec(**overrides: Any) -> ExecutionSpec:
@@ -56,7 +64,8 @@ def test_launch_renders_insecure_clientapp_args() -> None:
             "--token",
             "token",
             "--insecure",
-        ]
+        ],
+        env=ANY,
     )
     assert result.status == LaunchResultStatus.ACCEPTED
     assert result.message is None
@@ -81,7 +90,8 @@ def test_launch_renders_root_certificates_args() -> None:
             "token",
             "--root-certificates",
             "/path/to/root.pem",
-        ]
+        ],
+        env=ANY,
     )
 
 
@@ -107,10 +117,9 @@ def test_launch_suppresses_output_when_requested() -> None:
     with patch.object(subprocess, "Popen") as popen_mock:
         result = SubprocessExecutor().launch(_execution_spec(suppress_output=True))
 
-    assert popen_mock.call_args.kwargs == {
-        "stdout": subprocess.DEVNULL,
-        "stderr": subprocess.DEVNULL,
-    }
+    assert popen_mock.call_args.kwargs["env"] is not None
+    assert popen_mock.call_args.kwargs["stdout"] == subprocess.DEVNULL
+    assert popen_mock.call_args.kwargs["stderr"] == subprocess.DEVNULL
     assert result.status == LaunchResultStatus.ACCEPTED
 
 
@@ -140,7 +149,8 @@ def test_launch_renders_serverappio_task_args(
             "--token",
             "token",
             "--insecure",
-        ]
+        ],
+        env=ANY,
     )
 
 
@@ -153,6 +163,63 @@ def test_launch_does_not_suppress_output_by_default() -> None:
 
     assert "stdout" not in popen_mock.call_args.kwargs
     assert "stderr" not in popen_mock.call_args.kwargs
+
+
+@pytest.mark.parametrize(
+    "task_type",
+    [
+        TaskType.AGENT_APP,
+        TaskType.CLIENT_APP,
+        TaskType.SERVER_APP,
+        TaskType.SIMULATION,
+    ],
+    ids=["agentapp", "clientapp", "serverapp", "simulation"],
+)
+def test_launch_removes_provider_keys_for_fab_backed_tasks(
+    task_type: TaskType,
+) -> None:
+    """Test subprocess executor removes provider keys from FAB-backed tasks."""
+    env = {
+        **_PROVIDER_ENV,
+        "PATH": "/usr/bin",
+        "PYTHONPATH": "/path/to/python",
+        "UNRELATED_API_KEY": "keep-me",
+    }
+
+    with (
+        patch.dict(os.environ, env, clear=True),
+        patch.object(subprocess, "Popen") as popen_mock,
+    ):
+        SubprocessExecutor().launch(_execution_spec(task_type=task_type))
+
+    child_env = popen_mock.call_args.kwargs["env"]
+    for env_var in _PROVIDER_ENV:
+        assert env_var not in child_env
+    assert child_env["PATH"] == "/usr/bin"
+    assert child_env["PYTHONPATH"] == "/path/to/python"
+    assert child_env["UNRELATED_API_KEY"] == "keep-me"
+
+
+@pytest.mark.parametrize(
+    "task_type",
+    [TaskType.CONNECTOR, TaskType.MODEL],
+    ids=["connector", "model"],
+)
+def test_launch_keeps_provider_keys_for_flower_controlled_tasks(
+    task_type: TaskType,
+) -> None:
+    """Test subprocess executor keeps provider keys for Flower-controlled tasks."""
+    env = {**_PROVIDER_ENV, "PATH": "/usr/bin"}
+
+    with (
+        patch.dict(os.environ, env, clear=True),
+        patch.object(subprocess, "Popen") as popen_mock,
+    ):
+        SubprocessExecutor().launch(_execution_spec(task_type=task_type))
+
+    child_env = popen_mock.call_args.kwargs["env"]
+    for env_var, value in _PROVIDER_ENV.items():
+        assert child_env[env_var] == value
 
 
 def test_launch_raises_when_subprocess_cannot_start() -> None:

--- a/framework/py/flwr/supercore/superexec/plugin/base_ephemeral_exec_plugin.py
+++ b/framework/py/flwr/supercore/superexec/plugin/base_ephemeral_exec_plugin.py
@@ -20,7 +20,9 @@ import subprocess
 from collections.abc import Callable, Sequence
 
 from flwr.proto.task_pb2 import Task  # pylint: disable=E0611
+from flwr.supercore.constant import TaskType
 from flwr.supercore.exit import ExitCode, flwr_exit
+from flwr.supercore.superexec.environment import task_process_env
 
 from .exec_plugin import ExecPlugin
 
@@ -65,5 +67,5 @@ class BaseEphemeralExecPlugin(ExecPlugin):
         if self.cleanup_before_launch is not None:
             self.cleanup_before_launch()
         # Launch the app process and wait for it to finish
-        subprocess.run(cmds, check=False)
+        subprocess.run(cmds, check=False, env=task_process_env(TaskType(task.type)))
         flwr_exit(ExitCode.SUCCESS, "App process finished, exiting SuperExec.")

--- a/framework/py/flwr/supercore/superexec/plugin/base_ephemeral_exec_plugin_test.py
+++ b/framework/py/flwr/supercore/superexec/plugin/base_ephemeral_exec_plugin_test.py
@@ -15,13 +15,23 @@
 """Tests for SuperExec base ephemeral plugin behavior."""
 
 
-from unittest.mock import Mock, patch
+import os
+from unittest.mock import ANY, Mock, patch
+
+import pytest
 
 from flwr.supercore.constant import TaskType
 from flwr.supercore.exit import ExitCode
 from flwr.supercore.run import Run
 
 from .base_ephemeral_exec_plugin import BaseEphemeralExecPlugin
+
+_PROVIDER_ENV = {
+    "BRAVE_API_KEY": "brave-key",
+    "EXA_API_KEY": "exa-key",
+    "FLWR_MODEL_API_KEY": "model-key",
+    "TAVILY_API_KEY": "tavily-key",
+}
 
 
 def _get_run(_: int) -> Run:
@@ -93,6 +103,7 @@ def test_launch_task_runs_expected_command_and_exits() -> None:
             "1234",
         ],
         check=False,
+        env=ANY,
     )
     flwr_exit.assert_called_once_with(
         ExitCode.SUCCESS,
@@ -119,3 +130,63 @@ def test_launch_task_calls_cleanup_before_launch() -> None:
 
     # Assert
     assert call_log == ["cleanup", "subprocess"]
+
+
+@pytest.mark.parametrize(
+    "task_type",
+    [TaskType.AGENT_APP, TaskType.SERVER_APP, TaskType.SIMULATION],
+    ids=["agentapp", "serverapp", "simulation"],
+)
+def test_launch_task_removes_provider_keys_for_fab_backed_tasks(
+    task_type: TaskType,
+) -> None:
+    """Launch should remove provider keys from FAB-backed task env."""
+    plugin = _get_ephemeral_plugin()
+    env = {
+        **_PROVIDER_ENV,
+        "PATH": "/usr/bin",
+        "PYTHONPATH": "/path/to/python",
+        "UNRELATED_API_KEY": "keep-me",
+    }
+
+    with (
+        patch.dict(os.environ, env, clear=True),
+        patch(
+            "flwr.supercore.superexec.plugin.base_ephemeral_exec_plugin.subprocess.run"
+        ) as run,
+        patch("flwr.supercore.superexec.plugin.base_ephemeral_exec_plugin.flwr_exit"),
+    ):
+        plugin.launch_task(token="token", task=_get_task(task_type=task_type))
+
+    child_env = run.call_args.kwargs["env"]
+    for env_var in _PROVIDER_ENV:
+        assert env_var not in child_env
+    assert child_env["PATH"] == "/usr/bin"
+    assert child_env["PYTHONPATH"] == "/path/to/python"
+    assert child_env["UNRELATED_API_KEY"] == "keep-me"
+
+
+@pytest.mark.parametrize(
+    "task_type",
+    [TaskType.CONNECTOR, TaskType.MODEL],
+    ids=["connector", "model"],
+)
+def test_launch_task_keeps_provider_keys_for_flower_controlled_tasks(
+    task_type: TaskType,
+) -> None:
+    """Launch should keep provider keys for Flower-controlled task env."""
+    plugin = _get_ephemeral_plugin()
+    env = {**_PROVIDER_ENV, "PATH": "/usr/bin"}
+
+    with (
+        patch.dict(os.environ, env, clear=True),
+        patch(
+            "flwr.supercore.superexec.plugin.base_ephemeral_exec_plugin.subprocess.run"
+        ) as run,
+        patch("flwr.supercore.superexec.plugin.base_ephemeral_exec_plugin.flwr_exit"),
+    ):
+        plugin.launch_task(token="token", task=_get_task(task_type=task_type))
+
+    child_env = run.call_args.kwargs["env"]
+    for env_var, value in _PROVIDER_ENV.items():
+        assert child_env[env_var] == value


### PR DESCRIPTION
## Summary

- Add a SuperExec task-process environment helper that copies `os.environ` and removes only known provider API key variables for FAB-backed task types.
- Pass explicit child environments from subprocess and `serverapp-ephemeral` launches so `flwr-serverapp`, `flwr-agentapp`, `flwr-simulation`, and defensive `flwr-clientapp` launches do not receive raw provider keys.
- Preserve provider-key access for Flower-controlled `flwr-model` and `flwr-connector` task processes.

## Scope

This is PR 1 of the phased API-key process isolation hotfix. It intentionally does not add proxying, broad redaction, browser-use policy, Helm/Kapitan changes, connector-specific least privilege, or `/proc` parent-process exec replacement.

## Validation

- `uv run --all-extras --all-groups python -m pytest py/flwr/supercore/superexec/executor/subprocess_executor_test.py py/flwr/supercore/superexec/plugin/base_ephemeral_exec_plugin_test.py`
- `git diff --check`
