### PR TITLE
refactor(framework): Add fab declarative model

### DIFF
--- a/framework/py/flwr/supercore/state/schema/corestate_models.py
+++ b/framework/py/flwr/supercore/state/schema/corestate_models.py
@@ -14,7 +14,7 @@
 # ==============================================================================
 """SQLAlchemy declarative model definitions for CoreState."""
 
-from sqlalchemy import Float, Index, MetaData, String
+from sqlalchemy import Float, Index, LargeBinary, MetaData, String
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 
@@ -33,3 +33,13 @@ class NonceStore(FlwrBase):
     namespace: Mapped[str] = mapped_column(String, primary_key=True, nullable=False)
     nonce: Mapped[str] = mapped_column(String, primary_key=True, nullable=False)
     expires_at: Mapped[float] = mapped_column(Float, nullable=False)
+
+
+class Fab(FlwrBase):
+    """Represent stored FAB contents."""
+
+    __tablename__ = "fab"
+
+    fab_hash: Mapped[str] = mapped_column(String, primary_key=True)
+    content: Mapped[bytes] = mapped_column(LargeBinary, nullable=False)
+    verifications: Mapped[str] = mapped_column(String, nullable=False)

--- a/framework/py/flwr/supercore/state/schema/corestate_models_test.py
+++ b/framework/py/flwr/supercore/state/schema/corestate_models_test.py
@@ -16,6 +16,7 @@
 
 from typing import Any
 
+import pytest
 from sqlalchemy import Column, Table
 
 from flwr.supercore.state.schema.corestate_models import FlwrBase
@@ -68,10 +69,11 @@ def _primary_key_signature(table: Table) -> tuple[str, ...]:
     return tuple(column.name for column in table.primary_key.columns)
 
 
-def test_nonce_store_declarative_model_matches_core_metadata() -> None:
-    """Ensure nonce_store declarative metadata preserves the Core table schema."""
-    core_table = create_corestate_metadata().tables["nonce_store"]
-    model_table = FlwrBase.metadata.tables["nonce_store"]
+@pytest.mark.parametrize("table_name", ["nonce_store", "fab"])
+def test_declarative_model_matches_core_metadata(table_name: str) -> None:
+    """Ensure declarative metadata preserves the Core table schema."""
+    core_table = create_corestate_metadata().tables[table_name]
+    model_table = FlwrBase.metadata.tables[table_name]
 
     assert model_table.name == core_table.name
     assert [_column_signature(column) for column in model_table.columns] == [


### PR DESCRIPTION
Issue

### Description

Some state schema definitions are still represented only as SQLAlchemy Core tables.

### Related issues/PRs

N/A

## Proposal

### Explanation

This PR adds a declarative model for the existing `fab` table and extends the metadata parity test to cover it.

It does not change runtime behavior, migrations, schema, or public APIs.

### Checklist

- [x] Implement proposed change
- [x] Write tests
- [x] Update documentation
- [x] Address LLM-reviewer comments, if applicable (e.g., GitHub Copilot)
- [x] Make CI checks pass
- [x] Ping maintainers on Slack (channel `#contributions`)

### Any other comments?

No documentation update because this is an internal schema representation change only.

Tested from `framework/`:

```bash
uv run --no-sync --python=3.11.14 python -m pytest py/flwr/supercore/state/schema/corestate_models_test.py
uv run --no-sync --python=3.11.14 python -m ruff check py/flwr/supercore/state/schema/corestate_models.py py/flwr/supercore/state/schema/corestate_models_test.py
uv run --no-sync --python=3.11.14 python -m mypy py/flwr/supercore/state/schema/corestate_models.py py/flwr/supercore/state/schema/corestate_models_test.py
uv run --no-sync --python=3.11.14 python -m black --check py/flwr/supercore/state/schema/corestate_models.py py/flwr/supercore/state/schema/corestate_models_test.py
uv run --no-sync --python=3.11.14 python -m pytest py/flwr/supercore/state/alembic/utils_test.py -k "test_migrated_schema_matches_metadata"
uv run --no-sync --python=3.11.14 python -m devtool.check_pr_title 'refactor(framework): Add fab declarative model'