### PR TITLE
refactor(framework): Add automation declarative model

### DIFF
--- a/framework/py/flwr/supercore/state/schema/corestate_models.py
+++ b/framework/py/flwr/supercore/state/schema/corestate_models.py
@@ -92,6 +92,44 @@ class SeriesRuns(FlwrBase):
     run_id: Mapped[int] = mapped_column(BigInteger, unique=True, nullable=False)
 
 
+class Automation(FlwrBase):
+    """Represent an automation schedule."""
+
+    __tablename__ = "automation"
+    __table_args__ = (
+        Index("idx_automation_status_next_run_at", "status", "next_run_at"),
+        Index(
+            "idx_automation_federation_id_status_updated_at",
+            "federation_id",
+            "status",
+            "updated_at",
+        ),
+    )
+
+    automation_id: Mapped[int] = mapped_column(
+        Integer, primary_key=True, autoincrement=True, nullable=False
+    )
+    federation_id: Mapped[str] = mapped_column(String, nullable=False)
+    flwr_aid: Mapped[str] = mapped_column(String, nullable=False)
+    series_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    status: Mapped[str] = mapped_column(String, nullable=False)
+    start_run_request: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False
+    )
+    next_run_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False
+    )
+    fixed_interval: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    remaining_runs: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    stopped_at: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=True
+    )
+
+
 class Connector(FlwrBase):
     """Represent connector configuration for an account."""
 

--- a/framework/py/flwr/supercore/state/schema/corestate_models_test.py
+++ b/framework/py/flwr/supercore/state/schema/corestate_models_test.py
@@ -77,6 +77,7 @@ def _primary_key_signature(table: Table) -> tuple[str, ...]:
         "run_series",
         "series_context",
         "series_runs",
+        "automation",
         "connector",
         "connector_oauth_session",
         "run_connector",


### PR DESCRIPTION
Issue

### Description

Some state schema definitions are still represented only as SQLAlchemy Core tables.

### Related issues/PRs

N/A

## Proposal

### Explanation

This PR adds a declarative model for the existing `automation` table and extends the metadata parity test to cover it.

It does not change runtime behavior, migrations, schema, or public APIs.

### Checklist

- [x] Implement proposed change
- [x] Write tests
- [x] Update documentation
- [x] Address LLM-reviewer comments, if applicable (e.g., GitHub Copilot)
- [x] Make CI checks pass
- [x] Ping maintainers on Slack (channel `#contributions`)

### Any other comments?

No documentation update because this is an internal schema representation change only.

Tested from `framework/`:

```bash
uv run --no-sync --python=3.11.14 python -m pytest py/flwr/supercore/state/schema/corestate_models_test.py
uv run --no-sync --python=3.11.14 python -m ruff check py/flwr/supercore/state/schema/corestate_models.py py/flwr/supercore/state/schema/corestate_models_test.py
uv run --no-sync --python=3.11.14 python -m mypy py/flwr/supercore/state/schema/corestate_models.py py/flwr/supercore/state/schema/corestate_models_test.py
uv run --no-sync --python=3.11.14 python -m black --check py/flwr/supercore/state/schema/corestate_models.py py/flwr/supercore/state/schema/corestate_models_test.py
uv run --no-sync --python=3.11.14 python -m pytest py/flwr/supercore/state/alembic/utils_test.py -k "test_migrated_schema_matches_metadata"
uv run --no-sync --python=3.11.14 python -m devtool.check_pr_title 'refactor(framework): Add automation declarative model