### PR TITLE
ci(framework:skip): Publish intermediate framework Docker tags

### DIFF
--- a/.github/workflows/_docker-build.yml
+++ b/.github/workflows/_docker-build.yml
@@ -55,6 +55,11 @@ on:
         required: false
         type: string
         default: main
+      flwr-package-version:
+        description: "Flower package version to use when build-local-wheel is enabled."
+        required: false
+        type: string
+        default: ""
       docker-registry-user:
         description: "Docker registry username."
         required: false
@@ -114,6 +119,7 @@ jobs:
           PREPARE_FRAMEWORK: ${{ inputs.prepare-framework }}
           PATCH_BASE_DOCKERFILES: ${{ inputs.patch-base-dockerfiles }}
           BUILD_LOCAL_WHEEL: ${{ inputs.build-local-wheel }}
+          FLWR_PACKAGE_VERSION: ${{ inputs.flwr-package-version }}
         run: ./framework/dev/release/prepare-docker-build-context.sh
 
       - name: Resolve build args

--- a/.github/workflows/framework-docker-build-main.yml
+++ b/.github/workflows/framework-docker-build-main.yml
@@ -16,9 +16,9 @@ on:
         required: false
         default: main
       docker-image-tag:
-        description: "Docker tag to publish."
+        description: "Docker tag to publish. Defaults to <flower-version>-main.<run-id>.g<short-sha>."
         required: false
-        default: unstable
+        default: ""
       docker-registry:
         description: "Docker registry host. Defaults to vars.DOCKER_IMAGE_REGISTRY."
         required: false
@@ -41,14 +41,34 @@ env:
   DOCKER_IMAGE_REGISTRY_USER: ${{ inputs.docker-registry-user || vars.DOCKER_IMAGE_REGISTRY_USER }}
   DOCKER_IMAGE_NAMESPACE: ${{ inputs.docker-image-namespace || vars.DOCKER_IMAGE_NAMESPACE }}
   FLOWER_REPO_REF: ${{ inputs.flower-repo-ref || 'main' }}
-  DOCKER_IMAGE_TAG: ${{ inputs.docker-image-tag || 'unstable' }}
+  DOCKER_IMAGE_TAG: ${{ inputs.docker-image-tag }}
 
 jobs:
+  resolve-intermediate-version:
+    if: ${{ github.repository_owner == 'flwrlabs' }}
+    name: Resolve intermediate version
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    outputs:
+      flwr-version: ${{ steps.version.outputs.flwr-version }}
+      docker-image-tag: ${{ steps.version.outputs.docker-image-tag }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/bootstrap
+
+      - name: Resolve intermediate version
+        id: version
+        run: ./framework/dev/release/resolve-intermediate-version.sh
+
   prepare-docker-build-matrix:
     if: ${{ github.repository_owner == 'flwrlabs' }}
     name: Collect docker build parameters
     runs-on: ubuntu-22.04
     timeout-minutes: 20
+    needs: resolve-intermediate-version
     outputs:
       pip-version: ${{ steps.versions.outputs.pip-version }}
       setuptools-version: ${{ steps.versions.outputs.setuptools-version }}
@@ -97,13 +117,15 @@ jobs:
             --input matrix.raw.json \
             --output matrix.json \
             --docker-image-namespace "${DOCKER_IMAGE_NAMESPACE}" \
-            --tag "${DOCKER_IMAGE_TAG}"
+            --tag "${{ needs.resolve-intermediate-version.outputs.docker-image-tag }}" \
+            --strip-flwr-version-ref \
+            --build-local-wheel
           echo "matrix=$(cat matrix.json)" >> "$GITHUB_OUTPUT"
 
   build-docker-base-images:
     name: Build base images
     uses: ./.github/workflows/_docker-build.yml
-    needs: prepare-docker-build-matrix
+    needs: [prepare-docker-build-matrix, resolve-intermediate-version]
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.prepare-docker-build-matrix.outputs.matrix).base }}
@@ -116,7 +138,9 @@ jobs:
       dockerfile: ${{ matrix.images.file_dir }}/Dockerfile
       prepare-framework: true
       patch-base-dockerfiles: true
+      build-local-wheel: true
       flower-repo-ref: ${{ inputs.flower-repo-ref || 'main' }}
+      flwr-package-version: ${{ needs.resolve-intermediate-version.outputs.flwr-version }}
       build-args: |
         PIP_VERSION=${{ needs.prepare-docker-build-matrix.outputs.pip-version }}
         SETUPTOOLS_VERSION=${{ needs.prepare-docker-build-matrix.outputs.setuptools-version }}

--- a/framework/dev/release/dockerfile.base.ubuntu.local-wheel.patch
+++ b/framework/dev/release/dockerfile.base.ubuntu.local-wheel.patch
@@ -1,0 +1,18 @@
+diff --git a/framework/docker/base/ubuntu/Dockerfile b/framework/docker/base/ubuntu/Dockerfile
+--- a/framework/docker/base/ubuntu/Dockerfile
++++ b/framework/docker/base/ubuntu/Dockerfile
+@@ -67,3 +67,4 @@
+-ARG FLWR_VERSION
+-ARG FLWR_VERSION_REF
+-ARG FLWR_PACKAGE=flwr
++ARG COPY_PATH
++ARG FLWR_WHEEL
++# hadolint ignore=DL3045
++COPY ${COPY_PATH}/${FLWR_WHEEL} .
+@@ -71,5 +72 @@
+-RUN if [ -z "${FLWR_VERSION_REF}" ]; then \
+-    pip install -U --no-cache-dir ${FLWR_PACKAGE}==${FLWR_VERSION}; \
+-    else \
+-    pip install -U --no-cache-dir ${FLWR_PACKAGE}@${FLWR_VERSION_REF}; \
+-    fi
++RUN pip install -U --no-cache-dir ${FLWR_WHEEL}

--- a/framework/dev/release/prepare-docker-build-context.sh
+++ b/framework/dev/release/prepare-docker-build-context.sh
@@ -22,9 +22,12 @@ if [[ "${PREPARE_FRAMEWORK:-false}" == "true" ]]; then
 fi
 
 if [[ "${PATCH_BASE_DOCKERFILES:-false}" == "true" ]]; then
-  echo "No repository-specific Dockerfile patches are required in flwrlabs/flower."
+  git apply --unidiff-zero framework/dev/release/dockerfile.base.ubuntu.local-wheel.patch
 fi
 
 if [[ "${BUILD_LOCAL_WHEEL:-false}" == "true" ]]; then
+  if [[ -n "${FLWR_PACKAGE_VERSION:-}" ]]; then
+    (cd framework && uv version --frozen "${FLWR_PACKAGE_VERSION}")
+  fi
   (cd framework && ./dev/build.sh)
 fi

--- a/framework/dev/release/resolve-intermediate-version.sh
+++ b/framework/dev/release/resolve-intermediate-version.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Copyright 2026 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+set -euo pipefail
+
+pipeline_id="${PIPELINE_ID:-${GITHUB_RUN_ID:-}}"
+if [[ -z "${pipeline_id}" ]]; then
+  echo "Missing required configuration: PIPELINE_ID or GITHUB_RUN_ID" >&2
+  exit 1
+fi
+
+cd "$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"/../../
+
+python_bin="${PYTHON_BIN:-python}"
+if ! command -v "${python_bin}" >/dev/null 2>&1; then
+  python_bin="python3"
+fi
+
+base_version="$("${python_bin}" -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')"
+short_sha="${GITHUB_SHA:-$(git rev-parse HEAD)}"
+short_sha="${short_sha:0:7}"
+
+package_version="${base_version}.dev${pipeline_id}+g${short_sha}"
+docker_image_tag="${DOCKER_IMAGE_TAG:-${base_version}-main.${pipeline_id}.g${short_sha}}"
+
+{
+  echo "flwr-version=${package_version}"
+  echo "docker-image-tag=${docker_image_tag}"
+} >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
## What changed

- Derive an intermediate framework package version and Docker tag for main-branch Docker builds.
- Build an ephemeral local framework wheel with the intermediate version during the base image build.
- Install that local wheel into framework base images and publish only the Docker images with immutable tags like `1.33.0-main.<run-id>.g<short-sha>`.

## Why

We want traceable internal intermediate framework containers without publishing intermediate wheels to public artifact storage. The wheel is only a Docker build input and is not uploaded.

## Validation

- `bash -n framework/dev/release/resolve-intermediate-version.sh framework/dev/release/prepare-docker-build-context.sh`
- `git apply --unidiff-zero --check framework/dev/release/dockerfile.base.ubuntu.local-wheel.patch`
- YAML parse for `.github/workflows/framework-docker-build-main.yml` and `.github/workflows/_docker-build.yml`
- Docker matrix smoke test for local-wheel build args and immutable tags
- `PYTHONPATH=dev python3 -m devtool.check_pr_title 'ci(framework:skip): Publish intermediate framework Docker tags'`
- `git diff --cached --check`