### PR TITLE
Fix CLI imports with older pathspec

### DIFF
--- a/framework/py/flwr/cli/build.py
+++ b/framework/py/flwr/cli/build.py
@@ -15,6 +15,9 @@
 """Flower command line interface `build` command."""
 
 
+from __future__ import annotations
+
+
 import hashlib
 import zipfile
 from collections.abc import Mapping

--- a/framework/py/flwr/cli/utils.py
+++ b/framework/py/flwr/cli/utils.py
@@ -15,6 +15,9 @@
 """Flower command line interface utils."""
 
 
+from __future__ import annotations
+
+
 import hashlib
 import os
 import sys

--- a/framework/py/flwr/cli/utils_test.py
+++ b/framework/py/flwr/cli/utils_test.py
@@ -17,6 +17,8 @@
 
 import hashlib
 import os
+import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -189,6 +191,34 @@ def test_load_gitignore_patterns_with_pathspec() -> None:
 
     # Should not match normal files
     assert spec.match_file("good.py") is False
+
+
+def test_cli_modules_import_with_non_generic_pathspec(tmp_path: Path) -> None:
+    """Test CLI modules import with a pre-1.0 pathspec implementation."""
+    pathspec_package = tmp_path / "pathspec"
+    pathspec_package.mkdir()
+    (pathspec_package / "__init__.py").write_text(
+        "from . import pattern\n\n\nclass PathSpec:\n    pass\n",
+        encoding="utf-8",
+    )
+    (pathspec_package / "pattern.py").write_text(
+        "class Pattern:\n    pass\n",
+        encoding="utf-8",
+    )
+
+    source_root = Path(__file__).parents[2]
+    pythonpath = os.pathsep.join(
+        filter(None, [str(tmp_path), str(source_root), os.environ.get("PYTHONPATH")])
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", "import flwr.cli.build, flwr.cli.utils"],
+        env={**os.environ, "PYTHONPATH": pythonpath},
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
 
 
 def test_wait_for_control_api_channel_retries_until_ready() -> None:


### PR DESCRIPTION
## Summary

- defer `pathspec.PathSpec[...]` annotations in the CLI build and utility modules
- add a regression test covering imports with a pre-1.0, non-generic `PathSpec`

## Root cause

The latest `main` changes use generic `PathSpec` annotations, while Flower App runtime environments can still resolve `pathspec==0.12.1`. That version does not support subscription, so importing `flwr.cli.utils` raises `TypeError: type 'PathSpec' is not subscriptable`.

With postponed annotations, the annotations remain available to type checkers without being evaluated during runtime imports.

## Checks

- `uv run --no-sync --python=3.11.14 python -m pytest py/flwr/cli/utils_test.py py/flwr/cli/build_test.py -q`
- `uv run --no-sync --python=3.11.14 python -m mypy py/flwr/cli/utils.py py/flwr/cli/build.py`
- `uv run --no-sync --python=3.11.14 python -m ruff check py/flwr/cli/utils.py py/flwr/cli/build.py py/flwr/cli/utils_test.py --no-respect-gitignore`