### PR TITLE
fix(framework): Validate clipping_range in SecAggPlusWorkflow

### DIFF
--- a/framework/py/flwr/server/workflow/secure_aggregation/secaggplus_workflow.py
+++ b/framework/py/flwr/server/workflow/secure_aggregation/secaggplus_workflow.py
@@ -242,14 +242,14 @@ class SecAggPlusWorkflow:
             raise ValueError("`max_weight` must be greater than 0.")
 
         # Check `quantization_range`
-        if self.quantization_range <= 0:
-            raise ValueError("`quantization_range` must be greater than 0.")
-
-        # Check `quantization_range`
         if not isinstance(self.quantization_range, int) or self.quantization_range <= 0:
             raise ValueError(
                 "`quantization_range` must be an integer and greater than 0."
             )
+
+        # Check `clipping_range`
+        if self.clipping_range <= 0:
+            raise ValueError("`clipping_range` must be greater than 0.")
 
         # Check `modulus_range`
         if (

--- a/framework/py/flwr/server/workflow/secure_aggregation/secaggplus_workflow_test.py
+++ b/framework/py/flwr/server/workflow/secure_aggregation/secaggplus_workflow_test.py
@@ -1,0 +1,41 @@
+# Copyright 2025 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for the SecAgg+ workflow."""
+
+
+import pytest
+
+from .secaggplus_workflow import SecAggPlusWorkflow
+
+
+def test_valid_init_params() -> None:
+    """Test that valid init parameters do not raise."""
+    SecAggPlusWorkflow(num_shares=3, reconstruction_threshold=2)
+
+
+@pytest.mark.parametrize("clipping_range", [0.0, -1.0])
+def test_non_positive_clipping_range_raises(clipping_range: float) -> None:
+    """Test that a non-positive `clipping_range` is rejected at construction.
+
+    A `clipping_range` of 0 would otherwise surface later as an opaque
+    ZeroDivisionError inside quantization (`target_range / (2 * clipping_range)`),
+    and a negative value would silently produce reversed `np.clip` bounds.
+    """
+    with pytest.raises(ValueError, match="clipping_range"):
+        SecAggPlusWorkflow(
+            num_shares=3,
+            reconstruction_threshold=2,
+            clipping_range=clipping_range,
+        )


### PR DESCRIPTION
## Issue

### Description

`SecAggPlusWorkflow._check_init_params` validates `num_shares`, `reconstruction_threshold`, `max_weight`, `quantization_range` and `modulus_range`, but it never validates `clipping_range`. A non-positive `clipping_range` is therefore accepted silently at construction time and only fails much later, with a confusing error, deep inside quantization:

- `clipping_range = 0` → `ZeroDivisionError` at `quantizer = target_range / (2 * clipping_range)` in `flwr/common/secure_aggregation/quantization.py`.
- `clipping_range < 0` → `np.clip(arr, -clipping_range, clipping_range)` is called with `low > high`, silently producing wrong quantization rather than raising.

Separately, `_check_init_params` contains a redundant duplicate check on `quantization_range`: it is first tested with `if self.quantization_range <= 0` and then again with `if not isinstance(self.quantization_range, int) or self.quantization_range <= 0`. The second check fully subsumes the first.

### Related issues/PRs

None found.

## Proposal

### Explanation

- Add a `clipping_range` validation alongside the existing sibling checks, using the same style already used for `max_weight` and `quantization_range`:

  ```python
  # Check `clipping_range`
  if self.clipping_range <= 0:
      raise ValueError("`clipping_range` must be greater than 0.")
  ```

  This surfaces the problem clearly at construction time instead of as an opaque `ZeroDivisionError` (or silent misbehavior) during aggregation.

- Remove the redundant first `quantization_range` check, keeping the stricter one that also enforces the integer type.

Adds tests covering the new `clipping_range` validation (both `0` and a negative value) and a valid-construction case.

### Checklist

- [x] Implement proposed change
- [x] Write tests
- [ ] Update documentation (no user-facing docs affected)
- [ ] Address LLM-reviewer comments, if applicable
- [x] Make CI checks pass
- [ ] Ping maintainers on Slack (channel `#contributions`)

### Any other comments?

Small, self-contained hardening of the SecAgg+ init path. Happy to drop the redundant-check cleanup into a separate PR if maintainers prefer to keep this strictly to the missing validation.
