### PR TITLE
fix(framework): Scope SQL sessions by database

### DIFF
--- a/framework/py/flwr/supercore/sql_mixin.py
+++ b/framework/py/flwr/supercore/sql_mixin.py
@@ -37,8 +37,8 @@ from flwr.supercore.constant import (
 )
 from flwr.supercore.state.alembic.utils import run_migrations
 
-_current_session: ContextVar[Session | None] = ContextVar(
-    "current_sqlalchemy_session",
+_current_sessions: ContextVar[dict[object, Session] | None] = ContextVar(
+    "current_sqlalchemy_sessions",
     default=None,
 )
 
@@ -102,6 +102,15 @@ class SqlMixin(ABC):
         self.database_backend = make_url(self.database_url).get_backend_name()
         self._validate_allowed_dialects(self.database_backend)
 
+        # Persistent SQL states using the same database URL may share one
+        # transaction. In-memory SQLite engines are independent per instance, so
+        # they must not share sessions.
+        self._session_scope = (
+            self
+            if self.database_url == FLWR_IN_MEMORY_SQLITE_DB_URL
+            else self.database_url
+        )
+
         self._engine: Engine | None = None
         self._session_factory: sessionmaker[Session] | None = None
 
@@ -141,8 +150,9 @@ class SqlMixin(ABC):
         """Provide a transactional database session context.
 
         Yields a SQLAlchemy Session that automatically commits on success or rolls
-        back on exceptions. Re-entrant: nested calls reuse the same session. Use for
-        multi-statement transactions; prefer `query()` for single statements.
+        back on exceptions. Re-entrant for the same database scope: nested calls
+        reuse that scope's session. Use for multi-statement transactions; prefer
+        `query()` for single statements.
 
         Yields
         ------
@@ -155,9 +165,15 @@ class SqlMixin(ABC):
                 session.execute(text("DELETE FROM t WHERE id = :id"), {"id": 1})
                 session.execute(text("INSERT INTO t2 SELECT * FROM t"))
         """
-        existing = _current_session.get()
+        current_sessions = _current_sessions.get()
+        existing = (
+            current_sessions.get(self._session_scope)
+            if current_sessions is not None
+            else None
+        )
 
-        # Re-entrant: reuse the session if in a session context, no begin()
+        # Re-entrant: reuse the active session for this database scope, even when
+        # another database scope was entered more recently.
         if existing is not None:
             yield existing
             return
@@ -167,13 +183,15 @@ class SqlMixin(ABC):
 
         # Create new session; outermost scope owns the transaction
         session = self._session_factory()
-        token = _current_session.set(session)
+        token = _current_sessions.set(
+            {**(current_sessions or {}), self._session_scope: session}
+        )
 
         try:
             with session.begin():
                 yield session
         finally:
-            _current_session.reset(token)
+            _current_sessions.reset(token)
             session.close()
 
     def get_metadata(self) -> MetaData | None:
@@ -253,8 +271,9 @@ class SqlMixin(ABC):
         isolated transaction that is automatically committed. This is suitable for
         single SQL statements.
 
-        If called within a session() context, query() reuses the existing session
-        and transaction. This enables atomic multi-query operations:
+        If called within a session() context for the same database scope, query()
+        reuses the existing session and transaction. This enables atomic multi-query
+        operations:
 
             with self.session() as session:
                 self.query("UPDATE ...", {...})    # Shares same transaction

--- a/framework/py/flwr/supercore/sql_mixin.py
+++ b/framework/py/flwr/supercore/sql_mixin.py
@@ -99,17 +99,18 @@ class SqlMixin(ABC):
             database_path = ":memory:"
 
         self.database_url = self._normalize_database_url(database_path)
-        self.database_backend = make_url(self.database_url).get_backend_name()
+        parsed_database_url = make_url(self.database_url)
+        self.database_backend = parsed_database_url.get_backend_name()
         self._validate_allowed_dialects(self.database_backend)
+        self._is_in_memory_sqlite = (
+            self.database_backend == "sqlite"
+            and parsed_database_url.database in (None, "", ":memory:")
+        )
 
         # Persistent SQL states using the same database URL may share one
         # transaction. In-memory SQLite engines are independent per instance, so
         # they must not share sessions.
-        self._session_scope = (
-            self
-            if self.database_url == FLWR_IN_MEMORY_SQLITE_DB_URL
-            else self.database_url
-        )
+        self._session_scope = self if self._is_in_memory_sqlite else self.database_url
 
         self._engine: Engine | None = None
         self._session_factory: sessionmaker[Session] | None = None
@@ -230,7 +231,7 @@ class SqlMixin(ABC):
             engine_kwargs["connect_args"] = {"check_same_thread": False}
         # In-memory SQLite databases are per-connection; use StaticPool to ensure
         # all threads share the same database instance.
-        if self.database_url == FLWR_IN_MEMORY_SQLITE_DB_URL:
+        if self._is_in_memory_sqlite:
             engine_kwargs["poolclass"] = StaticPool
         self._engine = create_engine(self.database_url, **engine_kwargs)
 
@@ -247,7 +248,7 @@ class SqlMixin(ABC):
 
         # Create database
         metadata: MetaData | None = self.get_metadata()
-        if metadata and self.database_url == FLWR_IN_MEMORY_SQLITE_DB_URL:
+        if metadata and self._is_in_memory_sqlite:
             # In-memory databases: create tables directly from SQLAlchemy metadata
             metadata.create_all(self._engine)
         else:

--- a/framework/py/flwr/supercore/sql_mixin_test.py
+++ b/framework/py/flwr/supercore/sql_mixin_test.py
@@ -16,6 +16,7 @@
 
 
 import unittest
+from tempfile import TemporaryDirectory
 
 from sqlalchemy import Column, Integer, MetaData, Table
 from sqlalchemy.exc import IntegrityError
@@ -131,6 +132,31 @@ class TestSqlMixin(unittest.TestCase):
         self.assertEqual(rows[0]["value"], 101)
         self.assertEqual(rows[1]["value"], 201)
         self.assertEqual(rows[2]["value"], 301)
+
+    def test_nested_sessions_are_scoped_to_database(self) -> None:
+        """Test that nested sessions reuse only the matching database session."""
+        other_db = DummyDbSqlAlchemy(":memory:")
+        other_db.initialize()
+
+        with self.db.session() as outer_session:
+            with other_db.session() as other_session:
+                self.assertIsNot(other_session, outer_session)
+
+                with self.db.session() as reentered_session:
+                    self.assertIs(reentered_session, outer_session)
+
+    def test_instances_for_same_database_share_session(self) -> None:
+        """Test that instances for the same persistent database share a session."""
+        with TemporaryDirectory() as temp_dir:
+            database_path = f"{temp_dir}/state.db"
+            first_db = DummyDbSqlAlchemy(database_path)
+            second_db = DummyDbSqlAlchemy(database_path)
+            first_db.initialize()
+            second_db.initialize()
+
+            with first_db.session() as first_session:
+                with second_db.session() as second_session:
+                    self.assertIs(second_session, first_session)
 
     def test_query_without_session(self) -> None:
         """Test that query() works independently when not in a session context."""

--- a/framework/py/flwr/supercore/sql_mixin_test.py
+++ b/framework/py/flwr/supercore/sql_mixin_test.py
@@ -145,6 +145,19 @@ class TestSqlMixin(unittest.TestCase):
                 with self.db.session() as reentered_session:
                     self.assertIs(reentered_session, outer_session)
 
+    def test_in_memory_url_instances_do_not_share_session(self) -> None:
+        """Test that equivalent in-memory URL forms remain instance-scoped."""
+        for database_url in ("sqlite://", "sqlite+pysqlite:///:memory:"):
+            with self.subTest(database_url=database_url):
+                first_db = DummyDbSqlAlchemy(database_url)
+                second_db = DummyDbSqlAlchemy(database_url)
+                first_db.initialize()
+                second_db.initialize()
+
+                with first_db.session() as first_session:
+                    with second_db.session() as second_session:
+                        self.assertIsNot(second_session, first_session)
+
     def test_instances_for_same_database_share_session(self) -> None:
         """Test that instances for the same persistent database share a session."""
         with TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## What changed

- Track active SQLAlchemy sessions by database scope instead of using one process-context session for every `SqlMixin` instance.
- Reuse a session across independently constructed state adapters that target the same persistent database.
- Keep in-memory SQLite instances isolated because each instance owns an independent engine.
- Preserve the outer session when execution nests across databases and later re-enters it.

## Why

`SqlMixin.session()` previously stored one session in a `ContextVar`. A nested call through a different `SqlMixin` instance could therefore reuse a session connected to the wrong database. Replacing the single value with a scope-to-session mapping preserves re-entrancy without crossing database boundaries.

## Validation

- `python -m black --check py/flwr/supercore/sql_mixin.py py/flwr/supercore/sql_mixin_test.py`
- `python -m ruff check py/flwr/supercore/sql_mixin.py py/flwr/supercore/sql_mixin_test.py --no-respect-gitignore`
- `python -m pytest py/flwr/supercore/sql_mixin_test.py`