### PR TITLE
feat(framework): Mention `superlink` to login against upon an authentication error

### DIFF
--- a/framework/py/flwr/cli/utils.py
+++ b/framework/py/flwr/cli/utils.py
@@ -458,8 +458,13 @@ def flwr_cli_grpc_exc_handler(
         # of the FlowerError catalog.
         # pylint: disable-next=E1101
         if e.code() == grpc.StatusCode.UNAUTHENTICATED:
+            superlink = cast(
+                str | None, click.get_current_context().params.get("superlink")
+            )
+            if superlink is None:
+                superlink = read_superlink_connection().name
             raise click.ClickException(
-                "Authentication failed. Please run `flwr login`"
+                f"Authentication failed. Please run `flwr login {superlink}`"
                 " to authenticate and try again."
             ) from None
         if e.code() == grpc.StatusCode.UNAVAILABLE:

--- a/framework/py/flwr/cli/utils.py
+++ b/framework/py/flwr/cli/utils.py
@@ -458,13 +458,21 @@ def flwr_cli_grpc_exc_handler(
         # of the FlowerError catalog.
         # pylint: disable-next=E1101
         if e.code() == grpc.StatusCode.UNAUTHENTICATED:
-            superlink = cast(
-                str | None, click.get_current_context().params.get("superlink")
-            )
-            if superlink is None:
-                superlink = read_superlink_connection().name
+            login_command = "flwr login"
+
+            # Include the connection name when this handler runs within a CLI command.
+            if ctx := click.get_current_context(silent=True):
+                try:
+                    # Resolve the default connection when no name was explicitly given.
+                    connection = read_superlink_connection(
+                        cast(str | None, ctx.params.get("superlink"))
+                    )
+                    login_command += f" {connection.name}"
+                except click.ClickException:
+                    # Preserve the authentication error if the config cannot be read.
+                    pass
             raise click.ClickException(
-                f"Authentication failed. Please run `flwr login {superlink}`"
+                f"Authentication failed. Please run `{login_command}`"
                 " to authenticate and try again."
             ) from None
         if e.code() == grpc.StatusCode.UNAVAILABLE:

--- a/framework/py/flwr/cli/utils_test.py
+++ b/framework/py/flwr/cli/utils_test.py
@@ -73,18 +73,6 @@ def _grpc_error_with_details(details: str) -> grpc.RpcError:
     return cast(grpc.RpcError, _GrpcErrorWithDetails(details))
 
 
-class _UnauthenticatedGrpcError(grpc.RpcError):
-    """Test helper for an unauthenticated gRPC error."""
-
-    def details(self) -> str:
-        """Return gRPC error details."""
-        return "Access denied"
-
-    def code(self) -> grpc.StatusCode:
-        """Return the unauthenticated gRPC status code."""
-        return grpc.StatusCode.UNAUTHENTICATED
-
-
 def _flower_error_details(code: ApiErrorCode, public_details: str | None = None) -> str:
     """Return serialized FlowerError details as sent through gRPC."""
     return FlowerError(code, "internal details", public_details).to_json(
@@ -320,18 +308,28 @@ def test_grpc_unauthenticated_error_includes_connection_name(
 ) -> None:
     """Suggest logging in to the selected SuperLink connection."""
     command = click.Command("ls")
+    grpc_error = grpc.RpcError()
 
     with (
         click.Context(command, info_name="ls") as ctx,
         patch(
             "flwr.cli.utils.read_superlink_connection",
-            return_value=SuperLinkConnection(name="default", address="localhost:9093"),
+            return_value=SuperLinkConnection(
+                name=expected_name, address="localhost:9093"
+            ),
+        ),
+        patch.object(grpc_error, "details", return_value="Access denied", create=True),
+        patch.object(
+            grpc_error,
+            "code",
+            return_value=grpc.StatusCode.UNAUTHENTICATED,
+            create=True,
         ),
     ):
         ctx.params["superlink"] = superlink
         with pytest.raises(click.ClickException) as exc_info:
             with flwr_cli_grpc_exc_handler():
-                raise _UnauthenticatedGrpcError()
+                raise grpc_error
 
     assert exc_info.value.message == (
         f"Authentication failed. Please run `flwr login {expected_name}` "

--- a/framework/py/flwr/cli/utils_test.py
+++ b/framework/py/flwr/cli/utils_test.py
@@ -73,6 +73,18 @@ def _grpc_error_with_details(details: str) -> grpc.RpcError:
     return cast(grpc.RpcError, _GrpcErrorWithDetails(details))
 
 
+class _UnauthenticatedGrpcError(grpc.RpcError):
+    """Test helper for an unauthenticated gRPC error."""
+
+    def details(self) -> str:
+        """Return gRPC error details."""
+        return "Access denied"
+
+    def code(self) -> grpc.StatusCode:
+        """Return the unauthenticated gRPC status code."""
+        return grpc.StatusCode.UNAUTHENTICATED
+
+
 def _flower_error_details(code: ApiErrorCode, public_details: str | None = None) -> str:
     """Return serialized FlowerError details as sent through gRPC."""
     return FlowerError(code, "internal details", public_details).to_json(
@@ -297,6 +309,34 @@ def test_custom_grpc_err_handler() -> None:
             raise grpc_error
 
     mock_handler.assert_called_once_with(grpc_error)
+
+
+@pytest.mark.parametrize(
+    ("superlink", "expected_name"),
+    [("prod", "prod"), (None, "default")],
+)
+def test_grpc_unauthenticated_error_includes_connection_name(
+    superlink: str | None, expected_name: str
+) -> None:
+    """Suggest logging in to the selected SuperLink connection."""
+    command = click.Command("ls")
+
+    with (
+        click.Context(command, info_name="ls") as ctx,
+        patch(
+            "flwr.cli.utils.read_superlink_connection",
+            return_value=SuperLinkConnection(name="default", address="localhost:9093"),
+        ),
+    ):
+        ctx.params["superlink"] = superlink
+        with pytest.raises(click.ClickException) as exc_info:
+            with flwr_cli_grpc_exc_handler():
+                raise _UnauthenticatedGrpcError()
+
+    assert exc_info.value.message == (
+        f"Authentication failed. Please run `flwr login {expected_name}` "
+        "to authenticate and try again."
+    )
 
 
 def test_format_flower_error() -> None:


### PR DESCRIPTION
Before it response said plainly "do `flwr login`" w/o specifying the `SuperLinkConnection` name:

```shell
uv run --python=3.11.14 --all-extras --all-groups flwr ls supergrid
Using SuperLink: supergrid (supergrid.flower.ai)
📄 Listing all runs...
╭─ Error ──────────────────────────────────────────────────────────────────────────────────────╮
│ Authentication failed. Please run `flwr login` to authenticate and try again.                │
╰──────────────────────────────────────────────────────────────────────────────────────────────╯
```

Now, it indicates which one to use (based on the command that triggered it: in this example `flwr ls`):

```shell
uv run --python=3.11.14 --all-extras --all-groups flwr ls supergrid
Using SuperLink: supergrid (supergrid.flower.ai)
📄 Listing all runs...
╭─ Error ──────────────────────────────────────────────────────────────────────────────────────╮
│ Authentication failed. Please run `flwr login supergrid` to authenticate and try again.      │
╰──────────────────────────────────────────────────────────────────────────────────────────────╯
```