### PR TITLE
refactor(framework): Add connector declarative models

### DIFF
--- a/framework/py/flwr/supercore/state/schema/corestate_models.py
+++ b/framework/py/flwr/supercore/state/schema/corestate_models.py
@@ -90,3 +90,47 @@ class SeriesRuns(FlwrBase):
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     series_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
     run_id: Mapped[int] = mapped_column(BigInteger, unique=True, nullable=False)
+
+
+class Connector(FlwrBase):
+    """Represent connector configuration for an account."""
+
+    __tablename__ = "connector"
+
+    flwr_aid: Mapped[str] = mapped_column(String, primary_key=True, nullable=False)
+    connector_ref: Mapped[str] = mapped_column(String, primary_key=True, nullable=False)
+    credentials_json: Mapped[str] = mapped_column(String, nullable=False)
+    config_json: Mapped[str] = mapped_column(String, nullable=False)
+
+
+class ConnectorOAuthSession(FlwrBase):
+    """Represent an OAuth authorization session for a connector."""
+
+    __tablename__ = "connector_oauth_session"
+
+    oauth_session_id: Mapped[str] = mapped_column(
+        String, primary_key=True, nullable=False
+    )
+    flwr_aid: Mapped[str] = mapped_column(String, nullable=False)
+    connector_ref: Mapped[str] = mapped_column(String, nullable=False)
+    state: Mapped[str] = mapped_column(String, nullable=False)
+    redirect_uri: Mapped[str] = mapped_column(String, nullable=False)
+    pkce_verifier: Mapped[str | None] = mapped_column(String, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False
+    )
+    expires_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False
+    )
+    completed_at: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=True
+    )
+
+
+class RunConnector(FlwrBase):
+    """Represent the connectors attached to a run."""
+
+    __tablename__ = "run_connector"
+
+    run_id: Mapped[int] = mapped_column(BigInteger, primary_key=True, nullable=False)
+    connector_ref: Mapped[str] = mapped_column(String, primary_key=True, nullable=False)

--- a/framework/py/flwr/supercore/state/schema/corestate_models_test.py
+++ b/framework/py/flwr/supercore/state/schema/corestate_models_test.py
@@ -70,7 +70,17 @@ def _primary_key_signature(table: Table) -> tuple[str, ...]:
 
 
 @pytest.mark.parametrize(
-    "table_name", ["nonce_store", "fab", "run_series", "series_context", "series_runs"]
+    "table_name",
+    [
+        "nonce_store",
+        "fab",
+        "run_series",
+        "series_context",
+        "series_runs",
+        "connector",
+        "connector_oauth_session",
+        "run_connector",
+    ],
 )
 def test_declarative_model_matches_core_metadata(table_name: str) -> None:
     """Ensure declarative metadata preserves the Core table schema."""


### PR DESCRIPTION
Issue

### Description

Some state schema definitions are still represented only as SQLAlchemy Core tables.

### Related issues/PRs

N/A

## Proposal

### Explanation

This PR adds declarative models for the existing connector-related tables and extends the metadata parity test to cover them.

It does not change runtime behavior, migrations, schema, or public APIs.

### Checklist

- [x] Implement proposed change
- [x] Write tests
- [x] Update documentation
- [x] Address LLM-reviewer comments, if applicable (e.g., GitHub Copilot)
- [x] Make CI checks pass
- [x] Ping maintainers on Slack (channel `#contributions`)

### Any other comments?

No documentation update because this is an internal schema representation change only.

Tested from `framework/`:

```bash
uv run --no-sync --python=3.11.14 python -m pytest py/flwr/supercore/state/schema/corestate_models_test.py
uv run --no-sync --python=3.11.14 python -m ruff check py/flwr/supercore/state/schema/corestate_models.py py/flwr/supercore/state/schema/corestate_models_test.py
uv run --no-sync --python=3.11.14 python -m mypy py/flwr/supercore/state/schema/corestate_models.py py/flwr/supercore/state/schema/corestate_models_test.py
uv run --no-sync --python=3.11.14 python -m black --check py/flwr/supercore/state/schema/corestate_models.py py/flwr/supercore/state/schema/corestate_models_test.py
uv run --no-sync --python=3.11.14 python -m pytest py/flwr/supercore/state/alembic/utils_test.py -k "test_migrated_schema_matches_metadata"
uv run --no-sync --python=3.11.14 python -m devtool.check_pr_title 'refactor(framework): Add connector declarative models'