### PR TITLE
feat(framework): Add Python foundation image

### DIFF
--- a/framework/docker/python/README.md
+++ b/framework/docker/python/README.md
@@ -5,7 +5,7 @@ container images.
 
 The Ubuntu foundation image:
 
-- compiles the requested Python version with PyEnv;
+- installs the requested Python version from uv's prebuilt CPython distributions;
 - installs pinned pip and setuptools versions;
 - creates the shared Python virtual environment; and
 - includes the runtime libraries and non-root app user needed by downstream

--- a/framework/docker/python/README.md
+++ b/framework/docker/python/README.md
@@ -1,0 +1,15 @@
+# Python foundation images
+
+This directory contains reusable Python runtime foundations for framework
+container images.
+
+The Ubuntu foundation image:
+
+- compiles the requested Python version with PyEnv;
+- installs pinned pip and setuptools versions;
+- creates the shared Python virtual environment; and
+- includes the runtime libraries and non-root app user needed by downstream
+  images.
+
+The Dockerfile is platform-neutral and can be built for both Linux AMD64 and
+Linux ARM64 with Docker Buildx.

--- a/framework/docker/python/ubuntu/Dockerfile
+++ b/framework/docker/python/ubuntu/Dockerfile
@@ -35,15 +35,15 @@ ENV PYENV_ROOT=/root/.pyenv
 ENV PATH=$PYENV_ROOT/bin:$PATH
 # https://github.com/hadolint/hadolint/wiki/DL4006
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash
+RUN curl -fsSL https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash
 
 # hadolint ignore=DL3003
 RUN git clone https://github.com/pyenv/pyenv.git \
     && cd pyenv/plugins/python-build || exit \
     && ./install.sh
 
-# Issue: python-build only accepts the exact Python version e.g. 3.11.1 but
-# we want to allow more general versions like 3.11.
+# Issue: python-build only accepts the exact Python version e.g. 3.13.1 but
+# we want to allow more general versions like 3.13.
 # Solution: first use pyenv to get the exact version and then pass it to python-build.
 RUN LATEST=$(pyenv latest -k ${PYTHON_VERSION}) \
     && python-build "${LATEST}" /usr/local/bin/python
@@ -58,7 +58,7 @@ RUN pip install -U --no-cache-dir pip==${PIP_VERSION} setuptools==${SETUPTOOLS_V
     # Use a virtual environment so packages have the same location regardless
     # of whether the subsequent image build runs as root or app.
     && python -m venv /python/venv \
-    && pip install -U --no-cache-dir \
+    && /python/venv/bin/python -m pip install -U --no-cache-dir \
     pip==${PIP_VERSION} \
     setuptools==${SETUPTOOLS_VERSION}
 

--- a/framework/docker/python/ubuntu/Dockerfile
+++ b/framework/docker/python/ubuntu/Dockerfile
@@ -1,0 +1,100 @@
+# Copyright 2026 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===============================================================================
+
+# hadolint global ignore=DL3008
+ARG DISTRO=ubuntu
+ARG DISTRO_VERSION=24.04
+FROM $DISTRO:$DISTRO_VERSION AS python
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install system dependencies required to compile Python.
+RUN apt-get update \
+    && apt-get -y --no-install-recommends install \
+    clang-format git unzip ca-certificates openssh-client liblzma-dev \
+    build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev wget \
+    libsqlite3-dev curl llvm libncursesw5-dev xz-utils tk-dev libxml2-dev \
+    libxmlsec1-dev libffi-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install PyEnv and Python.
+ARG PYTHON_VERSION=3.13
+ENV PYENV_ROOT=/root/.pyenv
+ENV PATH=$PYENV_ROOT/bin:$PATH
+# https://github.com/hadolint/hadolint/wiki/DL4006
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash
+
+# hadolint ignore=DL3003
+RUN git clone https://github.com/pyenv/pyenv.git \
+    && cd pyenv/plugins/python-build || exit \
+    && ./install.sh
+
+# Issue: python-build only accepts the exact Python version e.g. 3.11.1 but
+# we want to allow more general versions like 3.11.
+# Solution: first use pyenv to get the exact version and then pass it to python-build.
+RUN LATEST=$(pyenv latest -k ${PYTHON_VERSION}) \
+    && python-build "${LATEST}" /usr/local/bin/python
+
+ENV PATH=/usr/local/bin/python/bin:$PATH
+
+ARG PIP_VERSION
+ARG SETUPTOOLS_VERSION
+# Keep the versions of pip and setuptools in sync with those installed in the
+# virtual environment.
+RUN pip install -U --no-cache-dir pip==${PIP_VERSION} setuptools==${SETUPTOOLS_VERSION} \
+    # Use a virtual environment so packages have the same location regardless
+    # of whether the subsequent image build runs as root or app.
+    && python -m venv /python/venv \
+    && pip install -U --no-cache-dir \
+    pip==${PIP_VERSION} \
+    setuptools==${SETUPTOOLS_VERSION}
+
+FROM $DISTRO:$DISTRO_VERSION AS foundation
+
+COPY --from=python /usr/local/bin/python /usr/local/bin/python
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PATH=/usr/local/bin/python/bin:$PATH
+
+RUN apt-get update \
+    && apt-get -y --no-install-recommends install \
+    libsqlite3-0 \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    # Add a non-root user for downstream framework images.
+    && useradd \
+    --no-create-home \
+    --home-dir /app \
+    -c "" \
+    --uid 49999 app \
+    && mkdir -p /app \
+    && chown -R app:app /app
+
+COPY --from=python --chown=app:app /python/venv /python/venv
+
+ENV PATH=/python/venv/bin:$PATH \
+    # Send stdout and stderr directly to the terminal.
+    PYTHONUNBUFFERED=1 \
+    # Docker images normally invoke Python once, so do not write bytecode.
+    PYTHONDONTWRITEBYTECODE=1 \
+    # Ensure that Python encoding is always UTF-8.
+    PYTHONIOENCODING=UTF-8 \
+    LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8
+
+WORKDIR /app
+USER app
+ENV HOME=/app

--- a/framework/docker/python/ubuntu/Dockerfile
+++ b/framework/docker/python/ubuntu/Dockerfile
@@ -20,44 +20,27 @@ FROM $DISTRO:$DISTRO_VERSION AS python
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Install system dependencies required to compile Python.
+# Install the certificate bundle required to download the managed Python build.
 RUN apt-get update \
     && apt-get -y --no-install-recommends install \
-    clang-format git unzip ca-certificates openssh-client liblzma-dev \
-    build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev wget \
-    libsqlite3-dev curl llvm libncursesw5-dev xz-utils tk-dev libxml2-dev \
-    libxmlsec1-dev libffi-dev \
+    ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-# Install PyEnv and Python.
+# Install Python from uv's managed, prebuilt CPython distributions.
+COPY --from=ghcr.io/astral-sh/uv:0.11.30@sha256:93b61e21202b1dab861092748e46bbd6e0e41dd84f59b9174efd2353186e1b47 /uv /uvx /bin/
+
 ARG PYTHON_VERSION=3.13
-ENV PYENV_ROOT=/root/.pyenv
-ENV PATH=$PYENV_ROOT/bin:$PATH
-# https://github.com/hadolint/hadolint/wiki/DL4006
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN curl -fsSL https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash
-
-# hadolint ignore=DL3003
-RUN git clone https://github.com/pyenv/pyenv.git \
-    && cd pyenv/plugins/python-build || exit \
-    && ./install.sh
-
-# Issue: python-build only accepts the exact Python version e.g. 3.13.1 but
-# we want to allow more general versions like 3.13.
-# Solution: first use pyenv to get the exact version and then pass it to python-build.
-RUN LATEST=$(pyenv latest -k ${PYTHON_VERSION}) \
-    && python-build "${LATEST}" /usr/local/bin/python
-
-ENV PATH=/usr/local/bin/python/bin:$PATH
+ENV UV_PYTHON_INSTALL_DIR=/usr/local/bin/python \
+    UV_PYTHON_BIN_DIR=/usr/local/bin/python/bin \
+    UV_PYTHON_INSTALL_BIN=1 \
+    PATH=/usr/local/bin/python/bin:$PATH
+RUN uv python install --managed-python --default --no-cache "${PYTHON_VERSION}"
 
 ARG PIP_VERSION
 ARG SETUPTOOLS_VERSION
-# Keep the versions of pip and setuptools in sync with those installed in the
-# virtual environment.
-RUN pip install -U --no-cache-dir pip==${PIP_VERSION} setuptools==${SETUPTOOLS_VERSION} \
-    # Use a virtual environment so packages have the same location regardless
-    # of whether the subsequent image build runs as root or app.
-    && python -m venv /python/venv \
+# Use a virtual environment so packages have the same location regardless of
+# whether the subsequent image build runs as root or app.
+RUN python -m venv /python/venv \
     && /python/venv/bin/python -m pip install -U --no-cache-dir \
     pip==${PIP_VERSION} \
     setuptools==${SETUPTOOLS_VERSION}


### PR DESCRIPTION
## Summary

- Add an Ubuntu Python foundation Dockerfile under `framework/docker/python/ubuntu`.
- Install Python 3.13 from uv's prebuilt CPython distributions instead of compiling it with PyEnv.
- Pin pip and setuptools and provide a reusable virtual environment.
- Include the runtime libraries and non-root `app` user required by downstream framework images.
- Keep Flower package installation out of the foundation so the image can be reused across framework image builds.
- Support Linux AMD64 and ARM64 through the existing multi-platform Docker build path.

## Performance

Measured with explicit cold Docker Buildx builds on the architecture-specific CI runners:

| Target | AMD64 | ARM64 |
| --- | ---: | ---: |
| Current production base target | 233 s | 186 s |
| Python foundation with PyEnv | 158 s | 129 s |
| Python foundation with uv | 23 s | 25 s |
| uv reduction vs PyEnv | 135 s (85%) | 104 s (81%) |
| uv reduction vs current base target | 210 s (90%) | 161 s (87%) |

The local ARM64 Python installation step dropped from approximately 262 seconds with PyEnv compilation to approximately 1.8 seconds with uv's prebuilt distribution. The uv runtime remains Python 3.13.14 with pip 26.0.1 and setuptools 82.0.0.

## Validation

- `docker buildx build --call=check --target foundation --file framework/docker/python/ubuntu/Dockerfile ...`
- Built and ran the foundation image locally on ARM64; Python, pip, and setuptools versions matched the pinned values.
- The foundation benchmark passed on AMD64 and ARM64.
- uv is pinned to `0.11.30` by image digest.