### PR TITLE
fix(framework): Guard DP clipping against zero-norm updates

### DIFF
--- a/framework/py/flwr/supercore/differential_privacy.py
+++ b/framework/py/flwr/supercore/differential_privacy.py
@@ -55,7 +55,7 @@ def clip_inputs_inplace(input_arrays: NDArrays, clipping_norm: float) -> None:
     input_norm = get_norm(input_arrays)
     # A zero-norm update (e.g. a client returning the global model unchanged)
     # has nothing to clip; guard against division by zero.
-    scaling_factor = min(1, clipping_norm / input_norm) if input_norm > 0 else 1.0
+    scaling_factor = min(1, clipping_norm / input_norm) if input_norm > 0 else 1
     for array in input_arrays:
         array *= scaling_factor
 
@@ -92,7 +92,7 @@ def adaptive_clip_inputs_inplace(input_arrays: NDArrays, clipping_norm: float) -
     input_norm = get_norm(input_arrays)
     # A zero-norm update (e.g. a client returning the global model unchanged)
     # has nothing to clip; guard against division by zero.
-    scaling_factor = min(1, clipping_norm / input_norm) if input_norm > 0 else 1.0
+    scaling_factor = min(1, clipping_norm / input_norm) if input_norm > 0 else 1
     for array in input_arrays:
         array *= scaling_factor
     return scaling_factor < 1

--- a/framework/py/flwr/supercore/differential_privacy.py
+++ b/framework/py/flwr/supercore/differential_privacy.py
@@ -53,7 +53,9 @@ def clip_inputs_inplace(input_arrays: NDArrays, clipping_norm: float) -> None:
     FlatClip method of the paper: https://arxiv.org/abs/1710.06963
     """
     input_norm = get_norm(input_arrays)
-    scaling_factor = min(1, clipping_norm / input_norm)
+    # A zero-norm update (e.g. a client returning the global model unchanged)
+    # has nothing to clip; guard against division by zero.
+    scaling_factor = min(1, clipping_norm / input_norm) if input_norm > 0 else 1.0
     for array in input_arrays:
         array *= scaling_factor
 
@@ -88,7 +90,9 @@ def adaptive_clip_inputs_inplace(input_arrays: NDArrays, clipping_norm: float) -
     FlatClip method of the paper: https://arxiv.org/abs/1710.06963
     """
     input_norm = get_norm(input_arrays)
-    scaling_factor = min(1, clipping_norm / input_norm)
+    # A zero-norm update (e.g. a client returning the global model unchanged)
+    # has nothing to clip; guard against division by zero.
+    scaling_factor = min(1, clipping_norm / input_norm) if input_norm > 0 else 1.0
     for array in input_arrays:
         array *= scaling_factor
     return scaling_factor < 1

--- a/framework/py/flwr/supercore/differential_privacy_test.py
+++ b/framework/py/flwr/supercore/differential_privacy_test.py
@@ -108,8 +108,10 @@ def test_clip_inputs_inplace() -> None:
 
 def test_clip_inputs_inplace_zero_norm() -> None:
     """Test clip_inputs_inplace does not raise on a zero-norm update."""
-    # Prepare: a client returning the global model unchanged yields a zero update
-    updates = [np.zeros((2, 2)), np.zeros(2)]
+    # Prepare: a client returning the global model unchanged yields a zero update.
+    # Include an integer-dtype array (e.g. a PyTorch num_batches_tracked buffer) so
+    # the in-place scaling does not break on integer arrays.
+    updates = [np.zeros((2, 2)), np.zeros(2), np.zeros(2, dtype=np.int64)]
     clipping_norm = 1.5
 
     # Execute: must not raise ZeroDivisionError
@@ -122,8 +124,9 @@ def test_clip_inputs_inplace_zero_norm() -> None:
 
 def test_adaptive_clip_inputs_inplace_zero_norm() -> None:
     """Test adaptive_clip_inputs_inplace does not raise on a zero-norm update."""
-    # Prepare
-    updates = [np.zeros((2, 2)), np.zeros(2)]
+    # Prepare: include an integer-dtype array (e.g. a PyTorch num_batches_tracked
+    # buffer) so the in-place scaling does not break on integer arrays.
+    updates = [np.zeros((2, 2)), np.zeros(2), np.zeros(2, dtype=np.int64)]
     clipping_norm = 1.5
 
     # Execute: must not raise ZeroDivisionError

--- a/framework/py/flwr/supercore/differential_privacy_test.py
+++ b/framework/py/flwr/supercore/differential_privacy_test.py
@@ -21,6 +21,7 @@ from .differential_privacy import (
     CLIENTS_DISCREPANCY_WARNING,
     KEY_CLIPPING_NORM,
     KEY_NORM_BIT,
+    adaptive_clip_inputs_inplace,
     add_gaussian_noise_inplace,
     clip_inputs_inplace,
     compute_adaptive_noise_params,
@@ -103,6 +104,35 @@ def test_clip_inputs_inplace() -> None:
     for updated, original_update in zip(updates, original_updates, strict=True):
         clip_norm = np.linalg.norm(original_update)
         assert np.all(updated <= clip_norm) and np.all(updated >= -clip_norm)
+
+
+def test_clip_inputs_inplace_zero_norm() -> None:
+    """Test clip_inputs_inplace does not raise on a zero-norm update."""
+    # Prepare: a client returning the global model unchanged yields a zero update
+    updates = [np.zeros((2, 2)), np.zeros(2)]
+    clipping_norm = 1.5
+
+    # Execute: must not raise ZeroDivisionError
+    clip_inputs_inplace(updates, clipping_norm)
+
+    # Assert: a zero update stays zero (nothing to clip)
+    for updated in updates:
+        assert np.all(updated == 0.0)
+
+
+def test_adaptive_clip_inputs_inplace_zero_norm() -> None:
+    """Test adaptive_clip_inputs_inplace does not raise on a zero-norm update."""
+    # Prepare
+    updates = [np.zeros((2, 2)), np.zeros(2)]
+    clipping_norm = 1.5
+
+    # Execute: must not raise ZeroDivisionError
+    norm_bit = adaptive_clip_inputs_inplace(updates, clipping_norm)
+
+    # Assert: a zero update is not clipped, so the norm bit is False
+    assert norm_bit is False
+    for updated in updates:
+        assert np.all(updated == 0.0)
 
 
 def test_compute_stdv() -> None:


### PR DESCRIPTION
## Issue

### Description

`clip_inputs_inplace` and `adaptive_clip_inputs_inplace` in `flwr/supercore/differential_privacy.py` compute the scaling factor as:

```python
scaling_factor = min(1, clipping_norm / input_norm)
```

When a sampled client returns a model update whose L2 norm is `0.0`, `input_norm` is zero and this division raises `ZeroDivisionError`. A zero-norm update is not an exotic case — it happens whenever a client returns the global model unchanged, e.g. a client configured with zero local epochs, a client whose optimizer made no update, or a degenerate/misbehaving client. Because the clipping runs inside `aggregate_fit`, the exception propagates and crashes the **entire round** for both `DifferentialPrivacyServerSideFixedClipping` and `DifferentialPrivacyServerSideAdaptiveClipping`.

Minimal reproduction:

```python
import numpy as np
from flwr.supercore.differential_privacy import clip_inputs_inplace

clip_inputs_inplace([np.zeros((3, 3))], clipping_norm=5.0)
# ZeroDivisionError: float division by zero
```

### Related issues/PRs

None found.

## Proposal

### Explanation

A zero-norm update has nothing to clip, so the scaling factor should simply be left at `1.0` (a no-op) instead of dividing by zero:

```python
scaling_factor = min(1, clipping_norm / input_norm) if input_norm > 0 else 1.0
```

The same one-line guard is applied to both `clip_inputs_inplace` and `adaptive_clip_inputs_inplace`. For the adaptive variant this also yields the correct `norm_bit` (`False`), since a zero-norm update is, by definition, not clipped.

Regression tests are added for both functions covering the zero-norm case, and I verified that normal over-norm (scaled down to `clipping_norm`) and under-norm (left unchanged) clipping behavior is preserved.

### Checklist

- [x] Implement proposed change
- [x] Write tests
- [ ] Update documentation (no user-facing docs affected)
- [ ] Address LLM-reviewer comments, if applicable
- [x] Make CI checks pass
- [ ] Ping maintainers on Slack (channel `#contributions`)

### Any other comments?

The fix is intentionally minimal and self-contained. Happy to adjust the guard's placement or add coverage for the strategy-level entry points if maintainers prefer.
