### PR TITLE
refactor(framework): Add object push declarative models

### DIFF
--- a/framework/py/flwr/supercore/state/schema/corestate_models.py
+++ b/framework/py/flwr/supercore/state/schema/corestate_models.py
@@ -25,6 +25,7 @@ from sqlalchemy import (
     Integer,
     LargeBinary,
     MetaData,
+    PrimaryKeyConstraint,
     String,
     text,
 )
@@ -262,3 +263,57 @@ class TaskMessage(FlwrBase):
     message_type: Mapped[str] = mapped_column(String, nullable=False)
     content: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True)
     error: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True)
+
+
+class ObjectPushSession(FlwrBase):
+    """Represent an object push session."""
+
+    __tablename__ = "object_push_sessions"
+    __table_args__ = (
+        Index("idx_object_push_sessions_run_id", "run_id"),
+        Index("idx_object_push_sessions_expires_at", "expires_at"),
+    )
+
+    session_id: Mapped[str] = mapped_column(String, primary_key=True, nullable=False)
+    run_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    expires_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False
+    )
+    pending_count: Mapped[int] = mapped_column(Integer, nullable=False)
+
+
+class ObjectPushSessionRoot(FlwrBase):
+    """Represent a root object for an object push session."""
+
+    __tablename__ = "object_push_session_roots"
+    __table_args__ = (Index("idx_object_push_session_roots_session_id", "session_id"),)
+
+    session_id: Mapped[str] = mapped_column(
+        String,
+        ForeignKey("object_push_sessions.session_id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    root_object_id: Mapped[str] = mapped_column(
+        String, primary_key=True, nullable=False
+    )
+
+
+class ObjectPushSessionPending(FlwrBase):
+    """Represent a pending object for an object push session."""
+
+    __tablename__ = "object_push_session_pending"
+    __table_args__ = (
+        PrimaryKeyConstraint("session_id", "object_id"),
+        Index(
+            "idx_object_push_session_pending_object_id_session_id",
+            "object_id",
+            "session_id",
+        ),
+    )
+
+    session_id: Mapped[str] = mapped_column(
+        String,
+        ForeignKey("object_push_sessions.session_id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    object_id: Mapped[str] = mapped_column(String, nullable=False)

--- a/framework/py/flwr/supercore/state/schema/corestate_models_test.py
+++ b/framework/py/flwr/supercore/state/schema/corestate_models_test.py
@@ -84,6 +84,9 @@ def _primary_key_signature(table: Table) -> tuple[str, ...]:
         "task",
         "task_event",
         "task_message",
+        "object_push_sessions",
+        "object_push_session_roots",
+        "object_push_session_pending",
     ],
 )
 def test_declarative_model_matches_core_metadata(table_name: str) -> None:


### PR DESCRIPTION
Issue

### Description

Some state schema definitions are still represented only as SQLAlchemy Core tables.

### Related issues/PRs

N/A

## Proposal

### Explanation

This PR adds declarative models for the existing object-push session tables and extends the metadata parity test to cover them.

It does not change runtime behavior, migrations, schema, or public APIs.

### Checklist

- [x] Implement proposed change
- [x] Write tests
- [x] Update documentation
- [x] Address LLM-reviewer comments, if applicable (e.g., GitHub Copilot)
- [x] Make CI checks pass
- [x] Ping maintainers on Slack (channel `#contributions`)

### Any other comments?

No documentation update because this is an internal schema representation change only.

Tested from `framework/`:

```bash
uv run --no-sync --python=3.11.14 python -m pytest py/flwr/supercore/state/schema/corestate_models_test.py
uv run --no-sync --python=3.11.14 python -m ruff check py/flwr/supercore/state/schema/corestate_models.py py/flwr/supercore/state/schema/corestate_models_test.py
uv run --no-sync --python=3.11.14 python -m mypy py/flwr/supercore/state/schema/corestate_models.py py/flwr/supercore/state/schema/corestate_models_test.py
uv run --no-sync --python=3.11.14 python -m black --check py/flwr/supercore/state/schema/corestate_models.py py/flwr/supercore/state/schema/corestate_models_test.py
uv run --no-sync --python=3.11.14 python -m pytest py/flwr/supercore/state/alembic/utils_test.py -k "test_migrated_schema_matches_metadata"
uv run --no-sync --python=3.11.14 python -m devtool.check_pr_title 'refactor(framework): Add object push declarative models
```