### PR TITLE
refactor(framework): Add task message declarative models

### DIFF
--- a/framework/py/flwr/supercore/state/schema/corestate_models.py
+++ b/framework/py/flwr/supercore/state/schema/corestate_models.py
@@ -20,6 +20,7 @@ from sqlalchemy import (
     TIMESTAMP,
     BigInteger,
     Float,
+    ForeignKey,
     Index,
     Integer,
     LargeBinary,
@@ -215,3 +216,49 @@ class Task(FlwrBase):
     )
 
     __mapper_args__ = {"primary_key": [task_id]}
+
+
+class TaskEvent(FlwrBase):
+    """Represent a task event."""
+
+    __tablename__ = "task_event"
+    __table_args__ = (
+        Index("idx_task_event_run_id_id", "run_id", "id"),
+        Index("idx_task_event_task_id", "task_id"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    timestamp: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False
+    )
+    run_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    task_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("task.task_id"), nullable=False
+    )
+    event: Mapped[str] = mapped_column(String, nullable=False)
+    data: Mapped[str] = mapped_column(String, nullable=False)
+
+
+class TaskMessage(FlwrBase):
+    """Represent a task message."""
+
+    __tablename__ = "task_message"
+    __table_args__ = (
+        Index("idx_task_message_dst_task_id_created_at", "dst_task_id", "created_at"),
+        Index("idx_task_message_run_id", "run_id"),
+    )
+
+    message_id: Mapped[str] = mapped_column(String, primary_key=True, nullable=False)
+    run_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    src_task_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("task.task_id"), nullable=False
+    )
+    dst_task_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("task.task_id"), nullable=False
+    )
+    reply_to_message_id: Mapped[str | None] = mapped_column(String, nullable=True)
+    created_at: Mapped[float] = mapped_column(Float, nullable=False)
+    ttl: Mapped[float] = mapped_column(Float, nullable=False)
+    message_type: Mapped[str] = mapped_column(String, nullable=False)
+    content: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True)
+    error: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True)

--- a/framework/py/flwr/supercore/state/schema/corestate_models_test.py
+++ b/framework/py/flwr/supercore/state/schema/corestate_models_test.py
@@ -82,6 +82,8 @@ def _primary_key_signature(table: Table) -> tuple[str, ...]:
         "connector_oauth_session",
         "run_connector",
         "task",
+        "task_event",
+        "task_message",
     ],
 )
 def test_declarative_model_matches_core_metadata(table_name: str) -> None:


### PR DESCRIPTION
## Issue

### Description

Some state schema definitions are still represented only as SQLAlchemy Core tables.

### Related issues/PRs

N/A

## Proposal

### Explanation

This PR adds declarative models for the existing task event and task message tables and extends the metadata parity test to cover them.

It does not change runtime behavior, migrations, schema, or public APIs.

### Checklist

- [x] Implement proposed change
- [x] Write tests
- [x] Update documentation
- [x] Address LLM-reviewer comments, if applicable (e.g., GitHub Copilot)
- [x] Make CI checks pass
- [x] Ping maintainers on Slack (channel `#contributions`)

### Any other comments?

No documentation update because this is an internal schema representation change only.

Tested from `framework/`:

```bash
uv run --no-sync --python=3.11.14 python -m pytest py/flwr/supercore/state/schema/corestate_models_test.py
uv run --no-sync --python=3.11.14 python -m ruff check py/flwr/supercore/state/schema/corestate_models.py py/flwr/supercore/state/schema/corestate_models_test.py
uv run --no-sync --python=3.11.14 python -m mypy py/flwr/supercore/state/schema/corestate_models.py py/flwr/supercore/state/schema/corestate_models_test.py
uv run --no-sync --python=3.11.14 python -m black --check py/flwr/supercore/state/schema/corestate_models.py py/flwr/supercore/state/schema/corestate_models_test.py
uv run --no-sync --python=3.11.14 python -m pytest py/flwr/supercore/state/alembic/utils_test.py -k "test_migrated_schema_matches_metadata"
uv run --no-sync --python=3.11.14 python -m devtool.check_pr_title 'refactor(framework): Add task message declarative models'
```