### PR TITLE
refactor(framework): Raise `ObjectPushError` when the server fails to store the object pushed

### DIFF
--- a/framework/py/flwr/supercore/inflatable/inflatable_protobuf_utils.py
+++ b/framework/py/flwr/supercore/inflatable/inflatable_protobuf_utils.py
@@ -27,7 +27,11 @@ from flwr.proto.message_pb2 import (  # pylint: disable=E0611
 )
 from flwr.proto.node_pb2 import Node  # pylint: disable=E0611
 
-from .inflatable_utils import ObjectIdNotPreregisteredError, ObjectUnavailableError
+from .inflatable_utils import (
+    ObjectIdNotPreregisteredError,
+    ObjectPushError,
+    ObjectUnavailableError,
+)
 
 ConfirmMessageReceivedProtobuf = Callable[
     [ConfirmMessageReceivedRequest], ConfirmMessageReceivedResponse
@@ -95,8 +99,8 @@ def make_push_object_fn_protobuf(
     -------
     Callable[[str, bytes], None]
         A function that takes an object ID and its content as bytes, and pushes it
-        to the servicer. The function raises `ObjectIdNotPreregisteredError` if
-        the object ID is not pre-registered.
+        to the servicer. The function raises `ObjectPushError` if the servicer fails
+        to store the object.
     """
 
     def push_object_fn(object_id: str, object_content: bytes) -> None:
@@ -109,7 +113,7 @@ def make_push_object_fn_protobuf(
         )
         response: PushObjectResponse = push_object_protobuf(request)
         if not response.stored:
-            raise ObjectIdNotPreregisteredError(object_id)
+            raise ObjectPushError(object_id, run_id, session_id)
 
     return push_object_fn
 

--- a/framework/py/flwr/supercore/inflatable/inflatable_protobuf_utils_test.py
+++ b/framework/py/flwr/supercore/inflatable/inflatable_protobuf_utils_test.py
@@ -32,6 +32,7 @@ from flwr.proto.message_pb2 import (  # pylint: disable=E0611
 from flwr.proto.node_pb2 import Node  # pylint: disable=E0611
 from flwr.supercore.inflatable.inflatable_utils import (
     ObjectIdNotPreregisteredError,
+    ObjectPushError,
     ObjectUnavailableError,
     pull_objects,
     push_objects,
@@ -123,6 +124,14 @@ class TestInflatableStubHelpers(unittest.TestCase):  # pylint: disable=R0902
         num_pushed_objects = sum(b != b"" for b in self.mock_store.values())
         assert self.mock_stub.PushObject.call_count == expected_obj_count
         assert num_pushed_objects == expected_obj_count
+
+    def test_push_object_failure(self) -> None:
+        """Test pushing an object that the receiver fails to store."""
+        with self.assertRaisesRegex(
+            ObjectPushError,
+            "Failed to push object with ID 'unknown-object' for run 1234",
+        ):
+            self.push_object_fn("unknown-object", b"content")
 
     @parameterized.expand(base_cases)  # type: ignore
     def test_pull_objects_success(

--- a/framework/py/flwr/supercore/inflatable/inflatable_utils.py
+++ b/framework/py/flwr/supercore/inflatable/inflatable_utils.py
@@ -120,8 +120,7 @@ class ObjectPushError(Exception):
         super().__init__(
             f"Failed to push object with ID '{object_id}' for run {run_id} using "
             f"session '{session_id}'. The push session may have expired or been "
-            "replaced, or the servicer may have "
-            "failed to store it."
+            "replaced."
         )
 
 

--- a/framework/py/flwr/supercore/inflatable/inflatable_utils.py
+++ b/framework/py/flwr/supercore/inflatable/inflatable_utils.py
@@ -113,6 +113,18 @@ class ObjectIdNotPreregisteredError(Exception):
         super().__init__(f"Object with ID '{object_id}' could not be found.")
 
 
+class ObjectPushError(Exception):
+    """Exception raised when an object could not be pushed."""
+
+    def __init__(self, object_id: str, run_id: int, session_id: str):
+        super().__init__(
+            f"Failed to push object with ID '{object_id}' for run {run_id} using "
+            f"session '{session_id}'. The push session may have expired or been "
+            "replaced, or the servicer may have "
+            "failed to store it."
+        )
+
+
 def get_num_workers(max_concurrent: int) -> int:
     """Get number of workers based on the number of CPU cores and the maximum
     allowed."""
@@ -137,8 +149,8 @@ def push_objects(
         `InflatableObject` instances.
     push_object_fn : Callable[[str, bytes], None]
         A function that takes an object ID and its content as bytes, and pushes
-        it to the servicer. This function should raise `ObjectIdNotPreregisteredError`
-        if the object ID is not pre-registered.
+        it to the servicer. This function should raise `ObjectPushError` if the
+        servicer fails to store the object.
     object_ids_to_push : Optional[set[str]] (default: None)
         A set of object IDs to push. If not provided, all objects will be pushed.
     keep_objects : bool (default: False)
@@ -187,8 +199,8 @@ def push_object_contents_from_iterable(
         `object_id` is the object ID, and `object_content` is the object content.
     push_object_fn : Callable[[str, bytes], None]
         A function that takes an object ID and its content as bytes, and pushes
-        it to the servicer. This function should raise `ObjectIdNotPreregisteredError`
-        if the object ID is not pre-registered.
+        it to the servicer. This function should raise `ObjectPushError` if the
+        servicer fails to store the object.
     max_concurrent_pushes : int (default: FLWR_PRIVATE_MAX_CONCURRENT_OBJ_PUSHES)
         The maximum number of concurrent pushes to perform.
     """


### PR DESCRIPTION
The new `ObjectPushError` error is a better fit than the error saying the object is not registered.