### PR TITLE
fix(framework): Retry failed reply uploads

### DIFF
--- a/framework/py/flwr/supernode/start_client_internal.py
+++ b/framework/py/flwr/supernode/start_client_internal.py
@@ -39,6 +39,7 @@ from flwr.common.config import get_fused_config_from_fab
 from flwr.common.constant import (
     CLIENTAPPIO_API_DEFAULT_SERVER_ADDRESS,
     ISOLATION_MODE_SUBPROCESS,
+    MAX_RETRY_DELAY,
     RUNTIME_DEPENDENCY_INSTALL,
     TRANSPORT_TYPE_GRPC_ADAPTER,
     TRANSPORT_TYPE_GRPC_RERE,
@@ -63,6 +64,7 @@ from flwr.supercore.inflatable.inflatable_object import (
     no_object_id_recompute,
 )
 from flwr.supercore.inflatable.inflatable_utils import (
+    ObjectPushError,
     pull_objects,
     push_object_contents_from_iterable,
 )
@@ -77,7 +79,11 @@ from flwr.supercore.primitives.asymmetric_ed25519 import (
     decode_base64url,
     verify_signature,
 )
-from flwr.supercore.retry import RetryInvoker, make_simple_grpc_retry_invoker
+from flwr.supercore.retry import (
+    RetryInvoker,
+    exponential,
+    make_simple_grpc_retry_invoker,
+)
 from flwr.supercore.run import Run, RunNotRunningException
 from flwr.supercore.telemetry import EventType
 from flwr.supercore.tls import get_client_tls_args
@@ -533,8 +539,11 @@ def _push_messages(
                 # therefore we can yield it after casting it to bytes
                 yield tree.object_id, cast(bytes, content)
 
-        # Send the message
-        try:
+        def send_message(
+            message: Message = message,
+            object_tree: ObjectTree = object_tree,
+        ) -> None:
+            """Send the message and all objects required by the SuperLink."""
             clientapp_runtime = state.get_message_processing_duration(
                 message_id=message.metadata.reply_to_message_id,
             )
@@ -554,7 +563,30 @@ def _push_messages(
                 # )
                 push_object_fn=partial(push_object, run_id, session_id),
             )
-            log(INFO, "Sent successfully")
+
+        # A PushMessages response can be lost after the SuperLink has accepted
+        # it, and a push session can be replaced while object uploads are in
+        # flight. Retrying the complete operation is safe because the message
+        # ID is stable and PushMessages is idempotent.
+        retry_invoker = RetryInvoker(
+            wait_gen_factory=lambda: exponential(max_delay=MAX_RETRY_DELAY),
+            recoverable_exceptions=(RpcError, ObjectPushError),
+            max_tries=None,
+            max_time=None,
+        )
+
+        def delete_local_message(message: Message = message) -> None:
+            """Delete a reply after success or a terminal stopped-run result."""
+            state.delete_messages(
+                message_ids=[
+                    message.metadata.message_id,
+                    message.metadata.reply_to_message_id,
+                ]
+            )
+            object_store.delete(message.metadata.message_id)
+
+        try:
+            retry_invoker.invoke(send_message)
         except RunNotRunningException:
             log(
                 INFO,
@@ -562,26 +594,20 @@ def _push_messages(
                 message.metadata.run_id,
                 message.metadata.message_id,
             )
+            delete_local_message()
         except Exception as err:  # pylint: disable=broad-except
             log(
                 ERROR,
-                "Failed to send message %s: %s",
+                "Failed to send message %s; retaining it for a later retry: %s",
                 message.metadata.message_id,
                 err,
             )
-        finally:
-            # Delete the message from the state
-            state.delete_messages(
-                message_ids=[
-                    message.metadata.message_id,
-                    message.metadata.reply_to_message_id,
-                ]
-            )
+        else:
+            log(INFO, "Sent successfully")
 
-            # Delete all its objects from the ObjectStore
-            # No need to delete objects of the message it replies to, as it is
-            # already deleted when the ClientApp calls `ConfirmMessageReceived`
-            object_store.delete(message.metadata.message_id)
+            # Delete local state only after the SuperLink has accepted the
+            # message and all required objects.
+            delete_local_message()
 
 
 @contextmanager

--- a/framework/py/flwr/supernode/start_client_internal_test.py
+++ b/framework/py/flwr/supernode/start_client_internal_test.py
@@ -19,6 +19,7 @@ import unittest
 from unittest.mock import Mock, patch
 
 import pytest
+from grpc import RpcError
 
 from flwr.app import ConfigRecord, Context, Message, RecordDict
 from flwr.app.message import remove_content_from_message
@@ -29,10 +30,12 @@ from flwr.supercore.inflatable.inflatable_object import (
     get_all_nested_objects,
     get_object_tree,
 )
+from flwr.supercore.inflatable.inflatable_utils import ObjectPushError
 
 from .start_client_internal import (
     FAB_VERIFICATION_ERROR,
     _pull_and_store_message,
+    _push_messages,
     start_client_internal,
 )
 
@@ -492,3 +495,101 @@ def test_start_client_internal_launches_superexec_with_bound_appio_address() -> 
 
     command = popen.call_args.args[0]
     assert command[command.index("--appio-api-address") + 1] == "localhost:54321"
+
+
+def _make_reply_message() -> Message:
+    """Create a reply message suitable for testing the sender path."""
+    instruction = Message(content=RecordDict(), dst_node_id=1, message_type="query")
+    reply = Message(content=RecordDict(), reply_to=instruction)
+    reply.metadata.__dict__["_run_id"] = 1
+    reply.metadata.__dict__["_message_id"] = reply.object_id
+    return reply
+
+
+def test_push_messages_deletes_local_state_only_after_success() -> None:
+    """A successful message and object push removes the local reply."""
+    state = Mock()
+    object_store = Mock()
+    message = _make_reply_message()
+    state.get_messages.return_value = [message]
+    state.get_message_processing_duration.return_value = 0.1
+    send = Mock(return_value=({"object-id"}, "session-id"))
+    push_object = Mock()
+
+    with patch(
+        "flwr.supernode.start_client_internal.push_object_contents_from_iterable"
+    ):
+        _push_messages(state, object_store, send, push_object)
+
+    state.delete_messages.assert_called_once_with(
+        message_ids=[message.metadata.message_id, message.metadata.reply_to_message_id]
+    )
+    object_store.delete.assert_called_once_with(message.metadata.message_id)
+
+
+def test_push_messages_retries_after_object_upload_failure() -> None:
+    """A failed object upload retries PushMessages with a new session."""
+    state = Mock()
+    object_store = Mock()
+    message = _make_reply_message()
+    state.get_messages.return_value = [message]
+    state.get_message_processing_duration.return_value = 0.1
+    send = Mock(
+        side_effect=[
+            ({"object-id"}, "old-session"),
+            ({"object-id"}, "new-session"),
+        ]
+    )
+    push_object = Mock()
+
+    with (
+        patch("flwr.supernode.start_client_internal.time.sleep"),
+        patch(
+            "flwr.supernode.start_client_internal.push_object_contents_from_iterable",
+            side_effect=[ObjectPushError("object-id", 1, "old-session"), None],
+        ),
+    ):
+        _push_messages(state, object_store, send, push_object)
+
+    assert send.call_count == 2
+    state.delete_messages.assert_called_once()
+    object_store.delete.assert_called_once_with(message.metadata.message_id)
+
+
+def test_push_messages_retries_after_push_messages_failure() -> None:
+    """A failed PushMessages call retries the complete message push."""
+    state = Mock()
+    object_store = Mock()
+    message = _make_reply_message()
+    state.get_messages.return_value = [message]
+    state.get_message_processing_duration.return_value = 0.1
+    send = Mock(
+        side_effect=[RpcError(), ({"object-id"}, "session-id")],
+    )
+
+    with (
+        patch("flwr.supernode.start_client_internal.time.sleep"),
+        patch(
+            "flwr.supernode.start_client_internal.push_object_contents_from_iterable"
+        ),
+    ):
+        _push_messages(state, object_store, send, Mock())
+
+    assert send.call_count == 2
+    state.delete_messages.assert_called_once()
+    object_store.delete.assert_called_once_with(message.metadata.message_id)
+
+
+def test_push_messages_retains_local_state_after_non_retryable_failure() -> None:
+    """A failed push does not delete a reply that still needs delivery."""
+    state = Mock()
+    object_store = Mock()
+    message = _make_reply_message()
+    state.get_messages.return_value = [message]
+    state.get_message_processing_duration.return_value = 0.1
+    send = Mock(side_effect=ValueError("push failed"))
+
+    _push_messages(state, object_store, send, Mock())
+
+    state.delete_messages.assert_not_called()
+    object_store.delete.assert_not_called()


### PR DESCRIPTION
## Summary

This addresses the remaining sender-side failure path in `_push_messages`.

The 1.33 release page and the sender-session RFC cover session creation, idempotent message storage, and safe retry semantics, but no path currently retries a SuperNode reply after a failed PushMessages or PushObject operation.

## Changes

- Retry the complete PushMessages plus object-upload operation after gRPC or ObjectPushError failures.
- Reuse the stable message ID so the server-side idempotency and sender-session logic can return a fresh session and only missing objects.
- Delete the local reply and its objects only after the complete send succeeds.
- Treat a stopped run as a terminal cleanup case.
- Retain local state when delivery fails instead of deleting it in finally.