### PR TITLE
ci: add names to baseline/docker matrix steps for readability

### DIFF
--- a/.github/workflows/baselines.yml
+++ b/.github/workflows/baselines.yml
@@ -27,7 +27,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - shell: bash
+      - name: Build baseline path filters
+        shell: bash
         run: |
           # create a list of all directories in baselines
           {
@@ -55,7 +56,8 @@ jobs:
         with:
           filters: ${{ env.FILTER_PATHS }}
 
-      - if: ${{ github.event.pull_request.head.repo.fork }}
+      - name: Reject multi-baseline changes from forks
+        if: ${{ github.event.pull_request.head.repo.fork }}
         run: |
           CHANGES=$(echo "${{ toJson(steps.filter.outputs.changes) }}" | jq '. | length')
           if [ "$CHANGES" -gt 1 ]; then

--- a/.github/workflows/framework-docker-build-main.yml
+++ b/.github/workflows/framework-docker-build-main.yml
@@ -84,12 +84,14 @@ jobs:
             exit 1
           fi
 
-      - id: versions
+      - name: Export dependency versions
+        id: versions
         run: |
           echo "pip-version=${{ steps.bootstrap.outputs.pip-version }}" >> "$GITHUB_OUTPUT"
           echo "setuptools-version=${{ steps.bootstrap.outputs.setuptools-version }}" >> "$GITHUB_OUTPUT"
 
-      - id: matrix
+      - name: Build Docker image matrix
+        id: matrix
         run: |
           FLWR_VERSION_REF="git+${{ github.server_url }}/${{ github.repository }}.git@${{ github.sha }}#subdirectory=framework"
           python framework/dev/build-docker-image-matrix.py --flwr-version "${FLWR_VERSION_REF}" --matrix unstable > matrix.raw.json


### PR DESCRIPTION
## Problem

Long unnamed `run` steps in baseline change detection and Docker matrix preparation show up as generic labels in the Actions UI.

## Changes

Semantics are unchanged: same commands, same `id`s, same `GITHUB_ENV` / `GITHUB_OUTPUT` keys, and the same job/step output wiring.

### `.github/workflows/baselines.yml`
- Add `name: Build baseline path filters`
- Add `name: Reject multi-baseline changes from forks`

### `.github/workflows/framework-docker-build-main.yml`
- Add `name: Export dependency versions` to `id: versions`
- Add `name: Build Docker image matrix` to `id: matrix`

## Test plan
- [ ] Confirm `steps.filter.outputs.changes` / `FILTER_PATHS` wiring is unchanged
- [ ] Confirm `steps.matrix.outputs.matrix` and `steps.versions.outputs.*` wiring is unchanged
