### PR TITLE
refactor(framework): Avoid repeated words in the error message

### DIFF
--- a/framework/py/flwr/superlink/servicer/control/control_handlers.py
+++ b/framework/py/flwr/superlink/servicer/control/control_handlers.py
@@ -669,12 +669,11 @@ def create_federation(
     # Ensure valid federation name is provided
     success, err_msg = validate_federation_name(request.federation_name)
     if not success:
-        details = f"Invalid federation name: '{request.federation_name}'. {err_msg}"
         raise FlowerError(
             ApiErrorCode.INVALID_FEDERATION_NAME,
             f"Invalid federation name in CreateFederation request: "
             f"federation_name={request.federation_name}. {err_msg}",
-            public_details=details,
+            public_details=err_msg,
         )
 
     # Construct federation ID


### PR DESCRIPTION
### Before
<img width="1298" height="183" alt="image" src="https://github.com/user-attachments/assets/07a4bfde-2fa8-447a-b8df-5509962849d8" />

### After
<img width="1298" height="172" alt="image" src="https://github.com/user-attachments/assets/45c846ef-fdd3-4a90-b575-509b841bf8b1" />
