### PR TITLE
fix(framework:skip): Isolate linkstate test from extension lifespans

### DIFF
--- a/framework/py/flwr/superlink/dependencies/linkstate_test.py
+++ b/framework/py/flwr/superlink/dependencies/linkstate_test.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import asyncio
 from typing import Any, cast
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 from fastapi import FastAPI, HTTPException, Request, status
@@ -88,7 +88,8 @@ def test_get_linkstate_returns_linkstate_after_startup(
         start_legacy_grpc=start_legacy_grpc,
     )
 
-    linkstate = asyncio.run(_get_linkstate_after_lifespan_startup(app))
+    with patch("flwr.superlink.extensions.get_lifespan_contexts", return_value=()):
+        linkstate = asyncio.run(_get_linkstate_after_lifespan_startup(app))
 
     assert app.state.linkstate_factory is state_factory_mock
     assert linkstate is expected_linkstate


### PR DESCRIPTION
## Summary

- Mock optional SuperLink extension lifespan hooks in the LinkState dependency test.
- Keep the test focused on LinkStateFactory initialization in both FastAPI modes.

## Why

`test_get_linkstate_returns_linkstate_after_startup` verifies that `get_linkstate`
returns the LinkState created by the configured LinkStateFactory. Optional
extension lifespan hooks are outside that test scope and can introduce unrelated
startup behavior.

## Validation

- `uv run --no-sync --python=3.11.14 python -m pytest py/flwr/superlink/dependencies/linkstate_test.py`
- `PYTHONPATH=dev python3 -m devtool.check_pr_title 'fix(framework:skip): Isolate linkstate test from extension lifespans'`
