### PR TITLE
ci(framework:skip): Fix SuperLink E2E polling deadline

### DIFF
--- a/framework/e2e/test_superlink.sh
+++ b/framework/e2e/test_superlink.sh
@@ -142,8 +142,13 @@ while [ "$SECONDS" -lt "$deadline" ]; do
         exit 0
         ;;
       finished:*)
-        status_details=$(echo "$output" | jq -r '.runs[0]["status-details"]')
-        echo "Training failed: ${status_details}"
+        status_details=$(echo "$output" | jq -r '.runs[0]["status-details"] // empty')
+        if [ -n "$status_details" ]; then
+          echo "Training failed: ${status_details}"
+        else
+          echo "Training failed with status ${status}:"
+          echo "$output"
+        fi
         exit 1
         ;;
     esac

--- a/framework/e2e/test_superlink.sh
+++ b/framework/e2e/test_superlink.sh
@@ -121,15 +121,27 @@ timeout 1m flwr run "." e2e
 
 training_timeout=240
 deadline=$((SECONDS + training_timeout))
+status_query_timeout=10
+
+check_process() {
+  local pid=$1
+  local name=$2
+  if ! kill -0 "$pid" 2>/dev/null; then
+    echo "$name exited before training completed."
+    return 1
+  fi
+}
 
 while [ "$SECONDS" -lt "$deadline" ]; do
-    if ! kill -0 "$sl_pid" 2>/dev/null; then
-      echo "SuperLink exited before training completed."
-      exit 1
-    fi
+    check_process "$sl_pid" "SuperLink"
+    check_process "$cl1_pid" "SuperNode 1"
+    check_process "$cl2_pid" "SuperNode 2"
 
     # Run the command and capture output
-    output=$(flwr ls e2e --format=json)
+    if ! output=$(timeout "${status_query_timeout}s" flwr ls e2e --format=json); then
+      echo "flwr ls failed or timed out after ${status_query_timeout} seconds."
+      exit 1
+    fi
 
     # Extract status from the first run (or loop over all if needed)
     status=$(echo "$output" | jq -r '.runs[0].status')

--- a/framework/e2e/test_superlink.sh
+++ b/framework/e2e/test_superlink.sh
@@ -69,10 +69,27 @@ else
   echo -e $"\n[tool.flwr.federations.e2e]\naddress = \"127.0.0.1:9093\"\nroot-certificates = \"certificates/ca.crt\"" >> pyproject.toml
 fi
 
-timeout 5m flower-superlink \
+background_pids=()
+cleanup() {
+  local exit_code=$?
+  trap - EXIT
+
+  if [ "${#background_pids[@]}" -gt 0 ]; then
+    kill "${background_pids[@]}" 2>/dev/null || true
+    sleep 1
+    kill -9 "${background_pids[@]}" 2>/dev/null || true
+    wait "${background_pids[@]}" 2>/dev/null || true
+  fi
+
+  exit "$exit_code"
+}
+trap cleanup EXIT
+
+flower-superlink \
   $server_arg $db_arg $server_auth \
   $runtime_dependency_install_arg &
-sl_pid=$(pgrep -f "flower-superlink")
+sl_pid=$!
+background_pids+=("$sl_pid")
 sleep 3
 
 # Trigger migration
@@ -84,36 +101,33 @@ if [ "$2" = "client-auth" ]; then
   flwr supernode register keys/client_credentials_2.pub e2e
 fi
 
-timeout 5m flower-supernode $client_arg \
+flower-supernode $client_arg \
   --superlink $server_address $client_auth_1 \
   --clientappio-api-address "localhost:9094" \
   --max-retries 0 &
 cl1_pid=$!
+background_pids+=("$cl1_pid")
 sleep 3
 
-timeout 5m flower-supernode $client_arg \
+flower-supernode $client_arg \
   --superlink $server_address $client_auth_2 \
   --clientappio-api-address "localhost:9096" \
   --max-retries 0 &
 cl2_pid=$!
+background_pids+=("$cl2_pid")
 sleep 3
 
 timeout 1m flwr run "." e2e
 
-# Initialize a flag to track if training is successful
-found_success=false
-timeout=240  # Timeout after 240 seconds
-elapsed=0
+training_timeout=240
+deadline=$((SECONDS + training_timeout))
 
-# Define a cleanup function
-cleanup_and_exit() {
-    kill $cl1_pid; kill $cl2_pid;
-    sleep 1; kill $sl_pid;
-    exit $1
-}
+while [ "$SECONDS" -lt "$deadline" ]; do
+    if ! kill -0 "$sl_pid" 2>/dev/null; then
+      echo "SuperLink exited before training completed."
+      exit 1
+    fi
 
-# Check for "finished:completed" status in a loop with a timeout
-while [ "$found_success" = false ] && [ $elapsed -lt $timeout ]; do
     # Run the command and capture output
     output=$(flwr ls e2e --format=json)
 
@@ -122,17 +136,21 @@ while [ "$found_success" = false ] && [ $elapsed -lt $timeout ]; do
 
     echo "Current status: $status"
 
-    if [ "$status" == "finished:completed" ]; then
-      found_success=true
-      echo "Training worked correctly!"
-      cleanup_and_exit 0
-    else
-      echo "⏳ Not completed yet, retrying in 2s..."
-      sleep 2
-    fi
+    case "$status" in
+      finished:completed)
+        echo "Training worked correctly!"
+        exit 0
+        ;;
+      finished:*)
+        status_details=$(echo "$output" | jq -r '.runs[0]["status-details"]')
+        echo "Training failed: ${status_details}"
+        exit 1
+        ;;
+    esac
+
+    echo "⏳ Not completed yet, retrying in 2s..."
+    sleep 2
 done
 
-if [ "$found_success" = false ]; then
-    echo "Training had an issue and timed out."
-    cleanup_and_exit 1
-fi
+echo "Training did not complete within ${training_timeout} seconds."
+exit 1


### PR DESCRIPTION
## Issue

### Description

`test_superlink.sh` initializes an `elapsed` counter but never advances it, so its advertised 240-second polling timeout never fires. The harness also starts its five-minute daemon timers before setup, submission, and the four-minute polling budget, allowing a valid slow run to outlive its services.

### Related issues/PRs

Follow-up to #7710. Related Windows harness fix: #7712.

## Proposal

### Explanation

Use a `SECONDS`-based deadline, track the exact service PIDs, and clean them up through an `EXIT` trap. The services now stay alive for the complete test while the existing ten-minute workflow timeout remains the final guard. Terminal failed states also stop immediately instead of consuming the full polling budget.

### Checklist

- [x] Implement proposed change
- [x] Validate the shell script with `bash -n`
- [x] Validate the patch with `git diff --check`
- [x] Make CI checks pass

### Any other comments?

This PR is intentionally limited to the SuperLink harness timeout/lifecycle issue.