### PR TITLE
ci(framework:skip): Add timeouts to E2E prerequisite jobs

### DIFF
--- a/.github/workflows/framework-e2e.yml
+++ b/.github/workflows/framework-e2e.yml
@@ -21,6 +21,7 @@ env:
 jobs:
   changes:
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     outputs:
       framework: ${{ steps.filter.outputs.framework }}
     steps:
@@ -39,6 +40,7 @@ jobs:
 
   wheel:
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     name: Build, test and upload wheel
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/framework-e2e.yml
+++ b/.github/workflows/framework-e2e.yml
@@ -81,7 +81,7 @@ jobs:
 
   superexec:
     runs-on: ubuntu-24.04
-    timeout-minutes: 5
+    timeout-minutes: 10
     needs: [changes, wheel]
     strategy:
       fail-fast: false
@@ -135,7 +135,7 @@ jobs:
 
   frameworks:
     runs-on: ubuntu-24.04
-    timeout-minutes: 5
+    timeout-minutes: 10
     needs: [changes, wheel]
     # Using approach described here:
     # https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs
@@ -262,7 +262,7 @@ jobs:
 
   strategies:
     runs-on: ubuntu-24.04
-    timeout-minutes: 5
+    timeout-minutes: 10
     needs: [changes, wheel]
     strategy:
       matrix:
@@ -315,7 +315,7 @@ jobs:
 
   apps:
     runs-on: ubuntu-24.04
-    timeout-minutes: 5
+    timeout-minutes: 10
     needs: [changes, wheel]
     env:
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
@@ -359,7 +359,7 @@ jobs:
 
   pull-app:
     runs-on: ubuntu-24.04
-    timeout-minutes: 5
+    timeout-minutes: 10
     needs: [changes, wheel]
     env:
       ACCOUNT: "flwrlabs"
@@ -402,7 +402,7 @@ jobs:
 
   build_and_install:
     runs-on: ubuntu-24.04
-    timeout-minutes: 5
+    timeout-minutes: 10
     needs: [changes, wheel]
     strategy:
       matrix:
@@ -436,7 +436,7 @@ jobs:
 
   numpy:
     runs-on: ubuntu-24.04
-    timeout-minutes: 5
+    timeout-minutes: 10
     needs: [changes, wheel]
     strategy:
       fail-fast: false
@@ -490,7 +490,7 @@ jobs:
     runs-on: windows-latest
     env:
       PYTHONIOENCODING: utf-8
-    timeout-minutes: 5
+    timeout-minutes: 10
     needs: [changes, wheel]
 
     name: Windows compatibility test
@@ -518,7 +518,7 @@ jobs:
 
   serverapp-heartbeat-test:
     runs-on: ubuntu-24.04
-    timeout-minutes: 5
+    timeout-minutes: 10
     needs: [changes, wheel]
     strategy:
       matrix:

--- a/.github/workflows/framework-e2e.yml
+++ b/.github/workflows/framework-e2e.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   changes:
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 5
     outputs:
       framework: ${{ steps.filter.outputs.framework }}
     steps:
@@ -40,7 +40,7 @@ jobs:
 
   wheel:
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 5
     name: Build, test and upload wheel
     steps:
       - uses: actions/checkout@v5
@@ -81,7 +81,7 @@ jobs:
 
   superexec:
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 5
     needs: [changes, wheel]
     strategy:
       fail-fast: false
@@ -135,7 +135,7 @@ jobs:
 
   frameworks:
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 5
     needs: [changes, wheel]
     # Using approach described here:
     # https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs
@@ -262,7 +262,7 @@ jobs:
 
   strategies:
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 5
     needs: [changes, wheel]
     strategy:
       matrix:
@@ -315,7 +315,7 @@ jobs:
 
   apps:
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 5
     needs: [changes, wheel]
     env:
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
@@ -359,7 +359,7 @@ jobs:
 
   pull-app:
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 5
     needs: [changes, wheel]
     env:
       ACCOUNT: "flwrlabs"
@@ -402,7 +402,7 @@ jobs:
 
   build_and_install:
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 5
     needs: [changes, wheel]
     strategy:
       matrix:
@@ -436,7 +436,7 @@ jobs:
 
   numpy:
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 5
     needs: [changes, wheel]
     strategy:
       fail-fast: false
@@ -490,7 +490,7 @@ jobs:
     runs-on: windows-latest
     env:
       PYTHONIOENCODING: utf-8
-    timeout-minutes: 10
+    timeout-minutes: 5
     needs: [changes, wheel]
 
     name: Windows compatibility test
@@ -518,7 +518,7 @@ jobs:
 
   serverapp-heartbeat-test:
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 5
     needs: [changes, wheel]
     strategy:
       matrix:


### PR DESCRIPTION
## Issue

### Description

The `changes` and `wheel` prerequisite jobs have no job-level timeout. A stalled checkout, path filter, dependency installation, wheel build/test, or artifact upload can therefore occupy a runner for GitHub Actions' default maximum and block every dependent E2E job.

### Related issues/PRs

Follow-up to #7710.

## Proposal

### Explanation

Add ten-minute job timeouts to both prerequisite jobs, matching the workflow's E2E execution jobs. In recent successful run 30451887715, the jobs completed in approximately 8 and 41 seconds, leaving substantial headroom while converting multi-hour stalls into prompt failures.

### Checklist

- [x] Implement proposed change
- [x] Parse the updated workflow as YAML
- [x] Validate the patch with `git diff --check`
- [x] Make CI checks pass

### Any other comments?

This PR is intentionally limited to workflow-level guards for the two shared prerequisite jobs.