### PR TITLE
feat(framework): Add new series command for flwr chat shell

### DIFF
--- a/framework/py/flwr/cli/chat.py
+++ b/framework/py/flwr/cli/chat.py
@@ -30,6 +30,7 @@ from flwr.cli.constant import (
     CHAT_EXIT_COMMAND,
     CHAT_FAILURE_EVENTS,
     CHAT_FLOWER_AGENT_APP_SPEC,
+    CHAT_NEW_COMMAND,
     CHAT_SUPERGRID_CONNECTION_NAME,
     CHAT_TERMINAL_EVENTS,
     CHAT_TEXT_DELTA_EVENT,
@@ -107,6 +108,10 @@ def _run_interactive_shell(  # pylint: disable=R0912
             continue
         if stripped_prompt.lower() == CHAT_EXIT_COMMAND:
             return
+        if stripped_prompt.lower() == CHAT_NEW_COMMAND:
+            series_id = None
+            console.print("Started a new chat.", style="notice")
+            continue
 
         run_id: int | None = None
         try:

--- a/framework/py/flwr/cli/chat.py
+++ b/framework/py/flwr/cli/chat.py
@@ -14,6 +14,7 @@
 # ==============================================================================
 """Flower command line interface `chat` command."""
 
+
 import json
 import sys
 from typing import cast
@@ -152,7 +153,8 @@ def _run_interactive_shell(  # pylint: disable=R0912
                         )
                 except click.ClickException as exc:
                     typer.echo(
-                        f"Warning: failed to stop run {run_id}: {exc.format_message()}",
+                        f"Warning: failed to stop run {run_id}: "
+                        f"{exc.format_message()}",
                         err=True,
                     )
             continue

--- a/framework/py/flwr/cli/chat.py
+++ b/framework/py/flwr/cli/chat.py
@@ -87,6 +87,7 @@ def _run_interactive_shell(
     stub: ControlStub, federation: str | None, console: Console
 ) -> None:
     """Run the prompt-response loop."""
+    series_id: int | None = None
     while True:
         try:
             prompt = input(CHAT_USER_PROMPT)
@@ -109,11 +110,16 @@ def _run_interactive_shell(
                 override_config=user_config_to_proto({CHAT_AGENT_INPUT_KEY: prompt}),
                 federation=federation or "",
             )
+            if series_id is not None:
+                req.series_id = series_id
+
             with flwr_cli_grpc_exc_handler():
                 res = stub.StartRun(req)
 
             if not res.HasField("run_id"):
                 raise click.ClickException("Failed to start chat run.")
+            if res.HasField("series_id"):
+                series_id = cast(int, res.series_id)
             _stream_agent_response(stub, cast(int, res.run_id), status, console)
 
 

--- a/framework/py/flwr/cli/chat.py
+++ b/framework/py/flwr/cli/chat.py
@@ -121,11 +121,16 @@ def _run_interactive_shell(
                     ),
                     federation=federation or "",
                 )
+                if series_id is not None:
+                    req.series_id = series_id
+
                 with flwr_cli_grpc_exc_handler():
                     res = stub.StartRun(req)
 
                 if not res.HasField("run_id"):
                     raise click.ClickException("Failed to start chat run.")
+                if res.HasField("series_id"):
+                    series_id = cast(int, res.series_id)
                 run_id = cast(int, res.run_id)
                 _stream_agent_response(stub, run_id, status, console)
         except KeyboardInterrupt:

--- a/framework/py/flwr/cli/chat.py
+++ b/framework/py/flwr/cli/chat.py
@@ -14,7 +14,6 @@
 # ==============================================================================
 """Flower command line interface `chat` command."""
 
-
 import json
 import sys
 from typing import cast
@@ -110,7 +109,9 @@ def _run_interactive_shell(  # pylint: disable=R0912
             return
         if stripped_prompt.lower() == CHAT_NEW_COMMAND:
             series_id = None
-            console.print("Started a new chat.", style="notice")
+            console.print(
+                "Your next message will start a fresh conversation.", style="notice"
+            )
             continue
 
         run_id: int | None = None
@@ -151,8 +152,7 @@ def _run_interactive_shell(  # pylint: disable=R0912
                         )
                 except click.ClickException as exc:
                     typer.echo(
-                        f"Warning: failed to stop run {run_id}: "
-                        f"{exc.format_message()}",
+                        f"Warning: failed to stop run {run_id}: {exc.format_message()}",
                         err=True,
                     )
             continue

--- a/framework/py/flwr/cli/chat.py
+++ b/framework/py/flwr/cli/chat.py
@@ -85,7 +85,7 @@ def chat() -> None:
         channel.close()
 
 
-def _run_interactive_shell(
+def _run_interactive_shell(  # pylint: disable=R0912
     stub: ControlStub, federation: str | None, console: Console
 ) -> None:
     """Run the prompt-response loop."""
@@ -197,7 +197,6 @@ def _stream_agent_response(
                     raise click.ClickException(_format_failure_event(payload))
                 elif event_type in CHAT_TERMINAL_EVENTS:
                     terminal_event_seen = True
-                    break
     finally:
         if response_started:
             console.print()

--- a/framework/py/flwr/cli/constant.py
+++ b/framework/py/flwr/cli/constant.py
@@ -51,6 +51,7 @@ CHAT_FLOWER_AGENT_APP_SPEC = "@flwrlabs/flwr-agent"
 CHAT_SUPERGRID_CONNECTION_NAME = "supergrid"
 CHAT_AGENT_INPUT_KEY = "agent.input"
 CHAT_EXIT_COMMAND = "/quit"
+CHAT_NEW_COMMAND = "/new"
 CHAT_TEXT_DELTA_EVENT = "response.output_text.delta"
 CHAT_TERMINAL_EVENTS = {"response.completed", "response.incomplete"}
 CHAT_FAILURE_EVENTS = {"error", "response.failed"}


### PR DESCRIPTION
**Why**
Users need a way to start a fresh conversation without restarting `flwr chat`.

**What**
Add a `/new` command that resets the current series so the next prompt starts a new run series.