### PR TITLE
refactor(framework): Add task declarative model

### DIFF
--- a/framework/py/flwr/supercore/state/schema/corestate_models.py
+++ b/framework/py/flwr/supercore/state/schema/corestate_models.py
@@ -25,6 +25,7 @@ from sqlalchemy import (
     LargeBinary,
     MetaData,
     String,
+    text,
 )
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
@@ -172,3 +173,45 @@ class RunConnector(FlwrBase):
 
     run_id: Mapped[int] = mapped_column(BigInteger, primary_key=True, nullable=False)
     connector_ref: Mapped[str] = mapped_column(String, primary_key=True, nullable=False)
+
+
+class Task(FlwrBase):
+    """Represent a task."""
+
+    __tablename__ = "task"
+    __table_args__ = (
+        Index("idx_task_run_id", "run_id"),
+        Index("idx_task_token", "token"),
+        Index("idx_task_active_until", "active_until"),
+    )
+
+    task_id: Mapped[int] = mapped_column(BigInteger, nullable=False, unique=True)
+    type: Mapped[str] = mapped_column(String, nullable=False)
+    run_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    fab_hash: Mapped[str | None] = mapped_column(String, nullable=True)
+    model_ref: Mapped[str | None] = mapped_column(String, nullable=True)
+    connector_ref: Mapped[str | None] = mapped_column(String, nullable=True)
+    token: Mapped[str | None] = mapped_column(String, nullable=True)
+    active_until: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=True
+    )
+    pending_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False
+    )
+    starting_at: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=True
+    )
+    running_at: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=True
+    )
+    finished_at: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=True
+    )
+    sub_status: Mapped[str] = mapped_column(
+        String, nullable=False, server_default=text("''")
+    )
+    details: Mapped[str] = mapped_column(
+        String, nullable=False, server_default=text("''")
+    )
+
+    __mapper_args__ = {"primary_key": [task_id]}

--- a/framework/py/flwr/supercore/state/schema/corestate_models_test.py
+++ b/framework/py/flwr/supercore/state/schema/corestate_models_test.py
@@ -19,7 +19,7 @@ from typing import Any
 import pytest
 from sqlalchemy import Column, Table
 
-from flwr.supercore.state.schema.corestate_models import FlwrBase
+from flwr.supercore.state.schema.corestate_models import FlwrBase, Task
 from flwr.supercore.state.schema.corestate_tables import create_corestate_metadata
 
 
@@ -81,6 +81,7 @@ def _primary_key_signature(table: Table) -> tuple[str, ...]:
         "connector",
         "connector_oauth_session",
         "run_connector",
+        "task",
     ],
 )
 def test_declarative_model_matches_core_metadata(table_name: str) -> None:
@@ -94,3 +95,8 @@ def test_declarative_model_matches_core_metadata(table_name: str) -> None:
     ]
     assert _primary_key_signature(model_table) == _primary_key_signature(core_table)
     assert _index_signature(model_table) == _index_signature(core_table)
+
+
+def test_task_mapper_uses_task_id_as_identity_key() -> None:
+    """Ensure the mapper-only primary key uses the existing unique task_id column."""
+    assert [column.name for column in Task.__mapper__.primary_key] == ["task_id"]


### PR DESCRIPTION
Issue

### Description

Some state schema definitions are still represented only as SQLAlchemy Core tables.

### Related issues/PRs

N/A

## Proposal

### Explanation

This PR adds a declarative model for the existing `task` table and extends the metadata parity test to cover it.

The model uses mapper-only primary key configuration because the existing table has a unique `task_id` column but no database primary key constraint. This keeps the table metadata unchanged while allowing SQLAlchemy ORM to map the table.

It does not change runtime behavior, migrations, schema, or public APIs.

### Checklist

- [x] Implement proposed change
- [x] Write tests
- [x] Update documentation
- [x] Address LLM-reviewer comments, if applicable (e.g., GitHub Copilot)
- [x] Make CI checks pass
- [x] Ping maintainers on Slack (channel `#contributions`)

### Any other comments?

No documentation update because this is an internal schema representation change only.

Tested from `framework/`:

```bash
uv run --no-sync --python=3.11.14 python -m pytest py/flwr/supercore/state/schema/corestate_models_test.py
uv run --no-sync --python=3.11.14 python -m ruff check py/flwr/supercore/state/schema/corestate_models.py py/flwr/supercore/state/schema/corestate_models_test.py
uv run --no-sync --python=3.11.14 python -m mypy py/flwr/supercore/state/schema/corestate_models.py py/flwr/supercore/state/schema/corestate_models_test.py
uv run --no-sync --python=3.11.14 python -m black --check py/flwr/supercore/state/schema/corestate_models.py py/flwr/supercore/state/schema/corestate_models_test.py
uv run --no-sync --python=3.11.14 python -m pytest py/flwr/supercore/state/alembic/utils_test.py -k "test_migrated_schema_matches_metadata"
uv run --no-sync --python=3.11.14 python -m devtool.check_pr_title 'refactor(framework): Add task declarative model