### PR TITLE
fix(framework): Handle malformed auth metadata in NodeAuthServerInterceptor

### DIFF
--- a/framework/py/flwr/server/superlink/fleet/grpc_rere/node_auth_server_interceptor.py
+++ b/framework/py/flwr/server/superlink/fleet/grpc_rere/node_auth_server_interceptor.py
@@ -21,6 +21,7 @@ from typing import Any
 
 import grpc
 from cryptography.exceptions import UnsupportedAlgorithm
+from cryptography.hazmat.primitives.asymmetric import ec
 from google.protobuf.message import Message as GrpcMessage
 
 from flwr.common.constant import (
@@ -94,6 +95,10 @@ class NodeAuthServerInterceptor(grpc.ServerInterceptor):  # type: ignore
             node_pk = bytes_to_public_key(node_pk_bytes)
         except (ValueError, UnsupportedAlgorithm):
             # Malformed public key bytes from an unauthenticated peer
+            return _unary_unary_rpc_terminator("Invalid public key")
+        if not isinstance(node_pk, ec.EllipticCurvePublicKey):
+            # A well-formed PEM key of the wrong type (e.g. RSA) loads successfully, so
+            # verify_signature would raise TypeError instead of returning False.
             return _unary_unary_rpc_terminator("Invalid public key")
         if not verify_signature(node_pk, timestamp_iso.encode("ascii"), signature):
             return _unary_unary_rpc_terminator("Invalid signature")

--- a/framework/py/flwr/server/superlink/fleet/grpc_rere/node_auth_server_interceptor.py
+++ b/framework/py/flwr/server/superlink/fleet/grpc_rere/node_auth_server_interceptor.py
@@ -20,6 +20,7 @@ from collections.abc import Callable
 from typing import Any
 
 import grpc
+from cryptography.exceptions import UnsupportedAlgorithm
 from google.protobuf.message import Message as GrpcMessage
 
 from flwr.common.constant import (
@@ -89,13 +90,22 @@ class NodeAuthServerInterceptor(grpc.ServerInterceptor):  # type: ignore
             return _unary_unary_rpc_terminator("Missing authentication metadata")
 
         # Verify the signature
-        node_pk = bytes_to_public_key(node_pk_bytes)
+        try:
+            node_pk = bytes_to_public_key(node_pk_bytes)
+        except (ValueError, UnsupportedAlgorithm):
+            # Malformed public key bytes from an unauthenticated peer
+            return _unary_unary_rpc_terminator("Invalid public key")
         if not verify_signature(node_pk, timestamp_iso.encode("ascii"), signature):
             return _unary_unary_rpc_terminator("Invalid signature")
 
         # Verify the timestamp
         current = now()
-        time_diff = current - datetime.datetime.fromisoformat(timestamp_iso)
+        try:
+            timestamp = datetime.datetime.fromisoformat(timestamp_iso)
+        except ValueError:
+            # Malformed (non-ISO) timestamp from an unauthenticated peer
+            return _unary_unary_rpc_terminator("Invalid timestamp")
+        time_diff = current - timestamp
         # Abort the RPC call if the timestamp is too old or in the future
         if not MIN_TIMESTAMP_DIFF < time_diff.total_seconds() < MAX_TIMESTAMP_DIFF:
             return _unary_unary_rpc_terminator("Invalid timestamp")

--- a/framework/py/flwr/server/superlink/fleet/grpc_rere/node_auth_server_interceptor.py
+++ b/framework/py/flwr/server/superlink/fleet/grpc_rere/node_auth_server_interceptor.py
@@ -105,6 +105,10 @@ class NodeAuthServerInterceptor(grpc.ServerInterceptor):  # type: ignore
         except ValueError:
             # Malformed (non-ISO) timestamp from an unauthenticated peer
             return _unary_unary_rpc_terminator("Invalid timestamp")
+        if timestamp.tzinfo is None:
+            # Offset-naive timestamp from an unauthenticated peer cannot be compared
+            # to the timezone-aware current time; reject instead of raising TypeError.
+            return _unary_unary_rpc_terminator("Invalid timestamp")
         time_diff = current - timestamp
         # Abort the RPC call if the timestamp is too old or in the future
         if not MIN_TIMESTAMP_DIFF < time_diff.total_seconds() < MAX_TIMESTAMP_DIFF:

--- a/framework/py/flwr/server/superlink/fleet/grpc_rere/node_auth_server_interceptor_test.py
+++ b/framework/py/flwr/server/superlink/fleet/grpc_rere/node_auth_server_interceptor_test.py
@@ -23,6 +23,8 @@ from typing import Any
 from unittest.mock import patch
 
 import grpc
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
 from parameterized import parameterized
 
 from flwr.common.constant import (
@@ -232,6 +234,25 @@ class TestNodeAuthServerInterceptor(unittest.TestCase):  # pylint: disable=R0902
         signature = sign_message(self.node_sk, timestamp.encode("ascii"))
         return [
             (PUBLIC_KEY_HEADER, self.node_pk_bytes),
+            (SIGNATURE_HEADER, signature),
+            (TIMESTAMP_HEADER, timestamp),
+        ]
+
+    def _make_metadata_with_wrong_key_type(self) -> list[Any]:
+        """Create metadata with a well-formed PEM key of the wrong type (RSA)."""
+        # An RSA key is valid PEM, so it loads successfully and reaches
+        # verify_signature, which expects an EC key.
+        rsa_pk = rsa.generate_private_key(
+            public_exponent=65537, key_size=2048
+        ).public_key()
+        rsa_pk_bytes = rsa_pk.public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        timestamp = now().isoformat()
+        signature = sign_message(self.node_sk, timestamp.encode("ascii"))
+        return [
+            (PUBLIC_KEY_HEADER, rsa_pk_bytes),
             (SIGNATURE_HEADER, signature),
             (TIMESTAMP_HEADER, timestamp),
         ]
@@ -464,6 +485,16 @@ class TestNodeAuthServerInterceptor(unittest.TestCase):  # pylint: disable=R0902
         # Execute & Assert
         with self.assertRaises(grpc.RpcError) as cm:
             rpc(self, self._make_metadata_with_malformed_timestamp())
+        assert cm.exception.code() == grpc.StatusCode.UNAUTHENTICATED
+
+    @parameterized.expand(rpcs)  # type: ignore
+    def test_unsuccessful_rpc_with_wrong_key_type(
+        self, rpc: Callable[[Any, list[Any]], Any]
+    ) -> None:
+        """Test that a wrong-type (non-EC) public key is rejected, not crashed on."""
+        # Execute & Assert
+        with self.assertRaises(grpc.RpcError) as cm:
+            rpc(self, self._make_metadata_with_wrong_key_type())
         assert cm.exception.code() == grpc.StatusCode.UNAUTHENTICATED
 
     @parameterized.expand(rpcs)  # type: ignore

--- a/framework/py/flwr/server/superlink/fleet/grpc_rere/node_auth_server_interceptor_test.py
+++ b/framework/py/flwr/server/superlink/fleet/grpc_rere/node_auth_server_interceptor_test.py
@@ -236,6 +236,19 @@ class TestNodeAuthServerInterceptor(unittest.TestCase):  # pylint: disable=R0902
             (TIMESTAMP_HEADER, timestamp),
         ]
 
+    def _make_metadata_with_offset_naive_timestamp(self) -> list[Any]:
+        """Create metadata with an ISO but offset-naive timestamp."""
+        # An offset-naive timestamp parses with fromisoformat but cannot be
+        # subtracted from the timezone-aware current time; sign it so it reaches
+        # the timestamp comparison step.
+        timestamp = now().replace(tzinfo=None).isoformat()
+        signature = sign_message(self.node_sk, timestamp.encode("ascii"))
+        return [
+            (PUBLIC_KEY_HEADER, self.node_pk_bytes),
+            (SIGNATURE_HEADER, signature),
+            (TIMESTAMP_HEADER, timestamp),
+        ]
+
     def _test_register_node(self, metadata: list[Any]) -> Any:
         """Test RegisterNode."""
         return self._register_node.with_call(
@@ -451,6 +464,16 @@ class TestNodeAuthServerInterceptor(unittest.TestCase):  # pylint: disable=R0902
         # Execute & Assert
         with self.assertRaises(grpc.RpcError) as cm:
             rpc(self, self._make_metadata_with_malformed_timestamp())
+        assert cm.exception.code() == grpc.StatusCode.UNAUTHENTICATED
+
+    @parameterized.expand(rpcs)  # type: ignore
+    def test_unsuccessful_rpc_with_offset_naive_timestamp(
+        self, rpc: Callable[[Any, list[Any]], Any]
+    ) -> None:
+        """Test that an offset-naive timestamp is rejected, not crashed on."""
+        # Execute & Assert
+        with self.assertRaises(grpc.RpcError) as cm:
+            rpc(self, self._make_metadata_with_offset_naive_timestamp())
         assert cm.exception.code() == grpc.StatusCode.UNAUTHENTICATED
 
 

--- a/framework/py/flwr/server/superlink/fleet/grpc_rere/node_auth_server_interceptor_test.py
+++ b/framework/py/flwr/server/superlink/fleet/grpc_rere/node_auth_server_interceptor_test.py
@@ -214,6 +214,28 @@ class TestNodeAuthServerInterceptor(unittest.TestCase):  # pylint: disable=R0902
             (TIMESTAMP_HEADER, timestamp),
         ]
 
+    def _make_metadata_with_malformed_public_key(self) -> list[Any]:
+        """Create metadata with a malformed (non-PEM) public key."""
+        timestamp = now().isoformat()
+        signature = sign_message(self.node_sk, timestamp.encode("ascii"))
+        return [
+            (PUBLIC_KEY_HEADER, b"not-a-valid-pem-public-key"),
+            (SIGNATURE_HEADER, signature),
+            (TIMESTAMP_HEADER, timestamp),
+        ]
+
+    def _make_metadata_with_malformed_timestamp(self) -> list[Any]:
+        """Create metadata with a malformed (non-ISO) timestamp."""
+        # Sign the malformed timestamp so it passes signature verification and
+        # reaches the timestamp parsing step.
+        timestamp = "not-a-valid-timestamp"
+        signature = sign_message(self.node_sk, timestamp.encode("ascii"))
+        return [
+            (PUBLIC_KEY_HEADER, self.node_pk_bytes),
+            (SIGNATURE_HEADER, signature),
+            (TIMESTAMP_HEADER, timestamp),
+        ]
+
     def _test_register_node(self, metadata: list[Any]) -> Any:
         """Test RegisterNode."""
         return self._register_node.with_call(
@@ -409,6 +431,26 @@ class TestNodeAuthServerInterceptor(unittest.TestCase):  # pylint: disable=R0902
         # Execute & Assert
         with self.assertRaises(grpc.RpcError) as cm:
             rpc(self, self._make_metadata_with_invalid_timestamp())
+        assert cm.exception.code() == grpc.StatusCode.UNAUTHENTICATED
+
+    @parameterized.expand(rpcs)  # type: ignore
+    def test_unsuccessful_rpc_with_malformed_public_key(
+        self, rpc: Callable[[Any, list[Any]], Any]
+    ) -> None:
+        """Test that malformed public key bytes are rejected, not crashed on."""
+        # Execute & Assert
+        with self.assertRaises(grpc.RpcError) as cm:
+            rpc(self, self._make_metadata_with_malformed_public_key())
+        assert cm.exception.code() == grpc.StatusCode.UNAUTHENTICATED
+
+    @parameterized.expand(rpcs)  # type: ignore
+    def test_unsuccessful_rpc_with_malformed_timestamp(
+        self, rpc: Callable[[Any, list[Any]], Any]
+    ) -> None:
+        """Test that a malformed (non-ISO) timestamp is rejected, not crashed on."""
+        # Execute & Assert
+        with self.assertRaises(grpc.RpcError) as cm:
+            rpc(self, self._make_metadata_with_malformed_timestamp())
         assert cm.exception.code() == grpc.StatusCode.UNAUTHENTICATED
 
 


### PR DESCRIPTION
## Issue

### Description

`NodeAuthServerInterceptor.intercept_service` parses two pieces of node-supplied auth metadata without guarding against malformed input:

```python
# Verify the signature
node_pk = bytes_to_public_key(node_pk_bytes)            # raises on malformed PEM
...
# Verify the timestamp
time_diff = current - datetime.datetime.fromisoformat(timestamp_iso)  # raises on non-ISO
```

- `bytes_to_public_key` calls `serialization.load_pem_public_key`, which raises `ValueError` (or `UnsupportedAlgorithm`) on non-PEM bytes.
- `datetime.fromisoformat` raises `ValueError` on a non-ISO string.

Both run *before* the interceptor's own graceful abort path, so an unauthenticated peer can send garbage bytes in the `PUBLIC_KEY_HEADER` (or a non-ISO string in `TIMESTAMP_HEADER`, signed so it clears the signature check) and raise an **unhandled exception inside the interceptor** instead of being cleanly rejected. This is inconsistent with how missing metadata, invalid signatures, and out-of-range timestamps are already handled — those all terminate the RPC with `UNAUTHENTICATED`.

The existing tests only cover *well-formed-but-wrong* values (`test_unsuccessful_rpc_with_invalid_public_key` uses a real key from `generate_key_pairs()`), so the malformed-input path was untested.

### Related issues/PRs

None found.

## Proposal

### Explanation

Wrap both parses and terminate the RPC with `UNAUTHENTICATED` on failure, matching the existing `_unary_unary_rpc_terminator(...)` style:

```python
try:
    node_pk = bytes_to_public_key(node_pk_bytes)
except (ValueError, UnsupportedAlgorithm):
    return _unary_unary_rpc_terminator("Invalid public key")
...
try:
    timestamp = datetime.datetime.fromisoformat(timestamp_iso)
except ValueError:
    return _unary_unary_rpc_terminator("Invalid timestamp")
```

Adds regression tests that send malformed (non-PEM, non-ISO) metadata across all Fleet RPCs and assert a clean `UNAUTHENTICATED` response rather than an interceptor crash.

### Checklist

- [x] Implement proposed change
- [x] Write tests
- [ ] Update documentation (no user-facing docs affected)
- [ ] Address LLM-reviewer comments, if applicable
- [x] Make CI checks pass
- [ ] Ping maintainers on Slack (channel `#contributions`)

### Any other comments?

Small, additive hardening on the authentication path; no behavior change for valid clients.
