### PR TITLE
fix(baselines): Replace torch.Tensor with torch.from_numpy in set_parameters helpers

### DIFF
--- a/baselines/fedmeta/fedmeta/client.py
+++ b/baselines/fedmeta/fedmeta/client.py
@@ -46,7 +46,7 @@ class FlowerClient(fl.client.NumPyClient):
     def set_parameters(self, parameters: NDArrays) -> None:
         """Change the parameters of the model using the given ones."""
         params_dict = zip(self.net.state_dict().keys(), parameters)
-        state_dict = OrderedDict({k: torch.Tensor(v) for k, v in params_dict})
+        state_dict = OrderedDict({k: torch.from_numpy(v) for k, v in params_dict})
         self.net.load_state_dict(state_dict, strict=True)
 
     def fit(  # type: ignore

--- a/baselines/fednova/fednova/baseline_client.py
+++ b/baselines/fednova/fednova/baseline_client.py
@@ -53,7 +53,7 @@ class FedAvgClient(
     def set_parameters(self, parameters: NDArrays) -> None:
         """Change the parameters of the model using the given ones."""
         params_dict = zip(self.net.state_dict().keys(), parameters)
-        state_dict = OrderedDict({k: torch.Tensor(v) for k, v in params_dict})
+        state_dict = OrderedDict({k: torch.from_numpy(v) for k, v in params_dict})
         self.net.load_state_dict(state_dict, strict=True)
 
     def fit(

--- a/baselines/fednova/fednova/main.py
+++ b/baselines/fednova/fednova/main.py
@@ -62,7 +62,7 @@ def main(cfg: DictConfig) -> None:  # pylint: disable=too-many-locals
         )
         model = instantiate(cfg.model)
         params_dict = zip(model.state_dict().keys(), checkpoint["arr_0"])
-        state_dict = OrderedDict({k: torch.Tensor(v) for k, v in params_dict})
+        state_dict = OrderedDict({k: torch.from_numpy(v) for k, v in params_dict})
         model.load_state_dict(state_dict)
         loss, metrics = test(model.to(device), testloader, device)
         print(f"----Loss: {loss}, Accuracy: {metrics['accuracy']} on Test set ------")

--- a/baselines/fednova/fednova/models.py
+++ b/baselines/fednova/fednova/models.py
@@ -179,7 +179,7 @@ def test(model, test_loader, device, *args) -> Tuple[float, Dict[str, float]]:
     if len(args) > 1:
         # load the model parameters
         params_dict = zip(model.state_dict().keys(), args[1])
-        state_dict = OrderedDict({k: torch.Tensor(v) for k, v in params_dict})
+        state_dict = OrderedDict({k: torch.from_numpy(v) for k, v in params_dict})
         model.load_state_dict(state_dict)
 
     model = model.to(device)

--- a/baselines/fedpara/fedpara/client.py
+++ b/baselines/fedpara/fedpara/client.py
@@ -40,7 +40,7 @@ class FlowerClient(fl.client.NumPyClient):
     def set_parameters(self, parameters: NDArrays) -> None:
         """Apply parameters to model state dict."""
         params_dict = zip(self.net.state_dict().keys(), parameters)
-        state_dict = OrderedDict({k: torch.Tensor(v) for k, v in params_dict})
+        state_dict = OrderedDict({k: torch.from_numpy(v) for k, v in params_dict})
         self.net.load_state_dict(state_dict, strict=True)
 
     def fit(
@@ -101,7 +101,7 @@ class PFlowerClient(fl.client.NumPyClient):
     def set_parameters(self, parameters: NDArrays, evaluate: bool) -> None:
         """Apply parameters to model state dict."""
         params_dict = zip(self.net.state_dict().keys(), parameters)
-        server_dict = OrderedDict({k: torch.Tensor(v) for k, v in params_dict})
+        server_dict = OrderedDict({k: torch.from_numpy(v) for k, v in params_dict})
         self.private_server_param = {
             k: server_dict[k]
             for k in get_keys_state_dict(

--- a/baselines/fedpara/fedpara/server.py
+++ b/baselines/fedpara/fedpara/server.py
@@ -57,7 +57,7 @@ def gen_evaluate_fn(
         """Use the entire CIFAR-10/100 test set for evaluation."""
         net = instantiate(model)
         params_dict = zip(net.state_dict().keys(), parameters_ndarrays)
-        state_dict = OrderedDict({k: torch.Tensor(v) for k, v in params_dict})
+        state_dict = OrderedDict({k: torch.from_numpy(v) for k, v in params_dict})
         net.load_state_dict(state_dict, strict=True)
         net.to(device)
 

--- a/baselines/fjord/fjord/utils/utils.py
+++ b/baselines/fjord/fjord/utils/utils.py
@@ -26,7 +26,7 @@ def set_parameters(net: Module, parameters: List[np.ndarray]) -> None:
     :param parameters: List of numpy arrays
     """
     params_dict = zip(net.state_dict().keys(), parameters)
-    state_dict = OrderedDict({k: torch.Tensor(v) for k, v in params_dict})
+    state_dict = OrderedDict({k: torch.from_numpy(v) for k, v in params_dict})
     net.load_state_dict(state_dict, strict=True)
 
 

--- a/baselines/fjord/fjord/utils/utils.py
+++ b/baselines/fjord/fjord/utils/utils.py
@@ -1,7 +1,7 @@
 """Utility functions for fjord."""
 
 import os
-from typing import List, Optional, OrderedDict
+from typing import List, Optional
 
 import numpy as np
 import torch
@@ -26,7 +26,7 @@ def set_parameters(net: Module, parameters: List[np.ndarray]) -> None:
     :param parameters: List of numpy arrays
     """
     params_dict = zip(net.state_dict().keys(), parameters)
-    state_dict = OrderedDict({k: torch.from_numpy(v) for k, v in params_dict})
+    state_dict = {k: torch.from_numpy(v) for k, v in params_dict}
     net.load_state_dict(state_dict, strict=True)
 
 

--- a/baselines/flwr_baselines/flwr_baselines/publications/fedavg_mnist/client.py
+++ b/baselines/flwr_baselines/flwr_baselines/publications/fedavg_mnist/client.py
@@ -42,7 +42,7 @@ class FlowerClient(fl.client.NumPyClient):
     def set_parameters(self, parameters: NDArrays) -> None:
         """Changes the parameters of the model using the given ones."""
         params_dict = zip(self.net.state_dict().keys(), parameters)
-        state_dict = OrderedDict({k: torch.Tensor(v) for k, v in params_dict})
+        state_dict = OrderedDict({k: torch.from_numpy(v) for k, v in params_dict})
         self.net.load_state_dict(state_dict, strict=True)
 
     def fit(

--- a/baselines/flwr_baselines/flwr_baselines/publications/fedavg_mnist/utils.py
+++ b/baselines/flwr_baselines/flwr_baselines/publications/fedavg_mnist/utils.py
@@ -123,7 +123,7 @@ def gen_evaluate_fn(
         # determine device
         net = model.Net()
         params_dict = zip(net.state_dict().keys(), parameters_ndarrays)
-        state_dict = OrderedDict({k: torch.Tensor(v) for k, v in params_dict})
+        state_dict = OrderedDict({k: torch.from_numpy(v) for k, v in params_dict})
         net.load_state_dict(state_dict, strict=True)
         net.to(device)
 

--- a/baselines/flwr_baselines/flwr_baselines/publications/leaf/femnist/client.py
+++ b/baselines/flwr_baselines/flwr_baselines/publications/leaf/femnist/client.py
@@ -18,7 +18,7 @@ def get_parameters(net: torch.nn.Module) -> NDArrays:
 def set_parameters(net: torch.nn.Module, parameters: NDArrays) -> None:
     """Set parameters to a PyTorch network."""
     params_dict = zip(net.state_dict().keys(), parameters)
-    state_dict = dict({k: torch.Tensor(v) for k, v in params_dict})
+    state_dict = dict({k: torch.from_numpy(v) for k, v in params_dict})
     # ignore argument type because Dict keeps order in the supported python versions
     net.load_state_dict(state_dict, strict=True)  # type: ignore
 

--- a/baselines/heterofl/heterofl/models.py
+++ b/baselines/heterofl/heterofl/models.py
@@ -508,7 +508,7 @@ def get_parameters(net) -> List[np.ndarray]:
 def set_parameters(net, parameters: List[np.ndarray]):
     """Set the model parameters with given parameters."""
     params_dict = zip(net.state_dict().keys(), parameters)
-    state_dict = OrderedDict({k: torch.Tensor(v) for k, v in params_dict})
+    state_dict = OrderedDict({k: torch.from_numpy(v) for k, v in params_dict})
     net.load_state_dict(state_dict, strict=True)
 
 

--- a/baselines/heterofl/heterofl/models.py
+++ b/baselines/heterofl/heterofl/models.py
@@ -508,7 +508,7 @@ def get_parameters(net) -> List[np.ndarray]:
 def set_parameters(net, parameters: List[np.ndarray]):
     """Set the model parameters with given parameters."""
     params_dict = zip(net.state_dict().keys(), parameters)
-    state_dict = OrderedDict({k: torch.from_numpy(v) for k, v in params_dict})
+    state_dict = {k: torch.from_numpy(v) for k, v in params_dict}
     net.load_state_dict(state_dict, strict=True)
 
 

--- a/baselines/heterofl/heterofl/server.py
+++ b/baselines/heterofl/heterofl/server.py
@@ -53,7 +53,7 @@ def gen_evaluate_fn(
 
         net = model
         params_dict = zip(intermediate_keys, parameters_ndarrays)
-        state_dict = OrderedDict({k: torch.Tensor(v) for k, v in params_dict})
+        state_dict = OrderedDict({k: torch.from_numpy(v) for k, v in params_dict})
         net.load_state_dict(state_dict, strict=False)
         net.to(device)
 

--- a/baselines/niid_bench/niid_bench/client_fedavg.py
+++ b/baselines/niid_bench/niid_bench/client_fedavg.py
@@ -1,6 +1,6 @@
 """Defines the client class and support functions for FedAvg."""
 
-from typing import Callable, Dict, List, OrderedDict
+from typing import Callable, Dict, List
 
 import flwr as fl
 import torch
@@ -44,7 +44,7 @@ class FlowerClientFedAvg(fl.client.NumPyClient):
     def set_parameters(self, parameters):
         """Set the local model parameters using given ones."""
         params_dict = zip(self.net.state_dict().keys(), parameters)
-        state_dict = OrderedDict({k: torch.from_numpy(v) for k, v in params_dict})
+        state_dict = {k: torch.from_numpy(v) for k, v in params_dict}
         self.net.load_state_dict(state_dict, strict=True)
 
     def fit(self, parameters, config: Dict[str, Scalar]):

--- a/baselines/niid_bench/niid_bench/client_fedavg.py
+++ b/baselines/niid_bench/niid_bench/client_fedavg.py
@@ -44,7 +44,7 @@ class FlowerClientFedAvg(fl.client.NumPyClient):
     def set_parameters(self, parameters):
         """Set the local model parameters using given ones."""
         params_dict = zip(self.net.state_dict().keys(), parameters)
-        state_dict = OrderedDict({k: torch.Tensor(v) for k, v in params_dict})
+        state_dict = OrderedDict({k: torch.from_numpy(v) for k, v in params_dict})
         self.net.load_state_dict(state_dict, strict=True)
 
     def fit(self, parameters, config: Dict[str, Scalar]):

--- a/baselines/niid_bench/niid_bench/client_fednova.py
+++ b/baselines/niid_bench/niid_bench/client_fednova.py
@@ -1,6 +1,6 @@
 """Defines the client class and support functions for FedNova."""
 
-from typing import Callable, Dict, List, OrderedDict
+from typing import Callable, Dict, List
 
 import flwr as fl
 import torch
@@ -44,7 +44,7 @@ class FlowerClientFedNova(fl.client.NumPyClient):
     def set_parameters(self, parameters):
         """Set the local model parameters using given ones."""
         params_dict = zip(self.net.state_dict().keys(), parameters)
-        state_dict = OrderedDict({k: torch.from_numpy(v) for k, v in params_dict})
+        state_dict = {k: torch.from_numpy(v) for k, v in params_dict}
         self.net.load_state_dict(state_dict, strict=True)
 
     def fit(self, parameters, config: Dict[str, Scalar]):

--- a/baselines/niid_bench/niid_bench/client_fednova.py
+++ b/baselines/niid_bench/niid_bench/client_fednova.py
@@ -44,7 +44,7 @@ class FlowerClientFedNova(fl.client.NumPyClient):
     def set_parameters(self, parameters):
         """Set the local model parameters using given ones."""
         params_dict = zip(self.net.state_dict().keys(), parameters)
-        state_dict = OrderedDict({k: torch.Tensor(v) for k, v in params_dict})
+        state_dict = OrderedDict({k: torch.from_numpy(v) for k, v in params_dict})
         self.net.load_state_dict(state_dict, strict=True)
 
     def fit(self, parameters, config: Dict[str, Scalar]):

--- a/baselines/niid_bench/niid_bench/client_fedprox.py
+++ b/baselines/niid_bench/niid_bench/client_fedprox.py
@@ -46,7 +46,7 @@ class FlowerClientFedProx(fl.client.NumPyClient):
     def set_parameters(self, parameters):
         """Set the local model parameters using given ones."""
         params_dict = zip(self.net.state_dict().keys(), parameters)
-        state_dict = OrderedDict({k: torch.Tensor(v) for k, v in params_dict})
+        state_dict = OrderedDict({k: torch.from_numpy(v) for k, v in params_dict})
         self.net.load_state_dict(state_dict, strict=True)
 
     def fit(self, parameters, config: Dict[str, Scalar]):

--- a/baselines/niid_bench/niid_bench/client_fedprox.py
+++ b/baselines/niid_bench/niid_bench/client_fedprox.py
@@ -1,6 +1,6 @@
 """Defines the client class and support functions for FedProx."""
 
-from typing import Callable, Dict, List, OrderedDict
+from typing import Callable, Dict, List
 
 import flwr as fl
 import torch
@@ -46,7 +46,7 @@ class FlowerClientFedProx(fl.client.NumPyClient):
     def set_parameters(self, parameters):
         """Set the local model parameters using given ones."""
         params_dict = zip(self.net.state_dict().keys(), parameters)
-        state_dict = OrderedDict({k: torch.from_numpy(v) for k, v in params_dict})
+        state_dict = {k: torch.from_numpy(v) for k, v in params_dict}
         self.net.load_state_dict(state_dict, strict=True)
 
     def fit(self, parameters, config: Dict[str, Scalar]):

--- a/baselines/niid_bench/niid_bench/client_scaffold.py
+++ b/baselines/niid_bench/niid_bench/client_scaffold.py
@@ -58,7 +58,7 @@ class FlowerClientScaffold(fl.client.NumPyClient):
     def set_parameters(self, parameters):
         """Set the local model parameters using given ones."""
         params_dict = zip(self.net.state_dict().keys(), parameters)
-        state_dict = OrderedDict({k: torch.Tensor(v) for k, v in params_dict})
+        state_dict = OrderedDict({k: torch.from_numpy(v) for k, v in params_dict})
         self.net.load_state_dict(state_dict, strict=True)
 
     def fit(self, parameters, config: Dict[str, Scalar]):

--- a/baselines/niid_bench/niid_bench/client_scaffold.py
+++ b/baselines/niid_bench/niid_bench/client_scaffold.py
@@ -1,7 +1,7 @@
 """Defines the client class and support functions for SCAFFOLD."""
 
 import os
-from typing import Callable, Dict, List, OrderedDict
+from typing import Callable, Dict, List
 
 import flwr as fl
 import torch
@@ -58,7 +58,7 @@ class FlowerClientScaffold(fl.client.NumPyClient):
     def set_parameters(self, parameters):
         """Set the local model parameters using given ones."""
         params_dict = zip(self.net.state_dict().keys(), parameters)
-        state_dict = OrderedDict({k: torch.from_numpy(v) for k, v in params_dict})
+        state_dict = {k: torch.from_numpy(v) for k, v in params_dict}
         self.net.load_state_dict(state_dict, strict=True)
 
     def fit(self, parameters, config: Dict[str, Scalar]):

--- a/baselines/niid_bench/niid_bench/server_scaffold.py
+++ b/baselines/niid_bench/niid_bench/server_scaffold.py
@@ -2,7 +2,6 @@
 
 import concurrent.futures
 from logging import DEBUG, INFO
-from typing import OrderedDict
 
 import torch
 from flwr.common import (
@@ -258,7 +257,7 @@ def gen_evaluate_fn(
         """Use the entire Emnist test set for evaluation."""
         net = instantiate(model)
         params_dict = zip(net.state_dict().keys(), parameters_ndarrays)
-        state_dict = OrderedDict({k: torch.from_numpy(v) for k, v in params_dict})
+        state_dict = {k: torch.from_numpy(v) for k, v in params_dict}
         net.load_state_dict(state_dict, strict=True)
         net.to(device)
 

--- a/baselines/niid_bench/niid_bench/server_scaffold.py
+++ b/baselines/niid_bench/niid_bench/server_scaffold.py
@@ -258,7 +258,7 @@ def gen_evaluate_fn(
         """Use the entire Emnist test set for evaluation."""
         net = instantiate(model)
         params_dict = zip(net.state_dict().keys(), parameters_ndarrays)
-        state_dict = OrderedDict({k: torch.Tensor(v) for k, v in params_dict})
+        state_dict = OrderedDict({k: torch.from_numpy(v) for k, v in params_dict})
         net.load_state_dict(state_dict, strict=True)
         net.to(device)
 

--- a/baselines/tamuna/tamuna/client.py
+++ b/baselines/tamuna/tamuna/client.py
@@ -61,7 +61,7 @@ class TamunaClient(fl.client.NumPyClient):
     def set_parameters(self, parameters: NDArrays) -> None:
         """Change the parameters of the model using the given ones."""
         params_dict = zip(self.net.state_dict().keys(), parameters)
-        state_dict = OrderedDict({k: torch.Tensor(v) for k, v in params_dict})
+        state_dict = OrderedDict({k: torch.from_numpy(v) for k, v in params_dict})
         self.net.load_state_dict(state_dict, strict=True)
 
     def fit(
@@ -139,7 +139,7 @@ class FedAvgClient(fl.client.NumPyClient):
     def set_parameters(self, parameters):
         """Change the parameters of the model using the given ones."""
         params_dict = zip(self.net.state_dict().keys(), parameters)
-        state_dict = OrderedDict({k: torch.Tensor(v) for k, v in params_dict})
+        state_dict = OrderedDict({k: torch.from_numpy(v) for k, v in params_dict})
         self.net.load_state_dict(state_dict, strict=True)
 
     def get_parameters(self, config: Dict[str, Scalar]):

--- a/baselines/tamuna/tamuna/server.py
+++ b/baselines/tamuna/tamuna/server.py
@@ -43,7 +43,7 @@ def gen_evaluate_fn(
         """Use the entire MNIST test set for evaluation."""
         net = instantiate(model)
         params_dict = zip(net.state_dict().keys(), parameters)
-        state_dict = OrderedDict({k: torch.Tensor(v) for k, v in params_dict})
+        state_dict = OrderedDict({k: torch.from_numpy(v) for k, v in params_dict})
         net.load_state_dict(state_dict, strict=True)
         net.to(device)
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/flwrlabs/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

`torch.Tensor(v)` does the wrong thing for zero dimensional numpy arrays. Models with BatchNorm layers have a `num_batches_tracked` entry in their state dict, which is a 0-d int64 array after the numpy round trip. `torch.Tensor()` turns it into an empty `tensor([])` instead of `tensor(0)`, so `load_state_dict(..., strict=True)` crashes:

```
RuntimeError: Error(s) in loading state_dict for Sequential:
    size mismatch for 1.num_batches_tracked: copying a param with shape torch.Size([0])
    from checkpoint, the shape in current model is torch.Size([])
```

This means the affected baselines break as soon as you swap in a model that uses BatchNorm (resnet18, mobilenet and friends). On top of that, `torch.Tensor` silently casts everything to float32, while `torch.from_numpy` keeps the original dtype.

<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->

### Related issues/PRs

Fixes #4344. The fix was agreed on in the issue thread by @jafermarq and @yan-gao-GY back then, but the replacement never landed for the baselines.

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal

### Explanation

Replaced all remaining `torch.Tensor(v)` occurrences with `torch.from_numpy(v)` in the `set_parameters` helpers: 21 spots across 19 files, all under `baselines/`. The examples and e2e apps were already migrated earlier (they use `torch.from_numpy`, lowercase `torch.tensor` or the new `to_torch_state_dict()` API), and newer baselines like floco and fedrep already use `torch.from_numpy` too. So after this PR the buggy pattern is gone from the repo.

No import changes needed, `torch` is already imported everywhere.

I verified the behavior with a small round trip repro (Conv2d + BatchNorm2d, state dict through numpy and back):

```
num_batches_tracked ndarray: array(0) () int64
torch.Tensor(v)     -> tensor([])
torch.from_numpy(v) -> tensor(0)
old path: RuntimeError: size mismatch for 1.num_batches_tracked
new path: loads fine, num_batches_tracked = tensor(0)
```

All 19 touched files still compile.

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

### Checklist

- [x] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [ ] Address LLM-reviewer comments, if applicable (e.g., GitHub Copilot)
- [x] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

The changes are mechanical on purpose, one line per spot, nothing else touched. Happy to adjust if you prefer `torch.from_numpy(np.copy(v))` in some places, though the parameters coming out of `parameters_to_ndarrays` are freshly allocated so sharing memory should be fine.

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.ai/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
