### PR TITLE
Use `None` instead of empty string for no description

### DIFF
--- a/framework/py/flwr/server/superlink/linkstate/in_memory_linkstate.py
+++ b/framework/py/flwr/server/superlink/linkstate/in_memory_linkstate.py
@@ -639,7 +639,7 @@ class InMemoryLinkState(LinkState, InMemoryCoreState):  # pylint: disable=R0902,
         flwr_aid: str | None,
         primary_task_type: str,
         series_id: int | None = None,
-        series_description: str = "",
+        series_description: str | None = None,
     ) -> int:
         """Create a new run."""
         with self.lock_task_store, self.lock:

--- a/framework/py/flwr/server/superlink/linkstate/linkstate.py
+++ b/framework/py/flwr/server/superlink/linkstate/linkstate.py
@@ -274,7 +274,7 @@ class LinkState(CoreState):  # pylint: disable=R0904
         flwr_aid: str | None,
         primary_task_type: str,
         series_id: int | None = None,
-        series_description: str = "",
+        series_description: str | None = None,
     ) -> int:
         """Create a new run.
 
@@ -300,9 +300,10 @@ class LinkState(CoreState):  # pylint: disable=R0904
             Optional run series ID. If `None`, a new run series is created for
             the federation. If set, the series must already exist and belong to
             the federation.
-        series_description : str (default: "")
-            Description for a newly created run series. Ignored when `series_id`
-            refers to an existing run series.
+        series_description : str | None (default: None)
+            Optional description for a newly created run series. Ignored when
+            `series_id` refers to an existing run series. `None` means no
+            description was provided; an empty string is an explicit description.
 
         Returns
         -------

--- a/framework/py/flwr/server/superlink/linkstate/linkstate_test.py
+++ b/framework/py/flwr/server/superlink/linkstate/linkstate_test.py
@@ -2317,6 +2317,17 @@ class SqlInMemoryStateTest(StateTest, unittest.TestCase):
         state.initialize()
         return state
 
+    def test_run_series_distinguishes_missing_and_empty_descriptions(self) -> None:
+        """Missing and explicitly empty descriptions remain distinct in SQL."""
+        state = self.state_factory()
+        self.assertIsNotNone(state.store_run_in_series(1, "@me/fed-a", series_id=None))
+        self.assertIsNotNone(
+            state.store_run_in_series(2, "@me/fed-a", series_id=None, description="")
+        )
+
+        rows = state.query("SELECT description FROM run_series")
+        self.assertCountEqual([row["description"] for row in rows], [None, ""])
+
     @parameterized.expand(
         [  # type: ignore
             ("claim", "_claim_message_ins_rows", (1, 3)),

--- a/framework/py/flwr/server/superlink/linkstate/sql_linkstate.py
+++ b/framework/py/flwr/server/superlink/linkstate/sql_linkstate.py
@@ -976,7 +976,7 @@ class SqlLinkState(LinkState, SqlCoreState):  # pylint: disable=R0904
         flwr_aid: str | None,
         primary_task_type: str,
         series_id: int | None = None,
-        series_description: str = "",
+        series_description: str | None = None,
     ) -> int:
         """Create a new run."""
         # Convert federation_config to JSON string for storage

--- a/framework/py/flwr/supercore/corestate/corestate.py
+++ b/framework/py/flwr/supercore/corestate/corestate.py
@@ -347,7 +347,7 @@ class CoreState(ABC):  # pylint: disable=R0904
         run_id: int,
         federation_id: str,
         series_id: int | None,
-        description: str = "",
+        description: str | None = None,
     ) -> int | None:
         """Store a run in a run series and return the series ID.
 
@@ -361,9 +361,10 @@ class CoreState(ABC):  # pylint: disable=R0904
             Caller-provided series ID. If `None`, a new series ID is generated
             and creation is attempted. If set, the matching series must already
             exist and belong to `federation_id`.
-        description : str (default: "")
-            Description for a newly created run series. Ignored when `series_id`
-            refers to an existing run series.
+        description : str | None (default: None)
+            Optional description for a newly created run series. Ignored when
+            `series_id` refers to an existing run series. `None` means no
+            description was provided; an empty string is an explicit description.
 
         Returns
         -------

--- a/framework/py/flwr/supercore/corestate/in_memory_corestate.py
+++ b/framework/py/flwr/supercore/corestate/in_memory_corestate.py
@@ -472,7 +472,7 @@ class InMemoryCoreState(
         run_id: int,
         federation_id: str,
         series_id: int | None,
-        description: str = "",
+        description: str | None = None,
     ) -> int | None:
         """Store a run in a run series and return the series ID."""
         with self.lock_run_series_store:
@@ -504,7 +504,7 @@ class InMemoryCoreState(
                 run_series = RunSeries(
                     series_id=new_series_id,
                     federation=federation_id,
-                    description=description,
+                    description=description if description is not None else "",
                     created_at=timestamp,
                     updated_at=timestamp,
                 )

--- a/framework/py/flwr/supercore/corestate/sql_corestate.py
+++ b/framework/py/flwr/supercore/corestate/sql_corestate.py
@@ -705,7 +705,7 @@ class SqlCoreState(CoreState, SqlMixin):  # pylint: disable=R0904
         run_id: int,
         federation_id: str,
         series_id: int | None,
-        description: str = "",
+        description: str | None = None,
     ) -> int | None:
         """Store a run in a run series and return the series ID."""
         insert_query = """
@@ -728,7 +728,7 @@ class SqlCoreState(CoreState, SqlMixin):  # pylint: disable=R0904
                         {
                             "series_id": uint64_to_int64(candidate),
                             "federation_id": federation_id,
-                            "description": description or None,
+                            "description": description,
                             "created_at": timestamp,
                             "updated_at": timestamp,
                         },

--- a/framework/py/flwr/superlink/servicer/control/control_handlers.py
+++ b/framework/py/flwr/superlink/servicer/control/control_handlers.py
@@ -243,9 +243,11 @@ def start_run(  # pylint: disable=too-many-locals, too-many-statements
             )
         fab_id, fab_version = get_metadata_from_config(fab_config)
         series_id = request.series_id if request.HasField("series_id") else None
-        series_description = ""
+        series_description: str | None = None
         if primary_task_type == TaskType.AGENT_APP and series_id is None:
-            series_description = _derive_run_series_description(fused_run_config)
+            series_description = (
+                _derive_run_series_description(fused_run_config) or None
+            )
 
         run_id = state.create_run(
             fab_id,


### PR DESCRIPTION
<!--
Thank you for opening a pull request (PR)!

Please rename your PRs following this [format](https://flower.ai/docs/framework/contributor-tutorial-contribute-on-github.html#pr-title-format).
Contribution guidelines: https://github.com/flwrlabs/flower/blob/main/CONTRIBUTING.md
-->

## Issue

### Description

<!--
Describe the problem addressed by this PR.

Example: The variable name `rnd` could be misinterpreted as an abbreviation of *random*, but it refers to the current server round.
-->

### Related issues/PRs

<!--
Link issues and/or PRs that are related to this PR.

Example: Fixes #123. See also #456 and #789.
-->

## Proposal

### Explanation

<!--
Explain the changes and how they improve the issue described above.

Example: The variable `rnd` was renamed to `server_round` to improve readability.
-->

### Checklist

- [ ] Implement proposed change
- [ ] Write tests
- [ ] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [ ] Address LLM-reviewer comments, if applicable (e.g., GitHub Copilot)
- [ ] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Any other comments?

<!--
Please be aware that it may take some time until the maintainers can review the PR.
Smaller PRs with good descriptions can be considered much more easily.

If you have an urgent request or question, please use the Flower Slack:

    https://flower.ai/join-slack/ (channel: #contributions)

Thank you for contributing to Flower!
-->
