### PR TITLE
fix(framework): Raise when Message-API aggregators get zero total weight

### DIFF
--- a/framework/py/flwr/serverapp/strategy/strategy_utils.py
+++ b/framework/py/flwr/serverapp/strategy/strategy_utils.py
@@ -81,7 +81,7 @@ def aggregate_arrayrecords(
     total_weight = sum(weights)
     if total_weight == 0:
         raise InconsistentMessageReplies(
-            reason=f"The total '{weighting_metric_name}' across all replies is zero, "
+            reason=f"The total `{weighting_metric_name}` across all replies is zero, "
             "so a weighted aggregation is undefined. Skipping aggregation."
         )
     weight_factors = [w / total_weight for w in weights]
@@ -121,7 +121,7 @@ def aggregate_metricrecords(
     total_weight = sum(weights)
     if total_weight == 0:
         raise InconsistentMessageReplies(
-            reason=f"The total '{weighting_metric_name}' across all replies is zero, "
+            reason=f"The total `{weighting_metric_name}` across all replies is zero, "
             "so a weighted aggregation is undefined. Skipping aggregation."
         )
     weight_factors = [w / total_weight for w in weights]

--- a/framework/py/flwr/serverapp/strategy/strategy_utils.py
+++ b/framework/py/flwr/serverapp/strategy/strategy_utils.py
@@ -79,6 +79,11 @@ def aggregate_arrayrecords(
 
     # Average
     total_weight = sum(weights)
+    if total_weight == 0:
+        raise InconsistentMessageReplies(
+            reason=f"The total '{weighting_metric_name}' across all replies is zero, "
+            "so a weighted aggregation is undefined. Skipping aggregation."
+        )
     weight_factors = [w / total_weight for w in weights]
 
     # Perform weighted aggregation
@@ -114,6 +119,11 @@ def aggregate_metricrecords(
 
     # Average
     total_weight = sum(weights)
+    if total_weight == 0:
+        raise InconsistentMessageReplies(
+            reason=f"The total '{weighting_metric_name}' across all replies is zero, "
+            "so a weighted aggregation is undefined. Skipping aggregation."
+        )
     weight_factors = [w / total_weight for w in weights]
 
     aggregated_metrics = MetricRecord()

--- a/framework/py/flwr/serverapp/strategy/strategy_utils_test.py
+++ b/framework/py/flwr/serverapp/strategy/strategy_utils_test.py
@@ -112,6 +112,23 @@ def test_arrayrecords_aggregation_with_ndim_zero() -> None:
     assert aggrd.object_id == ArrayRecord([np.array(avg_list[0])]).object_id
 
 
+def test_aggregation_with_zero_total_weight() -> None:
+    """aggregate_*records must raise, not divide by zero, when weights sum to zero."""
+    records = [
+        RecordDict(
+            {
+                "arrays": ArrayRecord([np.ones((2, 2))]),
+                "metrics": MetricRecord({"weight": 0.0, "acc": 1.0}),
+            }
+        )
+        for _ in range(3)
+    ]
+    with pytest.raises(InconsistentMessageReplies):
+        aggregate_arrayrecords(records, weighting_metric_name="weight")
+    with pytest.raises(InconsistentMessageReplies):
+        aggregate_metricrecords(records, weighting_metric_name="weight")
+
+
 def test_metricrecords_aggregation() -> None:
     """Test aggregation of MetricRecords."""
     num_replies = 3


### PR DESCRIPTION
Fixes #7708.

### Problem

`aggregate_arrayrecords` and `aggregate_metricrecords` (`serverapp/strategy/strategy_utils.py`) divide by `sum(weights)` with no zero guard. If every reply reports a zero weighting metric (default `num-examples`), `total_weight == 0` → `ZeroDivisionError`, crashing aggregation for `FedAvg` and every subclass. `validate_message_reply_consistency` doesn't check the sum.

Same class as #7645/#7646, but the new Message-API module those PRs don't touch.

### Change

Raise `InconsistentMessageReplies` (the module's own error for bad reply conditions) when the total is zero, in both aggregators.

### Testing

Added `test_aggregation_with_zero_total_weight`. It fails on the original code (`ZeroDivisionError`) and passes after the guard; the existing `strategy_utils` tests are unaffected (15/15 pass).