### PR TITLE
feat(framework): Support prefixed PostgreSQL environment variables

### DIFF
--- a/framework/py/flwr/superlink/main.py
+++ b/framework/py/flwr/superlink/main.py
@@ -14,14 +14,14 @@
 # ==============================================================================
 """SuperLink API."""
 
-
 from __future__ import annotations
 
 import os
 from collections.abc import AsyncIterator, Mapping
 from contextlib import AsyncExitStack, asynccontextmanager
 from logging import INFO
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
+from urllib.parse import quote
 
 from fastapi import FastAPI
 from fastapi.routing import APIRoute, iter_route_contexts
@@ -49,6 +49,47 @@ from flwr.superlink.routers.control.middlewares import (
 
 if TYPE_CHECKING:
     from flwr.superlink.cli.flower_superlink import SuperLinkLifespan
+
+
+_FLWR_POSTGRES_ENV_VARS = (
+    "FLWR_POSTGRES_HOST",
+    "FLWR_POSTGRES_PORT",
+    "FLWR_POSTGRES_DATABASE",
+    "FLWR_POSTGRES_USER",
+    "FLWR_POSTGRES_PASSWORD",
+)
+
+
+def _get_database_from_env() -> str:
+    """Return the database configured through environment variables."""
+    if database := os.getenv("FLWR_DATABASE"):
+        return database
+
+    postgres_values = {
+        env_var: os.getenv(env_var) for env_var in _FLWR_POSTGRES_ENV_VARS
+    }
+    if not any(postgres_values.values()):
+        return FLWR_IN_MEMORY_DB_NAME
+
+    missing = [env_var for env_var, value in postgres_values.items() if not value]
+    if missing:
+        missing_vars = ", ".join(missing)
+        raise ValueError(
+            "The PostgreSQL environment variables must be set together: "
+            f"{missing_vars}."
+        )
+
+    host = cast(str, postgres_values["FLWR_POSTGRES_HOST"])
+    port = cast(str, postgres_values["FLWR_POSTGRES_PORT"])
+    database = cast(str, postgres_values["FLWR_POSTGRES_DATABASE"])
+    user = cast(str, postgres_values["FLWR_POSTGRES_USER"])
+    password = cast(str, postgres_values["FLWR_POSTGRES_PASSWORD"])
+
+    return (
+        "postgresql+psycopg://"
+        f"{quote(user, safe='')}:{quote(password, safe='')}@"
+        f"{host}:{port}/{quote(database, safe='')}?sslmode=require"
+    )
 
 
 def generate_unique_route_id(route: APIRoute) -> str:
@@ -79,7 +120,7 @@ def create_app(
     """Create the SuperLink FastAPI app and its shared lifespan resources."""
     if config is None:
         is_simulation = False
-        database = os.getenv("FLWR_DATABASE", FLWR_IN_MEMORY_DB_NAME)
+        database = _get_database_from_env()
         authn_plugin, authz_plugin = load_control_auth_plugins(
             os.getenv("FLWR_ACCOUNT_AUTH_CONFIG"), verify_tls_cert=True
         )

--- a/framework/py/flwr/superlink/main_test.py
+++ b/framework/py/flwr/superlink/main_test.py
@@ -1,0 +1,84 @@
+# Copyright 2026 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for the SuperLink FastAPI app."""
+
+import pytest
+
+from flwr.supercore.constant import FLWR_IN_MEMORY_DB_NAME
+
+from .main import _FLWR_POSTGRES_ENV_VARS, _get_database_from_env
+
+
+def _clear_database_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Remove all database environment variables."""
+    monkeypatch.delenv("FLWR_DATABASE", raising=False)
+    for env_var in _FLWR_POSTGRES_ENV_VARS:
+        monkeypatch.delenv(env_var, raising=False)
+
+
+def test_get_database_from_env_defaults_to_in_memory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Database configuration should default to in-memory state."""
+    _clear_database_environment(monkeypatch)
+
+    assert _get_database_from_env() == FLWR_IN_MEMORY_DB_NAME
+
+
+def test_get_database_from_env_uses_explicit_database_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An explicit database URL should take precedence over PostgreSQL fields."""
+    monkeypatch.setenv("FLWR_DATABASE", "sqlite:///state.db")
+    for env_var in _FLWR_POSTGRES_ENV_VARS:
+        monkeypatch.setenv(env_var, "ignored")
+
+    assert _get_database_from_env() == "sqlite:///state.db"
+
+
+def test_get_database_from_env_builds_postgresql_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Prefixed PostgreSQL environment variables should form a safe URL."""
+    _clear_database_environment(monkeypatch)
+    values = {
+        "FLWR_POSTGRES_HOST": "postgres.example",
+        "FLWR_POSTGRES_PORT": "5432",
+        "FLWR_POSTGRES_DATABASE": "platform-api",
+        "FLWR_POSTGRES_USER": "platform@api",
+        "FLWR_POSTGRES_PASSWORD": "p@ss/word",
+    }
+    for env_var, value in values.items():
+        monkeypatch.setenv(env_var, value)
+
+    assert (
+        _get_database_from_env() == "postgresql+psycopg://platform%40api:p%40ss%2Fword@"
+        "postgres.example:5432/platform-api?sslmode=require"
+    )
+
+
+def test_get_database_from_env_rejects_partial_postgresql_configuration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Partial PostgreSQL configuration should fail instead of using memory."""
+    _clear_database_environment(monkeypatch)
+    monkeypatch.setenv("FLWR_POSTGRES_HOST", "postgres.example")
+
+    with pytest.raises(
+        ValueError,
+        match="FLWR_POSTGRES_PORT.*FLWR_POSTGRES_DATABASE.*FLWR_POSTGRES_USER.*"
+        "FLWR_POSTGRES_PASSWORD",
+    ):
+        _get_database_from_env()


### PR DESCRIPTION
## Summary

- support `FLWR_POSTGRES_HOST`, `FLWR_POSTGRES_PORT`, `FLWR_POSTGRES_DATABASE`, `FLWR_POSTGRES_USER`, and `FLWR_POSTGRES_PASSWORD` when starting the SuperLink FastAPI app through Uvicorn
- build an escaped `postgresql+psycopg` URL from those variables
- preserve `FLWR_DATABASE` as the higher-priority explicit database configuration
- reject partial PostgreSQL configuration instead of silently using in-memory state

## Motivation

The direct-Uvicorn SuperLink app previously defaulted to in-memory state whenever `FLWR_DATABASE` was absent. Deployments that already expose PostgreSQL credentials as individual environment variables could not configure the SQL-backed state required by the Enterprise federation manager.

## Validation

- `uv run --no-sync --python=3.11.14 python -m pytest py/flwr/superlink/main_test.py py/flwr/superlink/dependencies/linkstate_test.py py/flwr/superlink/cli/flower_superlink_test.py`
- `uv run --no-sync --python=3.11.14 python -m ruff check py/flwr/superlink/main.py py/flwr/superlink/main_test.py`
- `uv run --no-sync --python=3.11.14 python -m ruff format --check py/flwr/superlink/main.py py/flwr/superlink/main_test.py`
- `uv run --no-sync --python=3.11.14 python -m mypy py/flwr/superlink/main.py py/flwr/superlink/main_test.py`