### PR TITLE
ci(framework:skip): Run framework checks in parallel

### DIFF
--- a/.github/workflows/framework-test.yml
+++ b/.github/workflows/framework-test.yml
@@ -43,6 +43,46 @@ jobs:
               - 'dev/test.sh'
               - '.github/workflows/framework-test.yml'
 
+  quality:
+    runs-on: ubuntu-22.04
+    needs: changes
+    if: ${{ needs.changes.outputs.framework == 'true' }}
+    strategy:
+      matrix:
+        python: ['3.11', '3.12', '3.13']
+
+    name: Quality (Python ${{ matrix.python }})
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Bootstrap
+        uses: ./.github/actions/bootstrap
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Prepare framework
+        run: ./framework/dev/prepare-framework.sh
+      - name: Install dependencies
+        run: |
+          cd framework
+          uv sync --python=${{ matrix.python }} --locked --all-extras --all-groups
+      - name: Check if protos need recompilation
+        run: |
+          cd framework
+          uv run --no-sync ./dev/check-protos.sh
+      - name: Check if migrations are up to date
+        if: ${{ matrix.python == '3.11' }}
+        run: |
+          cd framework
+          uv run --no-sync ./dev/check-migrations.sh
+      - name: Lint and static checks
+        env:
+          RUN_PYTEST: 'false'
+        run: |
+          cd framework
+          uv run --no-sync ./dev/test.sh
+
   test_core:
     runs-on: ubuntu-22.04
     needs: changes
@@ -53,7 +93,7 @@ jobs:
         # In case of a mismatch, the job has to download Python to install it.
         python: ['3.11', '3.12', '3.13']
 
-    name: Python ${{ matrix.python }}
+    name: Pytest (Python ${{ matrix.python }})
 
     steps:
       - uses: actions/checkout@v5
@@ -72,21 +112,11 @@ jobs:
         run: |
           cd framework
           uv sync --python=${{ matrix.python }} --locked --all-extras --all-groups
-      - name: Check if protos need recompilation
+      - name: Test
         if: ${{ needs.changes.outputs.framework == 'true' }}
         run: |
           cd framework
-          uv run --no-sync ./dev/check-protos.sh
-      - name: Check if migrations are up to date
-        if: ${{ needs.changes.outputs.framework == 'true' && matrix.python == '3.11' }}
-        run: |
-          cd framework
-          uv run --no-sync ./dev/check-migrations.sh
-      - name: Lint + Test (isort/black/mypy/pylint/flake8/pytest)
-        if: ${{ needs.changes.outputs.framework == 'true' }}
-        run: |
-          cd framework
-          uv run --no-sync ./dev/test.sh
+          RAY_ENABLE_UV_RUN_RUNTIME_ENV=0 uv run --no-sync python -m pytest --cov=py/flwr
       - name: Check benchmarks and examples
         if: ${{ needs.changes.outputs.ex_bench == 'true' }}
         run: |

--- a/.github/workflows/framework-test.yml
+++ b/.github/workflows/framework-test.yml
@@ -43,82 +43,75 @@ jobs:
               - 'dev/test.sh'
               - '.github/workflows/framework-test.yml'
 
-  quality:
+  framework_checks:
     runs-on: ubuntu-22.04
     needs: changes
-    if: ${{ needs.changes.outputs.framework == 'true' }}
     strategy:
+      fail-fast: true
       matrix:
-        python: ['3.11', '3.12', '3.13']
+        include:
+          - task: quality
+            name: Quality
+            python: '3.11'
+          - task: quality
+            name: Quality
+            python: '3.12'
+          - task: quality
+            name: Quality
+            python: '3.13'
+          - task: pytest
+            name: Pytest
+            python: '3.11'
+          - task: pytest
+            name: Pytest
+            python: '3.12'
+          - task: pytest
+            name: Pytest
+            python: '3.13'
 
-    name: Quality (Python ${{ matrix.python }})
+    name: ${{ matrix.name }} (Python ${{ matrix.python }})
 
     steps:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Bootstrap
+        if: ${{ (matrix.task == 'quality' && needs.changes.outputs.framework == 'true') || (matrix.task == 'pytest' && (needs.changes.outputs.framework == 'true' || needs.changes.outputs.ex_bench == 'true')) }}
         uses: ./.github/actions/bootstrap
         with:
           python-version: ${{ matrix.python }}
       - name: Prepare framework
+        if: ${{ (matrix.task == 'quality' && needs.changes.outputs.framework == 'true') || (matrix.task == 'pytest' && (needs.changes.outputs.framework == 'true' || needs.changes.outputs.ex_bench == 'true')) }}
         run: ./framework/dev/prepare-framework.sh
       - name: Install dependencies
+        if: ${{ (matrix.task == 'quality' && needs.changes.outputs.framework == 'true') || (matrix.task == 'pytest' && (needs.changes.outputs.framework == 'true' || needs.changes.outputs.ex_bench == 'true')) }}
         run: |
           cd framework
           uv sync --python=${{ matrix.python }} --locked --all-extras --all-groups
       - name: Check if protos need recompilation
+        if: ${{ matrix.task == 'quality' && needs.changes.outputs.framework == 'true' }}
         run: |
           cd framework
           uv run --no-sync ./dev/check-protos.sh
       - name: Check if migrations are up to date
-        if: ${{ matrix.python == '3.11' }}
+        if: ${{ matrix.task == 'quality' && matrix.python == '3.11' && needs.changes.outputs.framework == 'true' }}
         run: |
           cd framework
           uv run --no-sync ./dev/check-migrations.sh
       - name: Lint and static checks
+        if: ${{ matrix.task == 'quality' && needs.changes.outputs.framework == 'true' }}
         env:
           RUN_PYTEST: 'false'
         run: |
           cd framework
           uv run --no-sync ./dev/test.sh
-
-  test_core:
-    runs-on: ubuntu-22.04
-    needs: changes
-    strategy:
-      matrix:
-        # Latest version which comes cached in the host image can be found here:
-        # https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md#python
-        # In case of a mismatch, the job has to download Python to install it.
-        python: ['3.11', '3.12', '3.13']
-
-    name: Pytest (Python ${{ matrix.python }})
-
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-      - name: Bootstrap
-        if: ${{ needs.changes.outputs.framework == 'true' || needs.changes.outputs.ex_bench == 'true' }}
-        uses: ./.github/actions/bootstrap
-        with:
-          python-version: ${{ matrix.python }}
-      - name: Prepare framework
-        if: ${{ needs.changes.outputs.framework == 'true' || needs.changes.outputs.ex_bench == 'true' }}
-        run: ./framework/dev/prepare-framework.sh
-      - name: Install dependencies
-        if: ${{ needs.changes.outputs.framework == 'true' || needs.changes.outputs.ex_bench == 'true' }}
-        run: |
-          cd framework
-          uv sync --python=${{ matrix.python }} --locked --all-extras --all-groups
       - name: Test
-        if: ${{ needs.changes.outputs.framework == 'true' }}
+        if: ${{ matrix.task == 'pytest' && needs.changes.outputs.framework == 'true' }}
         run: |
           cd framework
           RAY_ENABLE_UV_RUN_RUNTIME_ENV=0 uv run --no-sync python -m pytest --cov=py/flwr
       - name: Check benchmarks and examples
-        if: ${{ needs.changes.outputs.ex_bench == 'true' }}
+        if: ${{ matrix.task == 'pytest' && needs.changes.outputs.ex_bench == 'true' }}
         run: |
           cd framework
           uv run --no-sync ../dev/test.sh

--- a/framework/dev/test.sh
+++ b/framework/dev/test.sh
@@ -8,6 +8,8 @@ echo "=== test.sh ==="
 # Default value (true)
 RUN_FULL_TEST=${1:-true}
 echo "RUN_FULL_TEST: $RUN_FULL_TEST"
+RUN_PYTEST=${RUN_PYTEST:-true}
+echo "RUN_PYTEST: $RUN_PYTEST"
 
 echo "- Start Python checks"
 
@@ -60,9 +62,13 @@ python -m pylint --ignore=py/flwr/proto py/flwr
 echo "- pylint: done"
 
 echo "- pytest: start"
-# Ray's uv runtime-env hook can stall under `uv run` during pytest.
-RAY_ENABLE_UV_RUN_RUNTIME_ENV=0 python -m pytest --cov=py/flwr
-echo "- pytest: done"
+if $RUN_PYTEST; then
+    # Ray's uv runtime-env hook can stall under `uv run` during pytest.
+    RAY_ENABLE_UV_RUN_RUNTIME_ENV=0 python -m pytest --cov=py/flwr
+    echo "- pytest: done"
+else
+    echo "- pytest: skipped"
+fi
 
 echo "- All Python checks passed"
 

--- a/framework/dev/test.sh
+++ b/framework/dev/test.sh
@@ -62,13 +62,20 @@ python -m pylint --ignore=py/flwr/proto py/flwr
 echo "- pylint: done"
 
 echo "- pytest: start"
-if $RUN_PYTEST; then
+case "$RUN_PYTEST" in
+true)
     # Ray's uv runtime-env hook can stall under `uv run` during pytest.
     RAY_ENABLE_UV_RUN_RUNTIME_ENV=0 python -m pytest --cov=py/flwr
     echo "- pytest: done"
-else
+    ;;
+false)
     echo "- pytest: skipped"
-fi
+    ;;
+*)
+    echo "RUN_PYTEST must be 'true' or 'false' (got '$RUN_PYTEST')" >&2
+    exit 1
+    ;;
+esac
 
 echo "- All Python checks passed"
 


### PR DESCRIPTION
## Issue

### Description

The `Framework Python` workflow runs formatting, linting, type checking, schema checks, and pytest sequentially inside each Python-version matrix job. Pytest therefore cannot run concurrently with the quality checks, extending the workflow's critical path.

### Related issues/PRs

See [flwrlabs/labs#397](https://github.com/flwrlabs/labs/pull/397), where the equivalent six-job split reduced wall-clock time from 17m38s to 11m42s while retaining checks on every supported Python version.

## Proposal

### Explanation

Split framework validation into one six-entry matrix with fail-fast enabled:

- `Quality` runs formatting, linting, type checking, proto/schema checks, and other framework quality checks on Python 3.11, 3.12, and 3.13.
- `Pytest` runs the framework test suite independently on Python 3.11, 3.12, and 3.13.

Keeping all six entries in one matrix means a failure in any quality or pytest job cancels the remaining entries and fails the workflow.

Add a backward-compatible `RUN_PYTEST` environment variable to `framework/dev/test.sh`. It defaults to `true`, preserving every existing caller. Quality jobs set it to `false`, while the separate pytest jobs invoke pytest directly.

The existing Python 3.11 migration check and three-version benchmark/example coverage remain unchanged.

### Measured CI impact

Measured on the `Framework Python` workflow:

- [Baseline on `main`](https://github.com/flwrlabs/flower/actions/runs/29529057572): 12m25s wall-clock time; three matrix jobs consumed 29m06s of runner time.
- [Fail-fast six-entry matrix](https://github.com/flwrlabs/flower/actions/runs/29572837959): 8m40s wall-clock time; six matrix jobs consumed 36m03s of runner time.

This shortens the critical path by 3m45s (30%), at the cost of 6m57s (24%) more aggregate runner time because setup runs in six jobs instead of three.

### Checklist

- [x] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [ ] Address LLM-reviewer comments, if applicable (e.g., GitHub Copilot)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

Validation performed:

- parsed `.github/workflows/framework-test.yml` as YAML
- ran `bash -n framework/dev/test.sh`
- mocked command execution with `RUN_PYTEST=true`, confirming pytest remains enabled by default
- mocked command execution with `RUN_PYTEST=false`, confirming pytest is skipped and subsequent checks complete
- validated the PR title with `devtool.check_pr_title`
- ran `git diff --check`
