### PR TITLE
refactor(framework): Translate `FlowerError` in unary protobuf routes 

### DIFF
--- a/framework/py/flwr/supercore/protobuf/routing.py
+++ b/framework/py/flwr/supercore/protobuf/routing.py
@@ -34,6 +34,7 @@ from google.protobuf.message import DecodeError, Message
 from starlette.concurrency import run_in_threadpool
 from starlette.datastructures import State
 
+from flwr.supercore.error import http_error_translator
 from flwr.supercore.protobuf.constants import (
     PROTOBUF_MEDIA_TYPE,
     PROTOBUF_STREAM_MEDIA_TYPE,
@@ -233,21 +234,22 @@ class ProtobufRouter:
                 http_request: Request[State],
                 **dependency_values: object,
             ) -> Response:
-                _check_request_media_type(http_request)
-                proto_request = _parse_protobuf_body(
-                    await http_request.body(), request_type
-                )
-                result = await _call_handler(func, proto_request, dependency_values)
-                # Fail clearly when a handler violates its declared response contract.
-                if not isinstance(result, Message):
-                    raise HTTPException(
-                        status_code=500,
-                        detail="Invalid response returned from unary handler",
+                with http_error_translator(func.__name__):
+                    _check_request_media_type(http_request)
+                    proto_request = _parse_protobuf_body(
+                        await http_request.body(), request_type
                     )
-                return Response(
-                    content=result.SerializeToString(),
-                    media_type=PROTOBUF_MEDIA_TYPE,
-                )
+                    result = await _call_handler(func, proto_request, dependency_values)
+                    # Fail clearly if a handler violates its declared response contract.
+                    if not isinstance(result, Message):
+                        raise HTTPException(
+                            status_code=500,
+                            detail="Invalid response returned from unary handler",
+                        )
+                    return Response(
+                        content=result.SerializeToString(),
+                        media_type=PROTOBUF_MEDIA_TYPE,
+                    )
 
             wrapper.__name__ = func.__name__
             wrapper.__signature__ = (  # type: ignore[attr-defined]

--- a/framework/py/flwr/supercore/protobuf/routing_test.py
+++ b/framework/py/flwr/supercore/protobuf/routing_test.py
@@ -29,13 +29,13 @@ from flwr.proto.control_pb2 import (  # pylint: disable=E0611
     StreamLogsRequest,
     StreamLogsResponse,
 )
+from flwr.supercore.error import ApiErrorCode, FlowerError
+from flwr.supercore.error.catalog import API_ERROR_MAP
 from flwr.supercore.protobuf.constants import (
     PROTOBUF_MEDIA_TYPE,
     PROTOBUF_STREAM_MEDIA_TYPE,
 )
 from flwr.supercore.protobuf.routing import ProtobufRouter
-from flwr.supercore.error import ApiErrorCode, FlowerError
-from flwr.supercore.error.catalog import API_ERROR_MAP
 
 
 def test_unary_unary_parses_and_returns_protobuf() -> None:

--- a/framework/py/flwr/supercore/protobuf/routing_test.py
+++ b/framework/py/flwr/supercore/protobuf/routing_test.py
@@ -156,13 +156,11 @@ def test_unary_unary_translates_flower_error() -> None:
 
     error_spec = API_ERROR_MAP[ApiErrorCode.RUN_ID_NOT_FOUND]
     assert response.status_code == error_spec.http_status_code
-    assert response.json()["detail"] == json.dumps(
-        {
-            "code": ApiErrorCode.RUN_ID_NOT_FOUND,
-            "public_message": error_spec.public_message,
-            "public_details": None,
-        }
-    )
+    assert json.loads(response.json()["detail"]) == {
+        "code": ApiErrorCode.RUN_ID_NOT_FOUND,
+        "public_message": error_spec.public_message,
+        "public_details": None,
+    }
 
 
 def test_unary_stream_rejects_non_iterable_response() -> None:

--- a/framework/py/flwr/supercore/protobuf/routing_test.py
+++ b/framework/py/flwr/supercore/protobuf/routing_test.py
@@ -15,6 +15,7 @@
 """Tests for protobuf FastAPI routing helpers."""
 
 
+import json
 from collections.abc import AsyncIterator, Iterator
 from threading import get_ident
 from typing import Annotated, cast
@@ -33,6 +34,8 @@ from flwr.supercore.protobuf.constants import (
     PROTOBUF_STREAM_MEDIA_TYPE,
 )
 from flwr.supercore.protobuf.routing import ProtobufRouter
+from flwr.supercore.error import ApiErrorCode, FlowerError
+from flwr.supercore.error.catalog import API_ERROR_MAP
 
 
 def test_unary_unary_parses_and_returns_protobuf() -> None:
@@ -130,6 +133,36 @@ def test_unary_unary_rejects_non_protobuf_response() -> None:
 
     assert response.status_code == 500
     assert response.json()["detail"] == ("Invalid response returned from unary handler")
+
+
+def test_unary_unary_translates_flower_error() -> None:
+    """The router maps handler FlowerErrors to the HTTP error contract."""
+    app = FastAPI()
+    fastapi_router = APIRouter()
+    protobuf_router = ProtobufRouter(fastapi_router)
+
+    @protobuf_router.unary_unary("/rpc/ListRuns")
+    def list_runs(_request: ListRunsRequest) -> ListRunsResponse:
+        raise FlowerError(ApiErrorCode.RUN_ID_NOT_FOUND, "run 42 does not exist")
+
+    app.include_router(fastapi_router)
+    client = TestClient(app)
+
+    response = client.post(
+        "/rpc/ListRuns",
+        content=ListRunsRequest(run_id=42).SerializeToString(),
+        headers={"content-type": PROTOBUF_MEDIA_TYPE},
+    )
+
+    error_spec = API_ERROR_MAP[ApiErrorCode.RUN_ID_NOT_FOUND]
+    assert response.status_code == error_spec.http_status_code
+    assert response.json()["detail"] == json.dumps(
+        {
+            "code": ApiErrorCode.RUN_ID_NOT_FOUND,
+            "public_message": error_spec.public_message,
+            "public_details": None,
+        }
+    )
 
 
 def test_unary_stream_rejects_non_iterable_response() -> None:


### PR DESCRIPTION
`unary_stream` will need its own handling at a later date