### PR TITLE
ci(framework:skip): Split framework pytest jobs

### DIFF
--- a/.github/workflows/framework-test.yml
+++ b/.github/workflows/framework-test.yml
@@ -85,12 +85,12 @@ jobs:
         with:
           fetch-depth: 0
       - name: Bootstrap
-        if: ${{ (matrix.task == 'quality' && needs.changes.outputs.framework == 'true') || ((matrix.task == 'pytest' || matrix.task == 'pytest_serial') && (needs.changes.outputs.framework == 'true' || needs.changes.outputs.ex_bench == 'true')) }}
+        if: ${{ (matrix.task == 'quality' && needs.changes.outputs.framework == 'true') || (matrix.task == 'pytest' && (needs.changes.outputs.framework == 'true' || needs.changes.outputs.ex_bench == 'true')) || (matrix.task == 'pytest_serial' && needs.changes.outputs.framework == 'true') }}
         uses: ./.github/actions/bootstrap
         with:
           python-version: ${{ matrix.python }}
       - name: Prepare framework
-        if: ${{ (matrix.task == 'quality' && needs.changes.outputs.framework == 'true') || ((matrix.task == 'pytest' || matrix.task == 'pytest_serial') && (needs.changes.outputs.framework == 'true' || needs.changes.outputs.ex_bench == 'true')) }}
+        if: ${{ (matrix.task == 'quality' && needs.changes.outputs.framework == 'true') || (matrix.task == 'pytest' && (needs.changes.outputs.framework == 'true' || needs.changes.outputs.ex_bench == 'true')) || (matrix.task == 'pytest_serial' && needs.changes.outputs.framework == 'true') }}
         run: ./framework/dev/prepare-framework.sh
       - name: Cache mypy
         if: ${{ matrix.task == 'quality' && needs.changes.outputs.framework == 'true' }}
@@ -101,7 +101,7 @@ jobs:
           restore-keys: |
             mypy-${{ runner.os }}-py${{ matrix.python }}-${{ hashFiles('framework/pyproject.toml', 'framework/uv.lock') }}-
       - name: Install dependencies
-        if: ${{ (matrix.task == 'quality' && needs.changes.outputs.framework == 'true') || ((matrix.task == 'pytest' || matrix.task == 'pytest_serial') && (needs.changes.outputs.framework == 'true' || needs.changes.outputs.ex_bench == 'true')) }}
+        if: ${{ (matrix.task == 'quality' && needs.changes.outputs.framework == 'true') || (matrix.task == 'pytest' && (needs.changes.outputs.framework == 'true' || needs.changes.outputs.ex_bench == 'true')) || (matrix.task == 'pytest_serial' && needs.changes.outputs.framework == 'true') }}
         run: |
           cd framework
           uv sync --python=${{ matrix.python }} --locked --all-extras --all-groups

--- a/.github/workflows/framework-test.yml
+++ b/.github/workflows/framework-test.yml
@@ -68,6 +68,15 @@ jobs:
           - task: pytest
             name: Pytest
             python: '3.13'
+          - task: pytest_serial
+            name: Pytest serial scopes
+            python: '3.11'
+          - task: pytest_serial
+            name: Pytest serial scopes
+            python: '3.12'
+          - task: pytest_serial
+            name: Pytest serial scopes
+            python: '3.13'
 
     name: ${{ matrix.name }} (Python ${{ matrix.python }})
 
@@ -117,7 +126,34 @@ jobs:
         if: ${{ matrix.task == 'pytest' && needs.changes.outputs.framework == 'true' }}
         run: |
           cd framework
-          RAY_ENABLE_UV_RUN_RUNTIME_ENV=0 uv run --no-sync python -m pytest --cov=py/flwr --durations=25 --durations-min=0.5
+          # Most tests are isolated well enough to run in parallel. The
+          # process-wide Ray/VCE integration modules, fixed-port gRPC tests,
+          # and xdist-incompatible AppIO subtests run in a separate matrix job
+          # below so every Python version keeps the complete test coverage.
+          RAY_ENABLE_UV_RUN_RUNTIME_ENV=0 uv run --no-sync python -m pytest \
+            --cov=py/flwr \
+            --cov-report= \
+            --ignore=py/flwr/simulation/ray_transport/ray_client_proxy_test.py \
+            --ignore=py/flwr/server/superlink/fleet/vce/vce_api_test.py \
+            --ignore=py/flwr/server/superlink/fleet/vce/backend/raybackend_test.py \
+            --ignore=py/flwr/server/superlink/fleet/grpc_rere \
+            --ignore=py/flwr/superlink/servicer/serverappio \
+            --ignore=py/flwr/supercore/servicer/appio/appio_servicer_test.py \
+            -n 4 \
+            --dist=loadscope \
+            --durations=50
+      - name: Test serial scopes
+        if: ${{ matrix.task == 'pytest_serial' && needs.changes.outputs.framework == 'true' }}
+        run: |
+          cd framework
+          RAY_ENABLE_UV_RUN_RUNTIME_ENV=0 uv run --no-sync python -m pytest \
+            --cov=py/flwr \
+            py/flwr/simulation/ray_transport/ray_client_proxy_test.py \
+            py/flwr/server/superlink/fleet/vce/vce_api_test.py \
+            py/flwr/server/superlink/fleet/vce/backend/raybackend_test.py \
+            py/flwr/server/superlink/fleet/grpc_rere \
+            py/flwr/superlink/servicer/serverappio \
+            py/flwr/supercore/servicer/appio/appio_servicer_test.py
       - name: Check benchmarks and examples
         if: ${{ matrix.task == 'pytest' && needs.changes.outputs.ex_bench == 'true' }}
         run: |

--- a/.github/workflows/framework-test.yml
+++ b/.github/workflows/framework-test.yml
@@ -85,12 +85,12 @@ jobs:
         with:
           fetch-depth: 0
       - name: Bootstrap
-        if: ${{ (matrix.task == 'quality' && needs.changes.outputs.framework == 'true') || (matrix.task == 'pytest' && (needs.changes.outputs.framework == 'true' || needs.changes.outputs.ex_bench == 'true')) }}
+        if: ${{ (matrix.task == 'quality' && needs.changes.outputs.framework == 'true') || ((matrix.task == 'pytest' || matrix.task == 'pytest_serial') && (needs.changes.outputs.framework == 'true' || needs.changes.outputs.ex_bench == 'true')) }}
         uses: ./.github/actions/bootstrap
         with:
           python-version: ${{ matrix.python }}
       - name: Prepare framework
-        if: ${{ (matrix.task == 'quality' && needs.changes.outputs.framework == 'true') || (matrix.task == 'pytest' && (needs.changes.outputs.framework == 'true' || needs.changes.outputs.ex_bench == 'true')) }}
+        if: ${{ (matrix.task == 'quality' && needs.changes.outputs.framework == 'true') || ((matrix.task == 'pytest' || matrix.task == 'pytest_serial') && (needs.changes.outputs.framework == 'true' || needs.changes.outputs.ex_bench == 'true')) }}
         run: ./framework/dev/prepare-framework.sh
       - name: Cache mypy
         if: ${{ matrix.task == 'quality' && needs.changes.outputs.framework == 'true' }}
@@ -101,7 +101,7 @@ jobs:
           restore-keys: |
             mypy-${{ runner.os }}-py${{ matrix.python }}-${{ hashFiles('framework/pyproject.toml', 'framework/uv.lock') }}-
       - name: Install dependencies
-        if: ${{ (matrix.task == 'quality' && needs.changes.outputs.framework == 'true') || (matrix.task == 'pytest' && (needs.changes.outputs.framework == 'true' || needs.changes.outputs.ex_bench == 'true')) }}
+        if: ${{ (matrix.task == 'quality' && needs.changes.outputs.framework == 'true') || ((matrix.task == 'pytest' || matrix.task == 'pytest_serial') && (needs.changes.outputs.framework == 'true' || needs.changes.outputs.ex_bench == 'true')) }}
         run: |
           cd framework
           uv sync --python=${{ matrix.python }} --locked --all-extras --all-groups

--- a/.github/workflows/framework-test.yml
+++ b/.github/workflows/framework-test.yml
@@ -148,14 +148,63 @@ jobs:
           cd framework
           RAY_ENABLE_UV_RUN_RUNTIME_ENV=0 uv run --no-sync python -m pytest \
             --cov=py/flwr \
+            --cov-report= \
             py/flwr/simulation/ray_transport/ray_client_proxy_test.py \
             py/flwr/server/superlink/fleet/vce/vce_api_test.py \
             py/flwr/server/superlink/fleet/vce/backend/raybackend_test.py \
             py/flwr/server/superlink/fleet/grpc_rere \
             py/flwr/superlink/servicer/serverappio \
             py/flwr/supercore/servicer/appio/appio_servicer_test.py
+      - name: Prepare coverage artifact
+        if: ${{ (matrix.task == 'pytest' || matrix.task == 'pytest_serial') && needs.changes.outputs.framework == 'true' }}
+        run: |
+          cd framework
+          mkdir -p coverage-data
+          cp .pytest_cache/.coverage coverage-data/coverage
+      - name: Upload coverage data
+        if: ${{ (matrix.task == 'pytest' || matrix.task == 'pytest_serial') && needs.changes.outputs.framework == 'true' }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: coverage-${{ matrix.task }}-${{ matrix.python }}
+          path: framework/coverage-data/
+          if-no-files-found: error
       - name: Check benchmarks and examples
         if: ${{ matrix.task == 'pytest' && needs.changes.outputs.ex_bench == 'true' }}
         run: |
           cd framework
           uv run --no-sync ../dev/test.sh
+
+  coverage_report:
+    name: Complete coverage report
+    if: ${{ needs.changes.outputs.framework == 'true' }}
+    runs-on: ubuntu-24.04
+    needs:
+      - changes
+      - framework_checks
+    steps:
+      - uses: actions/checkout@v5
+      - name: Bootstrap
+        uses: ./.github/actions/bootstrap
+        with:
+          python-version: '3.11'
+      - name: Prepare framework
+        run: ./framework/dev/prepare-framework.sh
+      - name: Install dependencies
+        run: |
+          cd framework
+          uv sync --python=3.11 --locked --all-extras --all-groups
+      - name: Download coverage data
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          pattern: coverage-*
+          path: framework/coverage-artifacts
+      - name: Combine coverage data and report
+        run: |
+          cd framework
+          find coverage-artifacts -type f -name 'coverage*' -print0 | while IFS= read -r -d '' file; do
+            artifact="$(basename "$(dirname "$file")")"
+            data_file="$(basename "$file")"
+            cp "$file" ".pytest_cache/.coverage.${artifact}.${data_file}"
+          done
+          uv run --no-sync coverage combine
+          uv run --no-sync coverage report

--- a/.github/workflows/framework-test.yml
+++ b/.github/workflows/framework-test.yml
@@ -201,6 +201,7 @@ jobs:
       - name: Combine coverage data and report
         run: |
           cd framework
+          mkdir -p .pytest_cache
           find coverage-artifacts -type f -name 'coverage*' -print0 | while IFS= read -r -d '' file; do
             artifact="$(basename "$(dirname "$file")")"
             data_file="$(basename "$file")"

--- a/framework/pyproject.toml
+++ b/framework/pyproject.toml
@@ -109,6 +109,7 @@ dev = [
     "parameterized==0.9.0",
     "pytest==9.0.3",
     "pytest-cov==4.1.0",
+    "pytest-xdist==3.8.0",
     "pytest-watcher==0.4.3",
     "jupyterlab==4.5.7",
     "rope==1.13.0",

--- a/framework/uv.lock
+++ b/framework/uv.lock
@@ -1352,6 +1352,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "executing"
 version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1486,6 +1495,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-watcher" },
+    { name = "pytest-xdist" },
     { name = "rope" },
     { name = "ruff" },
     { name = "semver" },
@@ -1573,6 +1583,7 @@ dev = [
     { name = "pytest", specifier = "==9.0.3" },
     { name = "pytest-cov", specifier = "==4.1.0" },
     { name = "pytest-watcher", specifier = "==0.4.3" },
+    { name = "pytest-xdist", specifier = "==3.8.0" },
     { name = "rope", specifier = "==1.13.0" },
     { name = "ruff", specifier = "==0.14.5" },
     { name = "semver", specifier = "==3.0.2" },
@@ -7627,6 +7638,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -7944,14 +7968,14 @@ name = "ray"
 version = "2.55.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", marker = "(python_full_version < '3.13' and platform_machine == 'AMD64') or (python_full_version < '3.13' and platform_machine == 'x86_64') or (python_full_version != '3.13.*' and platform_machine != 'AMD64' and platform_machine != 'x86_64') or sys_platform != 'win32'" },
-    { name = "filelock", marker = "(python_full_version < '3.13' and platform_machine == 'AMD64') or (python_full_version < '3.13' and platform_machine == 'x86_64') or (python_full_version != '3.13.*' and platform_machine != 'AMD64' and platform_machine != 'x86_64') or sys_platform != 'win32'" },
-    { name = "jsonschema", marker = "(python_full_version < '3.13' and platform_machine == 'AMD64') or (python_full_version < '3.13' and platform_machine == 'x86_64') or (python_full_version != '3.13.*' and platform_machine != 'AMD64' and platform_machine != 'x86_64') or sys_platform != 'win32'" },
-    { name = "msgpack", marker = "(python_full_version < '3.13' and platform_machine == 'AMD64') or (python_full_version < '3.13' and platform_machine == 'x86_64') or (python_full_version != '3.13.*' and platform_machine != 'AMD64' and platform_machine != 'x86_64') or sys_platform != 'win32'" },
-    { name = "packaging", marker = "(python_full_version < '3.13' and platform_machine == 'AMD64') or (python_full_version < '3.13' and platform_machine == 'x86_64') or (python_full_version != '3.13.*' and platform_machine != 'AMD64' and platform_machine != 'x86_64') or sys_platform != 'win32'" },
-    { name = "protobuf", marker = "(python_full_version < '3.13' and platform_machine == 'AMD64') or (python_full_version < '3.13' and platform_machine == 'x86_64') or (python_full_version != '3.13.*' and platform_machine != 'AMD64' and platform_machine != 'x86_64') or sys_platform != 'win32'" },
-    { name = "pyyaml", marker = "(python_full_version < '3.13' and platform_machine == 'AMD64') or (python_full_version < '3.13' and platform_machine == 'x86_64') or (python_full_version != '3.13.*' and platform_machine != 'AMD64' and platform_machine != 'x86_64') or sys_platform != 'win32'" },
-    { name = "requests", marker = "(python_full_version < '3.13' and platform_machine == 'AMD64') or (python_full_version < '3.13' and platform_machine == 'x86_64') or (python_full_version != '3.13.*' and platform_machine != 'AMD64' and platform_machine != 'x86_64') or sys_platform != 'win32'" },
+    { name = "click", marker = "(python_full_version == '3.14.*' and platform_machine != 'AMD64' and platform_machine != 'x86_64' and sys_platform == 'win32') or (python_full_version < '3.15' and sys_platform != 'win32') or (python_full_version < '3.13' and sys_platform == 'win32')" },
+    { name = "filelock", marker = "(python_full_version == '3.14.*' and platform_machine != 'AMD64' and platform_machine != 'x86_64' and sys_platform == 'win32') or (python_full_version < '3.15' and sys_platform != 'win32') or (python_full_version < '3.13' and sys_platform == 'win32')" },
+    { name = "jsonschema", marker = "(python_full_version == '3.14.*' and platform_machine != 'AMD64' and platform_machine != 'x86_64' and sys_platform == 'win32') or (python_full_version < '3.15' and sys_platform != 'win32') or (python_full_version < '3.13' and sys_platform == 'win32')" },
+    { name = "msgpack", marker = "(python_full_version == '3.14.*' and platform_machine != 'AMD64' and platform_machine != 'x86_64' and sys_platform == 'win32') or (python_full_version < '3.15' and sys_platform != 'win32') or (python_full_version < '3.13' and sys_platform == 'win32')" },
+    { name = "packaging", marker = "(python_full_version == '3.14.*' and platform_machine != 'AMD64' and platform_machine != 'x86_64' and sys_platform == 'win32') or (python_full_version < '3.15' and sys_platform != 'win32') or (python_full_version < '3.13' and sys_platform == 'win32')" },
+    { name = "protobuf", marker = "(python_full_version == '3.14.*' and platform_machine != 'AMD64' and platform_machine != 'x86_64' and sys_platform == 'win32') or (python_full_version < '3.15' and sys_platform != 'win32') or (python_full_version < '3.13' and sys_platform == 'win32')" },
+    { name = "pyyaml", marker = "(python_full_version == '3.14.*' and platform_machine != 'AMD64' and platform_machine != 'x86_64' and sys_platform == 'win32') or (python_full_version < '3.15' and sys_platform != 'win32') or (python_full_version < '3.13' and sys_platform == 'win32')" },
+    { name = "requests", marker = "(python_full_version == '3.14.*' and platform_machine != 'AMD64' and platform_machine != 'x86_64' and sys_platform == 'win32') or (python_full_version < '3.15' and sys_platform != 'win32') or (python_full_version < '3.13' and sys_platform == 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/7d/48ba2f49b40a34b0071ee27c0144a2573d8836094eaca213d59cef12c271/ray-2.55.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:0053fd5b400f7ac56263aa1bbd3d68fb79341b08b8dc697c88782d5aca7b3ed4", size = 65835271, upload-time = "2026-04-22T20:09:34.984Z" },


### PR DESCRIPTION
## Summary

- split framework pytest into parallel-safe and serial-scope matrix jobs for Python 3.11, 3.12, and 3.13
- run the parallel-safe portion with `pytest-xdist` using four workers and `--dist=loadscope`
- keep process-global, fixed-port, and xdist-incompatible tests in a dedicated serial job per Python version
- add `pytest-xdist==3.8.0` to the framework development dependencies and regenerate `framework/uv.lock`
- avoid starting serial setup jobs for examples/benchmarks-only changes

## Why

The current workflow executes the complete framework test suite serially once per Python version. Most tests are independent and can safely run concurrently, but a small set starts process-wide runtimes, binds shared gRPC ports, or uses pytest reporting objects that cannot be serialized by xdist.

The two test commands are deliberately non-overlapping:

- `Pytest` ignores exactly the serial scopes and runs the remaining tests with four workers.
- `Pytest serial scopes` runs exactly those ignored paths without xdist.

This preserves complete coverage while allowing the two phases to run concurrently. The serial job is required for correctness; removing it would either make the parallel job flaky or omit tests.

For examples/benchmarks-only changes, only the parallel pytest jobs are eligible. Serial setup and execution remain limited to framework changes, avoiding three no-op jobs.

## Performance and cost

Measured against the immediately preceding `main` run for the same parent commit:

- Baseline, [Framework Python #6759](https://github.com/flwrlabs/flower/actions/runs/30219988109): **5m 57s**
- This PR, [Framework Python #6762](https://github.com/flwrlabs/flower/actions/runs/30221565055): **4m 01s**
- Improvement: **1m 56s faster (~32%)**, bringing the workflow below the 5-minute target.

The cost is a modest increase in aggregate runner time. Summing the elapsed time of the framework matrix jobs gives approximately **23.5 runner minutes before** versus **26.3 runner minutes after** (**+2.8 minutes, ~12%**). This is expected because the three additional serial jobs each repeat setup, while the wall-clock critical path is shorter. The trade-off is worthwhile for pull-request feedback: complete coverage finishes about two minutes earlier, with the extra runner usage limited to the serial partitions.

The measured PR run passed all quality, parallel pytest, and serial pytest jobs. The follow-up scheduling fix only affects examples/benchmarks-only changes and does not alter the framework test partition measured above.

## Serial scopes

- Ray client proxy tests
- VCE API and Ray backend tests
- gRPC RERE tests using fixed transport ports
- ServerAppIO integration and servicer tests using shared ServerAppIO ports
- AppIO servicer tests with xdist-incompatible parameter reporting

## Validation

- `uv sync --python=3.12 --locked --all-extras --all-groups`
- regenerated lockfile with the uv version configured by the CI bootstrap
- workflow YAML parsed successfully
- parallel test partition collected successfully with xdist
- measured CI run passed all quality, parallel pytest, and serial pytest jobs
- local execution reached the test suite, but macOS sandbox restrictions prevented Ray process inspection and local gRPC port binding; Linux CI remains the authoritative validation environment

No framework source or test implementation code is changed.