### PR TITLE
fix(framework): Raise when aggregate_qffl() receives a zero total h value

### DIFF
--- a/framework/py/flwr/server/strategy/aggregate.py
+++ b/framework/py/flwr/server/strategy/aggregate.py
@@ -226,10 +226,20 @@ def aggregate_qffl(
     parameters: NDArrays, deltas: list[NDArrays], hs_fll: list[NDArrays]
 ) -> NDArrays:
     """Compute weighted average based on Q-FFL paper."""
-    demominator: float = np.sum(np.asarray(hs_fll))
+    denominator: float = np.sum(np.asarray(hs_fll))
+
+    # Guard against a zero denominator: when every client's h value is zero their
+    # sum is zero, and dividing by it would return NaN updates as the new global
+    # model instead of failing the round.
+    if denominator == 0:
+        raise ValueError(
+            "aggregate_qffl() requires the sum of h values (hs_fll) to be greater "
+            "than zero"
+        )
+
     scaled_deltas = []
     for client_delta in deltas:
-        scaled_deltas.append([layer * 1.0 / demominator for layer in client_delta])
+        scaled_deltas.append([layer * 1.0 / denominator for layer in client_delta])
     updates = []
     for i in range(len(deltas[0])):
         tmp = scaled_deltas[0][i]

--- a/framework/py/flwr/server/strategy/aggregate_test.py
+++ b/framework/py/flwr/server/strategy/aggregate_test.py
@@ -16,14 +16,28 @@
 
 
 import numpy as np
+import pytest
 
 from .aggregate import (
     _aggregate_n_closest_weights,
     _check_weights_equality,
     _find_reference_weights,
     aggregate,
+    aggregate_qffl,
     weighted_loss_avg,
 )
+
+
+def test_aggregate_qffl_zero_denominator() -> None:
+    """Test aggregate_qffl raises when the h values sum to zero."""
+    # Prepare: every client reports a zero h value, so their sum is zero
+    parameters = [np.array([1.0, 2.0])]
+    deltas = [[np.array([0.1, 0.2])]]
+    hs_fll = [np.array([0.0])]
+
+    # Execute & Assert: must raise rather than divide by zero and return NaN weights
+    with pytest.raises(ValueError):
+        aggregate_qffl(parameters, deltas, hs_fll)
 
 
 def test_aggregate() -> None:


### PR DESCRIPTION
### what

`aggregate_qffl()` in `strategy/aggregate.py` divides every client delta by `sum(hs_fll)` with no guard. when every client reports a zero h value the sum is zero, so the division returns NaN/inf and those get applied as the new global model instead of the round failing.

### why

`aggregate()` and `weighted_loss_avg()` in the same file already guard their zero-total case and raise. qffl was just missed, so this brings it in line with the existing pattern. also fixes the misspelled local `demominator` -> `denominator`.

### how tested

added `test_aggregate_qffl_zero_denominator` in `aggregate_test.py` asserting `ValueError` on a zero total. run:

```
python -m pytest flwr/server/strategy/aggregate_test.py -k qffl -v
```

confirmed the pre-fix path returns `[inf, inf]` on a zero denominator, and the happy path output is unchanged.

### risk

low. only adds a guard on the all-zero-h edge case that previously produced corrupt updates. no behavior change for valid inputs.
