### PR TITLE
ci(*:skip): Upgrade CI to Ubuntu 24.04

### DIFF
--- a/.github/workflows/_docker-build.yml
+++ b/.github/workflows/_docker-build.yml
@@ -84,7 +84,7 @@ jobs:
       matrix:
         platform:
           [
-            { name: "amd64", docker: "linux/amd64", runner-os: "ubuntu-22.04" },
+            { name: "amd64", docker: "linux/amd64", runner-os: "ubuntu-24.04" },
             {
               name: "arm64",
               docker: "linux/arm64",
@@ -201,7 +201,7 @@ jobs:
 
   build-manifest:
     name: Build and push Docker manifest for all platforms
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     needs: build
     outputs:

--- a/.github/workflows/_repo-authorize-manual-trigger.yml
+++ b/.github/workflows/_repo-authorize-manual-trigger.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   authorize:
     name: Authorize manual trigger
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       # Reusable workflows inherit the caller's github context, so event_name is
       # the event that triggered the caller workflow, not "workflow_call".

--- a/.github/workflows/baselines.yml
+++ b/.github/workflows/baselines.yml
@@ -19,7 +19,7 @@ jobs:
   changes:
     # To re-enable, remove `if: false` from the changes job.
     if: ${{ false }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       pull-requests: read
     outputs:
@@ -64,7 +64,7 @@ jobs:
           fi
 
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: changes
     if: ${{ needs.changes.outputs.baselines != '' && toJson(fromJson(needs.changes.outputs.baselines)) != '[]' }}
     strategy:

--- a/.github/workflows/build-deploy-non-framework-docs.yml
+++ b/.github/workflows/build-deploy-non-framework-docs.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   build_and_deploy:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: Build and deploy (non-framework)
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/datasets-e2e.yml
+++ b/.github/workflows/datasets-e2e.yml
@@ -23,7 +23,7 @@ env:
 
 jobs:
   frameworks:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     # Using approach described here:
     # https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs

--- a/.github/workflows/datasets-test.yml
+++ b/.github/workflows/datasets-test.yml
@@ -31,7 +31,7 @@ env:
 
 jobs:
   test_core:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       max-parallel: 2
       matrix:

--- a/.github/workflows/devtool-test.yml
+++ b/.github/workflows/devtool-test.yml
@@ -35,7 +35,7 @@ env:
 
 jobs:
   lint:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       max-parallel: 2
       matrix:

--- a/.github/workflows/framework-cache-cleanup.yml
+++ b/.github/workflows/framework-cache-cleanup.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   e2e-cleanup:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     # Using approach described here:
     # https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs

--- a/.github/workflows/framework-docker-build-main.yml
+++ b/.github/workflows/framework-docker-build-main.yml
@@ -47,7 +47,7 @@ jobs:
   prepare-docker-build-matrix:
     if: ${{ github.repository_owner == 'flwrlabs' }}
     name: Collect docker build parameters
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     outputs:
       pip-version: ${{ steps.versions.outputs.pip-version }}

--- a/.github/workflows/framework-docker-readme.yml
+++ b/.github/workflows/framework-docker-readme.yml
@@ -11,7 +11,7 @@ jobs:
     collect:
       if: ${{ github.repository == 'flwrlabs/flower' }}
       name: Collect Docker READMEs
-      runs-on: ubuntu-22.04
+      runs-on: ubuntu-24.04
       timeout-minutes: 10
       outputs:
         readme_files: ${{ steps.filter.outputs.readme_files }}
@@ -29,7 +29,7 @@ jobs:
     update:
       if: ${{ needs.collect.outputs.readme_files != '' && toJson(fromJson(needs.collect.outputs.readme_files)) != '[]' }}
       name: Update Docker READMEs
-      runs-on: ubuntu-22.04
+      runs-on: ubuntu-24.04
       timeout-minutes: 10
       needs: collect
       strategy:

--- a/.github/workflows/framework-docs-dispatch-release-branches.yml
+++ b/.github/workflows/framework-docs-dispatch-release-branches.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   dispatch-release-docs-builds:
     if: ${{ github.repository == 'flwrlabs/flower' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Dispatch framework-docs.yml to release branches

--- a/.github/workflows/framework-docs-update-translations.yml
+++ b/.github/workflows/framework-docs-update-translations.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   update-and-pr:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/framework-docs.yml
+++ b/.github/workflows/framework-docs.yml
@@ -30,7 +30,7 @@ env:
 
 jobs:
   build_and_deploy:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: Build and deploy framework docs
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/framework-draft-release.yml
+++ b/.github/workflows/framework-draft-release.yml
@@ -12,7 +12,7 @@ jobs:
   publish:
     if: ${{ github.repository == 'flwrlabs/flower' }}
     name: Publish draft
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/framework-e2e.yml
+++ b/.github/workflows/framework-e2e.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   changes:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       framework: ${{ steps.filter.outputs.framework }}
     steps:
@@ -38,7 +38,7 @@ jobs:
               - '.github/workflows/framework-e2e.yml'
 
   wheel:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: Build, test and upload wheel
     steps:
       - uses: actions/checkout@v5
@@ -78,7 +78,7 @@ jobs:
       dir: ${{ steps.upload.outputs.DIR }}
 
   superexec:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     needs: [changes, wheel]
     strategy:
@@ -132,7 +132,7 @@ jobs:
         run: ./../test_control_api.sh "${{ matrix.connection }}" "${{ matrix.authentication}}" "${{ matrix.engine }}"
 
   frameworks:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     needs: [changes, wheel]
     # Using approach described here:
@@ -259,7 +259,7 @@ jobs:
           key: pythonloc-${{ runner.os }}-${{ matrix.directory }}-${{ env.pythonLocation }}-${{ hashFiles(format('./framework/e2e/{0}/pyproject.toml', matrix.directory)) }}
 
   strategies:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     needs: [changes, wheel]
     strategy:
@@ -312,7 +312,7 @@ jobs:
           python test.py "${{ matrix.strat }}"
 
   apps:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     needs: [changes, wheel]
     env:
@@ -356,7 +356,7 @@ jobs:
           fi
 
   pull-app:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     needs: [changes, wheel]
     env:
@@ -399,7 +399,7 @@ jobs:
           fi
 
   build_and_install:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     needs: [changes, wheel]
     strategy:
@@ -433,7 +433,7 @@ jobs:
           flwr install *.fab
 
   numpy:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     needs: [changes, wheel]
     strategy:
@@ -515,7 +515,7 @@ jobs:
         shell: bash
 
   serverapp-heartbeat-test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     needs: [changes, wheel]
     strategy:

--- a/.github/workflows/framework-release-nightly.yml
+++ b/.github/workflows/framework-release-nightly.yml
@@ -14,7 +14,7 @@ jobs:
     uses: ./.github/workflows/_repo-authorize-manual-trigger.yml
 
   release-nightly:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: Release nightly on PyPI
     if: github.repository == 'flwrlabs/flower'
     needs: authorize-manual-trigger

--- a/.github/workflows/framework-release.yml
+++ b/.github/workflows/framework-release.yml
@@ -47,7 +47,7 @@ jobs:
   publish-wheel:
     if: ${{ github.repository == 'flwrlabs/flower' }}
     name: Publish wheel
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     needs: authorize-manual-trigger
     outputs:
@@ -74,7 +74,7 @@ jobs:
 
   prepare-docker-build-matrix:
     name: Collect docker build parameters
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     needs: publish-wheel
     outputs:

--- a/.github/workflows/framework-test.yml
+++ b/.github/workflows/framework-test.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   changes:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       framework: ${{ steps.filter.outputs.framework }}
       ex_bench: ${{ steps.filter.outputs.ex_bench }}  # Examples and Benchmarks
@@ -44,7 +44,7 @@ jobs:
               - '.github/workflows/framework-test.yml'
 
   framework_checks:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: changes
     strategy:
       fail-fast: true

--- a/.github/workflows/intelligence-docs.yml
+++ b/.github/workflows/intelligence-docs.yml
@@ -23,7 +23,7 @@ env:
 
 jobs:
   check_format_docs:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: Check Docs Formatting
     steps:
       - uses: actions/checkout@v5
@@ -38,7 +38,7 @@ jobs:
           cd dev
           uv run --no-sync docstrfmt --check ../intelligence/docs/source
   build_ts_docs:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: Build TypeScript Docs
     steps:
       - uses: actions/checkout@v5
@@ -107,7 +107,7 @@ jobs:
           path: intelligence/docs/source/swift-api-ref/
 
   build_kt_docs:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: Build Kotlin Docs
     steps:
       - uses: actions/checkout@v5
@@ -132,7 +132,7 @@ jobs:
           path: intelligence/docs/source/kt-api-ref/
 
   build_and_deploy:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [build_ts_docs, build_kt_docs]
     name: Deploy Docs
     steps:

--- a/.github/workflows/intelligence-kt.yml
+++ b/.github/workflows/intelligence-kt.yml
@@ -24,7 +24,7 @@ env:
 jobs:
   fi_kt_format:
     name: Format Check
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     defaults:
       run:
         working-directory: intelligence/kt

--- a/.github/workflows/intelligence-release.yml
+++ b/.github/workflows/intelligence-release.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   check-version:
     name: Check version consistency
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -30,7 +30,7 @@ jobs:
     needs: check-version
     if: ${{ github.repository == 'flwrlabs/flower' }}
     name: Publish Flower Intelligence TypeScript SDK to NPM
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
       - name: Checkout code
@@ -63,7 +63,7 @@ jobs:
     needs: check-version
     if: ${{ github.repository == 'flwrlabs/flower' }}
     name: Publish Flower Intelligence Kotlin SDK to Maven Central
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
 
     env:

--- a/.github/workflows/intelligence-ts.yml
+++ b/.github/workflows/intelligence-ts.yml
@@ -24,7 +24,7 @@ env:
 jobs:
   fi_ts_build:
     name: Build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -47,7 +47,7 @@ jobs:
 
   fi_ts_format:
     name: Format Check
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -70,7 +70,7 @@ jobs:
 
   fi_ts_copyright:
     name: Copyright Check
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -81,7 +81,7 @@ jobs:
 
   fi_ts_lint:
     name: Lint Check
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -104,7 +104,7 @@ jobs:
 
   fi_ts_demos:
     name: Demos
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -142,7 +142,7 @@ jobs:
 
   fi_ts_tests:
     name: Tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -178,7 +178,7 @@ jobs:
 
   fi_ts_docs:
     name: Docs build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -201,7 +201,7 @@ jobs:
 
   fi_ts_release_dry_run:
     name: Release dry-run
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
       - name: Checkout code

--- a/.github/workflows/repo-check-pr-title.yml
+++ b/.github/workflows/repo-check-pr-title.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   pr_title_check:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: Title format
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/repo-check-uv-lock.yml
+++ b/.github/workflows/repo-check-uv-lock.yml
@@ -31,7 +31,7 @@ env:
 
 jobs:
   check-uv-lock:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: Check uv.lock files
     timeout-minutes: 10
 

--- a/.github/workflows/repo-label-pr-author.yaml
+++ b/.github/workflows/repo-label-pr-author.yaml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   label-prs:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/github-script@v8
         with:

--- a/.github/workflows/repo-ping-stale-pr.yml
+++ b/.github/workflows/repo-ping-stale-pr.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   ping-stale-external-prs:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       pull-requests: read
     env:

--- a/.github/workflows/repo-ping-stale-under-discussion.yml
+++ b/.github/workflows/repo-ping-stale-under-discussion.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   ping-stale-issues:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       issues: read
     env:

--- a/.github/workflows/repo-update-pr.yml
+++ b/.github/workflows/repo-update-pr.yml
@@ -6,7 +6,7 @@ on:
       - 'main'
 jobs:
   autoupdate:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Automatically update mergeable PRs
         uses: adRise/update-pr-branch@v0.10.2


### PR DESCRIPTION
## Summary

- Upgrade all GitHub Actions runner pins from `ubuntu-22.04` to `ubuntu-24.04`
- Update the amd64 Docker build matrix runner and manifest build job
- Keep the existing arm64 runner unchanged

## Motivation

Move Flower CI workloads to the newer Ubuntu 24.04 hosted runner image while keeping the workflow behavior unchanged.

This is based on the current `main` workflow layout. A prior draft PR (#6328) contains the same migration for an older repository layout.

## Validation

- Parsed all 29 workflow files as YAML
- Confirmed the PR title passes `devtool.check_pr_title`
- Confirmed no `ubuntu-22.04` runner pins remain under `.github`
- `git diff --check`