### PR TITLE
refactor(framework): Add run series declarative models

### DIFF
--- a/framework/py/flwr/supercore/state/schema/corestate_models.py
+++ b/framework/py/flwr/supercore/state/schema/corestate_models.py
@@ -14,7 +14,18 @@
 # ==============================================================================
 """SQLAlchemy declarative model definitions for CoreState."""
 
-from sqlalchemy import Float, Index, LargeBinary, MetaData, String
+from datetime import datetime
+
+from sqlalchemy import (
+    TIMESTAMP,
+    BigInteger,
+    Float,
+    Index,
+    Integer,
+    LargeBinary,
+    MetaData,
+    String,
+)
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 
@@ -43,3 +54,39 @@ class Fab(FlwrBase):
     fab_hash: Mapped[str] = mapped_column(String, primary_key=True)
     content: Mapped[bytes] = mapped_column(LargeBinary, nullable=False)
     verifications: Mapped[str] = mapped_column(String, nullable=False)
+
+
+class RunSeries(FlwrBase):
+    """Represent a run series."""
+
+    __tablename__ = "run_series"
+
+    series_id: Mapped[int] = mapped_column(BigInteger, primary_key=True, nullable=False)
+    federation_id: Mapped[str] = mapped_column(String, nullable=False)
+    description: Mapped[str | None] = mapped_column(String, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False
+    )
+
+
+class SeriesContext(FlwrBase):
+    """Represent context data for a run series."""
+
+    __tablename__ = "series_context"
+
+    series_id: Mapped[int] = mapped_column(BigInteger, primary_key=True, nullable=False)
+    context: Mapped[bytes | None] = mapped_column(LargeBinary)
+
+
+class SeriesRuns(FlwrBase):
+    """Represent the runs belonging to a run series."""
+
+    __tablename__ = "series_runs"
+    __table_args__ = (Index("idx_series_runs_series_id", "series_id"),)
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    series_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    run_id: Mapped[int] = mapped_column(BigInteger, unique=True, nullable=False)

--- a/framework/py/flwr/supercore/state/schema/corestate_models_test.py
+++ b/framework/py/flwr/supercore/state/schema/corestate_models_test.py
@@ -69,7 +69,9 @@ def _primary_key_signature(table: Table) -> tuple[str, ...]:
     return tuple(column.name for column in table.primary_key.columns)
 
 
-@pytest.mark.parametrize("table_name", ["nonce_store", "fab"])
+@pytest.mark.parametrize(
+    "table_name", ["nonce_store", "fab", "run_series", "series_context", "series_runs"]
+)
 def test_declarative_model_matches_core_metadata(table_name: str) -> None:
     """Ensure declarative metadata preserves the Core table schema."""
     core_table = create_corestate_metadata().tables[table_name]


### PR DESCRIPTION
## Issue

### Description

Some state schema definitions are still represented only as SQLAlchemy Core tables.

### Related issues/PRs

N/A

## Proposal

### Explanation

This PR adds declarative models for the existing run-series tables and extends the metadata parity test to cover them.

It does not change runtime behavior, migrations, schema, or public APIs.

### Checklist

- [x] Implement proposed change
- [x] Write tests
- [x] Update documentation
- [x] Address LLM-reviewer comments, if applicable (e.g., GitHub Copilot)
- [x] Make CI checks pass
- [x] Ping maintainers on Slack (channel `#contributions`)

### Any other comments?

No documentation update because this is an internal schema representation change only.

Tested from `framework/`:

```bash
uv run --no-sync --python=3.11.14 python -m pytest py/flwr/supercore/state/schema/corestate_models_test.py
uv run --no-sync --python=3.11.14 python -m ruff check py/flwr/supercore/state/schema/corestate_models.py py/flwr/supercore/state/schema/corestate_models_test.py
uv run --no-sync --python=3.11.14 python -m mypy py/flwr/supercore/state/schema/corestate_models.py py/flwr/supercore/state/schema/corestate_models_test.py
uv run --no-sync --python=3.11.14 python -m black --check py/flwr/supercore/state/schema/corestate_models.py py/flwr/supercore/state/schema/corestate_models_test.py
uv run --no-sync --python=3.11.14 python -m pytest py/flwr/supercore/state/alembic/utils_test.py -k "test_migrated_schema_matches_metadata"
uv run --no-sync --python=3.11.14 python -m devtool.check_pr_title 'refactor(framework): Add run series declarative models'
```